### PR TITLE
Change default STATIC_URL value

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = (env, argv) => {
   let output;
 
   if (!devMode) {
-    const publicPath = process.env.STATIC_URL || "/static/";
+    const publicPath = process.env.STATIC_URL || "/";
     output = {
       path: resolve(dashboardBuildPath),
       filename: "[name].[chunkhash].js",


### PR DESCRIPTION
By default, we should use the root value `/` as a `STATIC_URL` and not assume any path like `/static/`.