### PR TITLE
standarize the git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ These instructions will get you a copy of the project up and running on your loc
 Clone the repository:
 
 ```
-$ git clone git@github.com:mirumee/saleor-dashboard.git
+$ git clone https://github.com/mirumee/saleor-dashboard.git
 ```
 
 Enter the project directory:


### PR DESCRIPTION
The current github url for cloning fails for some users
when running `git clone git@github.com:mirumee/saleor-dashboard.git` I get.
`
Cloning into 'saleor-dashboard'...
Warning: Permanently added the RSA host key for IP address '1.2.4.3' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
`
### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted to `.pot` file.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
