### PR TITLE
Do not use `value` field

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -322,7 +322,6 @@ type AttributeValue implements Node {
   name: String
   slug: String
   type: AttributeValueType
-  value: String @deprecated(reason: "This field is deprecated")
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
   inputType: AttributeInputTypeEnum
 }
@@ -340,7 +339,6 @@ type AttributeValueCreate {
 
 input AttributeValueCreateInput {
   name: String!
-  value: String
 }
 
 type AttributeValueDelete {
@@ -351,7 +349,6 @@ type AttributeValueDelete {
 
 input AttributeValueInput {
   id: ID
-  name: String
   slug: String
   values: [String]!
 }
@@ -519,7 +516,7 @@ type Checkout implements Node {
   shippingAddress: Address
   shippingMethod: ShippingMethod
   note: String!
-  discountAmount: Money @deprecated(reason: "Use discount instead.")
+  discountAmount: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use discount instead.")
   discount: Money
   discountName: String
   translatedDiscountName: String
@@ -696,7 +693,6 @@ type Collection implements Node {
   meta: [MetaStore]!
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
-  publishedDate: Date @deprecated(reason: "publishedDate is deprecated, use publicationDate instead")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
 }
 
@@ -2045,7 +2041,7 @@ type Order implements Node {
   totalBalance: Money!
   userEmail: String
   isShippingRequired: Boolean!
-  discountAmount: Money! @deprecated(reason: "Deprecated: use discount instead.")
+  discountAmount: Money! @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use discount instead.")
 }
 
 enum OrderAction {
@@ -2187,7 +2183,6 @@ type OrderLine implements Node {
   quantityFulfilled: Int!
   taxRate: Float!
   digitalContentUrl: DigitalContentUrl
-  thumbnailUrl(size: Int): String @deprecated(reason: "thumbnailUrl is deprecated, use thumbnail instead")
   thumbnail(size: Int): Image
   unitPrice: TaxedMoney
   variant: ProductVariant
@@ -2265,8 +2260,6 @@ type Page implements Node {
   content: String!
   contentJson: JSONString!
   created: DateTime!
-  availableOn: Date @deprecated(reason: "availableOn is deprecated, use publicationDate instead")
-  isVisible: Boolean @deprecated(reason: "isVisible is deprecated, use isPublished instead")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
 }
 
@@ -2501,15 +2494,13 @@ type Product implements Node {
   privateMeta: [MetaStore]!
   meta: [MetaStore]!
   url: String!
-  thumbnailUrl(size: Int): String @deprecated(reason: "thumbnailUrl is deprecated, use\\n         thumbnail instead")
   thumbnail(size: Int): Image
-  availability: ProductPricingInfo @deprecated(reason: "Has been renamed to 'pricing'.")
+  availability: ProductPricingInfo @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, Has been renamed to 'pricing'.")
   pricing: ProductPricingInfo
   isAvailable: Boolean
   basePrice: Money
-  price: Money @deprecated(reason: "Has been replaced by 'basePrice'")
+  price: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been replaced by 'basePrice'")
   minimalVariantPrice: Money
-  taxRate: TaxRateType @deprecated(reason: "taxRate is deprecated. Use taxType to obtain taxCode for given tax gateway")
   taxType: TaxType
   attributes: [SelectedAttribute!]!
   purchaseCost: MoneyRange
@@ -2518,7 +2509,6 @@ type Product implements Node {
   variants: [ProductVariant]
   images: [ProductImage]
   collections: [Collection]
-  availableOn: Date @deprecated(reason: "availableOn is deprecated, use publicationDate instead")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   slug: String!
 }
@@ -2569,9 +2559,7 @@ input ProductCreateInput {
   descriptionJson: JSONString
   isPublished: Boolean
   name: String
-  price: Decimal
   basePrice: Decimal
-  taxRate: TaxRateType
   taxCode: String
   seo: SeoInput
   weight: WeightScalar
@@ -2654,9 +2642,7 @@ input ProductInput {
   descriptionJson: JSONString
   isPublished: Boolean
   name: String
-  price: Decimal
   basePrice: Decimal
-  taxRate: TaxRateType
   taxCode: String
   seo: SeoInput
   weight: WeightScalar
@@ -2678,7 +2664,7 @@ enum ProductOrderField {
 }
 
 type ProductPricingInfo {
-  available: Boolean @deprecated(reason: "This has been moved to the parent type as 'is_available'.")
+  available: Boolean @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'isAvailable'.")
   onSale: Boolean
   discount: TaxedMoney
   discountLocalCurrency: TaxedMoney
@@ -2779,7 +2765,6 @@ input ProductTypeInput {
   isShippingRequired: Boolean
   isDigital: Boolean
   weight: WeightScalar
-  taxRate: TaxRateType
   taxCode: String
 }
 
@@ -2831,8 +2816,8 @@ type ProductVariant implements Node {
   meta: [MetaStore]!
   stockQuantity: Int!
   priceOverride: Money
-  price: Money @deprecated(reason: "Has been replaced by 'pricing.price_undiscounted'")
-  availability: VariantPricingInfo @deprecated(reason: "Has been renamed to 'pricing'.")
+  price: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been replaced by 'pricing.priceUndiscounted'")
+  availability: VariantPricingInfo @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been renamed to 'pricing'.")
   pricing: VariantPricingInfo
   isAvailable: Boolean
   attributes: [SelectedAttribute!]!
@@ -2942,7 +2927,7 @@ type Query {
   collection(id: ID!): Collection
   collections(filter: CollectionFilterInput, query: String, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   product(id: ID!): Product
-  products(filter: ProductFilterInput, attributes: [AttributeScalar], categories: [ID], collections: [ID], priceLte: Float, priceGte: Float, sortBy: ProductOrder, stockAvailability: StockAvailability, query: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(filter: ProductFilterInput, attributes: [AttributeScalar], categories: [ID], collections: [ID], sortBy: ProductOrder, stockAvailability: StockAvailability, query: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   productType(id: ID!): ProductType
   productTypes(filter: ProductTypeFilterInput, query: String, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
   productVariant(id: ID!): ProductVariant
@@ -3098,7 +3083,7 @@ type SaleUpdate {
 
 type SelectedAttribute {
   attribute: Attribute!
-  value: AttributeValue @deprecated(reason: "Use values instead.")
+  value: AttributeValue @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use values instead.")
   values: [AttributeValue]!
 }
 
@@ -3580,7 +3565,7 @@ type VariantImageUnassign {
 }
 
 type VariantPricingInfo {
-  available: Boolean @deprecated(reason: "This has been moved to the parent type as 'is_available'.")
+  available: Boolean @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'isAvailable'.")
   onSale: Boolean
   discount: TaxedMoney
   discountLocalCurrency: TaxedMoney
@@ -3614,7 +3599,7 @@ type Voucher implements Node {
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   countries: [CountryDisplay]
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation
-  minAmountSpent: Money @deprecated(reason: "Use the minSpent field instead.")
+  minAmountSpent: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use the minSpent field instead.")
 }
 
 type VoucherAddCatalogues {
@@ -3698,11 +3683,7 @@ type VoucherTranslation implements Node {
 }
 
 enum VoucherTypeEnum {
-  PRODUCT
-  COLLECTION
-  CATEGORY
   SHIPPING
-  VALUE
   ENTIRE_ORDER
   SPECIFIC_PRODUCT
 }

--- a/src/attributes/fixtures.ts
+++ b/src/attributes/fixtures.ts
@@ -22,16 +22,14 @@ export const attribute: AttributeDetailsFragment = {
       id: "UHJvZHVjdEF0dHJpYnV0ZVZhbHVlOjI0",
       name: "John Doe",
       slug: "john-doe",
-      type: AttributeValueType.STRING,
-      value: ""
+      type: AttributeValueType.STRING
     },
     {
       __typename: "AttributeValue" as "AttributeValue",
       id: "UHJvZHVjdEF0dHJpYnV0ZVZhbHVlOjI1",
       name: "Milionare Pirate",
       slug: "milionare-pirate",
-      type: AttributeValueType.STRING,
-      value: ""
+      type: AttributeValueType.STRING
     }
   ],
   visibleInStorefront: true

--- a/src/attributes/queries.ts
+++ b/src/attributes/queries.ts
@@ -31,7 +31,6 @@ export const attributeDetailsFragment = gql`
       name
       slug
       type
-      value
     }
   }
 `;

--- a/src/attributes/types/AttributeCreate.ts
+++ b/src/attributes/types/AttributeCreate.ts
@@ -20,7 +20,6 @@ export interface AttributeCreate_attributeCreate_attribute_values {
   name: string | null;
   slug: string | null;
   type: AttributeValueType | null;
-  value: string | null;
 }
 
 export interface AttributeCreate_attributeCreate_attribute {

--- a/src/attributes/types/AttributeDetails.ts
+++ b/src/attributes/types/AttributeDetails.ts
@@ -14,7 +14,6 @@ export interface AttributeDetails_attribute_values {
   name: string | null;
   slug: string | null;
   type: AttributeValueType | null;
-  value: string | null;
 }
 
 export interface AttributeDetails_attribute {

--- a/src/attributes/types/AttributeDetailsFragment.ts
+++ b/src/attributes/types/AttributeDetailsFragment.ts
@@ -14,7 +14,6 @@ export interface AttributeDetailsFragment_values {
   name: string | null;
   slug: string | null;
   type: AttributeValueType | null;
-  value: string | null;
 }
 
 export interface AttributeDetailsFragment {

--- a/src/attributes/types/AttributeUpdate.ts
+++ b/src/attributes/types/AttributeUpdate.ts
@@ -20,7 +20,6 @@ export interface AttributeUpdate_attributeUpdate_attribute_values {
   name: string | null;
   slug: string | null;
   type: AttributeValueType | null;
-  value: string | null;
 }
 
 export interface AttributeUpdate_attributeUpdate_attribute {

--- a/src/attributes/types/AttributeValueCreate.ts
+++ b/src/attributes/types/AttributeValueCreate.ts
@@ -20,7 +20,6 @@ export interface AttributeValueCreate_attributeValueCreate_attribute_values {
   name: string | null;
   slug: string | null;
   type: AttributeValueType | null;
-  value: string | null;
 }
 
 export interface AttributeValueCreate_attributeValueCreate_attribute {

--- a/src/attributes/types/AttributeValueDelete.ts
+++ b/src/attributes/types/AttributeValueDelete.ts
@@ -20,7 +20,6 @@ export interface AttributeValueDelete_attributeValueDelete_attribute_values {
   name: string | null;
   slug: string | null;
   type: AttributeValueType | null;
-  value: string | null;
 }
 
 export interface AttributeValueDelete_attributeValueDelete_attribute {

--- a/src/attributes/types/AttributeValueUpdate.ts
+++ b/src/attributes/types/AttributeValueUpdate.ts
@@ -20,7 +20,6 @@ export interface AttributeValueUpdate_attributeValueUpdate_attribute_values {
   name: string | null;
   slug: string | null;
   type: AttributeValueType | null;
-  value: string | null;
 }
 
 export interface AttributeValueUpdate_attributeValueUpdate_attribute {

--- a/src/plugins/types/pluginFragment.ts
+++ b/src/plugins/types/pluginFragment.ts
@@ -3,10 +3,10 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL fragment: pluginFragment
+// GraphQL fragment: PluginFragment
 // ====================================================
 
-export interface pluginFragment {
+export interface PluginFragment {
   __typename: "Plugin";
   id: string;
   name: string;

--- a/src/plugins/types/pluginsDetailsFragment.ts
+++ b/src/plugins/types/pluginsDetailsFragment.ts
@@ -5,10 +5,10 @@
 import { ConfigurationTypeFieldEnum } from "./../../types/globalTypes";
 
 // ====================================================
-// GraphQL fragment: pluginsDetailsFragment
+// GraphQL fragment: PluginsDetailsFragment
 // ====================================================
 
-export interface pluginsDetailsFragment_configuration {
+export interface PluginsDetailsFragment_configuration {
   __typename: "ConfigurationItem";
   name: string;
   type: ConfigurationTypeFieldEnum | null;
@@ -17,11 +17,11 @@ export interface pluginsDetailsFragment_configuration {
   label: string | null;
 }
 
-export interface pluginsDetailsFragment {
+export interface PluginsDetailsFragment {
   __typename: "Plugin";
   id: string;
   name: string;
   description: string;
   active: boolean;
-  configuration: (pluginsDetailsFragment_configuration | null)[] | null;
+  configuration: (PluginsDetailsFragment_configuration | null)[] | null;
 }

--- a/src/storybook/stories/attributes/AttributeValueEditDialog.tsx
+++ b/src/storybook/stories/attributes/AttributeValueEditDialog.tsx
@@ -12,8 +12,7 @@ import Decorator from "../../Decorator";
 const props: AttributeValueEditDialogProps = {
   attributeValue: {
     ...attribute.values[0],
-    type: AttributeValueType.STRING,
-    value: ""
+    type: AttributeValueType.STRING
   },
   confirmButtonState: "default",
   disabled: false,

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -219,13 +219,9 @@ export enum TaxRateType {
 }
 
 export enum VoucherTypeEnum {
-  CATEGORY = "CATEGORY",
-  COLLECTION = "COLLECTION",
   ENTIRE_ORDER = "ENTIRE_ORDER",
-  PRODUCT = "PRODUCT",
   SHIPPING = "SHIPPING",
   SPECIFIC_PRODUCT = "SPECIFIC_PRODUCT",
-  VALUE = "VALUE",
 }
 
 export enum WeightUnitsEnum {
@@ -289,12 +285,10 @@ export interface AttributeUpdateInput {
 
 export interface AttributeValueCreateInput {
   name: string;
-  value?: string | null;
 }
 
 export interface AttributeValueInput {
   id?: string | null;
-  name?: string | null;
   slug?: string | null;
   values: (string | null)[];
 }
@@ -506,7 +500,6 @@ export interface ProductTypeInput {
   isShippingRequired?: boolean | null;
   isDigital?: boolean | null;
   weight?: any | null;
-  taxRate?: TaxRateType | null;
   taxCode?: string | null;
 }
 


### PR DESCRIPTION
I want to merge this change because it drop usage of `attribute { value }` field.

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
