### PR TITLE
Add fallback locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix plugins page translations - #141 by @benekex2
 - Add attributes to column picker - #136 by @dominik-zeglen
 - Fix table cell padding - #143 by @dominik-zeglen
+- Add fallback locale - #153 by @dominik-zeglen

--- a/src/components/Locale/Locale.tsx
+++ b/src/components/Locale/Locale.tsx
@@ -151,10 +151,12 @@ function getMatchingLocale(): Locale {
       }
     }
   }
+
+  return undefined;
 }
 
 const LocaleProvider: React.FC = ({ children }) => {
-  const [locale] = React.useState(getMatchingLocale());
+  const [locale] = React.useState(getMatchingLocale() || defaultLocale);
 
   return (
     <IntlProvider


### PR DESCRIPTION
I want to merge this change because it fixes some bugs causing `locale` to be `undefined`, which would make `<DateTime />` components explode.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
