### PR TITLE
Fix en locale matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Replace checkbox with switch component in "product type has variants" - #152 by @dominik-zeglen
 - Add password reset flow - #147 by @dominik-zeglen
 - Add support for multiple values in filters - #160 by @dominik-zeglen
+- Fix en locale matching - #165 by @dominik-zeglen

--- a/src/components/Locale/Locale.test.ts
+++ b/src/components/Locale/Locale.test.ts
@@ -1,0 +1,25 @@
+import { getMatchingLocale, Locale } from "./Locale";
+
+describe("Matches locale to browser settings", () => {
+  it("if first language is an exact match", () => {
+    const locales = ["fr", "es", "en"];
+
+    expect(getMatchingLocale(locales)).toBe(Locale.FR);
+  });
+
+  it("if there is an exact match, but it's not first preference", () => {
+    const locales = ["does-not-exist", "tr", "de", "fr"];
+
+    expect(getMatchingLocale(locales)).toBe(Locale.TR);
+  });
+
+  it("or returns undefined if there is no match", () => {
+    const locales = [
+      "does-not-exist-1",
+      "does-not-exist-2",
+      "does-not-exist-3"
+    ];
+
+    expect(getMatchingLocale(locales)).toBe(undefined);
+  });
+});

--- a/src/components/Locale/Locale.tsx
+++ b/src/components/Locale/Locale.tsx
@@ -52,7 +52,7 @@ export const LocaleContext = React.createContext<LocaleContextType>(
 
 const { Consumer: LocaleConsumer, Provider: RawLocaleProvider } = LocaleContext;
 
-enum Locale {
+export enum Locale {
   AR = "ar",
   AZ = "az",
   BG = "bg",
@@ -62,6 +62,7 @@ enum Locale {
   DA = "da",
   DE = "de",
   EL = "el",
+  EN = "en",
   ES = "es",
   ES_CO = "es-co",
   ET = "et",
@@ -107,6 +108,8 @@ const localeData: Record<Locale, LocaleMessages> = {
   [Locale.DA]: locale_DA,
   [Locale.DE]: locale_DE,
   [Locale.EL]: locale_EL,
+  // Default language
+  [Locale.EN]: undefined,
   [Locale.ES]: locale_ES,
   [Locale.ES_CO]: locale_ES_CO,
   [Locale.ET]: locale_ET,
@@ -141,10 +144,10 @@ const localeData: Record<Locale, LocaleMessages> = {
   [Locale.ZH_HANT]: locale_ZH_HANT
 };
 
-function getMatchingLocale(): Locale {
+export function getMatchingLocale(languages: readonly string[]): Locale {
   const localeEntries = Object.entries(Locale);
 
-  for (const preferredLocale of navigator.languages) {
+  for (const preferredLocale of languages) {
     for (const localeEntry of localeEntries) {
       if (localeEntry[1].toLowerCase() === preferredLocale.toLowerCase()) {
         return Locale[localeEntry[0]];
@@ -156,7 +159,9 @@ function getMatchingLocale(): Locale {
 }
 
 const LocaleProvider: React.FC = ({ children }) => {
-  const [locale] = React.useState(getMatchingLocale() || defaultLocale);
+  const [locale] = React.useState(
+    getMatchingLocale(navigator.languages) || defaultLocale
+  );
 
   return (
     <IntlProvider


### PR DESCRIPTION
I want to merge this change because this PR fixes bug causing users to see `en` locale only if no other `navigator.languages` matched. It caused `navigator.languages = ['en', 'fr', 'es']` to match `fr`, even though there is a `en` locale.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
