### PR TITLE
support .env config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 const webpack = require("webpack");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+require('dotenv').config();
 
 const resolve = path.resolve.bind(path, __dirname);
 


### PR DESCRIPTION
I want to merge this change because it adds support for reading env vars from .env file.

<!-- Please mention all relevant issue numbers. -->
Fixes #193 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted to `.pot` file.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
