### PR TITLE
Update address only one time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add service account section - #188 by @dominik-zeglen
 - Add variant creator - #177 by @dominik-zeglen
 - Add git hooks - #209 by @dominik-zeglen
+- Send address update mutation only once - #210 by @dominik-zeglen

--- a/src/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
+++ b/src/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
@@ -88,7 +88,7 @@ const CustomerAddressDialog = withStyles(styles, {})(
         maxWidth="sm"
       >
         <Form initial={initialForm} errors={errors} onSubmit={onConfirm}>
-          {({ change, data, errors, submit }) => {
+          {({ change, data, errors }) => {
             const handleCountrySelect = createSingleAutocompleteSelectHandler(
               change,
               setCountryDisplayName,
@@ -128,7 +128,6 @@ const CustomerAddressDialog = withStyles(styles, {})(
                     transitionState={confirmButtonState}
                     color="primary"
                     variant="contained"
-                    onClick={submit}
                     type="submit"
                   >
                     <FormattedMessage {...buttonMessages.save} />


### PR DESCRIPTION
I want to merge this change because it fixes bug causing address form submitting twice.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
