### PR TITLE
Do not send customer invitation email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add service account section - #188 by @dominik-zeglen
 - Add variant creator - #177 by @dominik-zeglen
 - Add git hooks - #209 by @dominik-zeglen
+- Do not send customer invitation email - #211 by @dominik-zeglen

--- a/src/customers/views/CustomerCreate.tsx
+++ b/src/customers/views/CustomerCreate.tsx
@@ -79,7 +79,7 @@ export const CustomerCreate: React.StatelessComponent<{}> = () => {
                         firstName: formData.customerFirstName,
                         lastName: formData.customerLastName,
                         note: formData.note,
-                        sendPasswordEmail: true
+                        sendPasswordEmail: false
                       }
                     }
                   });


### PR DESCRIPTION
I want to merge this change because dashboard has no information about storefront url, and until it has, we cannot send these mails.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
