### PR TITLE
Add mailing configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix attribute errors - #216 by @dominik-zeglen
 - Fix column picker - #228 by @dominik-zeglen
 - Add readonly mode - #229 by @dominik-zeglen
+- Add mailing configuration - #222 by @dominik-zeglen

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-10-24T13:15:53.475Z\n"
+"POT-Creation-Date: 2019-10-24T13:17:27.157Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -2745,6 +2745,14 @@ msgstr ""
 #. Customer created
 msgctxt "event"
 msgid "Customer created"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [src.siteSettings.components.SiteSettingsMailing.3211348653]
+#. defaultMessage is:
+#. Customer password reset URL
+msgctxt "description"
+msgid "Customer password reset URL"
 msgstr ""
 
 #: build/locale/src/customers/components/CustomerDetails/CustomerDetails.json

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-10-24T12:11:32.946Z\n"
+"POT-Creation-Date: 2019-10-24T13:15:53.475Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -1467,6 +1467,14 @@ msgctxt "section header"
 msgid "Authentication Keys"
 msgstr ""
 
+#: build/locale/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.json
+#. [src.siteSettings.components.SiteSettingsPage.4088830385] - section header
+#. defaultMessage is:
+#. Authentication Methods
+msgctxt "section header"
+msgid "Authentication Methods"
+msgstr ""
+
 #: build/locale/src/siteSettings/components/SiteSettingsKeys/SiteSettingsKeys.json
 #. [src.siteSettings.components.SiteSettingsKeys.1270286507] - authentication provider name
 #. defaultMessage is:
@@ -1476,11 +1484,11 @@ msgid "Authentication Type"
 msgstr ""
 
 #: build/locale/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.json
-#. [src.siteSettings.components.SiteSettingsPage.2824577864]
+#. [src.siteSettings.components.SiteSettingsPage.3619898341]
 #. defaultMessage is:
-#. Authentication keys
+#. Authentication method defines additional ways that customers can log in to your ecommerce.
 msgctxt "description"
-msgid "Authentication keys"
+msgid "Authentication method defines additional ways that customers can log in to your ecommerce."
 msgstr ""
 
 #: build/locale/src/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.json
@@ -1992,11 +2000,11 @@ msgid "Company"
 msgstr ""
 
 #: build/locale/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.json
-#. [src.siteSettings.components.SiteSettingsPage.3817101936]
+#. [src.siteSettings.components.SiteSettingsPage.2768400497] - section header
 #. defaultMessage is:
-#. Company information
-msgctxt "description"
-msgid "Company information"
+#. Company Information
+msgctxt "section header"
+msgid "Company Information"
 msgstr ""
 
 #: build/locale/src/translations/components/TranslationsEntitiesList/TranslationsEntitiesList.json
@@ -2021,6 +2029,14 @@ msgstr ""
 #. Configurable
 msgctxt "product type"
 msgid "Configurable"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [src.siteSettings.components.SiteSettingsMailing.297689661]
+#. defaultMessage is:
+#. Configurate your email address from which all automatic emails will be sent to your customers.
+msgctxt "description"
+msgid "Configurate your email address from which all automatic emails will be sent to your customers."
 msgstr ""
 
 #: build/locale/src/intl.json
@@ -3603,6 +3619,14 @@ msgctxt "description"
 msgid "Email Address"
 msgstr ""
 
+#: build/locale/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.json
+#. [src.siteSettings.components.SiteSettingsPage.3657173399]
+#. defaultMessage is:
+#. Email adress you provide here will be used as a contact adress for your customers.
+msgctxt "description"
+msgid "Email adress you provide here will be used as a contact adress for your customers."
+msgstr ""
+
 #: build/locale/src/intl.json
 #. [src.endDate]
 #. defaultMessage is:
@@ -4349,6 +4373,42 @@ msgstr ""
 #. Login
 msgctxt "button"
 msgid "Login"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [src.siteSettings.components.SiteSettingsMailing.280712237] - section header
+#. defaultMessage is:
+#. Mailing Configuration
+#: build/locale/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.json
+#. [src.siteSettings.components.SiteSettingsPage.280712237] - section header
+#. defaultMessage is:
+#. Mailing Configuration
+msgctxt "section header"
+msgid "Mailing Configuration"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [siteSettingsMailingHelperText] - helper text
+#. defaultMessage is:
+#. Mailing Configuration
+msgctxt "helper text"
+msgid "Mailing Configuration"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [src.siteSettings.components.SiteSettingsMailing.1124962330]
+#. defaultMessage is:
+#. Mailing email address
+msgctxt "description"
+msgid "Mailing email address"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [src.siteSettings.components.SiteSettingsMailing.70179174]
+#. defaultMessage is:
+#. Mailing email sender
+msgctxt "description"
+msgid "Mailing email sender"
 msgstr ""
 
 #: build/locale/src/intl.json
@@ -8051,12 +8111,36 @@ msgctxt "description"
 msgid "These are general information about your store. They define what is the URL of your store and what is shown in brow sers taskbar."
 msgstr ""
 
+#: build/locale/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.json
+#. [src.siteSettings.components.SiteSettingsPage.3799756739]
+#. defaultMessage is:
+#. These are general information about your store. They define what is the URL of your store and what is shown in browsers taskbar.
+msgctxt "description"
+msgid "These are general information about your store. They define what is the URL of your store and what is shown in browsers taskbar."
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [src.siteSettings.components.SiteSettingsMailing.3447841451]
+#. defaultMessage is:
+#. This URL will be used as a main URL for password resets. It will be sent via email.
+msgctxt "description"
+msgid "This URL will be used as a main URL for password resets. It will be sent via email."
+msgstr ""
+
 #: build/locale/src/webhooks/components/WebhookInfo/WebhookInfo.json
 #. [src.webhooks.components.WebhookInfo.3763861707] - webhook target url help text
 #. defaultMessage is:
 #. This URL will receive webhook POST requests
 msgctxt "webhook target url help text"
 msgid "This URL will receive webhook POST requests"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.json
+#. [src.siteSettings.components.SiteSettingsPage.1004240342]
+#. defaultMessage is:
+#. This adress will be used to generate invoices and calculate shipping rates.
+msgctxt "description"
+msgid "This adress will be used to generate invoices and calculate shipping rates."
 msgstr ""
 
 #: build/locale/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.json
@@ -8159,12 +8243,28 @@ msgctxt "product attribute error"
 msgid "This variant already exists"
 msgstr ""
 
+#: build/locale/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.json
+#. [src.siteSettings.components.SiteSettingsPage.866304242]
+#. defaultMessage is:
+#. This where you will find all of the settings determining your stores e-mails. You can determine main email address and some of the contents of your emails.
+msgctxt "description"
+msgid "This where you will find all of the settings determining your stores e-mails. You can determine main email address and some of the contents of your emails."
+msgstr ""
+
 #: build/locale/src/shipping/components/ShippingZoneRateDialog/ShippingZoneRateDialog.json
 #. [src.shipping.components.ShippingZoneRateDialog.1486599614]
 #. defaultMessage is:
 #. This will be shown to customers at checkout
 msgctxt "description"
 msgid "This will be shown to customers at checkout"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [src.siteSettings.components.SiteSettingsMailing.1672275992] - email sender
+#. defaultMessage is:
+#. This will be visible as "from" name
+msgctxt "email sender"
+msgid "This will be visible as \"from\" name"
 msgstr ""
 
 #: build/locale/src/pages/components/PageInfo/PageInfo.json
@@ -8441,6 +8541,14 @@ msgstr ""
 #. URL Linked
 msgctxt "description"
 msgid "URL Linked"
+msgstr ""
+
+#: build/locale/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.json
+#. [src.siteSettings.components.SiteSettingsMailing.50742153]
+#. defaultMessage is:
+#. URL address
+msgctxt "description"
+msgid "URL address"
 msgstr ""
 
 #: build/locale/src/siteSettings/components/SiteSettingsDetails/SiteSettingsDetails.json
@@ -8736,19 +8844,19 @@ msgid "Usage Limit"
 msgstr ""
 
 #: build/locale/src/attributes/components/AttributeProperties/AttributeProperties.json
+#. [src.attributes.components.AttributeProperties.1318123158] - attribute is filterable in storefront
+#. defaultMessage is:
+#. Use in Faceted Navigation
+msgctxt "attribute is filterable in storefront"
+msgid "Use in Faceted Navigation"
+msgstr ""
+
+#: build/locale/src/attributes/components/AttributeProperties/AttributeProperties.json
 #. [src.attributes.components.AttributeProperties.714335445] - use attribute in filtering
 #. defaultMessage is:
 #. Use in Filtering
 msgctxt "use attribute in filtering"
 msgid "Use in Filtering"
-msgstr ""
-
-#: build/locale/src/attributes/components/AttributeProperties/AttributeProperties.json
-#. [src.attributes.components.AttributeProperties.1564730914] - attribute is filterable in storefront
-#. defaultMessage is:
-#. Use in faceted navigation
-msgctxt "attribute is filterable in storefront"
-msgid "Use in faceted navigation"
 msgstr ""
 
 #: build/locale/src/attributes/components/AttributeList/AttributeList.json

--- a/schema.graphql
+++ b/schema.graphql
@@ -3767,6 +3767,7 @@ type Shop {
   defaultDigitalMaxDownloads: Int
   defaultDigitalUrlValidDays: Int
   companyAddress: Address
+  customerSetPasswordUrl: String
 }
 
 type ShopAddressUpdate {
@@ -3816,6 +3817,7 @@ input ShopSettingsInput {
   defaultDigitalUrlValidDays: Int
   defaultMailSenderName: String
   defaultMailSenderAddress: String
+  customerSetPasswordUrl: String
 }
 
 type ShopSettingsTranslate {

--- a/schema.graphql
+++ b/schema.graphql
@@ -3327,6 +3327,8 @@ type ProductVariantUpdatePrivateMeta {
 type Query {
   webhook(id: ID!): Webhook
   webhooks(filter: WebhookFilterInput, before: String, after: String, first: Int, last: Int): WebhookCountableConnection
+  webhookEvents: [WebhookEvent]
+  webhookSamplePayload(eventType: WebhookEventTypeEnum!): JSONString
   translations(kind: TranslatableKinds!, before: String, after: String, first: Int, last: Int): TranslatableItemConnection
   shop: Shop
   shippingZone(id: ID!): ShippingZone
@@ -3744,6 +3746,8 @@ type Shop {
   currencies: [String]!
   defaultCurrency: String!
   defaultCountry: CountryDisplay
+  defaultMailSenderName: String
+  defaultMailSenderAddress: String
   description: String
   domain: Domain!
   homepageCollection: Collection
@@ -3810,6 +3814,8 @@ input ShopSettingsInput {
   automaticFulfillmentDigitalProducts: Boolean
   defaultDigitalMaxDownloads: Int
   defaultDigitalUrlValidDays: Int
+  defaultMailSenderName: String
+  defaultMailSenderAddress: String
 }
 
 type ShopSettingsTranslate {
@@ -4317,6 +4323,7 @@ enum WebhookErrorCode {
 
 type WebhookEvent {
   eventType: WebhookEventTypeEnum
+  name: String
 }
 
 enum WebhookEventTypeEnum {

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -54,6 +54,8 @@ const styles = (theme: Theme) =>
     },
     uploadText: {
       color: theme.typography.body2.color,
+      fontSize: 12,
+      fontWeight: 600,
       textTransform: "uppercase"
     }
   });
@@ -93,7 +95,7 @@ export const ImageUpload = withStyles(styles, { name: "ImageUpload" })(
             >
               <input {...getInputProps()} className={classes.fileField} />
               <ImageIcon className={classes.photosIcon} />
-              <Typography className={classes.uploadText} variant="body1">
+              <Typography className={classes.uploadText}>
                 <FormattedMessage
                   defaultMessage="Drop here to upload"
                   description="image upload"

--- a/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
+++ b/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
@@ -1,0 +1,100 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import { Theme } from "@material-ui/core/styles";
+import TextField from "@material-ui/core/TextField";
+import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/styles";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import CardTitle from "@saleor/components/CardTitle";
+import FormSpacer from "@saleor/components/FormSpacer";
+import Hr from "@saleor/components/Hr";
+import { FormErrors } from "@saleor/types";
+import { SiteSettingsPageFormData } from "../SiteSettingsPage";
+
+interface SiteSettingsMailingProps {
+  data: SiteSettingsPageFormData;
+  errors: FormErrors<"email" | "passwordResetUrl">;
+  disabled: boolean;
+  onChange: (event: React.ChangeEvent<any>) => void;
+}
+
+const useStyles = makeStyles(
+  (theme: Theme) => ({
+    cardHelperText: {
+      position: "relative",
+      top: -theme.spacing.unit
+    },
+    cardHelperTextCaption: {
+      marginBottom: theme.spacing.unit * 2
+    }
+  }),
+  {
+    name: "SiteSettingsMailing"
+  }
+);
+
+const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
+  const { data, disabled, errors, onChange } = props;
+  const classes = useStyles(props);
+  const intl = useIntl();
+
+  return (
+    <Card>
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Mailing Configuration",
+          description: "section header"
+        })}
+      />
+      <CardContent>
+        <Typography className={classes.cardHelperText}>
+          <FormattedMessage
+            defaultMessage="Mailing Configuration"
+            description="helper text"
+            id="siteSettingsMailingHelperText"
+          />
+        </Typography>
+        <Typography className={classes.cardHelperTextCaption} variant="body1">
+          <FormattedMessage defaultMessage="Configurate your email address from which all automatic emails will be sent to your customers." />
+        </Typography>
+        <TextField
+          disabled={disabled}
+          error={!!errors.email}
+          fullWidth
+          name="email"
+          label={intl.formatMessage({
+            defaultMessage: "Mailing email address"
+          })}
+          helperText={errors.email}
+          value={data.name}
+          onChange={onChange}
+        />
+        <FormSpacer />
+        <Hr />
+        <FormSpacer />
+        <TextField
+          disabled={disabled}
+          error={!!errors.passwordResetUrl}
+          fullWidth
+          name="passwordResetUrl"
+          label={intl.formatMessage({
+            defaultMessage: "URL address"
+          })}
+          helperText={
+            errors.passwordResetUrl ||
+            intl.formatMessage({
+              defaultMessage:
+                "This URL will be used as a main URL for password resets. It will be sent via email."
+            })
+          }
+          value={data.domain}
+          onChange={onChange}
+        />
+      </CardContent>
+    </Card>
+  );
+};
+SiteSettingsMailing.displayName = "SiteSettingsMailing";
+export default SiteSettingsMailing;

--- a/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
+++ b/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
@@ -11,11 +11,17 @@ import CardTitle from "@saleor/components/CardTitle";
 import FormSpacer from "@saleor/components/FormSpacer";
 import Hr from "@saleor/components/Hr";
 import { FormErrors } from "@saleor/types";
-import { SiteSettingsPageFormData } from "../SiteSettingsPage";
 
+export interface SiteSettingsMailingFormData {
+  defaultMailSenderName: string;
+  defaultMailSenderAddress: string;
+  passwordResetUrl: string;
+}
 interface SiteSettingsMailingProps {
-  data: SiteSettingsPageFormData;
-  errors: FormErrors<"email" | "passwordResetUrl">;
+  data: SiteSettingsMailingFormData;
+  errors: FormErrors<
+    "defaultMailSenderAddress" | "defaultMailSenderName" | "passwordResetUrl"
+  >;
   disabled: boolean;
   onChange: (event: React.ChangeEvent<any>) => void;
 }
@@ -61,14 +67,33 @@ const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
         </Typography>
         <TextField
           disabled={disabled}
-          error={!!errors.email}
+          error={!!errors.defaultMailSenderAddress}
           fullWidth
-          name="email"
+          name="defaultMailSenderAddress"
           label={intl.formatMessage({
             defaultMessage: "Mailing email address"
           })}
-          helperText={errors.email}
-          value={data.name}
+          helperText={errors.defaultMailSenderAddress}
+          value={data.defaultMailSenderAddress}
+          onChange={onChange}
+        />
+        <FormSpacer />
+        <TextField
+          disabled={disabled}
+          error={!!errors.defaultMailSenderName}
+          fullWidth
+          name="defaultMailSenderAddress"
+          label={intl.formatMessage({
+            defaultMessage: "Mailing email sender"
+          })}
+          helperText={
+            errors.defaultMailSenderName ||
+            intl.formatMessage({
+              defaultMessage: 'This will be visible as "from" name',
+              description: "email sender"
+            })
+          }
+          value={data.defaultMailSenderAddress}
           onChange={onChange}
         />
         <FormSpacer />
@@ -89,7 +114,7 @@ const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
                 "This URL will be used as a main URL for password resets. It will be sent via email."
             })
           }
-          value={data.domain}
+          value={data.passwordResetUrl}
           onChange={onChange}
         />
       </CardContent>

--- a/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
+++ b/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
@@ -107,6 +107,9 @@ const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
           fullWidth
           name="customerSetPasswordUrl"
           label={intl.formatMessage({
+            defaultMessage: "Customer password reset URL"
+          })}
+          placeholder={intl.formatMessage({
             defaultMessage: "URL address"
           })}
           helperText={

--- a/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
+++ b/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
@@ -15,12 +15,14 @@ import { FormErrors } from "@saleor/types";
 export interface SiteSettingsMailingFormData {
   defaultMailSenderName: string;
   defaultMailSenderAddress: string;
-  passwordResetUrl: string;
+  customerSetPasswordUrl: string;
 }
 interface SiteSettingsMailingProps {
   data: SiteSettingsMailingFormData;
   errors: FormErrors<
-    "defaultMailSenderAddress" | "defaultMailSenderName" | "passwordResetUrl"
+    | "defaultMailSenderAddress"
+    | "defaultMailSenderName"
+    | "customerSetPasswordUrl"
   >;
   disabled: boolean;
   onChange: (event: React.ChangeEvent<any>) => void;
@@ -82,7 +84,7 @@ const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
           disabled={disabled}
           error={!!errors.defaultMailSenderName}
           fullWidth
-          name="defaultMailSenderAddress"
+          name="defaultMailSenderName"
           label={intl.formatMessage({
             defaultMessage: "Mailing email sender"
           })}
@@ -93,7 +95,7 @@ const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
               description: "email sender"
             })
           }
-          value={data.defaultMailSenderAddress}
+          value={data.defaultMailSenderName}
           onChange={onChange}
         />
         <FormSpacer />
@@ -101,20 +103,20 @@ const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
         <FormSpacer />
         <TextField
           disabled={disabled}
-          error={!!errors.passwordResetUrl}
+          error={!!errors.customerSetPasswordUrl}
           fullWidth
-          name="passwordResetUrl"
+          name="customerSetPasswordUrl"
           label={intl.formatMessage({
             defaultMessage: "URL address"
           })}
           helperText={
-            errors.passwordResetUrl ||
+            errors.customerSetPasswordUrl ||
             intl.formatMessage({
               defaultMessage:
                 "This URL will be used as a main URL for password resets. It will be sent via email."
             })
           }
-          value={data.passwordResetUrl}
+          value={data.customerSetPasswordUrl}
           onChange={onChange}
         />
       </CardContent>

--- a/src/siteSettings/components/SiteSettingsMailing/index.ts
+++ b/src/siteSettings/components/SiteSettingsMailing/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./SiteSettingsMailing";
+export * from "./SiteSettingsMailing";

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -86,18 +86,24 @@ const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
     maybe(() => shop.companyAddress.country.code, "")
   );
 
-  const initialForm: SiteSettingsPageFormData = {
+  const initialFormAddress: SiteSettingsPageAddressFormData = {
     city: maybe(() => shop.companyAddress.city, ""),
     companyName: maybe(() => shop.companyAddress.companyName, ""),
     country: maybe(() => shop.companyAddress.country.code, ""),
     countryArea: maybe(() => shop.companyAddress.countryArea, ""),
-    description: maybe(() => shop.description, ""),
-    domain: maybe(() => shop.domain.host, ""),
-    name: maybe(() => shop.name, ""),
     phone: maybe(() => shop.companyAddress.phone, ""),
     postalCode: maybe(() => shop.companyAddress.postalCode, ""),
     streetAddress1: maybe(() => shop.companyAddress.streetAddress1, ""),
     streetAddress2: maybe(() => shop.companyAddress.streetAddress2, "")
+  };
+  const initialForm: SiteSettingsPageFormData = {
+    ...initialFormAddress,
+    customerSetPasswordUrl: maybe(() => shop.customerSetPasswordUrl, ""),
+    defaultMailSenderAddress: maybe(() => shop.defaultMailSenderAddress, ""),
+    defaultMailSenderName: maybe(() => shop.defaultMailSenderName, ""),
+    description: maybe(() => shop.description, ""),
+    domain: maybe(() => shop.domain.host, ""),
+    name: maybe(() => shop.name, "")
   };
 
   return (

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -1,4 +1,6 @@
+import { Theme } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/styles";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -7,6 +9,7 @@ import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
 import Container from "@saleor/components/Container";
 import Form from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
+import Hr from "@saleor/components/Hr";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
@@ -20,6 +23,7 @@ import { SiteSettings_shop } from "../../types/SiteSettings";
 import SiteSettingsAddress from "../SiteSettingsAddress/SiteSettingsAddress";
 import SiteSettingsDetails from "../SiteSettingsDetails/SiteSettingsDetails";
 import SiteSettingsKeys from "../SiteSettingsKeys/SiteSettingsKeys";
+import SiteSettingsMailing from "../SiteSettingsMailing";
 
 export interface SiteSettingsPageAddressFormData {
   city: string;
@@ -36,7 +40,9 @@ export interface SiteSettingsPageFormData
   extends SiteSettingsPageAddressFormData {
   description: string;
   domain: string;
+  email: string;
   name: string;
+  passwordResetUrl: string;
 }
 
 export interface SiteSettingsPageProps {
@@ -50,16 +56,30 @@ export interface SiteSettingsPageProps {
   onSubmit: (data: SiteSettingsPageFormData) => void;
 }
 
-const SiteSettingsPage: React.StatelessComponent<SiteSettingsPageProps> = ({
-  disabled,
-  errors,
-  saveButtonBarState,
-  shop,
-  onBack,
-  onKeyAdd,
-  onKeyRemove,
-  onSubmit
-}) => {
+const useStyles = makeStyles(
+  (theme: Theme) => ({
+    hr: {
+      gridColumnEnd: "span 2",
+      margin: `${theme.spacing.unit}px 0`
+    }
+  }),
+  {
+    name: "SiteSettingsPage"
+  }
+);
+
+const SiteSettingsPage: React.FC<SiteSettingsPageProps> = props => {
+  const {
+    disabled,
+    errors,
+    saveButtonBarState,
+    shop,
+    onBack,
+    onKeyAdd,
+    onKeyRemove,
+    onSubmit
+  } = props;
+  const classes = useStyles(props);
   const intl = useIntl();
   const [displayCountry, setDisplayCountry] = useStateFromProps(
     maybe(() => shop.companyAddress.country.code, "")
@@ -105,18 +125,51 @@ const SiteSettingsPage: React.StatelessComponent<SiteSettingsPageProps> = ({
               title={intl.formatMessage(commonMessages.generalInformations)}
             />
             <Grid variant="inverted">
-              <Typography variant="h6">
-                {intl.formatMessage(sectionNames.siteSettings)}
-              </Typography>
+              <div>
+                <Typography>
+                  {intl.formatMessage(sectionNames.siteSettings)}
+                </Typography>
+                <Typography variant="body1">
+                  <FormattedMessage defaultMessage="These are general information about your store. They define what is the URL of your store and what is shown in browsers taskbar." />
+                </Typography>
+              </div>
               <SiteSettingsDetails
                 data={data}
                 errors={formErrors}
                 disabled={disabled}
                 onChange={change}
               />
-              <Typography variant="h6">
-                <FormattedMessage defaultMessage="Company information" />
-              </Typography>
+              <Hr className={classes.hr} />
+              <div>
+                <Typography>
+                  <FormattedMessage
+                    defaultMessage="Mailing Configuration"
+                    description="section header"
+                  />
+                </Typography>
+                <Typography variant="body1">
+                  <FormattedMessage defaultMessage="This where you will find all of the settings determining your stores e-mails. You can determine main email address and some of the contents of your emails." />
+                </Typography>
+              </div>
+              <SiteSettingsMailing
+                data={data}
+                errors={formErrors}
+                disabled={disabled}
+                onChange={change}
+              />
+              <Hr className={classes.hr} />
+              <div>
+                <Typography>
+                  <FormattedMessage
+                    defaultMessage="Company Information"
+                    description="section header"
+                  />
+                </Typography>
+                <Typography variant="body1">
+                  <FormattedMessage defaultMessage="This adress will be used to generate invoices and calculate shipping rates." />
+                  <FormattedMessage defaultMessage="Email adress you provide here will be used as a contact adress for your customers." />
+                </Typography>
+              </div>
               <SiteSettingsAddress
                 data={data}
                 displayCountry={displayCountry}
@@ -126,9 +179,18 @@ const SiteSettingsPage: React.StatelessComponent<SiteSettingsPageProps> = ({
                 onChange={change}
                 onCountryChange={handleCountryChange}
               />
-              <Typography variant="h6">
-                <FormattedMessage defaultMessage="Authentication keys" />
-              </Typography>
+              <Hr className={classes.hr} />
+              <div>
+                <Typography>
+                  <FormattedMessage
+                    defaultMessage="Authentication Methods"
+                    description="section header"
+                  />
+                </Typography>
+                <Typography variant="body1">
+                  <FormattedMessage defaultMessage="Authentication method defines additional ways that customers can log in to your ecommerce. " />
+                </Typography>
+              </div>
               <SiteSettingsKeys
                 disabled={disabled}
                 keys={maybe(() => shop.authorizationKeys)}
@@ -148,5 +210,6 @@ const SiteSettingsPage: React.StatelessComponent<SiteSettingsPageProps> = ({
     </Form>
   );
 };
+
 SiteSettingsPage.displayName = "SiteSettingsPage";
 export default SiteSettingsPage;

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -23,7 +23,9 @@ import { SiteSettings_shop } from "../../types/SiteSettings";
 import SiteSettingsAddress from "../SiteSettingsAddress/SiteSettingsAddress";
 import SiteSettingsDetails from "../SiteSettingsDetails/SiteSettingsDetails";
 import SiteSettingsKeys from "../SiteSettingsKeys/SiteSettingsKeys";
-import SiteSettingsMailing from "../SiteSettingsMailing";
+import SiteSettingsMailing, {
+  SiteSettingsMailingFormData
+} from "../SiteSettingsMailing";
 
 export interface SiteSettingsPageAddressFormData {
   city: string;
@@ -37,12 +39,11 @@ export interface SiteSettingsPageAddressFormData {
 }
 
 export interface SiteSettingsPageFormData
-  extends SiteSettingsPageAddressFormData {
+  extends SiteSettingsPageAddressFormData,
+    SiteSettingsMailingFormData {
   description: string;
   domain: string;
-  email: string;
   name: string;
-  passwordResetUrl: string;
 }
 
 export interface SiteSettingsPageProps {

--- a/src/siteSettings/fixtures.ts
+++ b/src/siteSettings/fixtures.ts
@@ -36,6 +36,9 @@ export const shop: SiteSettings_shop = {
       country: "United Arab Emirates"
     }
   ],
+  customerSetPasswordUrl: "https://example.com/reset-password",
+  defaultMailSenderAddress: "noreply@example.com",
+  defaultMailSenderName: "Saleor",
   description: "Lorem ipsum dolor sit amet",
   domain: {
     __typename: "Domain",

--- a/src/siteSettings/mutations.ts
+++ b/src/siteSettings/mutations.ts
@@ -63,7 +63,7 @@ const shopSettingsUpdate = gql`
   mutation ShopSettingsUpdate(
     $shopDomainInput: SiteDomainInput!
     $shopSettingsInput: ShopSettingsInput!
-    $addressInput: AddressInput!
+    $addressInput: AddressInput
   ) {
     shopSettingsUpdate(input: $shopSettingsInput) {
       errors {

--- a/src/siteSettings/queries.ts
+++ b/src/siteSettings/queries.ts
@@ -17,6 +17,9 @@ export const shopFragment = gql`
       code
       country
     }
+    customerSetPasswordUrl
+    defaultMailSenderAddress
+    defaultMailSenderName
     description
     domain {
       host

--- a/src/siteSettings/types/AuthorizationKeyAdd.ts
+++ b/src/siteSettings/types/AuthorizationKeyAdd.ts
@@ -58,6 +58,9 @@ export interface AuthorizationKeyAdd_authorizationKeyAdd_shop {
   authorizationKeys: (AuthorizationKeyAdd_authorizationKeyAdd_shop_authorizationKeys | null)[];
   companyAddress: AuthorizationKeyAdd_authorizationKeyAdd_shop_companyAddress | null;
   countries: (AuthorizationKeyAdd_authorizationKeyAdd_shop_countries | null)[];
+  customerSetPasswordUrl: string | null;
+  defaultMailSenderAddress: string | null;
+  defaultMailSenderName: string | null;
   description: string | null;
   domain: AuthorizationKeyAdd_authorizationKeyAdd_shop_domain;
   name: string;

--- a/src/siteSettings/types/AuthorizationKeyDelete.ts
+++ b/src/siteSettings/types/AuthorizationKeyDelete.ts
@@ -58,6 +58,9 @@ export interface AuthorizationKeyDelete_authorizationKeyDelete_shop {
   authorizationKeys: (AuthorizationKeyDelete_authorizationKeyDelete_shop_authorizationKeys | null)[];
   companyAddress: AuthorizationKeyDelete_authorizationKeyDelete_shop_companyAddress | null;
   countries: (AuthorizationKeyDelete_authorizationKeyDelete_shop_countries | null)[];
+  customerSetPasswordUrl: string | null;
+  defaultMailSenderAddress: string | null;
+  defaultMailSenderName: string | null;
   description: string | null;
   domain: AuthorizationKeyDelete_authorizationKeyDelete_shop_domain;
   name: string;

--- a/src/siteSettings/types/ShopFragment.ts
+++ b/src/siteSettings/types/ShopFragment.ts
@@ -52,6 +52,9 @@ export interface ShopFragment {
   authorizationKeys: (ShopFragment_authorizationKeys | null)[];
   companyAddress: ShopFragment_companyAddress | null;
   countries: (ShopFragment_countries | null)[];
+  customerSetPasswordUrl: string | null;
+  defaultMailSenderAddress: string | null;
+  defaultMailSenderName: string | null;
   description: string | null;
   domain: ShopFragment_domain;
   name: string;

--- a/src/siteSettings/types/ShopSettingsUpdate.ts
+++ b/src/siteSettings/types/ShopSettingsUpdate.ts
@@ -58,6 +58,9 @@ export interface ShopSettingsUpdate_shopSettingsUpdate_shop {
   authorizationKeys: (ShopSettingsUpdate_shopSettingsUpdate_shop_authorizationKeys | null)[];
   companyAddress: ShopSettingsUpdate_shopSettingsUpdate_shop_companyAddress | null;
   countries: (ShopSettingsUpdate_shopSettingsUpdate_shop_countries | null)[];
+  customerSetPasswordUrl: string | null;
+  defaultMailSenderAddress: string | null;
+  defaultMailSenderName: string | null;
   description: string | null;
   domain: ShopSettingsUpdate_shopSettingsUpdate_shop_domain;
   name: string;

--- a/src/siteSettings/types/SiteSettings.ts
+++ b/src/siteSettings/types/SiteSettings.ts
@@ -52,6 +52,9 @@ export interface SiteSettings_shop {
   authorizationKeys: (SiteSettings_shop_authorizationKeys | null)[];
   companyAddress: SiteSettings_shop_companyAddress | null;
   countries: (SiteSettings_shop_countries | null)[];
+  customerSetPasswordUrl: string | null;
+  defaultMailSenderAddress: string | null;
+  defaultMailSenderName: string | null;
   description: string | null;
   domain: SiteSettings_shop_domain;
   name: string;

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -142,6 +142,10 @@ export const SiteSettings: React.StatelessComponent<SiteSettingsProps> = ({
                             name: data.name
                           },
                           shopSettingsInput: {
+                            customerSetPasswordUrl: data.customerSetPasswordUrl,
+                            defaultMailSenderAddress:
+                              data.defaultMailSenderAddress,
+                            defaultMailSenderName: data.defaultMailSenderName,
                             description: data.description
                           }
                         }

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -13,6 +13,7 @@ import SiteSettingsKeyDialog, {
   SiteSettingsKeyDialogForm
 } from "../components/SiteSettingsKeyDialog";
 import SiteSettingsPage, {
+  SiteSettingsPageAddressFormData,
   SiteSettingsPageFormData
 } from "../components/SiteSettingsPage";
 import {
@@ -124,10 +125,21 @@ export const SiteSettings: React.StatelessComponent<SiteSettingsProps> = ({
                       });
                     const handleUpdateShopSettings = (
                       data: SiteSettingsPageFormData
-                    ) =>
-                      updateShopSettings({
-                        variables: {
-                          addressInput: {
+                    ) => {
+                      const areAddressInputFieldsModified = ([
+                        "city",
+                        "companyName",
+                        "country",
+                        "countryArea",
+                        "phone",
+                        "postalCode",
+                        "streetAddress1",
+                        "streetAddress2"
+                      ] as Array<keyof SiteSettingsPageAddressFormData>)
+                        .map(key => data[key])
+                        .some(field => field !== "");
+                      const addressInput = areAddressInputFieldsModified
+                        ? {
                             city: data.city,
                             companyName: data.companyName,
                             country: data.country,
@@ -136,7 +148,11 @@ export const SiteSettings: React.StatelessComponent<SiteSettingsProps> = ({
                             postalCode: data.postalCode,
                             streetAddress1: data.streetAddress1,
                             streetAddress2: data.streetAddress2
-                          },
+                          }
+                        : null;
+                      updateShopSettings({
+                        variables: {
+                          addressInput,
                           shopDomainInput: {
                             domain: data.domain,
                             name: data.name
@@ -150,6 +166,7 @@ export const SiteSettings: React.StatelessComponent<SiteSettingsProps> = ({
                           }
                         }
                       });
+                    };
 
                     const formTransitionState = getMutationState(
                       updateShopSettingsOpts.called,

--- a/src/storybook/stories/categories/CategoryUpdatePage.tsx
+++ b/src/storybook/stories/categories/CategoryUpdatePage.tsx
@@ -53,7 +53,13 @@ storiesOf("Views / Categories / Update category", module)
     />
   ))
   .add("no background", () => (
-    <CategoryUpdatePage {...updateProps} category={category} />
+    <CategoryUpdatePage
+      {...updateProps}
+      category={{
+        ...category,
+        backgroundImage: null
+      }}
+    />
   ))
   .add("no subcategories", () => (
     <CategoryUpdatePage {...updateProps} subcategories={[]} />

--- a/src/storybook/stories/siteSettings/SiteSettingsPage.tsx
+++ b/src/storybook/stories/siteSettings/SiteSettingsPage.tsx
@@ -29,6 +29,13 @@ storiesOf("Views / Site settings / Page", module)
   .add("form errors", () => (
     <SiteSettingsPage
       {...props}
-      errors={["description", "domain", "name"].map(field => formError(field))}
+      errors={[
+        "description",
+        "domain",
+        "name",
+        "defaultMailSenderAddress",
+        "defaultMailSenderName",
+        "customerSetPasswordUrl"
+      ].map(field => formError(field))}
     />
   ));

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -523,8 +523,7 @@ export default (colors: IThemeColors): Theme =>
         fontFamily
       },
       body1: {
-        fontSize: "0.75rem",
-        fontWeight: 600 as 600
+        fontSize: 14
       },
       body2: {
         fontSize: "1rem"

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -299,6 +299,7 @@ export enum WebhookEventTypeEnum {
   CUSTOMER_CREATED = "CUSTOMER_CREATED",
   ORDER_CANCELLED = "ORDER_CANCELLED",
   ORDER_CREATED = "ORDER_CREATED",
+  ORDER_FULFILLED = "ORDER_FULFILLED",
   ORDER_FULLY_PAID = "ORDER_FULLY_PAID",
   ORDER_UPDATED = "ORDER_UPDATED",
   PRODUCT_CREATED = "PRODUCT_CREATED",
@@ -748,6 +749,9 @@ export interface ShopSettingsInput {
   automaticFulfillmentDigitalProducts?: boolean | null;
   defaultDigitalMaxDownloads?: number | null;
   defaultDigitalUrlValidDays?: number | null;
+  defaultMailSenderName?: string | null;
+  defaultMailSenderAddress?: string | null;
+  customerSetPasswordUrl?: string | null;
 }
 
 export interface SiteDomainInput {


### PR DESCRIPTION
I want to merge this change because it adds mailing configuration.

### Screenshots
<img width="1578" alt="Screenshot 2019-10-21 at 16 20 55" src="https://user-images.githubusercontent.com/6833443/67213716-c8688500-f41e-11e9-838b-5dd8e3ad5f6c.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
