### PR TITLE
Use back instead of cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Improve autocomplete UX - #212 by @dominik-zeglen
 - Fix empty attribute values - #218 by @dominik-zeglen
 - Add language switch - #213 by @dominik-zeglen
+- Fix copy - #223, #224 by @dominik-zeglen

--- a/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
+++ b/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
@@ -83,7 +83,7 @@ const AttributeValueEditDialog: React.StatelessComponent<
             </DialogContent>
             <DialogActions>
               <Button onClick={onClose}>
-                <FormattedMessage {...buttonMessages.cancel} />
+                <FormattedMessage {...buttonMessages.back} />
               </Button>
               <ConfirmButton
                 transitionState={confirmButtonState}

--- a/src/categories/components/CategoryDeleteDialog/CategoryDeleteDialog.tsx
+++ b/src/categories/components/CategoryDeleteDialog/CategoryDeleteDialog.tsx
@@ -56,7 +56,7 @@ const CategoryDeleteDialog = withStyles(styles, {
     </DialogContent>
     <DialogActions>
       <Button onClick={onClose}>
-        <FormattedMessage {...buttonMessages.cancel} />
+        <FormattedMessage {...buttonMessages.back} />
       </Button>
       <Button
         className={classes.deleteButton}

--- a/src/components/AssignCategoryDialog/AssignCategoryDialog.tsx
+++ b/src/components/AssignCategoryDialog/AssignCategoryDialog.tsx
@@ -161,7 +161,7 @@ const AssignCategoriesDialog = withStyles(styles, {
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>
-            <FormattedMessage {...buttonMessages.cancel} />
+            <FormattedMessage {...buttonMessages.back} />
           </Button>
           <ConfirmButton
             transitionState={confirmButtonState}

--- a/src/components/AssignCollectionDialog/AssignCollectionDialog.tsx
+++ b/src/components/AssignCollectionDialog/AssignCollectionDialog.tsx
@@ -162,7 +162,7 @@ const AssignCollectionDialog = withStyles(styles, {
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>
-            <FormattedMessage {...buttonMessages.cancel} />
+            <FormattedMessage {...buttonMessages.back} />
           </Button>
           <ConfirmButton
             transitionState={confirmButtonState}

--- a/src/components/AssignProductDialog/AssignProductDialog.tsx
+++ b/src/components/AssignProductDialog/AssignProductDialog.tsx
@@ -174,7 +174,7 @@ const AssignProductDialog = withStyles(styles, {
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>
-            <FormattedMessage {...buttonMessages.cancel} />
+            <FormattedMessage {...buttonMessages.back} />
           </Button>
           <ConfirmButton
             transitionState={confirmButtonState}

--- a/src/components/SaveFilterTabDialog/SaveFilterTabDialog.tsx
+++ b/src/components/SaveFilterTabDialog/SaveFilterTabDialog.tsx
@@ -71,7 +71,7 @@ const SaveFilterTabDialog: React.FC<SaveFilterTabDialogProps> = ({
             </DialogContent>
             <DialogActions>
               <Button onClick={onClose}>
-                <FormattedMessage {...buttonMessages.cancel} />
+                <FormattedMessage {...buttonMessages.back} />
               </Button>
               <ConfirmButton
                 transitionState={confirmButtonState}

--- a/src/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
+++ b/src/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
@@ -122,7 +122,7 @@ const CustomerAddressDialog = withStyles(styles, {})(
                 </DialogContent>
                 <DialogActions>
                   <Button onClick={onClose}>
-                    <FormattedMessage {...buttonMessages.cancel} />
+                    <FormattedMessage {...buttonMessages.back} />
                   </Button>
                   <ConfirmButton
                     transitionState={confirmButtonState}

--- a/src/discounts/components/DiscountCountrySelectDialog/DiscountCountrySelectDialog.tsx
+++ b/src/discounts/components/DiscountCountrySelectDialog/DiscountCountrySelectDialog.tsx
@@ -176,7 +176,7 @@ const DiscountCountrySelectDialog = withStyles(styles, {
                 </DialogContent>
                 <DialogActions>
                   <Button onClick={onClose}>
-                    <FormattedMessage {...buttonMessages.cancel} />
+                    <FormattedMessage {...buttonMessages.back} />
                   </Button>
                   <ConfirmButton
                     transitionState={confirmButtonState}

--- a/src/navigation/components/MenuCreateDialog/MenuCreateDialog.tsx
+++ b/src/navigation/components/MenuCreateDialog/MenuCreateDialog.tsx
@@ -67,7 +67,7 @@ const MenuCreateDialog: React.FC<MenuCreateDialogProps> = ({
             </DialogContent>
             <DialogActions>
               <Button onClick={onClose}>
-                <FormattedMessage {...buttonMessages.cancel} />
+                <FormattedMessage {...buttonMessages.back} />
               </Button>
               <ConfirmButton
                 transitionState={confirmButtonState}

--- a/src/navigation/components/MenuItemDialog/MenuItemDialog.tsx
+++ b/src/navigation/components/MenuItemDialog/MenuItemDialog.tsx
@@ -289,7 +289,7 @@ const MenuItemDialog: React.StatelessComponent<MenuItemDialogProps> = ({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>
-          <FormattedMessage {...buttonMessages.cancel} />
+          <FormattedMessage {...buttonMessages.back} />
         </Button>
         <ConfirmButton
           transitionState={confirmButtonState}

--- a/src/orders/components/OrderAddressEditDialog/OrderAddressEditDialog.tsx
+++ b/src/orders/components/OrderAddressEditDialog/OrderAddressEditDialog.tsx
@@ -103,7 +103,7 @@ const OrderAddressEditDialog = withStyles(styles, {
                 </DialogContent>
                 <DialogActions>
                   <Button onClick={onClose}>
-                    <FormattedMessage {...buttonMessages.cancel} />
+                    <FormattedMessage {...buttonMessages.back} />
                   </Button>
                   <ConfirmButton
                     transitionState={confirmButtonState}

--- a/src/orders/components/OrderFulfillmentDialog/OrderFulfillmentDialog.tsx
+++ b/src/orders/components/OrderFulfillmentDialog/OrderFulfillmentDialog.tsx
@@ -203,7 +203,7 @@ const OrderFulfillmentDialog = withStyles(styles, {
                 </DialogContent>
                 <DialogActions>
                   <Button onClick={onClose}>
-                    <FormattedMessage {...buttonMessages.cancel} />
+                    <FormattedMessage {...buttonMessages.back} />
                   </Button>
                   <ConfirmButton
                     transitionState={confirmButtonState}

--- a/src/orders/components/OrderFulfillmentTrackingDialog/OrderFulfillmentTrackingDialog.tsx
+++ b/src/orders/components/OrderFulfillmentTrackingDialog/OrderFulfillmentTrackingDialog.tsx
@@ -54,7 +54,7 @@ const OrderFulfillmentTrackingDialog: React.StatelessComponent<
             </DialogContent>
             <DialogActions>
               <Button onClick={onClose}>
-                <FormattedMessage {...buttonMessages.cancel} />
+                <FormattedMessage {...buttonMessages.back} />
               </Button>
               <ConfirmButton
                 transitionState={confirmButtonState}

--- a/src/orders/components/OrderPaymentDialog/OrderPaymentDialog.tsx
+++ b/src/orders/components/OrderPaymentDialog/OrderPaymentDialog.tsx
@@ -79,7 +79,7 @@ const OrderPaymentDialog: React.StatelessComponent<OrderPaymentDialogProps> = ({
             </DialogContent>
             <DialogActions>
               <Button onClick={onClose}>
-                <FormattedMessage {...buttonMessages.cancel} />
+                <FormattedMessage {...buttonMessages.back} />
               </Button>
               <ConfirmButton
                 transitionState={confirmButtonState}

--- a/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
+++ b/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
@@ -328,7 +328,7 @@ const OrderProductAddDialog = withStyles(styles, {
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose}>
-            <FormattedMessage {...buttonMessages.cancel} />
+            <FormattedMessage {...buttonMessages.back} />
           </Button>
           <ConfirmButton
             transitionState={confirmButtonState}

--- a/src/orders/components/OrderShippingMethodEditDialog/OrderShippingMethodEditDialog.tsx
+++ b/src/orders/components/OrderShippingMethodEditDialog/OrderShippingMethodEditDialog.tsx
@@ -104,7 +104,7 @@ const OrderShippingMethodEditDialog = withStyles(styles, {
               </DialogContent>
               <DialogActions>
                 <Button onClick={onClose}>
-                  <FormattedMessage {...buttonMessages.cancel} />
+                  <FormattedMessage {...buttonMessages.back} />
                 </Button>
                 <ConfirmButton
                   transitionState={confirmButtonState}

--- a/src/productTypes/components/AssignAttributeDialog/AssignAttributeDialog.tsx
+++ b/src/productTypes/components/AssignAttributeDialog/AssignAttributeDialog.tsx
@@ -181,7 +181,7 @@ const AssignAttributeDialog: React.FC<AssignAttributeDialogProps> = ({
       )}
       <DialogActions>
         <Button onClick={onClose}>
-          <FormattedMessage {...buttonMessages.cancel} />
+          <FormattedMessage {...buttonMessages.back} />
         </Button>
         <ConfirmButton
           transitionState={confirmButtonState}

--- a/src/productTypes/components/ProductTypeAttributeEditDialog/ProductTypeAttributeEditDialog.tsx
+++ b/src/productTypes/components/ProductTypeAttributeEditDialog/ProductTypeAttributeEditDialog.tsx
@@ -90,7 +90,7 @@ const ProductTypeAttributeEditDialog: React.StatelessComponent<
             </DialogContent>
             <DialogActions>
               <Button onClick={onClose}>
-                <FormattedMessage {...buttonMessages.cancel} />
+                <FormattedMessage {...buttonMessages.back} />
               </Button>
               <Button color="primary" variant="contained" type="submit">
                 <FormattedMessage {...buttonMessages.confirm} />

--- a/src/products/components/ProductVariantDeleteDialog/ProductVariantDeleteDialog.tsx
+++ b/src/products/components/ProductVariantDeleteDialog/ProductVariantDeleteDialog.tsx
@@ -69,7 +69,7 @@ const ProductVariantDeleteDialog = withStyles(styles, {
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>
-          <FormattedMessage {...buttonMessages.cancel} />
+          <FormattedMessage {...buttonMessages.back} />
         </Button>
         <ConfirmButton
           transitionState={confirmButtonState}

--- a/src/services/components/ServiceTokenCreateDialog/ServiceTokenCreateDialog.tsx
+++ b/src/services/components/ServiceTokenCreateDialog/ServiceTokenCreateDialog.tsx
@@ -134,7 +134,7 @@ const ServiceTokenCreateDialog: React.FC<
                     color="primary"
                     onClick={onClose}
                   >
-                    <FormattedMessage {...buttonMessages.cancel} />
+                    <FormattedMessage {...buttonMessages.back} />
                   </Button>
                   <ConfirmButton
                     transitionState={confirmButtonState}

--- a/src/shipping/components/ShippingZoneCountriesAssignDialog/ShippingZoneCountriesAssignDialog.tsx
+++ b/src/shipping/components/ShippingZoneCountriesAssignDialog/ShippingZoneCountriesAssignDialog.tsx
@@ -214,7 +214,7 @@ const ShippingZoneCountriesAssignDialog = withStyles(styles, {
                 </DialogContent>
                 <DialogActions>
                   <Button onClick={onClose}>
-                    <FormattedMessage {...buttonMessages.cancel} />
+                    <FormattedMessage {...buttonMessages.back} />
                   </Button>
                   <ConfirmButton
                     transitionState={confirmButtonState}

--- a/src/shipping/components/ShippingZoneRateDialog/ShippingZoneRateDialog.tsx
+++ b/src/shipping/components/ShippingZoneRateDialog/ShippingZoneRateDialog.tsx
@@ -327,7 +327,7 @@ const ShippingZoneRateDialog = withStyles(styles, {
                 </DialogContent>
                 <DialogActions>
                   <Button onClick={onClose}>
-                    <FormattedMessage {...buttonMessages.cancel} />
+                    <FormattedMessage {...buttonMessages.back} />
                   </Button>
                   <ConfirmButton
                     disabled={disabled || !hasChanged}

--- a/src/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.tsx
+++ b/src/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.tsx
@@ -89,7 +89,7 @@ const SiteSettingsKeyDialog: React.StatelessComponent<
             </DialogContent>
             <DialogActions>
               <Button onClick={onClose}>
-                <FormattedMessage {...buttonMessages.cancel} />
+                <FormattedMessage {...buttonMessages.back} />
               </Button>
               <Button color="primary" type="submit" variant="contained">
                 <FormattedMessage

--- a/src/staff/components/StaffAddMemberDialog/StaffAddMemberDialog.tsx
+++ b/src/staff/components/StaffAddMemberDialog/StaffAddMemberDialog.tsx
@@ -141,7 +141,7 @@ const StaffAddMemberDialog = withStyles(styles, {
               </DialogContent>
               <DialogActions>
                 <Button onClick={onClose}>
-                  <FormattedMessage {...buttonMessages.cancel} />
+                  <FormattedMessage {...buttonMessages.back} />
                 </Button>
                 <ConfirmButton
                   color="primary"


### PR DESCRIPTION
I want to merge this change because I forgot about it in #223 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
