### PR TITLE
Add readonly mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add language switch - #213 by @dominik-zeglen
 - Fix copy - #223, #224 by @dominik-zeglen
 - Fix attribute errors - #216 by @dominik-zeglen
+- Add readonly mode - #229 by @dominik-zeglen

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-10-21T14:54:01.519Z\n"
+"POT-Creation-Date: 2019-10-24T12:11:32.946Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -6773,6 +6773,14 @@ msgstr ""
 #. Saleor ran into an unexpected problem
 msgctxt "description"
 msgid "Saleor ran into an unexpected problem"
+msgstr ""
+
+#: build/locale/src/intl.json
+#. [src.readOnly]
+#. defaultMessage is:
+#. Saleor runs in read-only mode. Changes not saved.
+msgctxt "description"
+msgid "Saleor runs in read-only mode. Changes not saved."
 msgstr ""
 
 #: build/locale/src/intl.json

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -47,6 +47,9 @@ export const commonMessages = defineMessages({
   properties: {
     defaultMessage: "Properties"
   },
+  readOnly: {
+    defaultMessage: "Saleor runs in read-only mode. Changes not saved."
+  },
   requiredField: {
     defaultMessage: "This field is required"
   },

--- a/src/mutations.tsx
+++ b/src/mutations.tsx
@@ -6,6 +6,7 @@ import { useIntl } from "react-intl";
 
 import useNotifier from "./hooks/useNotifier";
 import { commonMessages } from "./intl";
+import { maybe } from "./misc";
 
 export interface TypedMutationInnerProps<TData, TVariables> {
   children: (
@@ -32,9 +33,21 @@ export function TypedMutation<TData, TVariables>(
         mutation={mutation}
         onCompleted={onCompleted}
         onError={(err: ApolloError) => {
-          notify({
-            text: intl.formatMessage(commonMessages.somethingWentWrong)
-          });
+          if (
+            maybe(
+              () =>
+                err.graphQLErrors[0].extensions.exception.code ===
+                "ReadOnlyException"
+            )
+          ) {
+            notify({
+              text: intl.formatMessage(commonMessages.readOnly)
+            });
+          } else {
+            notify({
+              text: intl.formatMessage(commonMessages.somethingWentWrong)
+            });
+          }
           if (onError) {
             onError(err);
           }

--- a/src/queries.tsx
+++ b/src/queries.tsx
@@ -82,7 +82,7 @@ export function TypedQuery<TData, TVariables>(
             skip={skip}
             context={{ useBatching: true }}
           >
-            {queryData => {
+            {(queryData: QueryResult<TData, TVariables>) => {
               if (queryData.error) {
                 pushMessage({
                   text: intl.formatMessage(commonMessages.somethingWentWrong)


### PR DESCRIPTION
I want to merge this change because it handles ReadOnlyException from API.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [X] The changes are tested.
1. [x] Type definitions are up to date.
1. [X] Changes are mentioned in the changelog.
