### PR TITLE
add Dockerfile + nginx for production deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:10 as builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+ARG APP_MOUNT_URI
+ARG API_URI
+ARG STATIC_URL
+ENV API_URI ${API_URI:-http://localhost:8000/graphql/}
+ENV APP_MOUNT_URI ${APP_MOUNT_URI:-/dashboard/}
+ENV STATIC_URL ${STATIC_URL:-/dashboard/}
+RUN STATIC_URL=${STATIC_URL} API_URI=${API_URI} APP_MOUNT_URI=${APP_MOUNT_URI} npm run build
+
+FROM nginx:stable
+WORKDIR /app
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/build/ /app/

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,10 @@
+server {
+    listen       80;
+    server_name  localhost;
+    root   /app/dashboard/;
+    
+    location / {
+        index  index.html;
+        try_files $uri $uri/ /index.html$args;
+    }
+}

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -2,9 +2,10 @@ server {
     listen       80;
     server_name  localhost;
     root   /app/dashboard/;
-    
-    location / {
+
+    location /dashboard/ {
+        alias /app/dashboard/;
         index  index.html;
-        try_files $uri $uri/ /index.html$args;
+        try_files $uri $uri/ /dashboard/index.html$args;
     }
 }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -6,6 +6,6 @@ server {
     location /dashboard/ {
         alias /app/dashboard/;
         index  index.html;
-        try_files $uri $uri/ /dashboard/index.html$args;
+        try_files $uri $uri/ /dashboard/index.html;
     }
 }


### PR DESCRIPTION
I want to merge this change because :
- Add Dockerfile for production
- Nginx for serve the file generated by `npm run build`
- Fixing the issue #199 and #159 

Quick tutorial
```bash
$ docker build -t saleor-dashboard .
$ docker run --name saleor-dashboard -p 9000:80 -d saleor-dashboard:latest
```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted to `.pot` file.
1. [ ] Number of API calls is optimized.
1. [x] The changes are tested.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
