### PR TITLE
Use React.FC instead of deprecated React.StatelessComponent type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,3 +53,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mailing configuration - #222 by @dominik-zeglen
 - Fix minor bugs - #230 by @dominik-zeglen
 - Fix permission handling - #231 by @dominik-zeglen
+- Use React.FC instead of deprecated React.StatelessComponent type - #245 by @dominik-zeglen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "saleor",
-  "version": "0.0.0",
+  "name": "saleor-dashboard",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9470,7 +9470,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9488,11 +9489,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9505,15 +9508,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9616,7 +9622,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9626,6 +9633,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9638,17 +9646,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9665,6 +9676,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9737,7 +9749,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9747,6 +9760,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9822,7 +9836,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9852,6 +9867,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9869,6 +9885,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9907,11 +9924,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -15916,6 +15935,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "jest-file": "^1.0.0",
     "lint-staged": "^9.4.2",
     "plop": "^2.4.0",
+    "prettier": "^1.18.2",
     "react-intl-po": "^2.2.2",
     "react-test-renderer": "^16.8.6",
     "regenerator-runtime": "^0.11.1",
@@ -167,6 +168,7 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "tslint --fix",
+      "prettier --write",
       "git add"
     ]
   },

--- a/src/NotFound.tsx
+++ b/src/NotFound.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import NotFoundPage from "./components/NotFoundPage";
 import useNavigator from "./hooks/useNavigator";
 
-export const NotFound: React.StatelessComponent = () => {
+export const NotFound: React.FC = () => {
   const navigate = useNavigator();
 
   return <NotFoundPage onBack={() => navigate("/")} />;

--- a/src/attributes/components/AttributeBulkDeleteDialog/AttributeBulkDeleteDialog.tsx
+++ b/src/attributes/components/AttributeBulkDeleteDialog/AttributeBulkDeleteDialog.tsx
@@ -13,9 +13,13 @@ export interface AttributeBulkDeleteDialogProps {
   onClose: () => void;
 }
 
-const AttributeBulkDeleteDialog: React.StatelessComponent<
-  AttributeBulkDeleteDialogProps
-> = ({ confirmButtonState, quantity, onClose, onConfirm, open }) => {
+const AttributeBulkDeleteDialog: React.FC<AttributeBulkDeleteDialogProps> = ({
+  confirmButtonState,
+  quantity,
+  onClose,
+  onConfirm,
+  open
+}) => {
   const intl = useIntl();
 
   return (

--- a/src/attributes/components/AttributeList/AttributeList.tsx
+++ b/src/attributes/components/AttributeList/AttributeList.tsx
@@ -59,7 +59,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const numberOfColumns = 6;
 
-const AttributeList: React.StatelessComponent<AttributeListProps> = ({
+const AttributeList: React.FC<AttributeListProps> = ({
   attributes,
   disabled,
   isChecked,

--- a/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
+++ b/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
@@ -30,9 +30,7 @@ export interface AttributeValueEditDialogProps {
   onClose: () => void;
 }
 
-const AttributeValueEditDialog: React.StatelessComponent<
-  AttributeValueEditDialogProps
-> = ({
+const AttributeValueEditDialog: React.FC<AttributeValueEditDialogProps> = ({
   attributeValue,
   confirmButtonState,
   disabled,

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -22,9 +22,9 @@ interface AuthProviderOperationsProps {
     user: User;
   }) => React.ReactNode;
 }
-const AuthProviderOperations: React.StatelessComponent<
-  AuthProviderOperationsProps
-> = ({ children }) => {
+const AuthProviderOperations: React.FC<AuthProviderOperationsProps> = ({
+  children
+}) => {
   return (
     <TypedTokenAuthMutation>
       {(...tokenAuth) => (

--- a/src/auth/components/SectionRoute.tsx
+++ b/src/auth/components/SectionRoute.tsx
@@ -14,7 +14,7 @@ interface SectionRouteProps extends RouteProps {
   permissions?: PermissionEnum[];
 }
 
-export const SectionRoute: React.StatelessComponent<SectionRouteProps> = ({
+export const SectionRoute: React.FC<SectionRouteProps> = ({
   permissions,
   ...props
 }) => {

--- a/src/categories/components/CategoryCreatePage/CategoryCreatePage.tsx
+++ b/src/categories/components/CategoryCreatePage/CategoryCreatePage.tsx
@@ -36,9 +36,7 @@ export interface CategoryCreatePageProps {
   onBack();
 }
 
-export const CategoryCreatePage: React.StatelessComponent<
-  CategoryCreatePageProps
-> = ({
+export const CategoryCreatePage: React.FC<CategoryCreatePageProps> = ({
   disabled,
   onSubmit,
   onBack,

--- a/src/categories/components/CategoryListPage/CategoryListPage.tsx
+++ b/src/categories/components/CategoryListPage/CategoryListPage.tsx
@@ -24,7 +24,7 @@ export interface CategoryTableProps
   categories: CategoryFragment[];
 }
 
-export const CategoryListPage: React.StatelessComponent<CategoryTableProps> = ({
+export const CategoryListPage: React.FC<CategoryTableProps> = ({
   categories,
   currentTab,
   disabled,

--- a/src/categories/components/CategoryProducts/CategoryProducts.tsx
+++ b/src/categories/components/CategoryProducts/CategoryProducts.tsx
@@ -13,9 +13,7 @@ interface CategoryProductsProps extends PageListProps, ListActions {
   categoryName: string;
 }
 
-export const CategoryProducts: React.StatelessComponent<
-  CategoryProductsProps
-> = ({
+export const CategoryProducts: React.FC<CategoryProductsProps> = ({
   products,
   disabled,
   pageInfo,

--- a/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
+++ b/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
@@ -70,9 +70,7 @@ export interface CategoryUpdatePageProps
 const CategoriesTab = Tab(CategoryPageTab.categories);
 const ProductsTab = Tab(CategoryPageTab.products);
 
-export const CategoryUpdatePage: React.StatelessComponent<
-  CategoryUpdatePageProps
-> = ({
+export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
   changeTab,
   currentTab,
   category,

--- a/src/categories/index.tsx
+++ b/src/categories/index.tsx
@@ -19,7 +19,7 @@ import CategoryListComponent from "./views/CategoryList";
 interface CategoryDetailsRouteParams {
   id: string;
 }
-const CategoryDetails: React.StatelessComponent<
+const CategoryDetails: React.FC<
   RouteComponentProps<CategoryDetailsRouteParams>
 > = ({ location, match }) => {
   const qs = parseQs(location.search.substr(1));
@@ -38,7 +38,7 @@ const CategoryDetails: React.StatelessComponent<
 interface CategoryCreateRouteParams {
   id: string;
 }
-const CategoryCreate: React.StatelessComponent<
+const CategoryCreate: React.FC<
   RouteComponentProps<CategoryCreateRouteParams>
 > = ({ match }) => {
   return (
@@ -50,9 +50,7 @@ const CategoryCreate: React.StatelessComponent<
   );
 };
 
-const CategoryList: React.StatelessComponent<RouteComponentProps<{}>> = ({
-  location
-}) => {
+const CategoryList: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: CategoryListUrlQueryParams = qs;
   return <CategoryListComponent params={params} />;

--- a/src/categories/views/CategoryCreate.tsx
+++ b/src/categories/views/CategoryCreate.tsx
@@ -14,9 +14,9 @@ interface CategoryCreateViewProps {
   parentId: string;
 }
 
-export const CategoryCreateView: React.StatelessComponent<
-  CategoryCreateViewProps
-> = ({ parentId }) => {
+export const CategoryCreateView: React.FC<CategoryCreateViewProps> = ({
+  parentId
+}) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/categories/views/CategoryDetails.tsx
+++ b/src/categories/views/CategoryDetails.tsx
@@ -51,9 +51,10 @@ export function getActiveTab(tabName: string): CategoryPageTab {
     : CategoryPageTab.categories;
 }
 
-export const CategoryDetails: React.StatelessComponent<
-  CategoryDetailsProps
-> = ({ id, params }) => {
+export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
+  id,
+  params
+}) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/categories/views/CategoryList/CategoryList.tsx
+++ b/src/categories/views/CategoryList/CategoryList.tsx
@@ -42,9 +42,7 @@ interface CategoryListProps {
   params: CategoryListUrlQueryParams;
 }
 
-export const CategoryList: React.StatelessComponent<CategoryListProps> = ({
-  params
-}) => {
+export const CategoryList: React.FC<CategoryListProps> = ({ params }) => {
   const navigate = useNavigator();
   const paginate = usePaginator();
   const { isSelected, listElements, toggle, toggleAll, reset } = useBulkActions(

--- a/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
+++ b/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
@@ -57,9 +57,7 @@ const initialForm: CollectionCreatePageFormData = {
   seoTitle: ""
 };
 
-const CollectionCreatePage: React.StatelessComponent<
-  CollectionCreatePageProps
-> = ({
+const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
   disabled,
   errors,
   saveButtonBarState,

--- a/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
+++ b/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
@@ -47,9 +47,7 @@ export interface CollectionDetailsPageProps extends PageListProps, ListActions {
   onSubmit: (data: CollectionDetailsPageFormData) => void;
 }
 
-const CollectionDetailsPage: React.StatelessComponent<
-  CollectionDetailsPageProps
-> = ({
+const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
   collection,
   disabled,
   isFeatured,

--- a/src/collections/components/CollectionListPage/CollectionListPage.tsx
+++ b/src/collections/components/CollectionListPage/CollectionListPage.tsx
@@ -24,7 +24,7 @@ export interface CollectionListPageProps
   collections: CollectionList_collections_edges_node[];
 }
 
-const CollectionListPage: React.StatelessComponent<CollectionListPageProps> = ({
+const CollectionListPage: React.FC<CollectionListPageProps> = ({
   currentTab,
   disabled,
   initialSearch,

--- a/src/collections/containers/CollectionOperations.tsx
+++ b/src/collections/containers/CollectionOperations.tsx
@@ -59,9 +59,13 @@ interface CollectionUpdateOperationsProps {
   onRemove: (data: RemoveCollection) => void;
 }
 
-const CollectionOperations: React.StatelessComponent<
-  CollectionUpdateOperationsProps
-> = ({ children, onUpdate, onProductAssign, onProductUnassign, onRemove }) => (
+const CollectionOperations: React.FC<CollectionUpdateOperationsProps> = ({
+  children,
+  onUpdate,
+  onProductAssign,
+  onProductUnassign,
+  onRemove
+}) => (
   <TypedCollectionUpdateMutation onCompleted={onUpdate}>
     {(...updateCollection) => (
       <TypedCollectionRemoveMutation onCompleted={onRemove}>

--- a/src/collections/index.tsx
+++ b/src/collections/index.tsx
@@ -16,9 +16,7 @@ import CollectionCreate from "./views/CollectionCreate";
 import CollectionDetailsView from "./views/CollectionDetails";
 import CollectionListView from "./views/CollectionList";
 
-const CollectionList: React.StatelessComponent<RouteComponentProps<{}>> = ({
-  location
-}) => {
+const CollectionList: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: CollectionListUrlQueryParams = qs;
   return <CollectionListView params={params} />;
@@ -27,7 +25,7 @@ const CollectionList: React.StatelessComponent<RouteComponentProps<{}>> = ({
 interface CollectionDetailsRouteProps {
   id: string;
 }
-const CollectionDetails: React.StatelessComponent<
+const CollectionDetails: React.FC<
   RouteComponentProps<CollectionDetailsRouteProps>
 > = ({ location, match }) => {
   const qs = parseQs(location.search.substr(1));

--- a/src/collections/views/CollectionDetails.tsx
+++ b/src/collections/views/CollectionDetails.tsx
@@ -39,9 +39,10 @@ interface CollectionDetailsProps {
   params: CollectionUrlQueryParams;
 }
 
-export const CollectionDetails: React.StatelessComponent<
-  CollectionDetailsProps
-> = ({ id, params }) => {
+export const CollectionDetails: React.FC<CollectionDetailsProps> = ({
+  id,
+  params
+}) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const { isSelected, listElements, reset, toggle, toggleAll } = useBulkActions(

--- a/src/collections/views/CollectionList/CollectionList.tsx
+++ b/src/collections/views/CollectionList/CollectionList.tsx
@@ -49,9 +49,7 @@ interface CollectionListProps {
   params: CollectionListUrlQueryParams;
 }
 
-export const CollectionList: React.StatelessComponent<CollectionListProps> = ({
-  params
-}) => {
+export const CollectionList: React.FC<CollectionListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/components/AccountStatus/AccountStatus.tsx
+++ b/src/components/AccountStatus/AccountStatus.tsx
@@ -16,7 +16,7 @@ interface StaffStatusProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const StaffStatus: React.StatelessComponent<StaffStatusProps> = ({
+const StaffStatus: React.FC<StaffStatusProps> = ({
   data,
   disabled,
   label,

--- a/src/components/AddressFormatter/AddressFormatter.tsx
+++ b/src/components/AddressFormatter/AddressFormatter.tsx
@@ -8,9 +8,7 @@ interface AddressFormatterProps {
   address?: AddressType;
 }
 
-const AddressFormatter: React.StatelessComponent<AddressFormatterProps> = ({
-  address
-}) => {
+const AddressFormatter: React.FC<AddressFormatterProps> = ({ address }) => {
   if (!address) {
     return <Skeleton />;
   }

--- a/src/components/AppProgress/index.tsx
+++ b/src/components/AppProgress/index.tsx
@@ -9,9 +9,7 @@ export const AppProgressContext = React.createContext<IAppProgressContext>(
   undefined
 );
 
-export const AppProgressProvider: React.StatelessComponent<{}> = ({
-  children
-}) => {
+export const AppProgressProvider: React.FC<{}> = ({ children }) => {
   const [isProgress, setProgressState] = React.useState(false);
 
   return (

--- a/src/components/ControlledCheckbox.tsx
+++ b/src/components/ControlledCheckbox.tsx
@@ -11,9 +11,13 @@ interface ControlledCheckboxProps {
   onChange(event: any);
 }
 
-export const ControlledCheckbox: React.StatelessComponent<
-  ControlledCheckboxProps
-> = ({ checked, disabled, name, label, onChange }) => (
+export const ControlledCheckbox: React.FC<ControlledCheckboxProps> = ({
+  checked,
+  disabled,
+  name,
+  label,
+  onChange
+}) => (
   <FormControlLabel
     disabled={disabled}
     control={

--- a/src/components/Date/DateTime.tsx
+++ b/src/components/Date/DateTime.tsx
@@ -12,10 +12,7 @@ interface DateTimeProps {
   plain?: boolean;
 }
 
-export const DateTime: React.StatelessComponent<DateTimeProps> = ({
-  date,
-  plain
-}) => {
+export const DateTime: React.FC<DateTimeProps> = ({ date, plain }) => {
   const getTitle = (value: string, locale?: string, tz?: string) => {
     let date = moment(value).locale(locale);
     if (tz !== undefined) {

--- a/src/components/DebounceForm.tsx
+++ b/src/components/DebounceForm.tsx
@@ -3,14 +3,12 @@ import Debounce from "./Debounce";
 
 export interface DebounceFormProps {
   change: (event: React.ChangeEvent<any>, cb?: () => void) => void;
-  children: ((
-    props: (event: React.ChangeEvent<any>) => void
-  ) => React.ReactNode);
+  children: (props: (event: React.ChangeEvent<any>) => void) => React.ReactNode;
   submit: (event: React.FormEvent<any>) => void;
   time?: number;
 }
 
-export const DebounceForm: React.StatelessComponent<DebounceFormProps> = ({
+export const DebounceForm: React.FC<DebounceFormProps> = ({
   change,
   children,
   submit,

--- a/src/components/ErrorMessageCard/ErrorMessageCard.tsx
+++ b/src/components/ErrorMessageCard/ErrorMessageCard.tsx
@@ -7,9 +7,7 @@ interface ErrorMessageCardProps {
   message: string;
 }
 
-const ErrorMessageCard: React.StatelessComponent<ErrorMessageCardProps> = ({
-  message
-}) => (
+const ErrorMessageCard: React.FC<ErrorMessageCardProps> = ({ message }) => (
   <Card>
     <CardContent>
       <Typography variant="h5" component="h2">

--- a/src/components/FilterCard/FilterCard.tsx
+++ b/src/components/FilterCard/FilterCard.tsx
@@ -10,10 +10,7 @@ export interface FilterCardProps {
   handleClear();
 }
 
-const FilterCard: React.StatelessComponent<FilterCardProps> = ({
-  children,
-  handleClear
-}) => {
+const FilterCard: React.FC<FilterCardProps> = ({ children, handleClear }) => {
   const intl = useIntl();
 
   return (

--- a/src/components/Money/Money.tsx
+++ b/src/components/Money/Money.tsx
@@ -10,7 +10,7 @@ export interface MoneyProps {
   money: IMoney;
 }
 
-export const Money: React.StatelessComponent<MoneyProps> = ({ money }) => (
+export const Money: React.FC<MoneyProps> = ({ money }) => (
   <LocaleConsumer>
     {({ locale }) => {
       return money.amount.toLocaleString(locale, {

--- a/src/components/MoneyRange/MoneyRange.tsx
+++ b/src/components/MoneyRange/MoneyRange.tsx
@@ -15,10 +15,7 @@ const formatMoney = (money: IMoney, locale: string) =>
     style: "currency"
   });
 
-export const MoneyRange: React.StatelessComponent<MoneyRangeProps> = ({
-  from,
-  to
-}) => {
+export const MoneyRange: React.FC<MoneyRangeProps> = ({ from, to }) => {
   const intl = useIntl();
 
   return (

--- a/src/components/Percent/Percent.tsx
+++ b/src/components/Percent/Percent.tsx
@@ -6,7 +6,7 @@ interface PercentProps {
   amount: number;
 }
 
-const Percent: React.StatelessComponent<PercentProps> = ({ amount }) => (
+const Percent: React.FC<PercentProps> = ({ amount }) => (
   <LocaleConsumer>
     {({ locale }) => {
       return (amount / 100).toLocaleString(locale, {

--- a/src/components/Weight/Weight.tsx
+++ b/src/components/Weight/Weight.tsx
@@ -9,7 +9,7 @@ export interface WeightProps {
   weight: Weight;
 }
 
-const Weight: React.StatelessComponent<WeightProps> = ({ weight }) => (
+const Weight: React.FC<WeightProps> = ({ weight }) => (
   <FormattedMessage
     defaultMessage="{value} {unit}"
     description="weight"

--- a/src/components/WindowTitle/index.tsx
+++ b/src/components/WindowTitle/index.tsx
@@ -7,9 +7,7 @@ interface WindowTitleProps {
   title: string;
 }
 
-export const WindowTitle: React.StatelessComponent<WindowTitleProps> = ({
-  title
-}) => {
+export const WindowTitle: React.FC<WindowTitleProps> = ({ title }) => {
   const shop = useShop();
 
   return shop === undefined || !title ? null : (

--- a/src/customers/components/CustomerCreateNote/CustomerCreateNote.tsx
+++ b/src/customers/components/CustomerCreateNote/CustomerCreateNote.tsx
@@ -19,7 +19,7 @@ export interface CustomerCreateNoteProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const CustomerCreateNote: React.StatelessComponent<CustomerCreateNoteProps> = ({
+const CustomerCreateNote: React.FC<CustomerCreateNoteProps> = ({
   data,
   disabled,
   errors,

--- a/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
+++ b/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
@@ -52,7 +52,7 @@ export interface CustomerCreatePageProps {
   onSubmit: (data: CustomerCreatePageFormData) => void;
 }
 
-const CustomerCreatePage: React.StatelessComponent<CustomerCreatePageProps> = ({
+const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
   countries,
   disabled,
   errors,

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -39,9 +39,7 @@ export interface CustomerDetailsPageProps {
   onDelete: () => void;
 }
 
-const CustomerDetailsPage: React.StatelessComponent<
-  CustomerDetailsPageProps
-> = ({
+const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
   customer,
   disabled,
   errors,

--- a/src/customers/components/CustomerListPage/CustomerListPage.tsx
+++ b/src/customers/components/CustomerListPage/CustomerListPage.tsx
@@ -24,7 +24,7 @@ export interface CustomerListPageProps
   customers: ListCustomers_customers_edges_node[];
 }
 
-const CustomerListPage: React.StatelessComponent<CustomerListPageProps> = ({
+const CustomerListPage: React.FC<CustomerListPageProps> = ({
   currentTab,
   customers,
   disabled,

--- a/src/customers/index.tsx
+++ b/src/customers/index.tsx
@@ -19,9 +19,7 @@ import CustomerCreateView from "./views/CustomerCreate";
 import CustomerDetailsViewComponent from "./views/CustomerDetails";
 import CustomerListViewComponent from "./views/CustomerList";
 
-const CustomerListView: React.StatelessComponent<RouteComponentProps<{}>> = ({
-  location
-}) => {
+const CustomerListView: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: CustomerListUrlQueryParams = qs;
   return <CustomerListViewComponent params={params} />;
@@ -30,7 +28,7 @@ const CustomerListView: React.StatelessComponent<RouteComponentProps<{}>> = ({
 interface CustomerDetailsRouteParams {
   id: string;
 }
-const CustomerDetailsView: React.StatelessComponent<
+const CustomerDetailsView: React.FC<
   RouteComponentProps<CustomerDetailsRouteParams>
 > = ({ location, match }) => {
   const qs = parseQs(location.search.substr(1));
@@ -47,7 +45,7 @@ const CustomerDetailsView: React.StatelessComponent<
 interface CustomerAddressesRouteParams {
   id: string;
 }
-const CustomerAddressesView: React.StatelessComponent<
+const CustomerAddressesView: React.FC<
   RouteComponentProps<CustomerAddressesRouteParams>
 > = ({ match }) => {
   const qs = parseQs(location.search.substr(1));
@@ -61,7 +59,7 @@ const CustomerAddressesView: React.StatelessComponent<
   );
 };
 
-export const CustomerSection: React.StatelessComponent<{}> = () => {
+export const CustomerSection: React.FC<{}> = () => {
   const intl = useIntl();
 
   return (

--- a/src/customers/views/CustomerCreate.tsx
+++ b/src/customers/views/CustomerCreate.tsx
@@ -11,7 +11,7 @@ import { TypedCustomerCreateDataQuery } from "../queries";
 import { CreateCustomer } from "../types/CreateCustomer";
 import { customerListUrl, customerUrl } from "../urls";
 
-export const CustomerCreate: React.StatelessComponent<{}> = () => {
+export const CustomerCreate: React.FC<{}> = () => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/customers/views/CustomerDetails.tsx
+++ b/src/customers/views/CustomerDetails.tsx
@@ -29,9 +29,10 @@ interface CustomerDetailsViewProps {
   params: CustomerUrlQueryParams;
 }
 
-export const CustomerDetailsView: React.StatelessComponent<
-  CustomerDetailsViewProps
-> = ({ id, params }) => {
+export const CustomerDetailsView: React.FC<CustomerDetailsViewProps> = ({
+  id,
+  params
+}) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/customers/views/CustomerList/CustomerList.tsx
+++ b/src/customers/views/CustomerList/CustomerList.tsx
@@ -44,9 +44,7 @@ interface CustomerListProps {
   params: CustomerListUrlQueryParams;
 }
 
-export const CustomerList: React.StatelessComponent<CustomerListProps> = ({
-  params
-}) => {
+export const CustomerList: React.FC<CustomerListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
+++ b/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
@@ -36,7 +36,7 @@ export interface SaleCreatePageProps {
   onSubmit: (data: FormData) => void;
 }
 
-const SaleCreatePage: React.StatelessComponent<SaleCreatePageProps> = ({
+const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
   defaultCurrency,
   disabled,
   errors,

--- a/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
+++ b/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
@@ -77,7 +77,7 @@ const CategoriesTab = Tab(SaleDetailsPageTab.categories);
 const CollectionsTab = Tab(SaleDetailsPageTab.collections);
 const ProductsTab = Tab(SaleDetailsPageTab.products);
 
-const SaleDetailsPage: React.StatelessComponent<SaleDetailsPageProps> = ({
+const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
   activeTab,
   defaultCurrency,
   disabled,

--- a/src/discounts/components/SaleListPage/SaleListPage.tsx
+++ b/src/discounts/components/SaleListPage/SaleListPage.tsx
@@ -25,7 +25,7 @@ export interface SaleListPageProps
   sales: SaleList_sales_edges_node[];
 }
 
-const SaleListPage: React.StatelessComponent<SaleListPageProps> = ({
+const SaleListPage: React.FC<SaleListPageProps> = ({
   currentTab,
   initialSearch,
   onAdd,

--- a/src/discounts/components/SaleSummary/SaleSummary.tsx
+++ b/src/discounts/components/SaleSummary/SaleSummary.tsx
@@ -22,10 +22,7 @@ export interface SaleSummaryProps {
   sale: SaleDetails_sale;
 }
 
-const SaleSummary: React.StatelessComponent<SaleSummaryProps> = ({
-  defaultCurrency,
-  sale
-}) => {
+const SaleSummary: React.FC<SaleSummaryProps> = ({ defaultCurrency, sale }) => {
   const intl = useIntl();
 
   return (

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -51,7 +51,7 @@ export interface VoucherCreatePageProps {
   onSubmit: (data: FormData) => void;
 }
 
-const VoucherCreatePage: React.StatelessComponent<VoucherCreatePageProps> = ({
+const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
   defaultCurrency,
   disabled,
   errors,

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -96,7 +96,7 @@ const CategoriesTab = Tab(VoucherDetailsPageTab.categories);
 const CollectionsTab = Tab(VoucherDetailsPageTab.collections);
 const ProductsTab = Tab(VoucherDetailsPageTab.products);
 
-const VoucherDetailsPage: React.StatelessComponent<VoucherDetailsPageProps> = ({
+const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
   activeTab,
   defaultCurrency,
   disabled,

--- a/src/discounts/components/VoucherListPage/VoucherListPage.tsx
+++ b/src/discounts/components/VoucherListPage/VoucherListPage.tsx
@@ -25,7 +25,7 @@ export interface VoucherListPageProps
   vouchers: VoucherList_vouchers_edges_node[];
 }
 
-const VoucherListPage: React.StatelessComponent<VoucherListPageProps> = ({
+const VoucherListPage: React.FC<VoucherListPageProps> = ({
   currentTab,
   initialSearch,
   onAdd,

--- a/src/discounts/components/VoucherSummary/VoucherSummary.tsx
+++ b/src/discounts/components/VoucherSummary/VoucherSummary.tsx
@@ -23,7 +23,7 @@ export interface VoucherSummaryProps {
   voucher: VoucherDetails_voucher;
 }
 
-const VoucherSummary: React.StatelessComponent<VoucherSummaryProps> = ({
+const VoucherSummary: React.FC<VoucherSummaryProps> = ({
   defaultCurrency,
   voucher
 }) => {

--- a/src/discounts/index.tsx
+++ b/src/discounts/index.tsx
@@ -26,17 +26,16 @@ import VoucherCreateView from "./views/VoucherCreate";
 import VoucherDetailsViewComponent from "./views/VoucherDetails";
 import VoucherListViewComponent from "./views/VoucherList";
 
-const SaleListView: React.StatelessComponent<RouteComponentProps<{}>> = ({
-  location
-}) => {
+const SaleListView: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: SaleListUrlQueryParams = qs;
   return <SaleListViewComponent params={params} />;
 };
 
-const SaleDetailsView: React.StatelessComponent<
-  RouteComponentProps<{ id: string }>
-> = ({ match, location }) => {
+const SaleDetailsView: React.FC<RouteComponentProps<{ id: string }>> = ({
+  match,
+  location
+}) => {
   const { activeTab, ...qs } = parseQs(location.search.substr(1));
   const params: SaleUrlQueryParams = {
     ...qs,
@@ -50,17 +49,16 @@ const SaleDetailsView: React.StatelessComponent<
   );
 };
 
-const VoucherListView: React.StatelessComponent<RouteComponentProps<{}>> = ({
-  location
-}) => {
+const VoucherListView: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: VoucherListUrlQueryParams = qs;
   return <VoucherListViewComponent params={params} />;
 };
 
-const VoucherDetailsView: React.StatelessComponent<
-  RouteComponentProps<{ id: string }>
-> = ({ match, location }) => {
+const VoucherDetailsView: React.FC<RouteComponentProps<{ id: string }>> = ({
+  match,
+  location
+}) => {
   const { activeTab, ...qs } = parseQs(location.search.substr(1));
   const params: VoucherUrlQueryParams = {
     ...qs,
@@ -74,7 +72,7 @@ const VoucherDetailsView: React.StatelessComponent<
   );
 };
 
-export const DiscountSection: React.StatelessComponent<{}> = () => {
+export const DiscountSection: React.FC<{}> = () => {
   const intl = useIntl();
 
   return (

--- a/src/discounts/views/SaleCreate.tsx
+++ b/src/discounts/views/SaleCreate.tsx
@@ -19,7 +19,7 @@ function discountValueTypeEnum(type: SaleType): DiscountValueTypeEnum {
     : DiscountValueTypeEnum.PERCENTAGE;
 }
 
-export const SaleDetails: React.StatelessComponent = () => {
+export const SaleDetails: React.FC = () => {
   const navigate = useNavigator();
   const pushMessage = useNotifier();
   const shop = useShop();

--- a/src/discounts/views/SaleDetails.tsx
+++ b/src/discounts/views/SaleDetails.tsx
@@ -57,10 +57,7 @@ function discountValueTypeEnum(type: SaleType): DiscountValueTypeEnum {
     : DiscountValueTypeEnum.PERCENTAGE;
 }
 
-export const SaleDetails: React.StatelessComponent<SaleDetailsProps> = ({
-  id,
-  params
-}) => {
+export const SaleDetails: React.FC<SaleDetailsProps> = ({ id, params }) => {
   const navigate = useNavigator();
   const paginate = usePaginator();
   const notify = useNotifier();

--- a/src/discounts/views/SaleList/SaleList.tsx
+++ b/src/discounts/views/SaleList/SaleList.tsx
@@ -46,9 +46,7 @@ interface SaleListProps {
   params: SaleListUrlQueryParams;
 }
 
-export const SaleList: React.StatelessComponent<SaleListProps> = ({
-  params
-}) => {
+export const SaleList: React.FC<SaleListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/discounts/views/VoucherCreate.tsx
+++ b/src/discounts/views/VoucherCreate.tsx
@@ -17,7 +17,7 @@ import { RequirementsPicker } from "../types";
 import { VoucherCreate } from "../types/VoucherCreate";
 import { voucherListUrl, voucherUrl } from "../urls";
 
-export const VoucherDetails: React.StatelessComponent = () => {
+export const VoucherDetails: React.FC = () => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const shop = useShop();

--- a/src/discounts/views/VoucherDetails.tsx
+++ b/src/discounts/views/VoucherDetails.tsx
@@ -56,7 +56,7 @@ interface VoucherDetailsProps {
   params: VoucherUrlQueryParams;
 }
 
-export const VoucherDetails: React.StatelessComponent<VoucherDetailsProps> = ({
+export const VoucherDetails: React.FC<VoucherDetailsProps> = ({
   id,
   params
 }) => {

--- a/src/discounts/views/VoucherList/VoucherList.tsx
+++ b/src/discounts/views/VoucherList/VoucherList.tsx
@@ -46,9 +46,7 @@ interface VoucherListProps {
   params: VoucherListUrlQueryParams;
 }
 
-export const VoucherList: React.StatelessComponent<VoucherListProps> = ({
-  params
-}) => {
+export const VoucherList: React.FC<VoucherListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/home/components/HomeScreen.tsx
+++ b/src/home/components/HomeScreen.tsx
@@ -14,9 +14,7 @@ interface HomeScreenProps {
   };
 }
 
-export const HomeScreen: React.StatelessComponent<HomeScreenProps> = ({
-  user
-}) => {
+export const HomeScreen: React.FC<HomeScreenProps> = ({ user }) => {
   const intl = useIntl();
 
   return (

--- a/src/navigation/components/MenuDetailsPage/MenuDetailsPage.tsx
+++ b/src/navigation/components/MenuDetailsPage/MenuDetailsPage.tsx
@@ -37,7 +37,7 @@ export interface MenuDetailsPageProps {
   onSubmit: (data: MenuDetailsSubmitData) => Promise<boolean>;
 }
 
-const MenuDetailsPage: React.StatelessComponent<MenuDetailsPageProps> = ({
+const MenuDetailsPage: React.FC<MenuDetailsPageProps> = ({
   disabled,
   menu,
   saveButtonState,

--- a/src/navigation/components/MenuItemDialog/MenuItemDialog.tsx
+++ b/src/navigation/components/MenuItemDialog/MenuItemDialog.tsx
@@ -73,7 +73,7 @@ function getDisplayValue(menu: IMenu, value: string): string {
   return getMenuItemByValue(menu, value).label.toString();
 }
 
-const MenuItemDialog: React.StatelessComponent<MenuItemDialogProps> = ({
+const MenuItemDialog: React.FC<MenuItemDialogProps> = ({
   confirmButtonState,
   disabled,
   errors: apiErrors,

--- a/src/navigation/components/MenuListPage/MenuListPage.tsx
+++ b/src/navigation/components/MenuListPage/MenuListPage.tsx
@@ -17,7 +17,7 @@ export interface MenuListPageProps extends PageListProps, ListActions {
   onDelete: (id: string) => void;
 }
 
-const MenuListPage: React.StatelessComponent<MenuListPageProps> = ({
+const MenuListPage: React.FC<MenuListPageProps> = ({
   disabled,
   onAdd,
   onBack,

--- a/src/navigation/components/MenuProperties/MenuProperties.tsx
+++ b/src/navigation/components/MenuProperties/MenuProperties.tsx
@@ -14,7 +14,7 @@ export interface MenuPropertiesProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const MenuProperties: React.StatelessComponent<MenuPropertiesProps> = ({
+const MenuProperties: React.FC<MenuPropertiesProps> = ({
   data,
   disabled,
   onChange

--- a/src/orders/components/OrderBulkCancelDialog/OrderBulkCancelDialog.tsx
+++ b/src/orders/components/OrderBulkCancelDialog/OrderBulkCancelDialog.tsx
@@ -14,9 +14,13 @@ export interface OrderBulkCancelDialogProps {
   onConfirm: (restock: boolean) => void;
 }
 
-const OrderBulkCancelDialog: React.StatelessComponent<
-  OrderBulkCancelDialogProps
-> = ({ confirmButtonState, numberOfOrders, open, onClose, onConfirm }) => {
+const OrderBulkCancelDialog: React.FC<OrderBulkCancelDialogProps> = ({
+  confirmButtonState,
+  numberOfOrders,
+  open,
+  onClose,
+  onConfirm
+}) => {
   const intl = useIntl();
   const [restock, setRestock] = React.useState(true);
 

--- a/src/orders/components/OrderCustomerNote/OrderCustomerNote.tsx
+++ b/src/orders/components/OrderCustomerNote/OrderCustomerNote.tsx
@@ -11,9 +11,9 @@ interface OrderCustomerNoteProps {
   note: string;
 }
 
-export const OrderCustomerNote: React.StatelessComponent<
-  OrderCustomerNoteProps
-> = ({ note }) => {
+export const OrderCustomerNote: React.FC<OrderCustomerNoteProps> = ({
+  note
+}) => {
   const intl = useIntl();
 
   return (

--- a/src/orders/components/OrderDraftCancelDialog/OrderDraftCancelDialog.tsx
+++ b/src/orders/components/OrderDraftCancelDialog/OrderDraftCancelDialog.tsx
@@ -13,9 +13,13 @@ export interface OrderDraftCancelDialogProps {
   orderNumber: string;
 }
 
-const OrderDraftCancelDialog: React.StatelessComponent<
-  OrderDraftCancelDialogProps
-> = ({ confirmButtonState, onClose, onConfirm, open, orderNumber }) => {
+const OrderDraftCancelDialog: React.FC<OrderDraftCancelDialogProps> = ({
+  confirmButtonState,
+  onClose,
+  onConfirm,
+  open,
+  orderNumber
+}) => {
   const intl = useIntl();
 
   return (

--- a/src/orders/components/OrderDraftDetails/OrderDraftDetails.tsx
+++ b/src/orders/components/OrderDraftDetails/OrderDraftDetails.tsx
@@ -23,7 +23,7 @@ interface OrderDraftDetailsProps {
   onShippingMethodEdit: () => void;
 }
 
-const OrderDraftDetails: React.StatelessComponent<OrderDraftDetailsProps> = ({
+const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
   order,
   onOrderLineAdd,
   onOrderLineChange,

--- a/src/orders/components/OrderDraftFinalizeDialog/OrderDraftFinalizeDialog.tsx
+++ b/src/orders/components/OrderDraftFinalizeDialog/OrderDraftFinalizeDialog.tsx
@@ -46,9 +46,7 @@ function translateWarnings(
   };
 }
 
-const OrderDraftFinalizeDialog: React.StatelessComponent<
-  OrderDraftFinalizeDialogProps
-> = ({
+const OrderDraftFinalizeDialog: React.FC<OrderDraftFinalizeDialogProps> = ({
   confirmButtonState,
   open,
   warnings,

--- a/src/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
+++ b/src/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
@@ -25,7 +25,7 @@ export interface OrderDraftListPageProps
   orders: OrderDraftList_draftOrders_edges_node[];
 }
 
-const OrderDraftListPage: React.StatelessComponent<OrderDraftListPageProps> = ({
+const OrderDraftListPage: React.FC<OrderDraftListPageProps> = ({
   currentTab,
   disabled,
   initialSearch,

--- a/src/orders/components/OrderFulfillmentTrackingDialog/OrderFulfillmentTrackingDialog.tsx
+++ b/src/orders/components/OrderFulfillmentTrackingDialog/OrderFulfillmentTrackingDialog.tsx
@@ -25,7 +25,7 @@ interface OrderFulfillmentTrackingDialogProps {
   onConfirm(data: FormData);
 }
 
-const OrderFulfillmentTrackingDialog: React.StatelessComponent<
+const OrderFulfillmentTrackingDialog: React.FC<
   OrderFulfillmentTrackingDialogProps
 > = ({ confirmButtonState, open, trackingNumber, onConfirm, onClose }) => {
   const intl = useIntl();

--- a/src/orders/components/OrderMarkAsPaidDialog/OrderMarkAsPaidDialog.tsx
+++ b/src/orders/components/OrderMarkAsPaidDialog/OrderMarkAsPaidDialog.tsx
@@ -12,9 +12,12 @@ export interface OrderMarkAsPaidDialogProps {
   onConfirm: () => void;
 }
 
-const OrderMarkAsPaidDialog: React.StatelessComponent<
-  OrderMarkAsPaidDialogProps
-> = ({ confirmButtonState, onClose, onConfirm, open }) => {
+const OrderMarkAsPaidDialog: React.FC<OrderMarkAsPaidDialogProps> = ({
+  confirmButtonState,
+  onClose,
+  onConfirm,
+  open
+}) => {
   const intl = useIntl();
 
   return (

--- a/src/orders/components/OrderPaymentDialog/OrderPaymentDialog.tsx
+++ b/src/orders/components/OrderPaymentDialog/OrderPaymentDialog.tsx
@@ -26,7 +26,7 @@ interface OrderPaymentDialogProps {
   onSubmit: (data: FormData) => void;
 }
 
-const OrderPaymentDialog: React.StatelessComponent<OrderPaymentDialogProps> = ({
+const OrderPaymentDialog: React.FC<OrderPaymentDialogProps> = ({
   confirmButtonState,
   open,
   initial,

--- a/src/orders/components/OrderPaymentVoidDialog/OrderPaymentVoidDialog.tsx
+++ b/src/orders/components/OrderPaymentVoidDialog/OrderPaymentVoidDialog.tsx
@@ -19,9 +19,12 @@ interface OrderPaymentVoidDialogProps {
   onConfirm?();
 }
 
-const OrderPaymentVoidDialog: React.StatelessComponent<
-  OrderPaymentVoidDialogProps
-> = ({ confirmButtonState, open, onConfirm, onClose }) => (
+const OrderPaymentVoidDialog: React.FC<OrderPaymentVoidDialogProps> = ({
+  confirmButtonState,
+  open,
+  onConfirm,
+  onClose
+}) => (
   <Dialog onClose={onClose} open={open}>
     <DialogTitle>
       <FormattedMessage

--- a/src/orders/containers/OrderOperations.tsx
+++ b/src/orders/containers/OrderOperations.tsx
@@ -157,7 +157,7 @@ interface OrderOperationsProps {
   onOrderLineUpdate: (data: OrderLineUpdate) => void;
 }
 
-const OrderOperations: React.StatelessComponent<OrderOperationsProps> = ({
+const OrderOperations: React.FC<OrderOperationsProps> = ({
   children,
   onDraftUpdate,
   onOrderFulfillmentCreate,

--- a/src/orders/index.tsx
+++ b/src/orders/index.tsx
@@ -17,22 +17,18 @@ import OrderDetailsComponent from "./views/OrderDetails";
 import OrderDraftListComponent from "./views/OrderDraftList";
 import OrderListComponent from "./views/OrderList";
 
-const OrderList: React.StatelessComponent<RouteComponentProps<any>> = ({
-  location
-}) => {
+const OrderList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: OrderListUrlQueryParams = qs;
   return <OrderListComponent params={params} />;
 };
-const OrderDraftList: React.StatelessComponent<RouteComponentProps<any>> = ({
-  location
-}) => {
+const OrderDraftList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: OrderDraftListUrlQueryParams = qs;
   return <OrderDraftListComponent params={params} />;
 };
 
-const OrderDetails: React.StatelessComponent<RouteComponentProps<any>> = ({
+const OrderDetails: React.FC<RouteComponentProps<any>> = ({
   location,
   match
 }) => {

--- a/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
+++ b/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
@@ -47,9 +47,9 @@ interface OrderDetailsMessages {
   }) => React.ReactElement;
 }
 
-export const OrderDetailsMessages: React.StatelessComponent<
-  OrderDetailsMessages
-> = ({ children }) => {
+export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
+  children
+}) => {
   const navigate = useNavigator();
   const pushMessage = useNotifier();
   const intl = useIntl();

--- a/src/orders/views/OrderDetails/index.tsx
+++ b/src/orders/views/OrderDetails/index.tsx
@@ -76,10 +76,7 @@ interface OrderDetailsProps {
   params: OrderUrlQueryParams;
 }
 
-export const OrderDetails: React.StatelessComponent<OrderDetailsProps> = ({
-  id,
-  params
-}) => {
+export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
   const navigate = useNavigator();
   const { user } = useUser();
 

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -46,9 +46,7 @@ interface OrderDraftListProps {
   params: OrderDraftListUrlQueryParams;
 }
 
-export const OrderDraftList: React.StatelessComponent<OrderDraftListProps> = ({
-  params
-}) => {
+export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/orders/views/OrderList/OrderList.tsx
+++ b/src/orders/views/OrderList/OrderList.tsx
@@ -48,9 +48,7 @@ interface OrderListProps {
   params: OrderListUrlQueryParams;
 }
 
-export const OrderList: React.StatelessComponent<OrderListProps> = ({
-  params
-}) => {
+export const OrderList: React.FC<OrderListProps> = ({ params }) => {
   const formatDate = useDateLocalize();
   const navigate = useNavigator();
   const notify = useNotifier();

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -45,7 +45,7 @@ export interface PageDetailsPageProps {
   onSubmit: (data: FormData) => void;
 }
 
-const PageDetailsPage: React.StatelessComponent<PageDetailsPageProps> = ({
+const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
   disabled,
   errors,
   page,

--- a/src/pages/components/PageListPage/PageListPage.tsx
+++ b/src/pages/components/PageListPage/PageListPage.tsx
@@ -16,7 +16,7 @@ export interface PageListPageProps extends PageListProps, ListActions {
   onBack: () => void;
 }
 
-const PageListPage: React.StatelessComponent<PageListPageProps> = ({
+const PageListPage: React.FC<PageListPageProps> = ({
   disabled,
   settings,
   onAdd,

--- a/src/pages/components/PageSlug/PageSlug.tsx
+++ b/src/pages/components/PageSlug/PageSlug.tsx
@@ -15,7 +15,7 @@ export interface PageSlugProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const PageSlug: React.StatelessComponent<PageSlugProps> = ({
+const PageSlug: React.FC<PageSlugProps> = ({
   data,
   disabled,
   errors,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,17 +16,13 @@ import PageCreate from "./views/PageCreate";
 import PageDetailsComponent from "./views/PageDetails";
 import PageListComponent from "./views/PageList";
 
-const PageList: React.StatelessComponent<RouteComponentProps<any>> = ({
-  location
-}) => {
+const PageList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: PageListUrlQueryParams = qs;
   return <PageListComponent params={params} />;
 };
 
-const PageDetails: React.StatelessComponent<RouteComponentProps<any>> = ({
-  match
-}) => {
+const PageDetails: React.FC<RouteComponentProps<any>> = ({ match }) => {
   const qs = parseQs(location.search.substr(1));
   const params: PageUrlQueryParams = qs;
 

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -14,7 +14,7 @@ export interface PageCreateProps {
   id: string;
 }
 
-export const PageCreate: React.StatelessComponent<PageCreateProps> = () => {
+export const PageCreate: React.FC<PageCreateProps> = () => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/pages/views/PageDetails.tsx
+++ b/src/pages/views/PageDetails.tsx
@@ -37,10 +37,7 @@ const createPageInput = (data: FormData): PageInput => {
   };
 };
 
-export const PageDetails: React.StatelessComponent<PageDetailsProps> = ({
-  id,
-  params
-}) => {
+export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/pages/views/PageList.tsx
+++ b/src/pages/views/PageList.tsx
@@ -33,9 +33,7 @@ interface PageListProps {
   params: PageListUrlQueryParams;
 }
 
-export const PageList: React.StatelessComponent<PageListProps> = ({
-  params
-}) => {
+export const PageList: React.FC<PageListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/plugins/components/PluginInfo/PluginInfo.tsx
+++ b/src/plugins/components/PluginInfo/PluginInfo.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const PluginInfo: React.StatelessComponent<PluginInfoProps> = ({
+const PluginInfo: React.FC<PluginInfoProps> = ({
   data,
   description,
   name,

--- a/src/plugins/components/PluginSettings/PluginSettings.tsx
+++ b/src/plugins/components/PluginSettings/PluginSettings.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const PluginSettings: React.StatelessComponent<PluginSettingsProps> = ({
+const PluginSettings: React.FC<PluginSettingsProps> = ({
   data,
   disabled,
   errors,

--- a/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.tsx
+++ b/src/plugins/components/PluginsDetailsPage/PluginsDetailsPage.tsx
@@ -31,7 +31,7 @@ export interface PluginsDetailsPageProps {
   onSubmit: (data: FormData) => void;
 }
 
-const PluginsDetailsPage: React.StatelessComponent<PluginsDetailsPageProps> = ({
+const PluginsDetailsPage: React.FC<PluginsDetailsPageProps> = ({
   disabled,
   errors,
   plugin,

--- a/src/plugins/components/PluginsListPage/PluginsListPage.tsx
+++ b/src/plugins/components/PluginsListPage/PluginsListPage.tsx
@@ -14,7 +14,7 @@ export interface PluginsListPageProps extends PageListProps {
   onBack: () => void;
 }
 
-const PluginsListPage: React.StatelessComponent<PluginsListPageProps> = ({
+const PluginsListPage: React.FC<PluginsListPageProps> = ({
   disabled,
   settings,
   onBack,

--- a/src/plugins/index.tsx
+++ b/src/plugins/index.tsx
@@ -13,17 +13,13 @@ import {
 import PluginsDetailsComponent from "./views/PluginsDetails";
 import PluginsListComponent from "./views/PluginsList";
 
-const PluginList: React.StatelessComponent<RouteComponentProps<any>> = ({
-  location
-}) => {
+const PluginList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: PluginsListUrlQueryParams = qs;
   return <PluginsListComponent params={params} />;
 };
 
-const PageDetails: React.StatelessComponent<RouteComponentProps<any>> = ({
-  match
-}) => {
+const PageDetails: React.FC<RouteComponentProps<any>> = ({ match }) => {
   const qs = parseQs(location.search.substr(1));
   const params: PluginsListUrlQueryParams = qs;
 

--- a/src/plugins/views/PluginsDetails.tsx
+++ b/src/plugins/views/PluginsDetails.tsx
@@ -15,9 +15,7 @@ export interface PluginsDetailsProps {
   params: PluginsListUrlQueryParams;
 }
 
-export const PluginsDetails: React.StatelessComponent<PluginsDetailsProps> = ({
-  id
-}) => {
+export const PluginsDetails: React.FC<PluginsDetailsProps> = ({ id }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/plugins/views/PluginsList.tsx
+++ b/src/plugins/views/PluginsList.tsx
@@ -16,9 +16,7 @@ interface PluginsListProps {
   params: PluginsListUrlQueryParams;
 }
 
-export const PluginsList: React.StatelessComponent<PluginsListProps> = ({
-  params
-}) => {
+export const PluginsList: React.FC<PluginsListProps> = ({ params }) => {
   const navigate = useNavigator();
   const paginate = usePaginator();
   const { updateListSettings, settings } = useListSettings(

--- a/src/productTypes/components/ProductTypeAttributeEditDialog/ProductTypeAttributeEditDialog.tsx
+++ b/src/productTypes/components/ProductTypeAttributeEditDialog/ProductTypeAttributeEditDialog.tsx
@@ -37,7 +37,7 @@ export interface ProductTypeAttributeEditDialogProps {
   onConfirm: (data: FormData) => void;
 }
 
-const ProductTypeAttributeEditDialog: React.StatelessComponent<
+const ProductTypeAttributeEditDialog: React.FC<
   ProductTypeAttributeEditDialogProps
 > = ({ disabled, errors, name, opened, title, values, onClose, onConfirm }) => {
   const intl = useIntl();

--- a/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
+++ b/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
@@ -56,9 +56,7 @@ function handleTaxTypeChange(
   );
 }
 
-const ProductTypeCreatePage: React.StatelessComponent<
-  ProductTypeCreatePageProps
-> = ({
+const ProductTypeCreatePage: React.FC<ProductTypeCreatePageProps> = ({
   defaultWeightUnit,
   disabled,
   errors,

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -72,9 +72,7 @@ function handleTaxTypeChange(
   );
 }
 
-const ProductTypeDetailsPage: React.StatelessComponent<
-  ProductTypeDetailsPageProps
-> = ({
+const ProductTypeDetailsPage: React.FC<ProductTypeDetailsPageProps> = ({
   defaultWeightUnit,
   disabled,
   errors,

--- a/src/productTypes/components/ProductTypeListPage/ProductTypeListPage.tsx
+++ b/src/productTypes/components/ProductTypeListPage/ProductTypeListPage.tsx
@@ -26,9 +26,7 @@ export interface ProductTypeListPageProps
   onBack: () => void;
 }
 
-const ProductTypeListPage: React.StatelessComponent<
-  ProductTypeListPageProps
-> = ({
+const ProductTypeListPage: React.FC<ProductTypeListPageProps> = ({
   currentTab,
   initialSearch,
   onAdd,

--- a/src/productTypes/components/ProductTypeShipping/ProductTypeShipping.tsx
+++ b/src/productTypes/components/ProductTypeShipping/ProductTypeShipping.tsx
@@ -18,9 +18,12 @@ interface ProductTypeShippingProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const ProductTypeShipping: React.StatelessComponent<
-  ProductTypeShippingProps
-> = ({ data, defaultWeightUnit, disabled, onChange }) => {
+const ProductTypeShipping: React.FC<ProductTypeShippingProps> = ({
+  data,
+  defaultWeightUnit,
+  disabled,
+  onChange
+}) => {
   const intl = useIntl();
 
   return (

--- a/src/productTypes/containers/ProductTypeOperations.tsx
+++ b/src/productTypes/containers/ProductTypeOperations.tsx
@@ -90,9 +90,7 @@ interface ProductTypeOperationsProps {
   onProductTypeUpdate: (data: ProductTypeUpdate) => void;
 }
 
-const ProductTypeOperations: React.StatelessComponent<
-  ProductTypeOperationsProps
-> = ({
+const ProductTypeOperations: React.FC<ProductTypeOperationsProps> = ({
   children,
   productType,
   onAssignAttribute,

--- a/src/productTypes/index.tsx
+++ b/src/productTypes/index.tsx
@@ -16,9 +16,7 @@ import ProductTypeCreate from "./views/ProductTypeCreate";
 import ProductTypeListComponent from "./views/ProductTypeList";
 import ProductTypeUpdateComponent from "./views/ProductTypeUpdate";
 
-const ProductTypeList: React.StatelessComponent<RouteComponentProps<{}>> = ({
-  location
-}) => {
+const ProductTypeList: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: ProductTypeListUrlQueryParams = qs;
   return <ProductTypeListComponent params={params} />;
@@ -27,7 +25,7 @@ const ProductTypeList: React.StatelessComponent<RouteComponentProps<{}>> = ({
 interface ProductTypeUpdateRouteParams {
   id: string;
 }
-const ProductTypeUpdate: React.StatelessComponent<
+const ProductTypeUpdate: React.FC<
   RouteComponentProps<ProductTypeUpdateRouteParams>
 > = ({ match }) => {
   const qs = parseQs(location.search.substr(1));

--- a/src/productTypes/views/ProductTypeCreate.tsx
+++ b/src/productTypes/views/ProductTypeCreate.tsx
@@ -13,7 +13,7 @@ import { TypedProductTypeCreateDataQuery } from "../queries";
 import { ProductTypeCreate as ProductTypeCreateMutation } from "../types/ProductTypeCreate";
 import { productTypeListUrl, productTypeUrl } from "../urls";
 
-export const ProductTypeCreate: React.StatelessComponent = () => {
+export const ProductTypeCreate: React.FC = () => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/productTypes/views/ProductTypeList/ProductTypeList.tsx
+++ b/src/productTypes/views/ProductTypeList/ProductTypeList.tsx
@@ -45,9 +45,7 @@ interface ProductTypeListProps {
   params: ProductTypeListUrlQueryParams;
 }
 
-export const ProductTypeList: React.StatelessComponent<
-  ProductTypeListProps
-> = ({ params }) => {
+export const ProductTypeList: React.FC<ProductTypeListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -85,9 +85,7 @@ interface ProductCreatePageProps {
   onSubmit?(data: ProductCreatePageSubmitData);
 }
 
-export const ProductCreatePage: React.StatelessComponent<
-  ProductCreatePageProps
-> = ({
+export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
   currency,
   disabled,
   categories: categoryChoiceList,

--- a/src/products/containers/ProductImagesReorder.tsx
+++ b/src/products/containers/ProductImagesReorder.tsx
@@ -19,7 +19,7 @@ interface ProductImagesReorderProviderProps
   }>;
 }
 
-const ProductImagesReorderProvider: React.StatelessComponent<
+const ProductImagesReorderProvider: React.FC<
   ProductImagesReorderProviderProps
 > = ({ children, productId, productImages, ...mutationProps }) => (
   <TypedProductImagesReorder {...mutationProps}>

--- a/src/products/containers/ProductUpdateOperations.tsx
+++ b/src/products/containers/ProductUpdateOperations.tsx
@@ -85,9 +85,7 @@ interface ProductUpdateOperationsProps {
   onUpdate?: (data: ProductUpdate) => void;
 }
 
-const ProductUpdateOperations: React.StatelessComponent<
-  ProductUpdateOperationsProps
-> = ({
+const ProductUpdateOperations: React.FC<ProductUpdateOperationsProps> = ({
   product,
   children,
   onBulkProductVariantCreate,

--- a/src/products/containers/ProductVariantOperations.tsx
+++ b/src/products/containers/ProductVariantOperations.tsx
@@ -20,35 +20,37 @@ import {
 import { VariantUpdate, VariantUpdateVariables } from "../types/VariantUpdate";
 
 interface VariantDeleteOperationsProps {
-  children: (
-    props: {
-      deleteVariant: PartialMutationProviderOutput<
-        VariantDelete,
-        VariantDeleteVariables
-      >;
-      updateVariant: PartialMutationProviderOutput<
-        VariantUpdate,
-        VariantUpdateVariables
-      >;
-      assignImage: PartialMutationProviderOutput<
-        VariantImageAssign,
-        VariantImageAssignVariables
-      >;
-      unassignImage: PartialMutationProviderOutput<
-        VariantImageUnassign,
-        VariantImageUnassignVariables
-      >;
-    }
-  ) => React.ReactNode;
+  children: (props: {
+    deleteVariant: PartialMutationProviderOutput<
+      VariantDelete,
+      VariantDeleteVariables
+    >;
+    updateVariant: PartialMutationProviderOutput<
+      VariantUpdate,
+      VariantUpdateVariables
+    >;
+    assignImage: PartialMutationProviderOutput<
+      VariantImageAssign,
+      VariantImageAssignVariables
+    >;
+    unassignImage: PartialMutationProviderOutput<
+      VariantImageUnassign,
+      VariantImageUnassignVariables
+    >;
+  }) => React.ReactNode;
   onDelete?: (data: VariantDelete) => void;
   onImageAssign?: (data: VariantImageAssign) => void;
   onImageUnassign?: (data: VariantImageUnassign) => void;
   onUpdate?: (data: VariantUpdate) => void;
 }
 
-const VariantUpdateOperations: React.StatelessComponent<
-  VariantDeleteOperationsProps
-> = ({ children, onDelete, onUpdate, onImageAssign, onImageUnassign }) => {
+const VariantUpdateOperations: React.FC<VariantDeleteOperationsProps> = ({
+  children,
+  onDelete,
+  onUpdate,
+  onImageAssign,
+  onImageUnassign
+}) => {
   return (
     <TypedVariantImageAssignMutation onCompleted={onImageAssign}>
       {(...assignImage) => (

--- a/src/products/index.tsx
+++ b/src/products/index.tsx
@@ -26,9 +26,7 @@ import ProductUpdateComponent from "./views/ProductUpdate";
 import ProductVariantComponent from "./views/ProductVariant";
 import ProductVariantCreateComponent from "./views/ProductVariantCreate";
 
-const ProductList: React.StatelessComponent<RouteComponentProps<any>> = ({
-  location
-}) => {
+const ProductList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: ProductListUrlQueryParams = {
     ...qs,
@@ -40,9 +38,7 @@ const ProductList: React.StatelessComponent<RouteComponentProps<any>> = ({
   return <ProductListComponent params={params} />;
 };
 
-const ProductUpdate: React.StatelessComponent<RouteComponentProps<any>> = ({
-  match
-}) => {
+const ProductUpdate: React.FC<RouteComponentProps<any>> = ({ match }) => {
   const qs = parseQs(location.search.substr(1));
   const params: ProductUrlQueryParams = qs;
 
@@ -54,9 +50,7 @@ const ProductUpdate: React.StatelessComponent<RouteComponentProps<any>> = ({
   );
 };
 
-const ProductVariant: React.StatelessComponent<RouteComponentProps<any>> = ({
-  match
-}) => {
+const ProductVariant: React.FC<RouteComponentProps<any>> = ({ match }) => {
   const qs = parseQs(location.search.substr(1));
   const params: ProductVariantEditUrlQueryParams = qs;
 
@@ -69,7 +63,7 @@ const ProductVariant: React.StatelessComponent<RouteComponentProps<any>> = ({
   );
 };
 
-const ProductImage: React.StatelessComponent<RouteComponentProps<any>> = ({
+const ProductImage: React.FC<RouteComponentProps<any>> = ({
   location,
   match
 }) => {
@@ -85,9 +79,9 @@ const ProductImage: React.StatelessComponent<RouteComponentProps<any>> = ({
   );
 };
 
-const ProductVariantCreate: React.StatelessComponent<
-  RouteComponentProps<any>
-> = ({ match }) => {
+const ProductVariantCreate: React.FC<RouteComponentProps<any>> = ({
+  match
+}) => {
   return (
     <ProductVariantCreateComponent
       productId={decodeURIComponent(match.params.id)}

--- a/src/products/views/ProductCreate.tsx
+++ b/src/products/views/ProductCreate.tsx
@@ -21,9 +21,7 @@ interface ProductUpdateProps {
   id: string;
 }
 
-export const ProductUpdate: React.StatelessComponent<
-  ProductUpdateProps
-> = () => {
+export const ProductUpdate: React.FC<ProductUpdateProps> = () => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const shop = useShop();

--- a/src/products/views/ProductImage.tsx
+++ b/src/products/views/ProductImage.tsx
@@ -25,7 +25,7 @@ interface ProductImageProps {
   params: ProductImageUrlQueryParams;
 }
 
-export const ProductImage: React.StatelessComponent<ProductImageProps> = ({
+export const ProductImage: React.FC<ProductImageProps> = ({
   imageId,
   productId,
   params

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -61,9 +61,7 @@ interface ProductListProps {
   params: ProductListUrlQueryParams;
 }
 
-export const ProductList: React.StatelessComponent<ProductListProps> = ({
-  params
-}) => {
+export const ProductList: React.FC<ProductListProps> = ({ params }) => {
   const { locale } = useLocale();
   const navigate = useNavigator();
   const notify = useNotifier();

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -47,10 +47,7 @@ interface ProductUpdateProps {
   params: ProductUrlQueryParams;
 }
 
-export const ProductUpdate: React.StatelessComponent<ProductUpdateProps> = ({
-  id,
-  params
-}) => {
+export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const { isSelected, listElements, reset, toggle, toggleAll } = useBulkActions(

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -27,7 +27,7 @@ interface ProductUpdateProps {
   params: ProductVariantEditUrlQueryParams;
 }
 
-export const ProductVariant: React.StatelessComponent<ProductUpdateProps> = ({
+export const ProductVariant: React.FC<ProductUpdateProps> = ({
   variantId,
   productId,
   params

--- a/src/products/views/ProductVariantCreate.tsx
+++ b/src/products/views/ProductVariantCreate.tsx
@@ -18,9 +18,7 @@ interface ProductUpdateProps {
   productId: string;
 }
 
-export const ProductVariant: React.StatelessComponent<ProductUpdateProps> = ({
-  productId
-}) => {
+export const ProductVariant: React.FC<ProductUpdateProps> = ({ productId }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const shop = useShop();

--- a/src/services/components/ServiceListPage/ServiceListPage.tsx
+++ b/src/services/components/ServiceListPage/ServiceListPage.tsx
@@ -21,7 +21,7 @@ export interface ServiceListPageProps
   onRemove: (id: string) => void;
 }
 
-const ServiceListPage: React.StatelessComponent<ServiceListPageProps> = ({
+const ServiceListPage: React.FC<ServiceListPageProps> = ({
   currentTab,
   initialSearch,
   onAdd,

--- a/src/services/views/ServiceDetails/ServiceDetails.tsx
+++ b/src/services/views/ServiceDetails/ServiceDetails.tsx
@@ -39,7 +39,7 @@ interface OrderListProps {
   onTokenClose: () => void;
 }
 
-export const ServiceDetails: React.StatelessComponent<OrderListProps> = ({
+export const ServiceDetails: React.FC<OrderListProps> = ({
   id,
   params,
   token,

--- a/src/services/views/ServiceList/ServiceList.tsx
+++ b/src/services/views/ServiceList/ServiceList.tsx
@@ -42,9 +42,7 @@ interface ServiceListProps {
   params: ServiceListUrlQueryParams;
 }
 
-export const ServiceList: React.StatelessComponent<ServiceListProps> = ({
-  params
-}) => {
+export const ServiceList: React.FC<ServiceListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/shipping/components/ShippingWeightUnitForm/ShippingWeightUnitForm.tsx
+++ b/src/shipping/components/ShippingWeightUnitForm/ShippingWeightUnitForm.tsx
@@ -22,9 +22,11 @@ export interface ShippingWeightUnitFormProps {
   onSubmit: (unit: WeightUnitsEnum) => void;
 }
 
-const ShippingWeightUnitForm: React.StatelessComponent<
-  ShippingWeightUnitFormProps
-> = ({ defaultWeightUnit, disabled, onSubmit }) => {
+const ShippingWeightUnitForm: React.FC<ShippingWeightUnitFormProps> = ({
+  defaultWeightUnit,
+  disabled,
+  onSubmit
+}) => {
   const intl = useIntl();
   const initialForm: FormData = {
     unit: defaultWeightUnit

--- a/src/shipping/components/ShippingZoneCreatePage/ShippingZoneCreatePage.tsx
+++ b/src/shipping/components/ShippingZoneCreatePage/ShippingZoneCreatePage.tsx
@@ -31,9 +31,14 @@ export interface ShippingZoneCreatePageProps {
   onSubmit: (data: FormData) => void;
 }
 
-const ShippingZoneCreatePage: React.StatelessComponent<
-  ShippingZoneCreatePageProps
-> = ({ countries, disabled, errors, onBack, onSubmit, saveButtonBarState }) => {
+const ShippingZoneCreatePage: React.FC<ShippingZoneCreatePageProps> = ({
+  countries,
+  disabled,
+  errors,
+  onBack,
+  onSubmit,
+  saveButtonBarState
+}) => {
   const intl = useIntl();
   const [isModalOpened, setModalStatus] = React.useState(false);
   const toggleModal = () => setModalStatus(!isModalOpened);

--- a/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
@@ -38,9 +38,7 @@ export interface ShippingZoneDetailsPageProps {
   onWeightRateEdit: (id: string) => void;
 }
 
-const ShippingZoneDetailsPage: React.StatelessComponent<
-  ShippingZoneDetailsPageProps
-> = ({
+const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
   disabled,
   errors,
   onBack,

--- a/src/shipping/components/ShippingZoneInfo/ShippingZoneInfo.tsx
+++ b/src/shipping/components/ShippingZoneInfo/ShippingZoneInfo.tsx
@@ -15,7 +15,7 @@ export interface ShippingZoneInfoProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const ShippingZoneInfo: React.StatelessComponent<ShippingZoneInfoProps> = ({
+const ShippingZoneInfo: React.FC<ShippingZoneInfoProps> = ({
   data,
   errors,
   onChange

--- a/src/shipping/components/ShippingZonesListPage/ShippingZonesListPage.tsx
+++ b/src/shipping/components/ShippingZonesListPage/ShippingZonesListPage.tsx
@@ -24,9 +24,7 @@ export interface ShippingZonesListPageProps
   onSubmit: (unit: WeightUnitsEnum) => void;
 }
 
-const ShippingZonesListPage: React.StatelessComponent<
-  ShippingZonesListPageProps
-> = ({
+const ShippingZonesListPage: React.FC<ShippingZonesListPageProps> = ({
   defaultWeightUnit,
   disabled,
   userPermissions,

--- a/src/shipping/index.tsx
+++ b/src/shipping/index.tsx
@@ -16,9 +16,7 @@ import ShippingZoneCreate from "./views/ShippingZoneCreate";
 import ShippingZoneDetailsComponent from "./views/ShippingZoneDetails";
 import ShippingZonesListComponent from "./views/ShippingZonesList";
 
-const ShippingZonesList: React.StatelessComponent<RouteComponentProps<{}>> = ({
-  location
-}) => {
+const ShippingZonesList: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: ShippingZonesListUrlQueryParams = qs;
   return <ShippingZonesListComponent params={params} />;
@@ -27,7 +25,7 @@ const ShippingZonesList: React.StatelessComponent<RouteComponentProps<{}>> = ({
 interface ShippingZoneDetailsRouteProps {
   id: string;
 }
-const ShippingZoneDetails: React.StatelessComponent<
+const ShippingZoneDetails: React.FC<
   RouteComponentProps<ShippingZoneDetailsRouteProps>
 > = ({ location, match }) => {
   const qs = parseQs(location.search.substr(1));

--- a/src/shipping/views/ShippingZoneCreate.tsx
+++ b/src/shipping/views/ShippingZoneCreate.tsx
@@ -11,7 +11,7 @@ import { TypedCreateShippingZone } from "../mutations";
 import { CreateShippingZone } from "../types/CreateShippingZone";
 import { shippingZonesListUrl, shippingZoneUrl } from "../urls";
 
-const ShippingZoneCreate: React.StatelessComponent<{}> = () => {
+const ShippingZoneCreate: React.FC<{}> = () => {
   const navigate = useNavigator();
   const pushMessage = useNotifier();
   const shop = useShop();

--- a/src/shipping/views/ShippingZoneDetails/ShippingZoneDetailsDialogs.tsx
+++ b/src/shipping/views/ShippingZoneDetails/ShippingZoneDetailsDialogs.tsx
@@ -27,9 +27,7 @@ export interface ShippingZoneDetailsDialogsProps {
   updateRateTransitionState: ConfirmButtonTransitionState;
 }
 
-const ShippingZoneDetailsDialogs: React.StatelessComponent<
-  ShippingZoneDetailsDialogsProps
-> = ({
+const ShippingZoneDetailsDialogs: React.FC<ShippingZoneDetailsDialogsProps> = ({
   assignCountryTransitionState,
   createRateTransitionState,
   deleteRateTransitionState,

--- a/src/shipping/views/ShippingZoneDetails/ShippingZoneOperations.tsx
+++ b/src/shipping/views/ShippingZoneDetails/ShippingZoneOperations.tsx
@@ -61,9 +61,7 @@ interface ShippingZoneOperationsProps {
   onShippingZoneUpdate: (data: UpdateShippingZone) => void;
 }
 
-const ShippingZoneOperations: React.StatelessComponent<
-  ShippingZoneOperationsProps
-> = ({
+const ShippingZoneOperations: React.FC<ShippingZoneOperationsProps> = ({
   children,
   onShippingRateCreate,
   onShippingRateDelete,

--- a/src/shipping/views/ShippingZoneDetails/index.tsx
+++ b/src/shipping/views/ShippingZoneDetails/index.tsx
@@ -26,9 +26,10 @@ export interface ShippingZoneDetailsProps {
   params: ShippingZoneUrlQueryParams;
 }
 
-const ShippingZoneDetails: React.StatelessComponent<
-  ShippingZoneDetailsProps
-> = ({ id, params }) => {
+const ShippingZoneDetails: React.FC<ShippingZoneDetailsProps> = ({
+  id,
+  params
+}) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/shipping/views/ShippingZonesList.tsx
+++ b/src/shipping/views/ShippingZonesList.tsx
@@ -39,9 +39,9 @@ interface ShippingZonesListProps {
   params: ShippingZonesListUrlQueryParams;
 }
 
-export const ShippingZonesList: React.StatelessComponent<
-  ShippingZonesListProps
-> = ({ params }) => {
+export const ShippingZonesList: React.FC<ShippingZonesListProps> = ({
+  params
+}) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/siteSettings/components/SiteSettingsDetails/SiteSettingsDetails.tsx
+++ b/src/siteSettings/components/SiteSettingsDetails/SiteSettingsDetails.tsx
@@ -20,9 +20,12 @@ interface SiteSettingsDetailsProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const SiteSettingsDetails: React.StatelessComponent<
-  SiteSettingsDetailsProps
-> = ({ data, disabled, errors, onChange }) => {
+const SiteSettingsDetails: React.FC<SiteSettingsDetailsProps> = ({
+  data,
+  disabled,
+  errors,
+  onChange
+}) => {
   const intl = useIntl();
 
   return (

--- a/src/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.tsx
+++ b/src/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.tsx
@@ -29,9 +29,13 @@ export interface SiteSettingsKeyDialogProps
   onClose: () => void;
 }
 
-const SiteSettingsKeyDialog: React.StatelessComponent<
-  SiteSettingsKeyDialogProps
-> = ({ errors, initial, open, onClose, onSubmit }) => {
+const SiteSettingsKeyDialog: React.FC<SiteSettingsKeyDialogProps> = ({
+  errors,
+  initial,
+  open,
+  onClose,
+  onSubmit
+}) => {
   const intl = useIntl();
 
   return (

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -31,9 +31,7 @@ export interface SiteSettingsProps {
   params: SiteSettingsUrlQueryParams;
 }
 
-export const SiteSettings: React.StatelessComponent<SiteSettingsProps> = ({
-  params
-}) => {
+export const SiteSettings: React.FC<SiteSettingsProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();

--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -45,7 +45,7 @@ export interface StaffDetailsPageProps {
   onImageUpload(file: File);
 }
 
-const StaffDetailsPage: React.StatelessComponent<StaffDetailsPageProps> = ({
+const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
   canEditAvatar,
   canEditPreferences,
   canEditStatus,

--- a/src/staff/components/StaffListPage/StaffListPage.tsx
+++ b/src/staff/components/StaffListPage/StaffListPage.tsx
@@ -21,7 +21,7 @@ export interface StaffListPageProps
   onBack: () => void;
 }
 
-const StaffListPage: React.StatelessComponent<StaffListPageProps> = ({
+const StaffListPage: React.FC<StaffListPageProps> = ({
   currentTab,
   initialSearch,
   onAdd,

--- a/src/staff/index.tsx
+++ b/src/staff/index.tsx
@@ -14,9 +14,7 @@ import {
 import StaffDetailsComponent from "./views/StaffDetails";
 import StaffListComponent from "./views/StaffList";
 
-const StaffList: React.StatelessComponent<RouteComponentProps<{}>> = ({
-  location
-}) => {
+const StaffList: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: StaffListUrlQueryParams = qs;
   return <StaffListComponent params={params} />;
@@ -25,9 +23,9 @@ const StaffList: React.StatelessComponent<RouteComponentProps<{}>> = ({
 interface StaffDetailsRouteProps {
   id: string;
 }
-const StaffDetails: React.StatelessComponent<
-  RouteComponentProps<StaffDetailsRouteProps>
-> = ({ match }) => {
+const StaffDetails: React.FC<RouteComponentProps<StaffDetailsRouteProps>> = ({
+  match
+}) => {
   const qs = parseQs(location.search.substr(1));
   const params: StaffMemberDetailsUrlQueryParams = qs;
 

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -33,10 +33,7 @@ interface OrderListProps {
   params: StaffMemberDetailsUrlQueryParams;
 }
 
-export const StaffDetails: React.StatelessComponent<OrderListProps> = ({
-  id,
-  params
-}) => {
+export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const user = useUser();

--- a/src/staff/views/StaffList/StaffList.tsx
+++ b/src/staff/views/StaffList/StaffList.tsx
@@ -47,9 +47,7 @@ interface StaffListProps {
   params: StaffListUrlQueryParams;
 }
 
-export const StaffList: React.StatelessComponent<StaffListProps> = ({
-  params
-}) => {
+export const StaffList: React.FC<StaffListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();

--- a/src/taxes/components/CountryListPage/CountryListPage.tsx
+++ b/src/taxes/components/CountryListPage/CountryListPage.tsx
@@ -26,7 +26,7 @@ export interface CountryListPageProps {
   onTaxFetch: () => void;
 }
 
-const CountryListPage: React.StatelessComponent<CountryListPageProps> = ({
+const CountryListPage: React.FC<CountryListPageProps> = ({
   disabled,
   shop,
   onBack,

--- a/src/taxes/index.tsx
+++ b/src/taxes/index.tsx
@@ -10,9 +10,9 @@ import CountryTaxesComponent, {
   CountryTaxesParams
 } from "./views/CountryTaxes";
 
-const CountryTaxes: React.StatelessComponent<
-  RouteComponentProps<CountryTaxesParams>
-> = ({ match }) => <CountryTaxesComponent code={match.params.code} />;
+const CountryTaxes: React.FC<RouteComponentProps<CountryTaxesParams>> = ({
+  match
+}) => <CountryTaxesComponent code={match.params.code} />;
 
 const Component = () => {
   const intl = useIntl();

--- a/src/taxes/views/CountryList.tsx
+++ b/src/taxes/views/CountryList.tsx
@@ -8,7 +8,7 @@ import { TypedFetchTaxes, TypedUpdateTaxSettings } from "../mutations";
 import { TypedCountryListQuery } from "../queries";
 import { countryTaxRatesUrl } from "../urls";
 
-export const CountryList: React.StatelessComponent = () => {
+export const CountryList: React.FC = () => {
   const navigate = useNavigator();
 
   return (

--- a/src/taxes/views/CountryTaxes.tsx
+++ b/src/taxes/views/CountryTaxes.tsx
@@ -10,9 +10,7 @@ export interface CountryTaxesParams {
   code: string;
 }
 
-export const CountryTaxes: React.StatelessComponent<CountryTaxesParams> = ({
-  code
-}) => {
+export const CountryTaxes: React.FC<CountryTaxesParams> = ({ code }) => {
   const navigate = useNavigator();
 
   return (

--- a/src/translations/components/TranslationsCategoriesPage/TranslationsCategoriesPage.tsx
+++ b/src/translations/components/TranslationsCategoriesPage/TranslationsCategoriesPage.tsx
@@ -25,9 +25,7 @@ export const fieldNames = {
   seoTitle: "seoTitle"
 };
 
-const TranslationsCategoriesPage: React.StatelessComponent<
-  TranslationsCategoriesPageProps
-> = ({
+const TranslationsCategoriesPage: React.FC<TranslationsCategoriesPageProps> = ({
   activeField,
   disabled,
   languageCode,

--- a/src/translations/components/TranslationsCollectionsPage/TranslationsCollectionsPage.tsx
+++ b/src/translations/components/TranslationsCollectionsPage/TranslationsCollectionsPage.tsx
@@ -25,7 +25,7 @@ export const fieldNames = {
   seoTitle: "seoTitle"
 };
 
-const TranslationsCollectionsPage: React.StatelessComponent<
+const TranslationsCollectionsPage: React.FC<
   TranslationsCollectionsPageProps
 > = ({
   activeField,

--- a/src/translations/components/TranslationsEntitiesListPage/TranslationsEntitiesListPage.tsx
+++ b/src/translations/components/TranslationsEntitiesListPage/TranslationsEntitiesListPage.tsx
@@ -88,7 +88,7 @@ const tabs: TranslationsEntitiesListFilterTab[] = [
   "productTypes"
 ];
 
-const TranslationsEntitiesListPage: React.StatelessComponent<
+const TranslationsEntitiesListPage: React.FC<
   TranslationsEntitiesListPageProps
 > = ({ filters, language, onBack, children, ...searchProps }) => {
   const intl = useIntl();

--- a/src/translations/components/TranslationsLanguageListPage/TranslationsLanguageListPage.tsx
+++ b/src/translations/components/TranslationsLanguageListPage/TranslationsLanguageListPage.tsx
@@ -13,7 +13,7 @@ export interface TranslationsLanguageListPageProps {
   onRowClick: (code: string) => void;
 }
 
-const TranslationsLanguageListPage: React.StatelessComponent<
+const TranslationsLanguageListPage: React.FC<
   TranslationsLanguageListPageProps
 > = ({ languages, onRowClick }) => {
   const intl = useIntl();

--- a/src/translations/components/TranslationsPagesPage/TranslationsPagesPage.tsx
+++ b/src/translations/components/TranslationsPagesPage/TranslationsPagesPage.tsx
@@ -25,9 +25,7 @@ export const fieldNames = {
   title: "title"
 };
 
-const TranslationsPagesPage: React.StatelessComponent<
-  TranslationsPagesPageProps
-> = ({
+const TranslationsPagesPage: React.FC<TranslationsPagesPageProps> = ({
   activeField,
   disabled,
   languageCode,

--- a/src/translations/components/TranslationsProductTypesPage/TranslationsProductTypesPage.tsx
+++ b/src/translations/components/TranslationsProductTypesPage/TranslationsProductTypesPage.tsx
@@ -23,7 +23,7 @@ export const fieldNames = {
   value: "attributeValue"
 };
 
-const TranslationsProductTypesPage: React.StatelessComponent<
+const TranslationsProductTypesPage: React.FC<
   TranslationsProductTypesPageProps
 > = ({
   activeField,

--- a/src/translations/components/TranslationsProductsPage/TranslationsProductsPage.tsx
+++ b/src/translations/components/TranslationsProductsPage/TranslationsProductsPage.tsx
@@ -25,9 +25,7 @@ export const fieldNames = {
   seoTitle: "seoTitle"
 };
 
-const TranslationsProductsPage: React.StatelessComponent<
-  TranslationsProductsPageProps
-> = ({
+const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
   activeField,
   disabled,
   languageCode,

--- a/src/translations/components/TranslationsSalesPage/TranslationsSalesPage.tsx
+++ b/src/translations/components/TranslationsSalesPage/TranslationsSalesPage.tsx
@@ -21,9 +21,7 @@ export const fieldNames = {
   name: "name"
 };
 
-const TranslationsSalesPage: React.StatelessComponent<
-  TranslationsSalesPageProps
-> = ({
+const TranslationsSalesPage: React.FC<TranslationsSalesPageProps> = ({
   activeField,
   disabled,
   languageCode,

--- a/src/translations/components/TranslationsVouchersPage/TranslationsVouchersPage.tsx
+++ b/src/translations/components/TranslationsVouchersPage/TranslationsVouchersPage.tsx
@@ -21,9 +21,7 @@ export const fieldNames = {
   name: "name"
 };
 
-const TranslationsVouchersPage: React.StatelessComponent<
-  TranslationsVouchersPageProps
-> = ({
+const TranslationsVouchersPage: React.FC<TranslationsVouchersPageProps> = ({
   activeField,
   disabled,
   languages,

--- a/src/webhooks/components/WebhookEvents/WebhookEvents.tsx
+++ b/src/webhooks/components/WebhookEvents/WebhookEvents.tsx
@@ -19,7 +19,7 @@ interface WebhookEventsProps {
   onChange: (event: ChangeEvent, cb?: () => void) => void;
 }
 
-const WebhookEvents: React.StatelessComponent<WebhookEventsProps> = ({
+const WebhookEvents: React.FC<WebhookEventsProps> = ({
   data,
   disabled,
   onChange

--- a/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
+++ b/src/webhooks/components/WebhookInfo/WebhookInfo.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-const WebhookInfo: React.StatelessComponent<WebhookInfoProps> = ({
+const WebhookInfo: React.FC<WebhookInfoProps> = ({
   apiErrors,
   data,
   disabled,

--- a/src/webhooks/components/WebhooksListPage/WebhooksListPage.tsx
+++ b/src/webhooks/components/WebhooksListPage/WebhooksListPage.tsx
@@ -21,7 +21,7 @@ export interface WebhooksListPageProps
   onRemove: (id: string) => void;
 }
 
-const WebhooksListPage: React.StatelessComponent<WebhooksListPageProps> = ({
+const WebhooksListPage: React.FC<WebhooksListPageProps> = ({
   currentTab,
   initialSearch,
   onAdd,

--- a/src/webhooks/index.tsx
+++ b/src/webhooks/index.tsx
@@ -15,17 +15,13 @@ import WebhookCreate from "./views/WebhooksCreate";
 import WebhooksDetails from "./views/WebhooksDetails";
 import WebhooksList from "./views/WebhooksList";
 
-const WebhookList: React.StatelessComponent<RouteComponentProps<any>> = ({
-  location
-}) => {
+const WebhookList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: WebhooksListUrlQueryParams = qs;
   return <WebhooksList params={params} />;
 };
 
-const WebhookDetails: React.StatelessComponent<RouteComponentProps<any>> = ({
-  match
-}) => {
+const WebhookDetails: React.FC<RouteComponentProps<any>> = ({ match }) => {
   const qs = parseQs(location.search.substr(1));
   const params: WebhooksListUrlQueryParams = qs;
 

--- a/src/webhooks/views/WebhooksCreate.tsx
+++ b/src/webhooks/views/WebhooksCreate.tsx
@@ -22,9 +22,7 @@ export interface WebhooksCreateProps {
   params: WebhooksListUrlQueryParams;
 }
 
-export const WebhooksCreate: React.StatelessComponent<
-  WebhooksCreateProps
-> = () => {
+export const WebhooksCreate: React.FC<WebhooksCreateProps> = () => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();


### PR DESCRIPTION
I want to merge this change because it removes some of legacy code and adds prettier to pre-commit pipeline.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
