### PR TITLE
Update customer's details page design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix tax settings updating - #243 by @dominik-zeglen
 - Add secret fields in plugin configuration - #246 by @dominik-zeglen
 - Fix subcategories pagination - #249 by @dominik-zeglen
+- Update customer's details page design - #248 by @dominik-zeglen
 
 ## 2.0.0
 

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-11-08T10:47:25.155Z\n"
+"POT-Creation-Date: 2019-11-13T13:13:30.128Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -125,6 +125,14 @@ msgstr ""
 #. Active Dates
 msgctxt "time during voucher is active, header"
 msgid "Active Dates"
+msgstr ""
+
+#: build/locale/src/customers/components/CustomerDetails/CustomerDetails.json
+#. [src.customers.components.CustomerDetails.3298169382] - section subheader
+#. defaultMessage is:
+#. Active member since {date}
+msgctxt "section subheader"
+msgid "Active member since {date}"
 msgstr ""
 
 #: build/locale/src/home/components/HomeActivityCard/HomeActivityCard.json
@@ -2103,6 +2111,14 @@ msgctxt "subheader"
 msgid "Contact Information"
 msgstr ""
 
+#: build/locale/src/customers/components/CustomerInfo/CustomerInfo.json
+#. [src.customers.components.CustomerInfo.778526801] - customer contact section, header
+#. defaultMessage is:
+#. Contact Informations
+msgctxt "customer contact section, header"
+msgid "Contact Informations"
+msgstr ""
+
 #: build/locale/src/pages/components/PageInfo/PageInfo.json
 #. [src.pages.components.PageInfo.1116746286] - page content
 #. defaultMessage is:
@@ -2793,14 +2809,6 @@ msgstr ""
 #. Customer password reset URL
 msgctxt "description"
 msgid "Customer password reset URL"
-msgstr ""
-
-#: build/locale/src/customers/components/CustomerDetails/CustomerDetails.json
-#. [src.customers.components.CustomerDetails.2200102325] - section subheader
-#. defaultMessage is:
-#. Customer since: {date}
-msgctxt "section subheader"
-msgid "Customer since: {date}"
 msgstr ""
 
 #: build/locale/src/intl.json
@@ -5941,6 +5949,14 @@ msgstr ""
 #. Permissions
 msgctxt "description"
 msgid "Permissions"
+msgstr ""
+
+#: build/locale/src/customers/components/CustomerInfo/CustomerInfo.json
+#. [src.customers.components.CustomerInfo.252313757] - customer informations, header
+#. defaultMessage is:
+#. Personal Informations
+msgctxt "customer informations, header"
+msgid "Personal Informations"
 msgstr ""
 
 #: build/locale/src/taxes/components/CountryTaxesPage/CountryTaxesPage.json

--- a/src/components/CardTitle/CardTitle.tsx
+++ b/src/components/CardTitle/CardTitle.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles(theme => ({
   }),
   title: {
     flex: 1,
+    fontWeight: 500,
     lineHeight: 1
   },
   toolbar: {

--- a/src/components/ControlledCheckbox.tsx
+++ b/src/components/ControlledCheckbox.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import Checkbox from "./Checkbox";
 
 interface ControlledCheckboxProps {
+  className?: string;
   name: string;
   label?: React.ReactNode;
   checked: boolean;
@@ -16,7 +17,8 @@ export const ControlledCheckbox: React.FC<ControlledCheckboxProps> = ({
   disabled,
   name,
   label,
-  onChange
+  onChange,
+  ...props
 }) => (
   <FormControlLabel
     disabled={disabled}
@@ -29,6 +31,7 @@ export const ControlledCheckbox: React.FC<ControlledCheckboxProps> = ({
       />
     }
     label={label}
+    {...props}
   />
 );
 ControlledCheckbox.displayName = "ControlledCheckbox";

--- a/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
+++ b/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
@@ -98,7 +98,9 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
     })
   );
 
-  const handleSubmit = (formData: CustomerCreatePageFormData) => {
+  const handleSubmit = (
+    formData: CustomerCreatePageFormData & AddressTypeInput
+  ) => {
     const areAddressInputFieldsModified = ([
       "city",
       "companyName",
@@ -115,7 +117,7 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
       .some(field => field !== "");
 
     if (areAddressInputFieldsModified) {
-      handleSubmitWithAddress(formData as any);
+      handleSubmitWithAddress(formData);
     } else {
       onSubmit({
         address: null,

--- a/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
+++ b/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
@@ -9,6 +9,7 @@ import Form from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
+import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import { sectionNames } from "@saleor/intl";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import { UserError } from "../../../types";
@@ -67,12 +68,16 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
     label: country.country,
     value: country.code
   }));
+  const {
+    errors: validationErrors,
+    submit: handleSubmit
+  } = useAddressValidation(onSubmit);
 
   return (
     <Form
       initial={initialForm}
-      onSubmit={onSubmit}
-      errors={errors}
+      onSubmit={handleSubmit}
+      errors={[...errors, ...validationErrors]}
       confirmLeave
     >
       {({ change, data, errors: formErrors, hasChanged, submit }) => {

--- a/src/customers/components/CustomerDetails/CustomerDetails.tsx
+++ b/src/customers/components/CustomerDetails/CustomerDetails.tsx
@@ -9,39 +9,34 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import CardTitle from "@saleor/components/CardTitle";
 import { ControlledCheckbox } from "@saleor/components/ControlledCheckbox";
-import { FormSpacer } from "@saleor/components/FormSpacer";
 import Skeleton from "@saleor/components/Skeleton";
-import { commonMessages } from "@saleor/intl";
+import { maybe } from "@saleor/misc";
+import { FormErrors } from "@saleor/types";
 import { CustomerDetails_user } from "../../types/CustomerDetails";
 
 const useStyles = makeStyles(theme => ({
   cardTitle: {
-    height: 64
+    height: 72
   },
-  root: {
-    display: "grid" as "grid",
-    gridColumnGap: theme.spacing(2),
-    gridRowGap: theme.spacing(3),
-    gridTemplateColumns: "1fr 1fr"
+  checkbox: {
+    marginBottom: theme.spacing()
+  },
+  content: {
+    paddingTop: theme.spacing()
+  },
+  subtitle: {
+    marginTop: theme.spacing()
   }
 }));
 
 export interface CustomerDetailsProps {
   customer: CustomerDetails_user;
   data: {
-    firstName: string;
-    lastName: string;
-    email: string;
     isActive: boolean;
     note: string;
   };
   disabled: boolean;
-  errors: {
-    firstName?: string;
-    lastName?: string;
-    email?: string;
-    note?: string;
-  };
+  errors: FormErrors<"isActive" | "note">;
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
@@ -57,11 +52,15 @@ const CustomerDetails: React.FC<CustomerDetailsProps> = props => {
         className={classes.cardTitle}
         title={
           <>
-            <FormattedMessage {...commonMessages.generalInformations} />
+            {maybe<React.ReactNode>(() => customer.email, <Skeleton />)}
             {customer && customer.dateJoined ? (
-              <Typography variant="caption" component="div">
+              <Typography
+                className={classes.subtitle}
+                variant="caption"
+                component="div"
+              >
                 <FormattedMessage
-                  defaultMessage="Customer since: {date}"
+                  defaultMessage="Active member since {date}"
                   description="section subheader"
                   values={{
                     date: moment(customer.dateJoined).format("MMM YYYY")
@@ -74,9 +73,10 @@ const CustomerDetails: React.FC<CustomerDetailsProps> = props => {
           </>
         }
       />
-      <CardContent>
+      <CardContent className={classes.content}>
         <ControlledCheckbox
           checked={data.isActive}
+          className={classes.checkbox}
           disabled={disabled}
           label={intl.formatMessage({
             defaultMessage: "User account active",
@@ -85,44 +85,6 @@ const CustomerDetails: React.FC<CustomerDetailsProps> = props => {
           name="isActive"
           onChange={onChange}
         />
-        <FormSpacer />
-        <div className={classes.root}>
-          <TextField
-            disabled={disabled}
-            error={!!errors.firstName}
-            fullWidth
-            helperText={errors.firstName}
-            name="firstName"
-            type="text"
-            label={intl.formatMessage(commonMessages.firstName)}
-            value={data.firstName}
-            onChange={onChange}
-          />
-          <TextField
-            disabled={disabled}
-            error={!!errors.lastName}
-            fullWidth
-            helperText={errors.lastName}
-            name="lastName"
-            type="text"
-            label={intl.formatMessage(commonMessages.lastName)}
-            value={data.lastName}
-            onChange={onChange}
-          />
-        </div>
-        <FormSpacer />
-        <TextField
-          disabled={disabled}
-          error={!!errors.email}
-          fullWidth
-          helperText={errors.email}
-          name="email"
-          type="email"
-          label={intl.formatMessage(commonMessages.email)}
-          value={data.email}
-          onChange={onChange}
-        />
-        <FormSpacer />
         <TextField
           disabled={disabled}
           error={!!errors.note}

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -84,7 +84,6 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
               />
               <CardSpacer />
               <CustomerInfo
-                customer={customer}
                 data={data}
                 disabled={disabled}
                 errors={formErrors}

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -13,10 +13,11 @@ import { sectionNames } from "@saleor/intl";
 import { getUserName, maybe } from "../../../misc";
 import { UserError } from "../../../types";
 import { CustomerDetails_user } from "../../types/CustomerDetails";
-import CustomerAddresses from "../CustomerAddresses/CustomerAddresses";
-import CustomerDetails from "../CustomerDetails/CustomerDetails";
-import CustomerOrders from "../CustomerOrders/CustomerOrders";
-import CustomerStats from "../CustomerStats/CustomerStats";
+import CustomerAddresses from "../CustomerAddresses";
+import CustomerDetails from "../CustomerDetails";
+import CustomerInfo from "../CustomerInfo";
+import CustomerOrders from "../CustomerOrders";
+import CustomerStats from "../CustomerStats";
 
 export interface CustomerDetailsPageFormData {
   firstName: string;
@@ -75,6 +76,14 @@ const CustomerDetailsPage: React.FC<CustomerDetailsPageProps> = ({
           <Grid>
             <div>
               <CustomerDetails
+                customer={customer}
+                data={data}
+                disabled={disabled}
+                errors={formErrors}
+                onChange={change}
+              />
+              <CardSpacer />
+              <CustomerInfo
                 customer={customer}
                 data={data}
                 disabled={disabled}

--- a/src/customers/components/CustomerInfo/CustomerInfo.tsx
+++ b/src/customers/components/CustomerInfo/CustomerInfo.tsx
@@ -1,0 +1,128 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import { makeStyles } from "@material-ui/core/styles";
+import TextField from "@material-ui/core/TextField";
+import Typography from "@material-ui/core/Typography";
+import moment from "moment-timezone";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import CardTitle from "@saleor/components/CardTitle";
+import Grid from "@saleor/components/Grid";
+import Hr from "@saleor/components/Hr";
+import Skeleton from "@saleor/components/Skeleton";
+import { commonMessages } from "@saleor/intl";
+import { CustomerDetails_user } from "../../types/CustomerDetails";
+
+const useStyles = makeStyles(theme => ({
+  cardTitle: {
+    height: 64
+  },
+  content: {
+    paddingTop: theme.spacing(2)
+  },
+  hr: {
+    margin: theme.spacing(3, 0)
+  },
+  sectionHeader: {
+    marginBottom: theme.spacing()
+  }
+}));
+
+export interface CustomerDetailsProps {
+  customer: CustomerDetails_user;
+  data: {
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+  disabled: boolean;
+  errors: {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+  };
+  onChange: (event: React.ChangeEvent<any>) => void;
+}
+
+const CustomerDetails: React.FC<CustomerDetailsProps> = props => {
+  const { customer, data, disabled, errors, onChange } = props;
+  const classes = useStyles(props);
+
+  const intl = useIntl();
+
+  return (
+    <Card>
+      <CardTitle
+        className={classes.cardTitle}
+        title={
+          <>
+            <FormattedMessage {...commonMessages.generalInformations} />
+            {customer && customer.dateJoined ? (
+              <Typography variant="caption" component="div">
+                <FormattedMessage
+                  defaultMessage="Customer since: {date}"
+                  description="section subheader"
+                  values={{
+                    date: moment(customer.dateJoined).format("MMM YYYY")
+                  }}
+                />
+              </Typography>
+            ) : (
+              <Skeleton style={{ width: "10rem" }} />
+            )}
+          </>
+        }
+      />
+      <CardContent className={classes.content}>
+        <Typography className={classes.sectionHeader}>
+          <FormattedMessage {...commonMessages.generalInformations} />
+        </Typography>
+        <Grid variant="uniform">
+          <TextField
+            disabled={disabled}
+            error={!!errors.firstName}
+            fullWidth
+            helperText={errors.firstName}
+            name="firstName"
+            type="text"
+            label={intl.formatMessage(commonMessages.firstName)}
+            value={data.firstName}
+            onChange={onChange}
+          />
+          <TextField
+            disabled={disabled}
+            error={!!errors.lastName}
+            fullWidth
+            helperText={errors.lastName}
+            name="lastName"
+            type="text"
+            label={intl.formatMessage(commonMessages.lastName)}
+            value={data.lastName}
+            onChange={onChange}
+          />
+        </Grid>
+        <Hr className={classes.hr} />
+        <Typography className={classes.sectionHeader}>
+          <FormattedMessage
+            defaultMessage="Contact Informations"
+            description="customer contact section, header"
+          />
+        </Typography>
+        <TextField
+          disabled={disabled}
+          error={!!errors.email}
+          fullWidth
+          helperText={errors.email}
+          name="email"
+          type="email"
+          label={intl.formatMessage(commonMessages.email)}
+          value={data.email}
+          onChange={onChange}
+        />
+      </CardContent>
+    </Card>
+  );
+};
+CustomerDetails.displayName = "CustomerDetails";
+export default CustomerDetails;

--- a/src/customers/components/CustomerInfo/CustomerInfo.tsx
+++ b/src/customers/components/CustomerInfo/CustomerInfo.tsx
@@ -3,21 +3,15 @@ import CardContent from "@material-ui/core/CardContent";
 import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
-import moment from "moment-timezone";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import CardTitle from "@saleor/components/CardTitle";
 import Grid from "@saleor/components/Grid";
 import Hr from "@saleor/components/Hr";
-import Skeleton from "@saleor/components/Skeleton";
 import { commonMessages } from "@saleor/intl";
-import { CustomerDetails_user } from "../../types/CustomerDetails";
 
 const useStyles = makeStyles(theme => ({
-  cardTitle: {
-    height: 64
-  },
   content: {
     paddingTop: theme.spacing(2)
   },
@@ -29,8 +23,7 @@ const useStyles = makeStyles(theme => ({
   }
 }));
 
-export interface CustomerDetailsProps {
-  customer: CustomerDetails_user;
+export interface CustomerInfoProps {
   data: {
     firstName: string;
     lastName: string;
@@ -45,8 +38,8 @@ export interface CustomerDetailsProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const CustomerDetails: React.FC<CustomerDetailsProps> = props => {
-  const { customer, data, disabled, errors, onChange } = props;
+const CustomerInfo: React.FC<CustomerInfoProps> = props => {
+  const { data, disabled, errors, onChange } = props;
   const classes = useStyles(props);
 
   const intl = useIntl();
@@ -54,24 +47,11 @@ const CustomerDetails: React.FC<CustomerDetailsProps> = props => {
   return (
     <Card>
       <CardTitle
-        className={classes.cardTitle}
         title={
-          <>
-            <FormattedMessage {...commonMessages.generalInformations} />
-            {customer && customer.dateJoined ? (
-              <Typography variant="caption" component="div">
-                <FormattedMessage
-                  defaultMessage="Customer since: {date}"
-                  description="section subheader"
-                  values={{
-                    date: moment(customer.dateJoined).format("MMM YYYY")
-                  }}
-                />
-              </Typography>
-            ) : (
-              <Skeleton style={{ width: "10rem" }} />
-            )}
-          </>
+          <FormattedMessage
+            defaultMessage="Personal Informations"
+            description="customer informations, header"
+          />
         }
       />
       <CardContent className={classes.content}>
@@ -124,5 +104,5 @@ const CustomerDetails: React.FC<CustomerDetailsProps> = props => {
     </Card>
   );
 };
-CustomerDetails.displayName = "CustomerDetails";
-export default CustomerDetails;
+CustomerInfo.displayName = "CustomerInfo";
+export default CustomerInfo;

--- a/src/customers/components/CustomerInfo/index.ts
+++ b/src/customers/components/CustomerInfo/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./CustomerInfo";
+export * from "./CustomerInfo";

--- a/src/customers/views/CustomerCreate.tsx
+++ b/src/customers/views/CustomerCreate.tsx
@@ -4,11 +4,10 @@ import { useIntl } from "react-intl";
 import { WindowTitle } from "@saleor/components/WindowTitle";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import { maybe, transformFormToAddress } from "../../misc";
+import { maybe } from "../../misc";
 import CustomerCreatePage from "../components/CustomerCreatePage";
 import { TypedCreateCustomerMutation } from "../mutations";
 import { TypedCustomerCreateDataQuery } from "../queries";
-import { AddressTypeInput } from "../types";
 import { CreateCustomer } from "../types/CreateCustomer";
 import { customerListUrl, customerUrl } from "../urls";
 

--- a/src/customers/views/CustomerCreate.tsx
+++ b/src/customers/views/CustomerCreate.tsx
@@ -58,43 +58,11 @@ export const CustomerCreate: React.FC<{}> = () => {
                 }
                 onBack={() => navigate(customerListUrl())}
                 onSubmit={formData => {
-                  const areAddressInputFieldsModified = ([
-                    "city",
-                    "companyName",
-                    "country",
-                    "countryArea",
-                    "firstName",
-                    "lastName",
-                    "phone",
-                    "postalCode",
-                    "streetAddress1",
-                    "streetAddress2"
-                  ] as Array<keyof AddressTypeInput>)
-                    .map(key => formData[key])
-                    .some(field => field !== "");
-
-                  const address = {
-                    city: formData.city,
-                    cityArea: formData.cityArea,
-                    companyName: formData.companyName,
-                    country: formData.country,
-                    countryArea: formData.countryArea,
-                    firstName: formData.firstName,
-                    lastName: formData.lastName,
-                    phone: formData.phone,
-                    postalCode: formData.postalCode,
-                    streetAddress1: formData.streetAddress1,
-                    streetAddress2: formData.streetAddress2
-                  };
                   createCustomer({
                     variables: {
                       input: {
-                        defaultBillingAddress: areAddressInputFieldsModified
-                          ? transformFormToAddress(address)
-                          : null,
-                        defaultShippingAddress: areAddressInputFieldsModified
-                          ? transformFormToAddress(address)
-                          : null,
+                        defaultBillingAddress: formData.address,
+                        defaultShippingAddress: formData.address,
                         email: formData.email,
                         firstName: formData.customerFirstName,
                         lastName: formData.customerLastName,

--- a/src/hooks/useAddressValidation.ts
+++ b/src/hooks/useAddressValidation.ts
@@ -8,14 +8,14 @@ import { UserError } from "@saleor/types";
 import { AddressInput } from "@saleor/types/globalTypes";
 import { add, remove } from "@saleor/utils/lists";
 
-interface UseAddressValidation {
+interface UseAddressValidation<T> {
   errors: UserError[];
-  submit: (data: AddressTypeInput) => void;
+  submit: (data: T & AddressTypeInput) => void;
 }
 
-function useAddressValidation(
-  onSubmit: (address: AddressInput) => void
-): UseAddressValidation {
+function useAddressValidation<T>(
+  onSubmit: (address: T & AddressInput) => void
+): UseAddressValidation<T> {
   const intl = useIntl();
   const [validationErrors, setValidationErrors] = useState<UserError[]>([]);
 
@@ -26,7 +26,7 @@ function useAddressValidation(
 
   return {
     errors: validationErrors,
-    submit: (data: AddressTypeInput) => {
+    submit: (data: T & AddressTypeInput) => {
       try {
         setValidationErrors(
           remove(

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -339,9 +339,9 @@ export function capitalize(s: string) {
   return s.charAt(0).toLocaleUpperCase() + s.slice(1);
 }
 
-export function transformFormToAddress(
-  address: AddressTypeInput
-): AddressInput {
+export function transformFormToAddress<T>(
+  address: T & AddressTypeInput
+): T & AddressInput {
   return {
     ...address,
     country: findInEnum(address.country, CountryCode)

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -342,6 +342,9 @@ export default (colors: IThemeColors): Theme =>
             }
           }
         },
+        message: {
+          fontSize: 16
+        },
         root: {
           backgroundColor: colors.background.paper,
           boxShadow:

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -397,12 +397,12 @@ export default (colors: IThemeColors): Theme =>
       },
       MuiTableCell: {
         body: {
-          fontSize: ".875rem",
+          fontSize: "1rem",
           paddingBottom: 8,
           paddingTop: 8
         },
         head: {
-          fontSize: ".875rem"
+          fontSize: "1rem"
         },
         paddingCheckbox: {
           "&:first-child": {


### PR DESCRIPTION
I want to merge this change because it updates design of customer's details page.
Also increases font size in tables, which improves readability and keeps project in-date with the designs.

Resolves #84 

### Screenshots
Before:
<img width="1680" alt="Screenshot 2019-11-12 at 13 42 26" src="https://user-images.githubusercontent.com/6833443/68672621-487f9780-0552-11ea-9a08-3122a7577d64.png">

After:
<img width="1680" alt="Screenshot 2019-11-12 at 13 41 13" src="https://user-images.githubusercontent.com/6833443/68672576-31d94080-0552-11ea-9a8a-43e355ea8e81.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
