### PR TITLE
Fix disappearing products description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix subcategories pagination - #249 by @dominik-zeglen
 - Update customer's details page design - #248 by @dominik-zeglen
 - Use Apollo Hooks - #254 by @dominik-zeglen
+- Fix disappearing products description - #259 by @dominik-zeglen
 
 ## 2.0.0
 

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -112,7 +112,11 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
     set: setAttributeData
   } = useFormset<ProductAttributeInputData>([]);
 
-  const initialDescription = convertToRaw(ContentState.createFromText(""));
+  // Ensures that it will not change after component rerenders, because it
+  // generates different block keys and it causes editor to lose its content.
+  const initialDescription = React.useRef(
+    convertToRaw(ContentState.createFromText(""))
+  );
   const initialData: FormData = {
     basePrice: 0,
     category: "",
@@ -219,7 +223,7 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
                   data={data}
                   disabled={disabled}
                   errors={errors}
-                  initialDescription={initialDescription}
+                  initialDescription={initialDescription.current}
                   onChange={change}
                 />
                 <CardSpacer />


### PR DESCRIPTION
I want to merge this change because it fixes bug causing description field to be cleared after selecting anything from dropdown input in product create view.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
