### PR TITLE
Fix error cleanup when switching product variants

### DIFF
--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useIntl } from "react-intl";
 
 import placeholderImg from "@assets/images/placeholder255x255.png";
@@ -43,6 +43,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
       require={["productVariant"]}
     >
       {({ data, loading }) => {
+        const [errors, setErrors] = useState([]);
         const variant = data ? data.productVariant : undefined;
         const handleBack = () => navigate(productUrl(productId));
         const handleDelete = () => {
@@ -54,8 +55,10 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
           navigate(productUrl(productId));
         };
         const handleUpdate = (data: VariantUpdate) => {
-          if (!maybe(() => data.productVariantUpdate.productErrors.length)) {
+          if (!data.productVariantUpdate.productErrors.length) {
             notify({ text: intl.formatMessage(commonMessages.savedChanges) });
+          } else {
+            setErrors(data.productVariantUpdate.productErrors);
           }
         };
 
@@ -107,12 +110,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
                 <>
                   <WindowTitle title={maybe(() => data.productVariant.name)} />
                   <ProductVariantPage
-                    errors={maybe(
-                      () =>
-                        updateVariant.opts.data.productVariantUpdate
-                          .productErrors,
-                      []
-                    )}
+                    errors={errors}
                     saveButtonBarState={formTransitionState}
                     loading={disableFormSave}
                     placeholderImage={placeholderImg}
@@ -146,6 +144,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
                     }}
                     onVariantClick={variantId => {
                       navigate(productVariantEditUrl(productId, variantId));
+                      setErrors([]);
                     }}
                   />
                   <ProductVariantDeleteDialog

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 
 import placeholderImg from "@assets/images/placeholder255x255.png";
@@ -35,6 +35,10 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
+  const [errors, setErrors] = useState([]);
+  useEffect(() => {
+    setErrors([]);
+  }, [variantId]);
 
   return (
     <TypedProductVariantQuery
@@ -43,7 +47,6 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
       require={["productVariant"]}
     >
       {({ data, loading }) => {
-        const [errors, setErrors] = useState([]);
         const variant = data ? data.productVariant : undefined;
         const handleBack = () => navigate(productUrl(productId));
         const handleDelete = () => {
@@ -144,7 +147,6 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
                     }}
                     onVariantClick={variantId => {
                       navigate(productVariantEditUrl(productId, variantId));
-                      setErrors([]);
                     }}
                   />
                   <ProductVariantDeleteDialog


### PR DESCRIPTION
I want to merge this change because it fixes #239 

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
