### PR TITLE
Fix case when country is not selected by user in site settings company address

### DIFF
--- a/src/customers/types.ts
+++ b/src/customers/types.ts
@@ -4,8 +4,8 @@ export interface AddressTypeInput {
   companyName?: string;
   country: string;
   countryArea?: string;
-  firstName: string;
-  lastName: string;
+  firstName?: string;
+  lastName?: string;
   phone: string;
   postalCode: string;
   streetAddress1: string;

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -140,7 +140,9 @@ export const SiteSettings: React.FC<SiteSettingsProps> = ({ params }) => {
                         ? {
                             city: data.city,
                             companyName: data.companyName,
-                            country: findInEnum(data.country, CountryCode),
+                            country: maybe(() =>
+                              findInEnum(data.country, CountryCode)
+                            ),
                             countryArea: data.countryArea,
                             phone: data.phone,
                             postalCode: data.postalCode,

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -13,7 +13,7 @@ import SiteSettingsKeyDialog, {
   SiteSettingsKeyDialogForm
 } from "../components/SiteSettingsKeyDialog";
 import SiteSettingsPage, {
-  SiteSettingsPageAddressFormData,
+  areAddressInputFieldsModified,
   SiteSettingsPageFormData
 } from "../components/SiteSettingsPage";
 import {
@@ -76,6 +76,7 @@ export const SiteSettings: React.FC<SiteSettingsProps> = ({ params }) => {
       });
     }
   };
+
   return (
     <TypedSiteSettingsQuery displayLoader>
       {siteSettings => (
@@ -124,32 +125,20 @@ export const SiteSettings: React.FC<SiteSettingsProps> = ({ params }) => {
                     const handleUpdateShopSettings = (
                       data: SiteSettingsPageFormData
                     ) => {
-                      const areAddressInputFieldsModified = ([
-                        "city",
-                        "companyName",
-                        "country",
-                        "countryArea",
-                        "phone",
-                        "postalCode",
-                        "streetAddress1",
-                        "streetAddress2"
-                      ] as Array<keyof SiteSettingsPageAddressFormData>)
-                        .map(key => data[key])
-                        .some(field => field !== "");
-                      const addressInput = areAddressInputFieldsModified
+                      const addressInput = areAddressInputFieldsModified(data)
                         ? {
                             city: data.city,
                             companyName: data.companyName,
-                            country: maybe(() =>
-                              findInEnum(data.country, CountryCode)
-                            ),
+                            country: findInEnum(data.country, CountryCode),
                             countryArea: data.countryArea,
                             phone: data.phone,
                             postalCode: data.postalCode,
                             streetAddress1: data.streetAddress1,
                             streetAddress2: data.streetAddress2
                           }
-                        : null;
+                        : {
+                            companyName: data.companyName
+                          };
                       updateShopSettings({
                         variables: {
                           addressInput,


### PR DESCRIPTION
I want to merge this change because it fixes #282 
Should be merged along with backend fix available at:
https://github.com/mirumee/saleor/pull/5031

### Screenshots

![image](https://user-images.githubusercontent.com/12252472/70060082-2bcf0080-15e2-11ea-8402-f63cd94291e7.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
