### PR TITLE
Add ability to reset own password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix dropdown clickable areas - #281 by @dominik-zeglen
 - Use eslint - #285 by @dominik-zeglen
 - Enforce using "name" property in style hooks - #288 by @dominik-zeglen
+- Add ability to reset own password - #289 by @dominik-zeglen
 
 ## 2.0.0
 

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-12-03T16:48:22.955Z\n"
+"POT-Creation-Date: 2019-12-04T10:13:32.661Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -1239,10 +1239,6 @@ msgstr ""
 #. [src.components.AssignCollectionDialog.3992923611] - dialog header
 #. defaultMessage is:
 #. Assign Collection
-#: build/locale/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.json
-#. [src.staff.components.StaffPasswordResetDialog.3992923611] - dialog header
-#. defaultMessage is:
-#. Assign Collection
 msgctxt "dialog header"
 msgid "Assign Collection"
 msgstr ""
@@ -1857,6 +1853,14 @@ msgstr ""
 #. Category name
 msgctxt "description"
 msgid "Category name"
+msgstr ""
+
+#: build/locale/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.json
+#. [src.staff.components.StaffPasswordResetDialog.2521568990] - dialog header
+#. defaultMessage is:
+#. Change Password
+msgctxt "dialog header"
+msgid "Change Password"
 msgstr ""
 
 #: build/locale/src/staff/components/StaffProperties/StaffProperties.json

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-12-04T10:13:32.661Z\n"
+"POT-Creation-Date: 2019-12-04T14:17:34.264Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -1872,10 +1872,10 @@ msgid "Change photo"
 msgstr ""
 
 #: build/locale/src/staff/components/StaffPassword/StaffPassword.json
-#. [src.staff.components.StaffPassword.1434811103] -  utton
+#. [src.staff.components.StaffPassword.1434811103] - button
 #. defaultMessage is:
 #. Change your password
-msgctxt " utton"
+msgctxt "button"
 msgid "Change your password"
 msgstr ""
 

--- a/locale/messages.pot
+++ b/locale/messages.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2019-11-26T14:34:48.426Z\n"
+"POT-Creation-Date: 2019-12-03T16:48:22.955Z\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -1239,6 +1239,10 @@ msgstr ""
 #. [src.components.AssignCollectionDialog.3992923611] - dialog header
 #. defaultMessage is:
 #. Assign Collection
+#: build/locale/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.json
+#. [src.staff.components.StaffPasswordResetDialog.3992923611] - dialog header
+#. defaultMessage is:
+#. Assign Collection
 msgctxt "dialog header"
 msgid "Assign Collection"
 msgstr ""
@@ -1861,6 +1865,14 @@ msgstr ""
 #. Change photo
 msgctxt "button"
 msgid "Change photo"
+msgstr ""
+
+#: build/locale/src/staff/components/StaffPassword/StaffPassword.json
+#. [src.staff.components.StaffPassword.1434811103] -  utton
+#. defaultMessage is:
+#. Change your password
+msgctxt " utton"
+msgid "Change your password"
 msgstr ""
 
 #: build/locale/src/products/components/ProductPricing/ProductPricing.json
@@ -4911,6 +4923,14 @@ msgctxt "description"
 msgid "New Password"
 msgstr ""
 
+#: build/locale/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.json
+#. [src.staff.components.StaffPasswordResetDialog.1254879564] - input label
+#. defaultMessage is:
+#. New Password
+msgctxt "input label"
+msgid "New Password"
+msgstr ""
+
 #: build/locale/src/products/views/ProductCreate.json
 #. [src.products.views.1591632382] - page header
 #. defaultMessage is:
@@ -4925,6 +4945,14 @@ msgstr ""
 #. New Variant
 msgctxt "variant name"
 msgid "New Variant"
+msgstr ""
+
+#: build/locale/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.json
+#. [src.staff.components.StaffPasswordResetDialog.1651415182]
+#. defaultMessage is:
+#. New password must be at least 8 characters long
+msgctxt "description"
+msgid "New password must be at least 8 characters long"
 msgstr ""
 
 #: build/locale/src/taxes/components/CountryTaxesPage/CountryTaxesPage.json
@@ -5947,6 +5975,14 @@ msgctxt "description"
 msgid "Password"
 msgstr ""
 
+#: build/locale/src/staff/components/StaffPassword/StaffPassword.json
+#. [src.staff.components.StaffPassword.2237029987] - header
+#. defaultMessage is:
+#. Password
+msgctxt "header"
+msgid "Password"
+msgstr ""
+
 #: build/locale/src/auth/components/NewPasswordPage/NewPasswordPage.json
 #. [src.auth.components.NewPasswordPage.4253911811]
 #. defaultMessage is:
@@ -6213,6 +6249,14 @@ msgstr ""
 #. Previous
 msgctxt "previous step, button"
 msgid "Previous"
+msgstr ""
+
+#: build/locale/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.json
+#. [src.staff.components.StaffPasswordResetDialog.53359254] - input label
+#. defaultMessage is:
+#. Previous Password
+msgctxt "input label"
+msgid "Previous Password"
 msgstr ""
 
 #: build/locale/src/categories/components/CategoryProductList/CategoryProductList.json
@@ -9665,6 +9709,14 @@ msgstr ""
 #. Yes
 msgctxt "description"
 msgid "Yes"
+msgstr ""
+
+#: build/locale/src/staff/components/StaffPassword/StaffPassword.json
+#. [src.staff.components.StaffPassword.1274006906]
+#. defaultMessage is:
+#. You should change your password every month to avoid security issues.
+msgctxt "description"
+msgid "You should change your password every month to avoid security issues."
 msgstr ""
 
 #: build/locale/src/products/components/ProductVariantCreateDialog/ProductVariantCreateSummary.json

--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -19,6 +19,7 @@ import { PermissionEnum } from "../../../types/globalTypes";
 import { StaffMemberDetails_user } from "../../types/StaffMemberDetails";
 import StaffPreferences from "../StaffPreferences";
 import StaffProperties from "../StaffProperties/StaffProperties";
+import StaffPassword from "../StaffPassword/StaffPassword";
 
 interface FormData {
   hasFullAccess: boolean;
@@ -39,6 +40,7 @@ export interface StaffDetailsPageProps {
   saveButtonBarState: ConfirmButtonTransitionState;
   staffMember: StaffMemberDetails_user;
   onBack: () => void;
+  onChangePassword: () => void;
   onDelete: () => void;
   onImageDelete: () => void;
   onSubmit: (data: FormData) => void;
@@ -55,6 +57,7 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
   saveButtonBarState,
   staffMember,
   onBack,
+  onChangePassword,
   onDelete,
   onImageDelete,
   onImageUpload,
@@ -100,6 +103,12 @@ const StaffDetailsPage: React.FC<StaffDetailsPageProps> = ({
                 onImageUpload={onImageUpload}
                 onImageDelete={onImageDelete}
               />
+              {canEditPreferences && (
+                <>
+                  <CardSpacer />
+                  <StaffPassword onChangePassword={onChangePassword} />
+                </>
+              )}
             </div>
             <div>
               {canEditPreferences && (

--- a/src/staff/components/StaffPassword/StaffPassword.tsx
+++ b/src/staff/components/StaffPassword/StaffPassword.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import CardTitle from "@saleor/components/CardTitle";
+
+interface StaffPasswordProps {
+  onChangePassword: () => void;
+}
+
+const StaffPassword: React.FC<StaffPasswordProps> = ({ onChangePassword }) => {
+  const intl = useIntl();
+
+  return (
+    <Card>
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Password",
+          description: "header"
+        })}
+        toolbar={
+          <Button color="primary" onClick={onChangePassword}>
+            <FormattedMessage
+              defaultMessage="Change your password"
+              description=" utton"
+            />
+          </Button>
+        }
+      />
+      <CardContent>
+        <Typography>
+          <FormattedMessage defaultMessage="You should change your password every month to avoid security issues." />
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+};
+
+StaffPassword.displayName = "StaffPassword";
+export default StaffPassword;

--- a/src/staff/components/StaffPassword/StaffPassword.tsx
+++ b/src/staff/components/StaffPassword/StaffPassword.tsx
@@ -25,7 +25,7 @@ const StaffPassword: React.FC<StaffPasswordProps> = ({ onChangePassword }) => {
           <Button color="primary" onClick={onChangePassword}>
             <FormattedMessage
               defaultMessage="Change your password"
-              description=" utton"
+              description="button"
             />
           </Button>
         }

--- a/src/staff/components/StaffPassword/index.ts
+++ b/src/staff/components/StaffPassword/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./StaffPassword";
+export * from "./StaffPassword";

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import TextField from "@material-ui/core/TextField";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { DialogProps, UserError } from "@saleor/types";
+import { buttonMessages } from "@saleor/intl";
+import Form from "@saleor/components/Form";
+import ConfirmButton, {
+  ConfirmButtonTransitionState
+} from "@saleor/components/ConfirmButton";
+import FormSpacer from "@saleor/components/FormSpacer";
+
+interface StaffPasswordResetDialogFormData {
+  password: string;
+  previousPassword: string;
+}
+export interface StaffPasswordResetDialogProps extends DialogProps {
+  confirmButtonState: ConfirmButtonTransitionState;
+  errors: UserError[];
+  onSubmit: (password: string) => void;
+}
+
+const initialForm: StaffPasswordResetDialogFormData = {
+  password: "",
+  previousPassword: ""
+};
+
+const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
+  confirmButtonState,
+  errors: apiErrors,
+  open,
+  onClose,
+  onSubmit
+}) => {
+  const intl = useIntl();
+
+  return (
+    <Dialog onClose={onClose} open={open} fullWidth maxWidth="sm">
+      <DialogTitle>
+        <FormattedMessage
+          defaultMessage="Assign Collection"
+          description="dialog header"
+        />
+      </DialogTitle>
+      <Form
+        errors={apiErrors}
+        initial={initialForm}
+        onSubmit={data => onSubmit(data.password)}
+      >
+        {({ change, data, errors, submit }) => (
+          <>
+            <DialogContent>
+              <TextField
+                error={!!errors.previousPassword}
+                fullWidth
+                helperText={errors.previousPassword}
+                label={intl.formatMessage({
+                  defaultMessage: "Previous Password",
+                  description: "input label"
+                })}
+                name="previousPassword"
+                type="password"
+                onChange={change}
+              />
+              <FormSpacer />
+              <TextField
+                error={!!errors.password}
+                fullWidth
+                helperText={
+                  errors.password ||
+                  intl.formatMessage({
+                    defaultMessage:
+                      "New password must be at least 5 characters long"
+                  })
+                }
+                label={intl.formatMessage({
+                  defaultMessage: "New Password",
+                  description: "input label"
+                })}
+                name="password"
+                type="password"
+                onChange={change}
+              />
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={onClose}>
+                <FormattedMessage {...buttonMessages.back} />
+              </Button>
+              <ConfirmButton
+                disabled={data.password.length <= 4}
+                transitionState={confirmButtonState}
+                color="primary"
+                variant="contained"
+                type="submit"
+                onClick={submit}
+              >
+                <FormattedMessage {...buttonMessages.save} />
+              </ConfirmButton>
+            </DialogActions>
+          </>
+        )}
+      </Form>
+    </Dialog>
+  );
+};
+
+StaffPasswordResetDialog.displayName = "StaffPasswordResetDialog";
+export default StaffPasswordResetDialog;

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
@@ -45,7 +45,7 @@ const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
     <Dialog onClose={onClose} open={open} fullWidth maxWidth="sm">
       <DialogTitle>
         <FormattedMessage
-          defaultMessage="Assign Collection"
+          defaultMessage="Change Password"
           description="dialog header"
         />
       </DialogTitle>

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
@@ -73,7 +73,7 @@ const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
                   errors.newPassword ||
                   intl.formatMessage({
                     defaultMessage:
-                      "New newPassword must be at least 8 characters long"
+                      "New password must be at least 8 characters long"
                   })
                 }
                 label={intl.formatMessage({

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
@@ -14,6 +14,7 @@ import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
 import FormSpacer from "@saleor/components/FormSpacer";
+import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 
 interface StaffPasswordResetDialogFormData {
   password: string;
@@ -38,6 +39,7 @@ const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
   onSubmit
 }) => {
   const intl = useIntl();
+  const dialogErrors = useModalDialogErrors(apiErrors, open);
 
   return (
     <Dialog onClose={onClose} open={open} fullWidth maxWidth="sm">
@@ -47,7 +49,7 @@ const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
           description="dialog header"
         />
       </DialogTitle>
-      <Form errors={apiErrors} initial={initialForm} onSubmit={onSubmit}>
+      <Form errors={dialogErrors} initial={initialForm} onSubmit={onSubmit}>
         {({ change, data, errors, submit }) => (
           <>
             <DialogContent>

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
@@ -90,7 +90,7 @@ const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
                 <FormattedMessage {...buttonMessages.back} />
               </Button>
               <ConfirmButton
-                disabled={!(data.newPassword.length >= 8)}
+                disabled={data.newPassword.length < 8}
                 transitionState={confirmButtonState}
                 color="primary"
                 variant="contained"

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
@@ -17,8 +17,8 @@ import FormSpacer from "@saleor/components/FormSpacer";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 
 interface StaffPasswordResetDialogFormData {
-  password: string;
-  previousPassword: string;
+  newPassword: string;
+  oldPassword: string;
 }
 export interface StaffPasswordResetDialogProps extends DialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
@@ -27,8 +27,8 @@ export interface StaffPasswordResetDialogProps extends DialogProps {
 }
 
 const initialForm: StaffPasswordResetDialogFormData = {
-  password: "",
-  previousPassword: ""
+  newPassword: "",
+  oldPassword: ""
 };
 
 const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
@@ -54,33 +54,33 @@ const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
           <>
             <DialogContent>
               <TextField
-                error={!!errors.previousPassword}
+                error={!!errors.oldPassword}
                 fullWidth
-                helperText={errors.previousPassword}
+                helperText={errors.oldPassword}
                 label={intl.formatMessage({
                   defaultMessage: "Previous Password",
                   description: "input label"
                 })}
-                name="previousPassword"
+                name="oldPassword"
                 type="password"
                 onChange={change}
               />
               <FormSpacer />
               <TextField
-                error={!!errors.password}
+                error={!!errors.newPassword}
                 fullWidth
                 helperText={
-                  errors.password ||
+                  errors.newPassword ||
                   intl.formatMessage({
                     defaultMessage:
-                      "New password must be at least 5 characters long"
+                      "New newPassword must be at least 8 characters long"
                   })
                 }
                 label={intl.formatMessage({
                   defaultMessage: "New Password",
                   description: "input label"
                 })}
-                name="password"
+                name="newPassword"
                 type="password"
                 onChange={change}
               />
@@ -90,7 +90,7 @@ const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
                 <FormattedMessage {...buttonMessages.back} />
               </Button>
               <ConfirmButton
-                disabled={data.password.length <= 4}
+                disabled={!(data.newPassword.length >= 8)}
                 transitionState={confirmButtonState}
                 color="primary"
                 variant="contained"

--- a/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
+++ b/src/staff/components/StaffPasswordResetDialog/StaffPasswordResetDialog.tsx
@@ -22,7 +22,7 @@ interface StaffPasswordResetDialogFormData {
 export interface StaffPasswordResetDialogProps extends DialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
   errors: UserError[];
-  onSubmit: (password: string) => void;
+  onSubmit: (data: StaffPasswordResetDialogFormData) => void;
 }
 
 const initialForm: StaffPasswordResetDialogFormData = {
@@ -47,11 +47,7 @@ const StaffPasswordResetDialog: React.FC<StaffPasswordResetDialogProps> = ({
           description="dialog header"
         />
       </DialogTitle>
-      <Form
-        errors={apiErrors}
-        initial={initialForm}
-        onSubmit={data => onSubmit(data.password)}
-      >
+      <Form errors={apiErrors} initial={initialForm} onSubmit={onSubmit}>
         {({ change, data, errors, submit }) => (
           <>
             <DialogContent>

--- a/src/staff/components/StaffPasswordResetDialog/index.ts
+++ b/src/staff/components/StaffPasswordResetDialog/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./StaffPasswordResetDialog";
+export * from "./StaffPasswordResetDialog";

--- a/src/staff/mutations.ts
+++ b/src/staff/mutations.ts
@@ -1,5 +1,6 @@
 import gql from "graphql-tag";
 
+import makeMutation from "@saleor/hooks/makeMutation";
 import { TypedMutation } from "../mutations";
 import { staffMemberDetailsFragment } from "./queries";
 import { StaffAvatarDelete } from "./types/StaffAvatarDelete";
@@ -19,6 +20,10 @@ import {
   StaffMemberUpdate,
   StaffMemberUpdateVariables
 } from "./types/StaffMemberUpdate";
+import {
+  ChangeStaffPassword,
+  ChangeStaffPasswordVariables
+} from "./types/ChangeStaffPassword";
 
 const staffMemberAddMutation = gql`
   ${staffMemberDetailsFragment}
@@ -114,3 +119,18 @@ export const TypedStaffAvatarDeleteMutation = TypedMutation<
   StaffAvatarDelete,
   StaffMemberDeleteVariables
 >(staffAvatarDeleteMutation);
+
+const changeStaffPassword = gql`
+  mutation ChangeStaffPassword($newPassword: String!, $oldPassword: String!) {
+    passwordChange(newPassword: $newPassword, oldPassword: $oldPassword) {
+      errors {
+        field
+        message
+      }
+    }
+  }
+`;
+export const useChangeStaffPassword = makeMutation<
+  ChangeStaffPassword,
+  ChangeStaffPasswordVariables
+>(changeStaffPassword);

--- a/src/staff/types/ChangeStaffPassword.ts
+++ b/src/staff/types/ChangeStaffPassword.ts
@@ -1,0 +1,27 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: ChangeStaffPassword
+// ====================================================
+
+export interface ChangeStaffPassword_passwordChange_errors {
+  __typename: "Error";
+  field: string | null;
+  message: string | null;
+}
+
+export interface ChangeStaffPassword_passwordChange {
+  __typename: "PasswordChange";
+  errors: ChangeStaffPassword_passwordChange_errors[] | null;
+}
+
+export interface ChangeStaffPassword {
+  passwordChange: ChangeStaffPassword_passwordChange | null;
+}
+
+export interface ChangeStaffPasswordVariables {
+  newPassword: string;
+  oldPassword: string;
+}

--- a/src/staff/urls.ts
+++ b/src/staff/urls.ts
@@ -27,7 +27,10 @@ export const staffListUrl = (params?: StaffListUrlQueryParams) =>
   staffListPath + "?" + stringifyQs(params);
 
 export const staffMemberDetailsPath = (id: string) => urlJoin(staffSection, id);
-export type StaffMemberDetailsUrlDialog = "remove" | "remove-avatar";
+export type StaffMemberDetailsUrlDialog =
+  | "change-password"
+  | "remove"
+  | "remove-avatar";
 export type StaffMemberDetailsUrlQueryParams = Dialog<
   StaffMemberDetailsUrlDialog
 >;

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -128,6 +128,13 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
                                 canRemove={!isUserSameAsViewer}
                                 disabled={loading}
                                 onBack={() => navigate(staffListUrl())}
+                                onChangePassword={() =>
+                                  navigate(
+                                    staffMemberDetailsUrl(id, {
+                                      action: "change-password"
+                                    })
+                                  )
+                                }
                                 onDelete={() =>
                                   navigate(
                                     staffMemberDetailsUrl(id, {

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -261,10 +261,7 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
                                 onClose={closeModal}
                                 onSubmit={data =>
                                   changePassword({
-                                    variables: {
-                                      newPassword: data.password,
-                                      oldPassword: data.previousPassword
-                                    }
+                                    variables: data
                                   })
                                 }
                               />

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -27,6 +27,7 @@ import {
   staffMemberDetailsUrl,
   StaffMemberDetailsUrlQueryParams
 } from "../urls";
+import StaffPasswordResetDialog from "../components/StaffPasswordResetDialog";
 
 interface OrderListProps {
   id: string;
@@ -39,6 +40,14 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
   const user = useUser();
   const intl = useIntl();
   const shop = useShop();
+
+  const closeModal = () =>
+    navigate(
+      staffMemberDetailsUrl(id, {
+        ...params,
+        action: undefined
+      })
+    );
 
   return (
     <TypedStaffMemberDetailsQuery
@@ -182,9 +191,7 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
                                 })}
                                 confirmButtonState={deleteTransitionState}
                                 variant="delete"
-                                onClose={() =>
-                                  navigate(staffMemberDetailsUrl(id))
-                                }
+                                onClose={closeModal}
                                 onConfirm={deleteStaffMember}
                               >
                                 <DialogContentText>
@@ -204,9 +211,7 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
                                 })}
                                 confirmButtonState={deleteAvatarTransitionState}
                                 variant="delete"
-                                onClose={() =>
-                                  navigate(staffMemberDetailsUrl(id))
-                                }
+                                onClose={closeModal}
                                 onConfirm={deleteStaffAvatar}
                               >
                                 <DialogContentText>
@@ -222,6 +227,13 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
                                   />
                                 </DialogContentText>
                               </ActionDialog>
+                              <StaffPasswordResetDialog
+                                confirmButtonState="default"
+                                errors={[]}
+                                open={params.action === "change-password"}
+                                onClose={closeModal}
+                                onSubmit={() => undefined}
+                              />
                             </>
                           );
                         }}

--- a/src/storybook/stories/staff/StaffDetailsPage.tsx
+++ b/src/storybook/stories/staff/StaffDetailsPage.tsx
@@ -16,6 +16,7 @@ const props: Omit<StaffDetailsPageProps, "classes"> = {
   canRemove: true,
   disabled: false,
   onBack: () => undefined,
+  onChangePassword: () => undefined,
   onDelete: () => undefined,
   onImageDelete: () => undefined,
   onImageUpload: () => undefined,


### PR DESCRIPTION
I want to merge this change because it resolves #283 

### Screenshots
<img width="1680" alt="Screenshot 2019-12-03 at 17 46 06" src="https://user-images.githubusercontent.com/6833443/70071010-e10ab400-15f4-11ea-967a-b5a6fbcc0dd7.png">
<img width="1680" alt="Screenshot 2019-12-03 at 17 46 28" src="https://user-images.githubusercontent.com/6833443/70071011-e1a34a80-15f4-11ea-85fb-a00bdf6c58cd.png">
<img width="1680" alt="Screenshot 2019-12-03 at 17 46 36" src="https://user-images.githubusercontent.com/6833443/70071012-e1a34a80-15f4-11ea-9909-df96814130f4.png">


### Pull Request Checklist

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
