### PR TITLE
Add filtering to draft orders

### DIFF
--- a/src/components/Filter/FilterContent.tsx
+++ b/src/components/Filter/FilterContent.tsx
@@ -148,6 +148,29 @@ const FilterContent: React.FC<FilterContentProps> = ({
               </div>
               {filterField.active && (
                 <div className={classes.filterSettings}>
+                  {filterField.type === FieldType.text && (
+                    <TextField
+                      fullWidth
+                      name={filterField.name}
+                      InputProps={{
+                        classes: {
+                          input: classes.input
+                        }
+                      }}
+                      value={filterField.value[0]}
+                      onChange={event =>
+                        onFilterPropertyChange({
+                          payload: {
+                            name: filterField.name,
+                            update: {
+                              value: [event.target.value, filterField.value[1]]
+                            }
+                          },
+                          type: "set-property"
+                        })
+                      }
+                    />
+                  )}
                   {[FieldType.date, FieldType.price, FieldType.number].includes(
                     filterField.type
                   ) && (

--- a/src/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
+++ b/src/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
@@ -6,34 +6,42 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
-import SearchBar from "@saleor/components/SearchBar";
 import { sectionNames } from "@saleor/intl";
 import {
   ListActions,
   PageListProps,
-  SearchPageProps,
   TabPageProps,
-  SortPage
+  SortPage,
+  FilterPageProps
 } from "@saleor/types";
 import { OrderDraftListUrlSortField } from "@saleor/orders/urls";
-import { OrderDraftList_draftOrders_edges_node } from "../../types/OrderDraftList";
+import {
+  OrderDraftFilterKeys,
+  createFilterStructure
+} from "@saleor/orders/views/OrderDraftList/filter";
+import { OrderDraftListFilterOpts } from "@saleor/orders/types";
+import FilterBar from "@saleor/components/FilterBar";
 import OrderDraftList from "../OrderDraftList";
+import { OrderDraftList_draftOrders_edges_node } from "../../types/OrderDraftList";
 
 export interface OrderDraftListPageProps
   extends PageListProps,
     ListActions,
-    SearchPageProps,
+    FilterPageProps<OrderDraftFilterKeys, OrderDraftListFilterOpts>,
     SortPage<OrderDraftListUrlSortField>,
     TabPageProps {
   orders: OrderDraftList_draftOrders_edges_node[];
 }
 
 const OrderDraftListPage: React.FC<OrderDraftListPageProps> = ({
+  currencySymbol,
   currentTab,
   disabled,
+  filterOpts,
   initialSearch,
   onAdd,
   onAll,
+  onFilterChange,
   onSearchChange,
   onTabChange,
   onTabDelete,
@@ -42,6 +50,8 @@ const OrderDraftListPage: React.FC<OrderDraftListPageProps> = ({
   ...listProps
 }) => {
   const intl = useIntl();
+
+  const structure = createFilterStructure(intl, filterOpts);
 
   return (
     <Container>
@@ -59,18 +69,21 @@ const OrderDraftListPage: React.FC<OrderDraftListPageProps> = ({
         </Button>
       </PageHeader>
       <Card>
-        <SearchBar
+        <FilterBar
           allTabLabel={intl.formatMessage({
             defaultMessage: "All Drafts",
             description: "tab name"
           })}
+          currencySymbol={currencySymbol}
           currentTab={currentTab}
+          filterStructure={structure}
           initialSearch={initialSearch}
           searchPlaceholder={intl.formatMessage({
             defaultMessage: "Search Draft"
           })}
           tabs={tabs}
           onAll={onAll}
+          onFilterChange={onFilterChange}
           onSearchChange={onSearchChange}
           onTabChange={onTabChange}
           onTabDelete={onTabDelete}

--- a/src/orders/types.ts
+++ b/src/orders/types.ts
@@ -5,3 +5,8 @@ export interface OrderListFilterOpts {
   created: FilterOpts<MinMax>;
   status: FilterOpts<OrderStatusFilter[]>;
 }
+
+export interface OrderDraftListFilterOpts {
+  created: FilterOpts<MinMax>;
+  customer: FilterOpts<string>;
+}

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -55,6 +55,9 @@ export const orderListUrl = (params?: OrderListUrlQueryParams): string => {
 
 export const orderDraftListPath = urlJoin(orderSectionUrl, "drafts");
 export enum OrderDraftListUrlFiltersEnum {
+  createdFrom = "createdFrom",
+  createdTo = "createdTo",
+  customer = "customer",
   query = "query"
 }
 export type OrderDraftListUrlFilters = Filters<OrderDraftListUrlFiltersEnum>;

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -34,7 +34,6 @@ import { OrderDraftBulkCancel } from "../../types/OrderDraftBulkCancel";
 import { OrderDraftCreate } from "../../types/OrderDraftCreate";
 import {
   orderDraftListUrl,
-  OrderDraftListUrlFilters,
   OrderDraftListUrlQueryParams,
   orderUrl,
   OrderDraftListUrlDialog
@@ -204,7 +203,7 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
               initialSearch={params.query || ""}
               onSearchChange={handleSearchChange}
               onFilterChange={changeFilters}
-              onAll={() => navigate(orderDraftListUrl())}
+              onAll={resetFilters}
               onTabChange={handleTabChange}
               onTabDelete={() => openModal("delete-search")}
               onTabSave={() => openModal("save-search")}

--- a/src/orders/views/OrderDraftList/filter.ts
+++ b/src/orders/views/OrderDraftList/filter.ts
@@ -1,22 +1,124 @@
+import { IntlShape } from "react-intl";
+
 import { OrderDraftFilterInput } from "@saleor/types/globalTypes";
-import {
-  createFilterTabUtils,
-  createFilterUtils
-} from "../../../utils/filters";
+import { maybe } from "@saleor/misc";
+import { OrderDraftListFilterOpts } from "@saleor/orders/types";
+import { IFilter, IFilterElement } from "@saleor/components/Filter";
+import { createTextField, createDateField } from "@saleor/utils/filters/fields";
 import {
   OrderDraftListUrlFilters,
   OrderDraftListUrlFiltersEnum,
   OrderDraftListUrlQueryParams
 } from "../../urls";
+import {
+  createFilterTabUtils,
+  createFilterUtils
+} from "../../../utils/filters";
+import messages from "./messages";
 
 export const ORDER_DRAFT_FILTERS_KEY = "orderDraftFilters";
+
+export enum OrderDraftFilterKeys {
+  created = "created",
+  customer = "customer"
+}
+
+export function getFilterOpts(
+  params: OrderDraftListUrlFilters
+): OrderDraftListFilterOpts {
+  return {
+    created: {
+      active: maybe(
+        () =>
+          [params.createdFrom, params.createdTo].some(
+            field => field !== undefined
+          ),
+        false
+      ),
+      value: {
+        max: maybe(() => params.createdTo),
+        min: maybe(() => params.createdFrom)
+      }
+    },
+    customer: {
+      active: !!maybe(() => params.customer),
+      value: params.customer
+    }
+  };
+}
+
+export function createFilterStructure(
+  intl: IntlShape,
+  opts: OrderDraftListFilterOpts
+): IFilter<OrderDraftFilterKeys> {
+  return [
+    {
+      ...createDateField(
+        OrderDraftFilterKeys.created,
+        intl.formatMessage(messages.created),
+        opts.created.value
+      ),
+      active: opts.created.active
+    },
+    {
+      ...createTextField(
+        OrderDraftFilterKeys.customer,
+        intl.formatMessage(messages.customer),
+        opts.customer.value
+      ),
+      active: opts.customer.active
+    }
+  ];
+}
 
 export function getFilterVariables(
   params: OrderDraftListUrlFilters
 ): OrderDraftFilterInput {
   return {
+    created: {
+      gte: params.createdFrom,
+      lte: params.createdTo
+    },
+    customer: params.customer,
     search: params.query
   };
+}
+
+export function getFilterQueryParam(
+  filter: IFilterElement<OrderDraftFilterKeys>
+): OrderDraftListUrlFilters {
+  const { active, multiple, name, value } = filter;
+
+  switch (name) {
+    case OrderDraftFilterKeys.created:
+      if (!active) {
+        return {
+          createdFrom: undefined,
+          createdTo: undefined
+        };
+      }
+      if (multiple) {
+        return {
+          createdFrom: value[0],
+          createdTo: value[1]
+        };
+      }
+
+      return {
+        createdFrom: value[0],
+        createdTo: value[0]
+      };
+
+    case OrderDraftFilterKeys.customer:
+      if (!active) {
+        return {
+          customer: undefined
+        };
+      }
+      return {
+        customer: value[0]
+      };
+  }
 }
 
 export const {

--- a/src/orders/views/OrderDraftList/messages.ts
+++ b/src/orders/views/OrderDraftList/messages.ts
@@ -1,0 +1,14 @@
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  customer: {
+    defaultMessage: "Customer",
+    description: "draft order"
+  },
+  created: {
+    defaultMessage: "Created",
+    description: "draft order"
+  }
+});
+
+export default messages;

--- a/src/storybook/stories/orders/OrderDraftListPage.tsx
+++ b/src/storybook/stories/orders/OrderDraftListPage.tsx
@@ -7,7 +7,8 @@ import {
   pageListProps,
   searchPageProps,
   tabPageProps,
-  sortPageProps
+  sortPageProps,
+  filterPageProps
 } from "../../../fixtures";
 import OrderDraftListPage, {
   OrderDraftListPageProps
@@ -21,6 +22,20 @@ const props: OrderDraftListPageProps = {
   ...searchPageProps,
   ...sortPageProps,
   ...tabPageProps,
+  ...filterPageProps,
+  filterOpts: {
+    created: {
+      active: false,
+      value: {
+        max: undefined,
+        min: undefined
+      }
+    },
+    customer: {
+      active: false,
+      value: undefined
+    }
+  },
   onAdd: () => undefined,
   orders,
   sort: {

--- a/src/utils/filters/fields.ts
+++ b/src/utils/filters/fields.ts
@@ -64,3 +64,18 @@ export function createOptionsField<T extends string>(
     value: defaultValue
   };
 }
+
+export function createTextField<T extends string>(
+  name: T,
+  label: string,
+  defaultValue: string
+): IFilterElement<T> {
+  return {
+    active: false,
+    label,
+    multiple: false,
+    name,
+    type: FieldType.text,
+    value: [defaultValue]
+  };
+}


### PR DESCRIPTION
I want to merge this change because it adds filtering to draft orders.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
