### PR TITLE
Add filtering to sales and vouchers

### DIFF
--- a/src/components/Filter/types.ts
+++ b/src/components/Filter/types.ts
@@ -3,6 +3,7 @@ import { MultiAutocompleteChoiceType } from "../MultiAutocompleteSelectField";
 
 export enum FieldType {
   date,
+  dateTime,
   number,
   price,
   options,

--- a/src/discounts/components/SaleListPage/SaleListPage.tsx
+++ b/src/discounts/components/SaleListPage/SaleListPage.tsx
@@ -5,23 +5,28 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
-import SearchBar from "@saleor/components/SearchBar";
+import FilterBar from "@saleor/components/FilterBar";
 import { sectionNames } from "@saleor/intl";
 import {
   ListActions,
   PageListProps,
-  SearchPageProps,
   TabPageProps,
-  SortPage
+  SortPage,
+  FilterPageProps
 } from "@saleor/types";
 import { SaleListUrlSortField } from "@saleor/discounts/urls";
+import {
+  SaleFilterKeys,
+  createFilterStructure
+} from "@saleor/discounts/views/SaleList/filter";
+import { SaleListFilterOpts } from "@saleor/discounts/types";
 import { SaleList_sales_edges_node } from "../../types/SaleList";
 import SaleList from "../SaleList";
 
 export interface SaleListPageProps
   extends PageListProps,
     ListActions,
-    SearchPageProps,
+    FilterPageProps<SaleFilterKeys, SaleListFilterOpts>,
     SortPage<SaleListUrlSortField>,
     TabPageProps {
   defaultCurrency: string;
@@ -29,10 +34,13 @@ export interface SaleListPageProps
 }
 
 const SaleListPage: React.FC<SaleListPageProps> = ({
+  currencySymbol,
   currentTab,
+  filterOpts,
   initialSearch,
   onAdd,
   onAll,
+  onFilterChange,
   onSearchChange,
   onTabChange,
   onTabDelete,
@@ -42,6 +50,8 @@ const SaleListPage: React.FC<SaleListPageProps> = ({
 }) => {
   const intl = useIntl();
 
+  const structure = createFilterStructure(intl, filterOpts);
+
   return (
     <Container>
       <PageHeader title={intl.formatMessage(sectionNames.sales)}>
@@ -50,18 +60,21 @@ const SaleListPage: React.FC<SaleListPageProps> = ({
         </Button>
       </PageHeader>
       <Card>
-        <SearchBar
+        <FilterBar
           allTabLabel={intl.formatMessage({
             defaultMessage: "All Sales",
             description: "tab name"
           })}
+          currencySymbol={currencySymbol}
           currentTab={currentTab}
+          filterStructure={structure}
           initialSearch={initialSearch}
           searchPlaceholder={intl.formatMessage({
             defaultMessage: "Search Sale"
           })}
           tabs={tabs}
           onAll={onAll}
+          onFilterChange={onFilterChange}
           onSearchChange={onSearchChange}
           onTabChange={onTabChange}
           onTabDelete={onTabDelete}

--- a/src/discounts/components/VoucherListPage/VoucherListPage.tsx
+++ b/src/discounts/components/VoucherListPage/VoucherListPage.tsx
@@ -5,23 +5,28 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
-import SearchBar from "@saleor/components/SearchBar";
+import FilterBar from "@saleor/components/FilterBar";
 import { sectionNames } from "@saleor/intl";
 import {
   ListActions,
   PageListProps,
-  SearchPageProps,
   TabPageProps,
-  SortPage
+  SortPage,
+  FilterPageProps
 } from "@saleor/types";
 import { VoucherListUrlSortField } from "@saleor/discounts/urls";
+import {
+  createFilterStructure,
+  VoucherFilterKeys
+} from "@saleor/discounts/views/VoucherList/filter";
+import { VoucherListFilterOpts } from "@saleor/discounts/types";
 import { VoucherList_vouchers_edges_node } from "../../types/VoucherList";
 import VoucherList from "../VoucherList";
 
 export interface VoucherListPageProps
   extends PageListProps,
     ListActions,
-    SearchPageProps,
+    FilterPageProps<VoucherFilterKeys, VoucherListFilterOpts>,
     SortPage<VoucherListUrlSortField>,
     TabPageProps {
   defaultCurrency: string;
@@ -29,10 +34,13 @@ export interface VoucherListPageProps
 }
 
 const VoucherListPage: React.FC<VoucherListPageProps> = ({
+  currencySymbol,
   currentTab,
+  filterOpts,
   initialSearch,
   onAdd,
   onAll,
+  onFilterChange,
   onSearchChange,
   onTabChange,
   onTabDelete,
@@ -41,6 +49,8 @@ const VoucherListPage: React.FC<VoucherListPageProps> = ({
   ...listProps
 }) => {
   const intl = useIntl();
+
+  const structure = createFilterStructure(intl, filterOpts);
 
   return (
     <Container>
@@ -53,18 +63,21 @@ const VoucherListPage: React.FC<VoucherListPageProps> = ({
         </Button>
       </PageHeader>
       <Card>
-        <SearchBar
+        <FilterBar
           allTabLabel={intl.formatMessage({
             defaultMessage: "All Vouchers",
             description: "tab name"
           })}
+          currencySymbol={currencySymbol}
           currentTab={currentTab}
+          filterStructure={structure}
           initialSearch={initialSearch}
           searchPlaceholder={intl.formatMessage({
             defaultMessage: "Search Voucher"
           })}
           tabs={tabs}
           onAll={onAll}
+          onFilterChange={onFilterChange}
           onSearchChange={onSearchChange}
           onTabChange={onTabChange}
           onTabDelete={onTabDelete}

--- a/src/discounts/types.ts
+++ b/src/discounts/types.ts
@@ -1,13 +1,21 @@
 import { FilterOpts, MinMax } from "@saleor/types";
 import {
   DiscountStatusEnum,
-  DiscountValueTypeEnum
+  DiscountValueTypeEnum,
+  VoucherDiscountType
 } from "@saleor/types/globalTypes";
 
 export interface SaleListFilterOpts {
   saleType: FilterOpts<DiscountValueTypeEnum>;
   started: FilterOpts<MinMax>;
   status: FilterOpts<DiscountStatusEnum[]>;
+}
+
+export interface VoucherListFilterOpts {
+  saleType: FilterOpts<VoucherDiscountType[]>;
+  started: FilterOpts<MinMax>;
+  status: FilterOpts<DiscountStatusEnum[]>;
+  timesUsed: FilterOpts<MinMax>;
 }
 
 export enum RequirementsPicker {

--- a/src/discounts/types.ts
+++ b/src/discounts/types.ts
@@ -1,3 +1,15 @@
+import { FilterOpts, MinMax } from "@saleor/types";
+import {
+  DiscountStatusEnum,
+  DiscountValueTypeEnum
+} from "@saleor/types/globalTypes";
+
+export interface SaleListFilterOpts {
+  saleType: FilterOpts<DiscountValueTypeEnum>;
+  started: FilterOpts<MinMax>;
+  status: FilterOpts<DiscountStatusEnum[]>;
+}
+
 export enum RequirementsPicker {
   ORDER = "ORDER",
   ITEM = "ITEM",

--- a/src/discounts/urls.ts
+++ b/src/discounts/urls.ts
@@ -8,7 +8,8 @@ import {
   Filters,
   Pagination,
   TabActionDialog,
-  Sort
+  Sort,
+  FiltersWithMultipleValues
 } from "../types";
 import { SaleDetailsPageTab } from "./components/SaleDetailsPage";
 import { VoucherDetailsPageTab } from "./components/VoucherDetailsPage";
@@ -18,9 +19,16 @@ export const discountSection = "/discounts/";
 export const saleSection = urlJoin(discountSection, "sales");
 export const saleListPath = saleSection;
 export enum SaleListUrlFiltersEnum {
+  type = "type",
+  startedFrom = "startedFrom",
+  startedTo = "startedTo",
   query = "query"
 }
-export type SaleListUrlFilters = Filters<SaleListUrlFiltersEnum>;
+export enum SaleListUrlFiltersWithMultipleValues {
+  status = "status"
+}
+export type SaleListUrlFilters = Filters<SaleListUrlFiltersEnum> &
+  FiltersWithMultipleValues<SaleListUrlFiltersWithMultipleValues>;
 export type SaleListUrlDialog = "remove" | TabActionDialog;
 export enum SaleListUrlSortField {
   name = "name",

--- a/src/discounts/urls.ts
+++ b/src/discounts/urls.ts
@@ -67,9 +67,18 @@ export const saleAddUrl = saleAddPath;
 export const voucherSection = urlJoin(discountSection, "vouchers");
 export const voucherListPath = voucherSection;
 export enum VoucherListUrlFiltersEnum {
+  startedFrom = "startedFrom",
+  startedTo = "startedTo",
+  timesUsedFrom = "timesUsedFrom",
+  timesUsedTo = "timesUsedTo",
   query = "query"
 }
-export type VoucherListUrlFilters = Filters<VoucherListUrlFiltersEnum>;
+export enum VoucherListUrlFiltersWithMultipleValues {
+  status = "status",
+  type = "type"
+}
+export type VoucherListUrlFilters = Filters<VoucherListUrlFiltersEnum> &
+  FiltersWithMultipleValues<VoucherListUrlFiltersWithMultipleValues>;
 export type VoucherListUrlDialog = "remove" | TabActionDialog;
 export enum VoucherListUrlSortField {
   code = "code",

--- a/src/discounts/views/SaleList/filter.ts
+++ b/src/discounts/views/SaleList/filter.ts
@@ -1,22 +1,192 @@
-import { SaleFilterInput } from "@saleor/types/globalTypes";
+import { IntlShape } from "react-intl";
+
+import {
+  SaleFilterInput,
+  DiscountStatusEnum,
+  DiscountValueTypeEnum
+} from "@saleor/types/globalTypes";
+import { maybe, findValueInEnum, joinDateTime } from "@saleor/misc";
+import { SaleListFilterOpts } from "@saleor/discounts/types";
+import { IFilter, IFilterElement } from "@saleor/components/Filter";
+import {
+  createDateField,
+  createOptionsField
+} from "@saleor/utils/filters/fields";
 import {
   createFilterTabUtils,
-  createFilterUtils
+  createFilterUtils,
+  dedupeFilter
 } from "../../../utils/filters";
 import {
   SaleListUrlFilters,
   SaleListUrlFiltersEnum,
   SaleListUrlQueryParams
 } from "../../urls";
+import messages from "./messages";
 
 export const SALE_FILTERS_KEY = "saleFilters";
+
+export enum SaleFilterKeys {
+  saleType = "saleType",
+  started = "started",
+  status = "status"
+}
+
+export function getFilterOpts(params: SaleListUrlFilters): SaleListFilterOpts {
+  return {
+    saleType: {
+      active: !!maybe(() => params.type),
+      value: maybe(() => findValueInEnum(params.type, DiscountValueTypeEnum))
+    },
+    started: {
+      active: maybe(
+        () =>
+          [params.startedFrom, params.startedTo].some(
+            field => field !== undefined
+          ),
+        false
+      ),
+      value: {
+        max: maybe(() => params.startedTo, ""),
+        min: maybe(() => params.startedFrom, "")
+      }
+    },
+    status: {
+      active: !!maybe(() => params.status),
+      value: maybe(
+        () =>
+          dedupeFilter(
+            params.status.map(status =>
+              findValueInEnum(status, DiscountStatusEnum)
+            )
+          ),
+        []
+      )
+    }
+  };
+}
+
+export function createFilterStructure(
+  intl: IntlShape,
+  opts: SaleListFilterOpts
+): IFilter<SaleFilterKeys> {
+  return [
+    {
+      ...createDateField(
+        SaleFilterKeys.started,
+        intl.formatMessage(messages.started),
+        opts.started.value
+      ),
+      active: opts.started.active
+    },
+    {
+      ...createOptionsField(
+        SaleFilterKeys.status,
+        intl.formatMessage(messages.status),
+        opts.status.value,
+        true,
+        [
+          {
+            label: intl.formatMessage(messages.active),
+            value: DiscountStatusEnum.ACTIVE
+          },
+          {
+            label: intl.formatMessage(messages.expired),
+            value: DiscountStatusEnum.EXPIRED
+          },
+          {
+            label: intl.formatMessage(messages.scheduled),
+            value: DiscountStatusEnum.SCHEDULED
+          }
+        ]
+      ),
+      active: opts.status.active
+    },
+    {
+      ...createOptionsField(
+        SaleFilterKeys.saleType,
+        intl.formatMessage(messages.type),
+        [opts.saleType.value],
+        false,
+        [
+          {
+            label: intl.formatMessage(messages.fixed),
+            value: DiscountValueTypeEnum.FIXED
+          },
+          {
+            label: intl.formatMessage(messages.percentage),
+            value: DiscountValueTypeEnum.PERCENTAGE
+          }
+        ]
+      ),
+      active: opts.saleType.active
+    }
+  ];
+}
 
 export function getFilterVariables(
   params: SaleListUrlFilters
 ): SaleFilterInput {
   return {
-    search: params.query
+    saleType:
+      params.type && findValueInEnum(params.type, DiscountValueTypeEnum),
+    search: params.query,
+    started: {
+      gte: joinDateTime(params.startedFrom),
+      lte: joinDateTime(params.startedTo)
+    },
+    status:
+      params.status &&
+      params.status.map(status => findValueInEnum(status, DiscountStatusEnum))
   };
+}
+
+export function getFilterQueryParam(
+  filter: IFilterElement<SaleFilterKeys>
+): SaleListUrlFilters {
+  const { active, multiple, name, value } = filter;
+
+  switch (name) {
+    case SaleFilterKeys.saleType:
+      if (!active) {
+        return {
+          type: undefined
+        };
+      }
+
+      return {
+        type: findValueInEnum(value[0], DiscountValueTypeEnum)
+      };
+
+    case SaleFilterKeys.started:
+      if (!active) {
+        return {
+          startedFrom: undefined,
+          startedTo: undefined
+        };
+      }
+      if (multiple) {
+        return {
+          startedFrom: value[0],
+          startedTo: value[1]
+        };
+      }
+
+      return {
+        startedFrom: value[0],
+        startedTo: value[0]
+      };
+
+    case SaleFilterKeys.status:
+      if (!active) {
+        return {
+          status: undefined
+        };
+      }
+      return {
+        status: value.map(val => findValueInEnum(val, DiscountStatusEnum))
+      };
+  }
 }
 
 export const {

--- a/src/discounts/views/SaleList/messages.ts
+++ b/src/discounts/views/SaleList/messages.ts
@@ -1,0 +1,37 @@
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  active: {
+    defaultMessage: "Active",
+    description: "sale status"
+  },
+  expired: {
+    defaultMessage: "Expired",
+    description: "sale status"
+  },
+  fixed: {
+    defaultMessage: "Fixed amount",
+    description: "discount type"
+  },
+  percentage: {
+    defaultMessage: "Percentage",
+    description: "discount type"
+  },
+  scheduled: {
+    defaultMessage: "Scheduled",
+    description: "sale status"
+  },
+  started: {
+    defaultMessage: "Started",
+    description: "sale start date"
+  },
+  status: {
+    defaultMessage: "Status",
+    description: "sale status"
+  },
+  type: {
+    defaultMessage: "Discount Type"
+  }
+});
+
+export default messages;

--- a/src/discounts/views/VoucherList/filter.ts
+++ b/src/discounts/views/VoucherList/filter.ts
@@ -1,22 +1,248 @@
-import { VoucherFilterInput } from "@saleor/types/globalTypes";
+import { IntlShape } from "react-intl";
+
+import {
+  VoucherFilterInput,
+  DiscountStatusEnum,
+  DiscountValueTypeEnum,
+  VoucherDiscountType
+} from "@saleor/types/globalTypes";
+import { maybe, findValueInEnum, joinDateTime } from "@saleor/misc";
+import { VoucherListFilterOpts } from "@saleor/discounts/types";
+import { IFilter, IFilterElement } from "@saleor/components/Filter";
+import {
+  createDateField,
+  createOptionsField,
+  createNumberField
+} from "@saleor/utils/filters/fields";
 import {
   createFilterTabUtils,
-  createFilterUtils
+  createFilterUtils,
+  dedupeFilter
 } from "../../../utils/filters";
 import {
   VoucherListUrlFilters,
   VoucherListUrlFiltersEnum,
   VoucherListUrlQueryParams
 } from "../../urls";
+import messages from "./messages";
 
-export const VOUCHER_FILTERS_KEY = "VoucherFilters";
+export const VOUCHER_FILTERS_KEY = "voucherFilters";
+
+export enum VoucherFilterKeys {
+  saleType = "saleType",
+  started = "started",
+  status = "status",
+  timesUsed = "timesUsed"
+}
+
+export function getFilterOpts(
+  params: VoucherListUrlFilters
+): VoucherListFilterOpts {
+  return {
+    saleType: {
+      active: !!maybe(() => params.type),
+      value: maybe(
+        () =>
+          dedupeFilter(
+            params.type.map(type => findValueInEnum(type, VoucherDiscountType))
+          ),
+        []
+      )
+    },
+    started: {
+      active: maybe(
+        () =>
+          [params.startedFrom, params.startedTo].some(
+            field => field !== undefined
+          ),
+        false
+      ),
+      value: {
+        max: maybe(() => params.startedTo, ""),
+        min: maybe(() => params.startedFrom, "")
+      }
+    },
+    status: {
+      active: !!maybe(() => params.status),
+      value: maybe(
+        () =>
+          dedupeFilter(
+            params.status.map(status =>
+              findValueInEnum(status, DiscountStatusEnum)
+            )
+          ),
+        []
+      )
+    },
+    timesUsed: {
+      active: maybe(
+        () =>
+          [params.timesUsedFrom, params.timesUsedTo].some(
+            field => field !== undefined
+          ),
+        false
+      ),
+      value: {
+        max: maybe(() => params.timesUsedTo, ""),
+        min: maybe(() => params.timesUsedFrom, "")
+      }
+    }
+  };
+}
+
+export function createFilterStructure(
+  intl: IntlShape,
+  opts: VoucherListFilterOpts
+): IFilter<VoucherFilterKeys> {
+  return [
+    {
+      ...createDateField(
+        VoucherFilterKeys.started,
+        intl.formatMessage(messages.started),
+        opts.started.value
+      ),
+      active: opts.started.active
+    },
+    {
+      ...createNumberField(
+        VoucherFilterKeys.timesUsed,
+        intl.formatMessage(messages.timesUsed),
+        opts.timesUsed.value
+      ),
+      active: opts.timesUsed.active
+    },
+    {
+      ...createOptionsField(
+        VoucherFilterKeys.status,
+        intl.formatMessage(messages.status),
+        opts.status.value,
+        true,
+        [
+          {
+            label: intl.formatMessage(messages.active),
+            value: DiscountStatusEnum.ACTIVE
+          },
+          {
+            label: intl.formatMessage(messages.expired),
+            value: DiscountStatusEnum.EXPIRED
+          },
+          {
+            label: intl.formatMessage(messages.scheduled),
+            value: DiscountStatusEnum.SCHEDULED
+          }
+        ]
+      ),
+      active: opts.status.active
+    },
+    {
+      ...createOptionsField(
+        VoucherFilterKeys.saleType,
+        intl.formatMessage(messages.type),
+        opts.saleType.value,
+        false,
+        [
+          {
+            label: intl.formatMessage(messages.fixed),
+            value: DiscountValueTypeEnum.FIXED
+          },
+          {
+            label: intl.formatMessage(messages.percentage),
+            value: DiscountValueTypeEnum.PERCENTAGE
+          }
+        ]
+      ),
+      active: opts.saleType.active
+    }
+  ];
+}
 
 export function getFilterVariables(
   params: VoucherListUrlFilters
 ): VoucherFilterInput {
   return {
-    search: params.query
+    discountType:
+      params.type &&
+      params.type.map(type => findValueInEnum(type, VoucherDiscountType)),
+    search: params.query,
+    started: {
+      gte: joinDateTime(params.startedFrom),
+      lte: joinDateTime(params.startedTo)
+    },
+    status:
+      params.status &&
+      params.status.map(status => findValueInEnum(status, DiscountStatusEnum)),
+    timesUsed: {
+      gte: parseInt(params.timesUsedFrom, 0),
+      lte: parseInt(params.timesUsedTo, 0)
+    }
   };
+}
+
+export function getFilterQueryParam(
+  filter: IFilterElement<VoucherFilterKeys>
+): VoucherListUrlFilters {
+  const { active, multiple, name, value } = filter;
+
+  switch (name) {
+    case VoucherFilterKeys.saleType:
+      if (!active) {
+        return {
+          type: undefined
+        };
+      }
+
+      return {
+        type: value.map(type => findValueInEnum(type, VoucherDiscountType))
+      };
+
+    case VoucherFilterKeys.started:
+      if (!active) {
+        return {
+          startedFrom: undefined,
+          startedTo: undefined
+        };
+      }
+      if (multiple) {
+        return {
+          startedFrom: value[0],
+          startedTo: value[1]
+        };
+      }
+
+      return {
+        startedFrom: value[0],
+        startedTo: value[0]
+      };
+
+    case VoucherFilterKeys.timesUsed:
+      if (!active) {
+        return {
+          timesUsedFrom: undefined,
+          timesUsedTo: undefined
+        };
+      }
+      if (multiple) {
+        return {
+          timesUsedFrom: value[0],
+          timesUsedTo: value[1]
+        };
+      }
+
+      return {
+        timesUsedFrom: value[0],
+        timesUsedTo: value[0]
+      };
+
+    case VoucherFilterKeys.status:
+      if (!active) {
+        return {
+          status: undefined
+        };
+      }
+      return {
+        status: value.map(val => findValueInEnum(val, DiscountStatusEnum))
+      };
+  }
 }
 
 export const {

--- a/src/discounts/views/VoucherList/messages.ts
+++ b/src/discounts/views/VoucherList/messages.ts
@@ -1,0 +1,41 @@
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  active: {
+    defaultMessage: "Active",
+    description: "voucher status"
+  },
+  expired: {
+    defaultMessage: "Expired",
+    description: "voucher status"
+  },
+  fixed: {
+    defaultMessage: "Fixed amount",
+    description: "discount type"
+  },
+  percentage: {
+    defaultMessage: "Percentage",
+    description: "discount type"
+  },
+  scheduled: {
+    defaultMessage: "Scheduled",
+    description: "voucher status"
+  },
+  started: {
+    defaultMessage: "Started",
+    description: "voucher start date"
+  },
+  status: {
+    defaultMessage: "Status",
+    description: "voucher status"
+  },
+  timesUsed: {
+    defaultMessage: "Times used",
+    description: "voucher"
+  },
+  type: {
+    defaultMessage: "Discount Type"
+  }
+});
+
+export default messages;

--- a/src/storybook/stories/discounts/SaleListPage.tsx
+++ b/src/storybook/stories/discounts/SaleListPage.tsx
@@ -2,6 +2,10 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import { SaleListUrlSortField } from "@saleor/discounts/urls";
+import {
+  DiscountValueTypeEnum,
+  DiscountStatusEnum
+} from "@saleor/types/globalTypes";
 import SaleListPage, {
   SaleListPageProps
 } from "../../../discounts/components/SaleListPage";
@@ -9,19 +13,36 @@ import { saleList } from "../../../discounts/fixtures";
 import {
   listActionsProps,
   pageListProps,
-  searchPageProps,
   tabPageProps,
-  sortPageProps
+  sortPageProps,
+  filterPageProps
 } from "../../../fixtures";
 import Decorator from "../../Decorator";
 
 const props: SaleListPageProps = {
   ...listActionsProps,
   ...pageListProps.default,
-  ...searchPageProps,
+  ...filterPageProps,
   ...sortPageProps,
   ...tabPageProps,
   defaultCurrency: "USD",
+  filterOpts: {
+    saleType: {
+      active: false,
+      value: DiscountValueTypeEnum.FIXED
+    },
+    started: {
+      active: false,
+      value: {
+        max: undefined,
+        min: undefined
+      }
+    },
+    status: {
+      active: false,
+      value: [DiscountStatusEnum.ACTIVE]
+    }
+  },
   sales: saleList,
   sort: {
     ...sortPageProps.sort,

--- a/src/storybook/stories/discounts/VoucherListPage.tsx
+++ b/src/storybook/stories/discounts/VoucherListPage.tsx
@@ -2,6 +2,10 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import { VoucherListUrlSortField } from "@saleor/discounts/urls";
+import {
+  VoucherDiscountType,
+  DiscountStatusEnum
+} from "@saleor/types/globalTypes";
 import VoucherListPage, {
   VoucherListPageProps
 } from "../../../discounts/components/VoucherListPage";
@@ -11,7 +15,8 @@ import {
   pageListProps,
   searchPageProps,
   tabPageProps,
-  sortPageProps
+  sortPageProps,
+  filterPageProps
 } from "../../../fixtures";
 import Decorator from "../../Decorator";
 
@@ -21,7 +26,32 @@ const props: VoucherListPageProps = {
   ...searchPageProps,
   ...sortPageProps,
   ...tabPageProps,
+  ...filterPageProps,
   defaultCurrency: "USD",
+  filterOpts: {
+    saleType: {
+      active: false,
+      value: [VoucherDiscountType.FIXED, VoucherDiscountType.PERCENTAGE]
+    },
+    started: {
+      active: false,
+      value: {
+        max: undefined,
+        min: undefined
+      }
+    },
+    status: {
+      active: false,
+      value: [DiscountStatusEnum.ACTIVE]
+    },
+    timesUsed: {
+      active: false,
+      value: {
+        max: undefined,
+        min: undefined
+      }
+    }
+  },
   sort: {
     ...sortPageProps.sort,
     sort: VoucherListUrlSortField.code


### PR DESCRIPTION
I want to merge this change because it adds support for filtering in sale and voucher lists.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
