### PR TITLE
Add filtering to product type list

### DIFF
--- a/src/productTypes/components/ProductTypeListPage/ProductTypeListPage.tsx
+++ b/src/productTypes/components/ProductTypeListPage/ProductTypeListPage.tsx
@@ -6,13 +6,18 @@ import { FormattedMessage, useIntl } from "react-intl";
 import AppHeader from "@saleor/components/AppHeader";
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
-import SearchBar from "@saleor/components/SearchBar";
+import FilterBar from "@saleor/components/FilterBar";
 import { sectionNames } from "@saleor/intl";
 import { ProductTypeListUrlSortField } from "@saleor/productTypes/urls";
 import {
+  ProductTypeFilterKeys,
+  createFilterStructure
+} from "@saleor/productTypes/views/ProductTypeList/filter";
+import { ProductTypeListFilterOpts } from "@saleor/productTypes/types";
+import {
   ListActions,
   PageListProps,
-  SearchPageProps,
+  FilterPageProps,
   TabPageProps,
   SortPage
 } from "../../../types";
@@ -22,7 +27,7 @@ import ProductTypeList from "../ProductTypeList";
 export interface ProductTypeListPageProps
   extends PageListProps,
     ListActions,
-    SearchPageProps,
+    FilterPageProps<ProductTypeFilterKeys, ProductTypeListFilterOpts>,
     SortPage<ProductTypeListUrlSortField>,
     TabPageProps {
   productTypes: ProductTypeList_productTypes_edges_node[];
@@ -30,11 +35,14 @@ export interface ProductTypeListPageProps
 }
 
 const ProductTypeListPage: React.FC<ProductTypeListPageProps> = ({
+  currencySymbol,
   currentTab,
+  filterOpts,
   initialSearch,
   onAdd,
   onAll,
   onBack,
+  onFilterChange,
   onSearchChange,
   onTabChange,
   onTabDelete,
@@ -43,6 +51,8 @@ const ProductTypeListPage: React.FC<ProductTypeListPageProps> = ({
   ...listProps
 }) => {
   const intl = useIntl();
+
+  const structure = createFilterStructure(intl, filterOpts);
 
   return (
     <Container>
@@ -58,18 +68,21 @@ const ProductTypeListPage: React.FC<ProductTypeListPageProps> = ({
         </Button>
       </PageHeader>
       <Card>
-        <SearchBar
+        <FilterBar
           allTabLabel={intl.formatMessage({
             defaultMessage: "All Product Types",
             description: "tab name"
           })}
+          currencySymbol={currencySymbol}
           currentTab={currentTab}
+          filterStructure={structure}
           initialSearch={initialSearch}
           searchPlaceholder={intl.formatMessage({
             defaultMessage: "Search Product Type"
           })}
           tabs={tabs}
           onAll={onAll}
+          onFilterChange={onFilterChange}
           onSearchChange={onSearchChange}
           onTabChange={onTabChange}
           onTabDelete={onTabDelete}

--- a/src/productTypes/types.ts
+++ b/src/productTypes/types.ts
@@ -1,0 +1,10 @@
+import { FilterOpts } from "@saleor/types";
+import {
+  ProductTypeConfigurable,
+  ProductTypeEnum
+} from "@saleor/types/globalTypes";
+
+export interface ProductTypeListFilterOpts {
+  configurable: FilterOpts<ProductTypeConfigurable>;
+  type: FilterOpts<ProductTypeEnum>;
+}

--- a/src/productTypes/urls.ts
+++ b/src/productTypes/urls.ts
@@ -16,6 +16,8 @@ const productTypeSection = "/product-types/";
 
 export const productTypeListPath = productTypeSection;
 export enum ProductTypeListUrlFiltersEnum {
+  configurable = "configurable",
+  type = "type",
   query = "query"
 }
 export type ProductTypeListUrlFilters = Filters<ProductTypeListUrlFiltersEnum>;

--- a/src/productTypes/views/ProductTypeList/filter.ts
+++ b/src/productTypes/views/ProductTypeList/filter.ts
@@ -1,4 +1,14 @@
-import { ProductTypeFilterInput } from "@saleor/types/globalTypes";
+import { IntlShape } from "react-intl";
+
+import {
+  ProductTypeFilterInput,
+  ProductTypeConfigurable,
+  ProductTypeEnum
+} from "@saleor/types/globalTypes";
+import { IFilterElement, IFilter } from "@saleor/components/Filter";
+import { maybe, findValueInEnum } from "@saleor/misc";
+import { createOptionsField } from "@saleor/utils/filters/fields";
+import { commonMessages } from "@saleor/intl";
 import {
   createFilterTabUtils,
   createFilterUtils
@@ -8,15 +18,121 @@ import {
   ProductTypeListUrlFiltersEnum,
   ProductTypeListUrlQueryParams
 } from "../../urls";
+import { ProductTypeListFilterOpts } from "../../types";
+import messages from "./messages";
 
 export const PRODUCT_TYPE_FILTERS_KEY = "productTypeFilters";
+
+export enum ProductTypeFilterKeys {
+  configurable = "configurable",
+  type = "type"
+}
+
+export function getFilterOpts(
+  params: ProductTypeListUrlFilters
+): ProductTypeListFilterOpts {
+  return {
+    configurable: {
+      active: !!maybe(() => params.configurable),
+      value: maybe(() =>
+        findValueInEnum(params.configurable, ProductTypeConfigurable)
+      )
+    },
+    type: {
+      active: !!maybe(() => params.type),
+      value: maybe(() => findValueInEnum(params.type, ProductTypeEnum))
+    }
+  };
+}
+
+export function createFilterStructure(
+  intl: IntlShape,
+  opts: ProductTypeListFilterOpts
+): IFilter<ProductTypeFilterKeys> {
+  return [
+    {
+      ...createOptionsField(
+        ProductTypeFilterKeys.configurable,
+        intl.formatMessage(messages.configurable),
+        [opts.configurable.value],
+        false,
+        [
+          {
+            label: intl.formatMessage(commonMessages.yes),
+            value: ProductTypeConfigurable.CONFIGURABLE
+          },
+          {
+            label: intl.formatMessage(commonMessages.no),
+            value: ProductTypeConfigurable.SIMPLE
+          }
+        ]
+      ),
+      active: opts.configurable.active
+    },
+    {
+      ...createOptionsField(
+        ProductTypeFilterKeys.type,
+        intl.formatMessage(messages.type),
+        [opts.type.value],
+        false,
+        [
+          {
+            label: intl.formatMessage(messages.digital),
+            value: ProductTypeEnum.DIGITAL
+          },
+          {
+            label: intl.formatMessage(messages.shippable),
+            value: ProductTypeEnum.SHIPPABLE
+          }
+        ]
+      ),
+      active: opts.type.active
+    }
+  ];
+}
 
 export function getFilterVariables(
   params: ProductTypeListUrlFilters
 ): ProductTypeFilterInput {
   return {
+    configurable: params.configurable
+      ? findValueInEnum(params.configurable, ProductTypeConfigurable)
+      : undefined,
+    productType: params.type
+      ? findValueInEnum(params.type, ProductTypeEnum)
+      : undefined,
     search: params.query
   };
+}
+
+export function getFilterQueryParam(
+  filter: IFilterElement<ProductTypeFilterKeys>
+): ProductTypeListUrlFilters {
+  const { active, name, value } = filter;
+
+  switch (name) {
+    case ProductTypeFilterKeys.configurable:
+      if (!active) {
+        return {
+          configurable: undefined
+        };
+      }
+
+      return {
+        configurable: value[0]
+      };
+
+    case ProductTypeFilterKeys.type:
+      if (!active) {
+        return {
+          type: undefined
+        };
+      }
+
+      return {
+        type: value[0]
+      };
+  }
 }
 
 export const {

--- a/src/productTypes/views/ProductTypeList/messages.ts
+++ b/src/productTypes/views/ProductTypeList/messages.ts
@@ -1,0 +1,22 @@
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  configurable: {
+    defaultMessage: "Configurable",
+    description: "product type"
+  },
+  digital: {
+    defaultMessage: "Digital",
+    description: "product"
+  },
+  shippable: {
+    defaultMessage: "Shippable",
+    description: "product"
+  },
+  type: {
+    defaultMessage: "Type",
+    description: "product type is digital or physical"
+  }
+});
+
+export default messages;

--- a/src/storybook/stories/productTypes/ProductTypeListPage.tsx
+++ b/src/storybook/stories/productTypes/ProductTypeListPage.tsx
@@ -3,11 +3,16 @@ import React from "react";
 
 import { ProductTypeListUrlSortField } from "@saleor/productTypes/urls";
 import {
+  ProductTypeConfigurable,
+  ProductTypeEnum
+} from "@saleor/types/globalTypes";
+import {
   listActionsProps,
   pageListProps,
   searchPageProps,
   tabPageProps,
-  sortPageProps
+  sortPageProps,
+  filterPageProps
 } from "../../../fixtures";
 import ProductTypeListPage, {
   ProductTypeListPageProps
@@ -20,6 +25,17 @@ const props: ProductTypeListPageProps = {
   ...pageListProps.default,
   ...searchPageProps,
   ...sortPageProps,
+  ...filterPageProps,
+  filterOpts: {
+    configurable: {
+      active: false,
+      value: ProductTypeConfigurable.CONFIGURABLE
+    },
+    type: {
+      active: false,
+      value: ProductTypeEnum.SHIPPABLE
+    }
+  },
   sort: {
     ...sortPageProps.sort,
     sort: ProductTypeListUrlSortField.name


### PR DESCRIPTION
I want to merge this change because it adds filtering to product type list.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
