### PR TITLE
Stop using deprecated fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Move mutation state to mutation - #297 by @dominik-zeglen
 - Add table sorting - #292 by @dominik-zeglen
 - Unify dialog handling - #296 by @dominik-zeglen
+- Stop using deprecated fields - #357 by @dominik-zeglen
 
 ## 2.0.0
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -301,8 +301,6 @@ type AttributeReorderValues {
   productErrors: [ProductError!]
 }
 
-scalar AttributeScalar
-
 enum AttributeSortField {
   NAME
   SLUG
@@ -635,7 +633,6 @@ type Checkout implements Node {
   shippingAddress: Address
   shippingMethod: ShippingMethod
   note: String!
-  discountAmount: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use discount instead.")
   discount: Money
   discountName: String
   translatedDiscountName: String
@@ -831,12 +828,6 @@ type CheckoutUpdatePrivateMeta {
   errors: [Error!]
   checkoutErrors: [CheckoutError!]
   checkout: Checkout
-}
-
-type CheckoutUpdateVoucher {
-  errors: [Error!]
-  checkout: Checkout
-  checkoutErrors: [CheckoutError!]
 }
 
 type ChoiceValue {
@@ -1698,7 +1689,7 @@ type FulfillmentUpdateTracking {
 
 input FulfillmentUpdateTrackingInput {
   trackingNumber: String
-  notifyCustomer: Boolean
+  notifyCustomer: Boolean = false
 }
 
 type GatewayConfigLine {
@@ -1939,7 +1930,6 @@ input MenuInput {
 type MenuItem implements Node {
   id: ID!
   name: String!
-  sortOrder: Int @deprecated(reason: "Will be dropped in 2.10 and is deprecated since 2.9: use the position in list instead and relative calculus to determine shift position.")
   menu: Menu!
   parent: MenuItem
   category: Category
@@ -2293,7 +2283,6 @@ type Mutation {
   checkoutPaymentCreate(checkoutId: ID!, input: PaymentInput!): CheckoutPaymentCreate
   checkoutShippingAddressUpdate(checkoutId: ID!, shippingAddress: AddressInput!): CheckoutShippingAddressUpdate
   checkoutShippingMethodUpdate(checkoutId: ID, shippingMethodId: ID!): CheckoutShippingMethodUpdate
-  checkoutUpdateVoucher(checkoutId: ID!, voucherCode: String): CheckoutUpdateVoucher
   checkoutUpdateMetadata(id: ID!, input: MetaInput!): CheckoutUpdateMeta
   checkoutClearMetadata(id: ID!, input: MetaPath!): CheckoutClearMeta
   checkoutUpdatePrivateMetadata(id: ID!, input: MetaInput!): CheckoutUpdatePrivateMeta
@@ -2404,7 +2393,6 @@ type Order implements Node {
   totalBalance: Money!
   userEmail: String
   isShippingRequired: Boolean!
-  discountAmount: Money! @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use discount instead.")
 }
 
 enum OrderAction {
@@ -2936,6 +2924,7 @@ enum PermissionEnum {
   MANAGE_SETTINGS
   MANAGE_TRANSLATIONS
   MANAGE_WEBHOOKS
+  MANAGE_CHECKOUTS
 }
 
 type Plugin implements Node {
@@ -3006,11 +2995,9 @@ type Product implements Node {
   meta: [MetaStore]!
   url: String!
   thumbnail(size: Int): Image
-  availability: ProductPricingInfo @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, Has been renamed to `pricing`.")
   pricing: ProductPricingInfo
   isAvailable: Boolean
   basePrice: Money
-  price: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been replaced by `basePrice`")
   minimalVariantPrice: Money
   taxType: TaxType
   attributes: [SelectedAttribute!]!
@@ -3125,8 +3112,8 @@ input ProductFilterInput {
 }
 
 type ProductImage implements Node {
-  sortOrder: Int
   id: ID!
+  sortOrder: Int
   alt: String!
   url(size: Int): String!
 }
@@ -3210,7 +3197,6 @@ enum ProductOrderField {
 }
 
 type ProductPricingInfo {
-  available: Boolean @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'isAvailable'.")
   onSale: Boolean
   discount: TaxedMoney
   discountLocalCurrency: TaxedMoney
@@ -3396,8 +3382,6 @@ type ProductVariant implements Node {
   quantity: Int!
   stockQuantity: Int!
   priceOverride: Money
-  price: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been replaced by 'pricing.priceUndiscounted'")
-  availability: VariantPricingInfo @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been renamed to `pricing`.")
   pricing: VariantPricingInfo
   isAvailable: Boolean
   attributes: [SelectedAttribute!]!
@@ -3537,34 +3521,33 @@ type Query {
   shippingZones(before: String, after: String, first: Int, last: Int): ShippingZoneCountableConnection
   digitalContent(id: ID!): DigitalContent
   digitalContents(before: String, after: String, first: Int, last: Int): DigitalContentCountableConnection
-  attributes(query: String, inCategory: ID, inCollection: ID, filter: AttributeFilterInput, sortBy: AttributeSortingInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
+  attributes(filter: AttributeFilterInput, sortBy: AttributeSortingInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
   attribute(id: ID!): Attribute
-  categories(query: String, filter: CategoryFilterInput, sortBy: CategorySortingInput, level: Int, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  categories(filter: CategoryFilterInput, sortBy: CategorySortingInput, level: Int, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   category(id: ID!): Category
   collection(id: ID!): Collection
-  collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, query: String, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
+  collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   product(id: ID!): Product
-  products(filter: ProductFilterInput, attributes: [AttributeScalar], categories: [ID], collections: [ID], sortBy: ProductOrder, stockAvailability: StockAvailability, query: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(filter: ProductFilterInput, sortBy: ProductOrder, stockAvailability: StockAvailability, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   productType(id: ID!): ProductType
-  productTypes(filter: ProductTypeFilterInput, query: String, sortBy: ProductTypeSortingInput, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
+  productTypes(filter: ProductTypeFilterInput, sortBy: ProductTypeSortingInput, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
   productVariant(id: ID!): ProductVariant
   productVariants(ids: [ID], before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   reportProductSales(period: ReportingPeriod!, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   payment(id: ID!): Payment
   payments(before: String, after: String, first: Int, last: Int): PaymentCountableConnection
-  paymentClientToken(gateway: String!): String @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use payment gateway config instead in availablePaymentGateways.")
   page(id: ID, slug: String): Page
-  pages(query: String, sortBy: PageSortingInput, filter: PageFilterInput, before: String, after: String, first: Int, last: Int): PageCountableConnection
+  pages(sortBy: PageSortingInput, filter: PageFilterInput, before: String, after: String, first: Int, last: Int): PageCountableConnection
   homepageEvents(before: String, after: String, first: Int, last: Int): OrderEventCountableConnection
   order(id: ID!): Order
-  orders(sortBy: OrderSortingInput, filter: OrderFilterInput, query: String, created: ReportingPeriod, status: OrderStatusFilter, before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, query: String, created: ReportingPeriod, before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  orders(sortBy: OrderSortingInput, filter: OrderFilterInput, created: ReportingPeriod, status: OrderStatusFilter, before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, created: ReportingPeriod, before: String, after: String, first: Int, last: Int): OrderCountableConnection
   ordersTotal(period: ReportingPeriod): TaxedMoney
   orderByToken(token: UUID!): Order
   menu(id: ID, name: String): Menu
-  menus(query: String, sortBy: MenuSortingInput, filter: MenuFilterInput, before: String, after: String, first: Int, last: Int): MenuCountableConnection
+  menus(sortBy: MenuSortingInput, filter: MenuFilterInput, before: String, after: String, first: Int, last: Int): MenuCountableConnection
   menuItem(id: ID!): MenuItem
-  menuItems(query: String, sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
+  menuItems(sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
   giftCard(id: ID!): GiftCard
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   plugin(id: ID!): Plugin
@@ -3579,9 +3562,10 @@ type Query {
   checkoutLine(id: ID): CheckoutLine
   checkoutLines(before: String, after: String, first: Int, last: Int): CheckoutLineCountableConnection
   addressValidationRules(countryCode: CountryCode!, countryArea: String, city: String, cityArea: String): AddressValidationData
-  customers(filter: CustomerFilterInput, sortBy: UserSortingInput, query: String, before: String, after: String, first: Int, last: Int): UserCountableConnection
+  address(id: ID!): Address
+  customers(filter: CustomerFilterInput, sortBy: UserSortingInput, before: String, after: String, first: Int, last: Int): UserCountableConnection
   me: User
-  staffUsers(filter: StaffUserInput, sortBy: UserSortingInput, query: String, before: String, after: String, first: Int, last: Int): UserCountableConnection
+  staffUsers(filter: StaffUserInput, sortBy: UserSortingInput, before: String, after: String, first: Int, last: Int): UserCountableConnection
   serviceAccounts(filter: ServiceAccountFilterInput, sortBy: ServiceAccountSortingInput, before: String, after: String, first: Int, last: Int): ServiceAccountCountableConnection
   serviceAccount(id: ID!): ServiceAccount
   user(id: ID!): User
@@ -3725,7 +3709,6 @@ type SaleUpdate {
 
 type SelectedAttribute {
   attribute: Attribute!
-  value: AttributeValue @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use values instead.")
   values: [AttributeValue]!
 }
 
@@ -4106,7 +4089,6 @@ input StaffCreateInput {
   isActive: Boolean
   note: String
   permissions: [PermissionEnum]
-  sendPasswordEmail: Boolean
   redirectUrl: String
 }
 
@@ -4341,7 +4323,6 @@ input UserCreateInput {
   email: String
   isActive: Boolean
   note: String
-  sendPasswordEmail: Boolean
   redirectUrl: String
 }
 
@@ -4390,7 +4371,6 @@ type VariantImageUnassign {
 }
 
 type VariantPricingInfo {
-  available: Boolean @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'isAvailable'.")
   onSale: Boolean
   discount: TaxedMoney
   discountLocalCurrency: TaxedMoney
@@ -4424,7 +4404,6 @@ type Voucher implements Node {
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   countries: [CountryDisplay]
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation
-  minAmountSpent: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use the minSpent field instead.")
 }
 
 type VoucherAddCatalogues {
@@ -4610,6 +4589,7 @@ enum WebhookEventTypeEnum {
   ORDER_FULFILLED
   CUSTOMER_CREATED
   PRODUCT_CREATED
+  CHECKOUT_QUANTITY_CHANGED
 }
 
 input WebhookFilterInput {

--- a/src/attributes/queries.ts
+++ b/src/attributes/queries.ts
@@ -54,8 +54,6 @@ const attributeList = gql`
   ${pageInfoFragment}
   query AttributeList(
     $filter: AttributeFilterInput
-    $inCategory: ID
-    $inCollection: ID
     $before: String
     $after: String
     $first: Int
@@ -64,8 +62,6 @@ const attributeList = gql`
   ) {
     attributes(
       filter: $filter
-      inCategory: $inCategory
-      inCollection: $inCollection
       before: $before
       after: $after
       first: $first

--- a/src/attributes/types/AttributeList.ts
+++ b/src/attributes/types/AttributeList.ts
@@ -51,8 +51,6 @@ export interface AttributeList {
 
 export interface AttributeListVariables {
   filter?: AttributeFilterInput | null;
-  inCategory?: string | null;
-  inCollection?: string | null;
   before?: string | null;
   after?: string | null;
   first?: number | null;

--- a/src/customers/views/CustomerCreate.tsx
+++ b/src/customers/views/CustomerCreate.tsx
@@ -65,8 +65,7 @@ export const CustomerCreate: React.FC<{}> = () => {
                         email: formData.email,
                         firstName: formData.customerFirstName,
                         lastName: formData.customerLastName,
-                        note: formData.note,
-                        sendPasswordEmail: false
+                        note: formData.note
                       }
                     }
                   });

--- a/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
+++ b/src/discounts/components/VoucherCreatePage/VoucherCreatePage.tsx
@@ -32,8 +32,8 @@ export interface FormData {
   endTime: string;
   hasEndDate: boolean;
   hasUsageLimit: boolean;
-  minAmountSpent: string;
   minCheckoutItemsQuantity: string;
+  minSpent: string;
   requirementsPicker: RequirementsPicker;
   startDate: string;
   startTime: string;
@@ -70,8 +70,8 @@ const VoucherCreatePage: React.FC<VoucherCreatePageProps> = ({
     endTime: "",
     hasEndDate: false,
     hasUsageLimit: false,
-    minAmountSpent: "0",
     minCheckoutItemsQuantity: "0",
+    minSpent: "0",
     requirementsPicker: RequirementsPicker.NONE,
     startDate: "",
     startTime: "",

--- a/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
+++ b/src/discounts/components/VoucherDetailsPage/VoucherDetailsPage.tsx
@@ -55,7 +55,7 @@ export interface FormData {
   endTime: string;
   hasEndDate: boolean;
   hasUsageLimit: boolean;
-  minAmountSpent: string;
+  minSpent: string;
   minCheckoutItemsQuantity: string;
   requirementsPicker: RequirementsPicker;
   startDate: string;
@@ -132,7 +132,7 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
   const intl = useIntl();
 
   let requirementsPickerInitValue;
-  if (maybe(() => voucher.minAmountSpent.amount) > 0) {
+  if (maybe(() => voucher.minSpent.amount) > 0) {
     requirementsPickerInitValue = RequirementsPicker.ORDER;
   } else if (maybe(() => voucher.minCheckoutItemsQuantity) > 0) {
     requirementsPickerInitValue = RequirementsPicker.ITEM;
@@ -152,11 +152,11 @@ const VoucherDetailsPage: React.FC<VoucherDetailsPageProps> = ({
     endTime: splitDateTime(maybe(() => voucher.endDate, "")).time,
     hasEndDate: maybe(() => !!voucher.endDate),
     hasUsageLimit: maybe(() => !!voucher.usageLimit),
-    minAmountSpent: maybe(() => voucher.minAmountSpent.amount.toString(), "0"),
     minCheckoutItemsQuantity: maybe(
       () => voucher.minCheckoutItemsQuantity.toString(),
       "0"
     ),
+    minSpent: maybe(() => voucher.minSpent.amount.toString(), "0"),
     requirementsPicker: requirementsPickerInitValue,
     startDate: splitDateTime(maybe(() => voucher.startDate, "")).date,
     startTime: splitDateTime(maybe(() => voucher.startDate, "")).time,

--- a/src/discounts/components/VoucherList/VoucherList.tsx
+++ b/src/discounts/components/VoucherList/VoucherList.tsx
@@ -233,9 +233,9 @@ const VoucherList: React.FC<VoucherListProps> = props => {
                   {maybe<React.ReactNode>(() => voucher.code, <Skeleton />)}
                 </TableCell>
                 <TableCell className={classes.colMinSpent}>
-                  {voucher && voucher.minAmountSpent ? (
-                    <Money money={voucher.minAmountSpent} />
-                  ) : voucher && voucher.minAmountSpent === null ? (
+                  {voucher && voucher.minSpent ? (
+                    <Money money={voucher.minSpent} />
+                  ) : voucher && voucher.minSpent === null ? (
                     "-"
                   ) : (
                     <Skeleton />

--- a/src/discounts/components/VoucherRequirements/VoucherRequirements.tsx
+++ b/src/discounts/components/VoucherRequirements/VoucherRequirements.tsx
@@ -15,7 +15,7 @@ interface VoucherRequirementsProps {
   data: FormData;
   defaultCurrency: string;
   disabled: boolean;
-  errors: FormErrors<"minAmountSpent" | "minCheckoutItemsQuantity">;
+  errors: FormErrors<"minSpent" | "minCheckoutItemsQuantity">;
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
@@ -76,11 +76,11 @@ const VoucherRequirements = ({
         {data.requirementsPicker === RequirementsPicker.ORDER ? (
           <TextField
             disabled={disabled}
-            error={!!errors.minAmountSpent}
-            helperText={errors.minAmountSpent}
+            error={!!errors.minSpent}
+            helperText={errors.minSpent}
             label={minimalOrderValueText}
-            name={"minAmountSpent" as keyof FormData}
-            value={data.minAmountSpent}
+            name={"minSpent" as keyof FormData}
+            value={data.minSpent}
             onChange={onChange}
             fullWidth
           />

--- a/src/discounts/components/VoucherSummary/VoucherSummary.tsx
+++ b/src/discounts/components/VoucherSummary/VoucherSummary.tsx
@@ -121,12 +121,7 @@ const VoucherSummary: React.FC<VoucherSummaryProps> = ({
         </Typography>
         <Typography>
           {maybe<React.ReactNode>(
-            () =>
-              voucher.minAmountSpent ? (
-                <Money money={voucher.minAmountSpent} />
-              ) : (
-                "-"
-              ),
+            () => (voucher.minSpent ? <Money money={voucher.minSpent} /> : "-"),
             <Skeleton />
           )}
         </Typography>

--- a/src/discounts/fixtures.ts
+++ b/src/discounts/fixtures.ts
@@ -72,8 +72,8 @@ export const voucherList: VoucherList_vouchers_edges_node[] = [
     discountValueType: "PERCENTAGE" as DiscountValueTypeEnum,
     endDate: null,
     id: "Vm91Y2hlcjox",
-    minAmountSpent: null,
     minCheckoutItemsQuantity: null,
+    minSpent: null,
     startDate: "2019-01-03",
     usageLimit: null
   },
@@ -85,12 +85,12 @@ export const voucherList: VoucherList_vouchers_edges_node[] = [
     discountValueType: "FIXED" as DiscountValueTypeEnum,
     endDate: null,
     id: "Vm91Y2hlcjoy",
-    minAmountSpent: {
+    minCheckoutItemsQuantity: 0,
+    minSpent: {
       __typename: "Money" as "Money",
       amount: 200,
       currency: "USD"
     },
-    minCheckoutItemsQuantity: 0,
     startDate: "2019-01-03",
     usageLimit: 150
   }
@@ -281,12 +281,12 @@ export const voucherDetails: VoucherDetails_voucher = {
   discountValueType: DiscountValueTypeEnum.FIXED,
   endDate: null,
   id: "Vm91Y2hlcjoy",
-  minAmountSpent: {
+  minCheckoutItemsQuantity: 0,
+  minSpent: {
     __typename: "Money",
     amount: 200,
     currency: "USD"
   },
-  minCheckoutItemsQuantity: 0,
   products: {
     __typename: "ProductCountableConnection",
     edges: [],

--- a/src/discounts/queries.ts
+++ b/src/discounts/queries.ts
@@ -92,7 +92,7 @@ export const voucherFragment = gql`
       code
       country
     }
-    minAmountSpent {
+    minSpent {
       currency
       amount
     }

--- a/src/discounts/types/VoucherCataloguesAdd.ts
+++ b/src/discounts/types/VoucherCataloguesAdd.ts
@@ -20,7 +20,7 @@ export interface VoucherCataloguesAdd_voucherCataloguesAdd_voucher_countries {
   country: string;
 }
 
-export interface VoucherCataloguesAdd_voucherCataloguesAdd_voucher_minAmountSpent {
+export interface VoucherCataloguesAdd_voucherCataloguesAdd_voucher_minSpent {
   __typename: "Money";
   currency: string;
   amount: number;
@@ -140,7 +140,7 @@ export interface VoucherCataloguesAdd_voucherCataloguesAdd_voucher {
   discountValueType: DiscountValueTypeEnum;
   discountValue: number;
   countries: (VoucherCataloguesAdd_voucherCataloguesAdd_voucher_countries | null)[] | null;
-  minAmountSpent: VoucherCataloguesAdd_voucherCataloguesAdd_voucher_minAmountSpent | null;
+  minSpent: VoucherCataloguesAdd_voucherCataloguesAdd_voucher_minSpent | null;
   minCheckoutItemsQuantity: number | null;
   type: VoucherTypeEnum;
   used: number;

--- a/src/discounts/types/VoucherCataloguesRemove.ts
+++ b/src/discounts/types/VoucherCataloguesRemove.ts
@@ -20,7 +20,7 @@ export interface VoucherCataloguesRemove_voucherCataloguesRemove_voucher_countri
   country: string;
 }
 
-export interface VoucherCataloguesRemove_voucherCataloguesRemove_voucher_minAmountSpent {
+export interface VoucherCataloguesRemove_voucherCataloguesRemove_voucher_minSpent {
   __typename: "Money";
   currency: string;
   amount: number;
@@ -140,7 +140,7 @@ export interface VoucherCataloguesRemove_voucherCataloguesRemove_voucher {
   discountValueType: DiscountValueTypeEnum;
   discountValue: number;
   countries: (VoucherCataloguesRemove_voucherCataloguesRemove_voucher_countries | null)[] | null;
-  minAmountSpent: VoucherCataloguesRemove_voucherCataloguesRemove_voucher_minAmountSpent | null;
+  minSpent: VoucherCataloguesRemove_voucherCataloguesRemove_voucher_minSpent | null;
   minCheckoutItemsQuantity: number | null;
   type: VoucherTypeEnum;
   used: number;

--- a/src/discounts/types/VoucherCreate.ts
+++ b/src/discounts/types/VoucherCreate.ts
@@ -20,7 +20,7 @@ export interface VoucherCreate_voucherCreate_voucher_countries {
   country: string;
 }
 
-export interface VoucherCreate_voucherCreate_voucher_minAmountSpent {
+export interface VoucherCreate_voucherCreate_voucher_minSpent {
   __typename: "Money";
   currency: string;
   amount: number;
@@ -36,7 +36,7 @@ export interface VoucherCreate_voucherCreate_voucher {
   discountValueType: DiscountValueTypeEnum;
   discountValue: number;
   countries: (VoucherCreate_voucherCreate_voucher_countries | null)[] | null;
-  minAmountSpent: VoucherCreate_voucherCreate_voucher_minAmountSpent | null;
+  minSpent: VoucherCreate_voucherCreate_voucher_minSpent | null;
   minCheckoutItemsQuantity: number | null;
 }
 

--- a/src/discounts/types/VoucherDetails.ts
+++ b/src/discounts/types/VoucherDetails.ts
@@ -14,7 +14,7 @@ export interface VoucherDetails_voucher_countries {
   country: string;
 }
 
-export interface VoucherDetails_voucher_minAmountSpent {
+export interface VoucherDetails_voucher_minSpent {
   __typename: "Money";
   currency: string;
   amount: number;
@@ -134,7 +134,7 @@ export interface VoucherDetails_voucher {
   discountValueType: DiscountValueTypeEnum;
   discountValue: number;
   countries: (VoucherDetails_voucher_countries | null)[] | null;
-  minAmountSpent: VoucherDetails_voucher_minAmountSpent | null;
+  minSpent: VoucherDetails_voucher_minSpent | null;
   minCheckoutItemsQuantity: number | null;
   type: VoucherTypeEnum;
   used: number;

--- a/src/discounts/types/VoucherDetailsFragment.ts
+++ b/src/discounts/types/VoucherDetailsFragment.ts
@@ -14,7 +14,7 @@ export interface VoucherDetailsFragment_countries {
   country: string;
 }
 
-export interface VoucherDetailsFragment_minAmountSpent {
+export interface VoucherDetailsFragment_minSpent {
   __typename: "Money";
   currency: string;
   amount: number;
@@ -134,7 +134,7 @@ export interface VoucherDetailsFragment {
   discountValueType: DiscountValueTypeEnum;
   discountValue: number;
   countries: (VoucherDetailsFragment_countries | null)[] | null;
-  minAmountSpent: VoucherDetailsFragment_minAmountSpent | null;
+  minSpent: VoucherDetailsFragment_minSpent | null;
   minCheckoutItemsQuantity: number | null;
   type: VoucherTypeEnum;
   used: number;

--- a/src/discounts/types/VoucherFragment.ts
+++ b/src/discounts/types/VoucherFragment.ts
@@ -14,7 +14,7 @@ export interface VoucherFragment_countries {
   country: string;
 }
 
-export interface VoucherFragment_minAmountSpent {
+export interface VoucherFragment_minSpent {
   __typename: "Money";
   currency: string;
   amount: number;
@@ -30,6 +30,6 @@ export interface VoucherFragment {
   discountValueType: DiscountValueTypeEnum;
   discountValue: number;
   countries: (VoucherFragment_countries | null)[] | null;
-  minAmountSpent: VoucherFragment_minAmountSpent | null;
+  minSpent: VoucherFragment_minSpent | null;
   minCheckoutItemsQuantity: number | null;
 }

--- a/src/discounts/types/VoucherList.ts
+++ b/src/discounts/types/VoucherList.ts
@@ -14,7 +14,7 @@ export interface VoucherList_vouchers_edges_node_countries {
   country: string;
 }
 
-export interface VoucherList_vouchers_edges_node_minAmountSpent {
+export interface VoucherList_vouchers_edges_node_minSpent {
   __typename: "Money";
   currency: string;
   amount: number;
@@ -30,7 +30,7 @@ export interface VoucherList_vouchers_edges_node {
   discountValueType: DiscountValueTypeEnum;
   discountValue: number;
   countries: (VoucherList_vouchers_edges_node_countries | null)[] | null;
-  minAmountSpent: VoucherList_vouchers_edges_node_minAmountSpent | null;
+  minSpent: VoucherList_vouchers_edges_node_minSpent | null;
   minCheckoutItemsQuantity: number | null;
 }
 

--- a/src/discounts/types/VoucherUpdate.ts
+++ b/src/discounts/types/VoucherUpdate.ts
@@ -20,7 +20,7 @@ export interface VoucherUpdate_voucherUpdate_voucher_countries {
   country: string;
 }
 
-export interface VoucherUpdate_voucherUpdate_voucher_minAmountSpent {
+export interface VoucherUpdate_voucherUpdate_voucher_minSpent {
   __typename: "Money";
   currency: string;
   amount: number;
@@ -36,7 +36,7 @@ export interface VoucherUpdate_voucherUpdate_voucher {
   discountValueType: DiscountValueTypeEnum;
   discountValue: number;
   countries: (VoucherUpdate_voucherUpdate_voucher_countries | null)[] | null;
-  minAmountSpent: VoucherUpdate_voucherUpdate_voucher_minAmountSpent | null;
+  minSpent: VoucherUpdate_voucherUpdate_voucher_minSpent | null;
   minCheckoutItemsQuantity: number | null;
 }
 

--- a/src/discounts/views/VoucherCreate.tsx
+++ b/src/discounts/views/VoucherCreate.tsx
@@ -65,7 +65,7 @@ export const VoucherDetails: React.FC = () => {
                     minAmountSpent:
                       formData.requirementsPicker !== RequirementsPicker.ORDER
                         ? 0
-                        : parseFloat(formData.minAmountSpent),
+                        : parseFloat(formData.minSpent),
                     minCheckoutItemsQuantity:
                       formData.requirementsPicker !== RequirementsPicker.ITEM
                         ? 0

--- a/src/discounts/views/VoucherDetails.tsx
+++ b/src/discounts/views/VoucherDetails.tsx
@@ -318,7 +318,7 @@ export const VoucherDetails: React.FC<VoucherDetailsProps> = ({
                                         formData.requirementsPicker !==
                                         RequirementsPicker.ORDER
                                           ? 0
-                                          : parseFloat(formData.minAmountSpent),
+                                          : parseFloat(formData.minSpent),
                                       minCheckoutItemsQuantity:
                                         formData.requirementsPicker !==
                                         RequirementsPicker.ITEM

--- a/src/home/components/HomeProductListCard/HomeProductListCard.tsx
+++ b/src/home/components/HomeProductListCard/HomeProductListCard.tsx
@@ -93,7 +93,7 @@ export const HomeProductList: React.FC<HomeProductListProps> = props => {
                       <Typography color={"textSecondary"}>
                         {maybe(() =>
                           variant.attributes
-                            .map(attribute => attribute.value.name)
+                            .map(attribute => attribute.values[0].name)
                             .join(" / ")
                         )}
                       </Typography>

--- a/src/home/fixtures.ts
+++ b/src/home/fixtures.ts
@@ -289,12 +289,14 @@ export const shop: (placeholderImage: string) => Home = (
           attributes: [
             {
               __typename: "SelectedAttribute",
-              value: {
-                __typename: "AttributeValue",
-                id: "QXR0cmlidXRlVmFsdWU6OTI=",
-                name: "XS",
-                sortOrder: 0
-              }
+              values: [
+                {
+                  __typename: "AttributeValue",
+                  id: "QXR0cmlidXRlVmFsdWU6OTI=",
+                  name: "XS",
+                  sortOrder: 0
+                }
+              ]
             }
           ],
           id: "UHJvZHVjdFZhcmlhbnQ6NDM=",

--- a/src/home/queries.ts
+++ b/src/home/queries.ts
@@ -34,7 +34,7 @@ const home = gql`
             }
           }
           attributes {
-            value {
+            values {
               id
               name
             }

--- a/src/home/types/Home.ts
+++ b/src/home/types/Home.ts
@@ -50,7 +50,7 @@ export interface Home_productTopToday_edges_node_revenue {
   gross: Home_productTopToday_edges_node_revenue_gross;
 }
 
-export interface Home_productTopToday_edges_node_attributes_value {
+export interface Home_productTopToday_edges_node_attributes_values {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
@@ -58,7 +58,7 @@ export interface Home_productTopToday_edges_node_attributes_value {
 
 export interface Home_productTopToday_edges_node_attributes {
   __typename: "SelectedAttribute";
-  value: Home_productTopToday_edges_node_attributes_value | null;
+  values: (Home_productTopToday_edges_node_attributes_values | null)[];
 }
 
 export interface Home_productTopToday_edges_node_product_thumbnail {

--- a/src/navigation/fixtures.ts
+++ b/src/navigation/fixtures.ts
@@ -48,7 +48,6 @@ export const menu: MenuDetails_menu = {
           level: 0,
           name: "Jewelry",
           page: null,
-          sortOrder: 0,
           url: null
         },
         {
@@ -64,7 +63,6 @@ export const menu: MenuDetails_menu = {
           level: 0,
           name: "Glasses",
           page: null,
-          sortOrder: 1,
           url: null
         }
       ],
@@ -73,7 +71,6 @@ export const menu: MenuDetails_menu = {
       level: 0,
       name: "Accessories",
       page: null,
-      sortOrder: 0,
       url: null
     },
     {
@@ -89,7 +86,6 @@ export const menu: MenuDetails_menu = {
       level: 0,
       name: "Groceries",
       page: null,
-      sortOrder: 1,
       url: null
     },
     {
@@ -105,7 +101,6 @@ export const menu: MenuDetails_menu = {
       level: 0,
       name: "Apparel",
       page: null,
-      sortOrder: 2,
       url: null
     }
   ],

--- a/src/navigation/queries.ts
+++ b/src/navigation/queries.ts
@@ -31,7 +31,6 @@ export const menuItemFragment = gql`
       id
       title
     }
-    sortOrder
     url
   }
 `;

--- a/src/navigation/types/MenuDetails.ts
+++ b/src/navigation/types/MenuDetails.ts
@@ -140,7 +140,6 @@ export interface MenuDetails_menu_items_children_children_children_children_chil
   level: number;
   name: string;
   page: MenuDetails_menu_items_children_children_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
 }
 
@@ -152,7 +151,6 @@ export interface MenuDetails_menu_items_children_children_children_children_chil
   level: number;
   name: string;
   page: MenuDetails_menu_items_children_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetails_menu_items_children_children_children_children_children_children | null)[] | null;
 }
@@ -165,7 +163,6 @@ export interface MenuDetails_menu_items_children_children_children_children {
   level: number;
   name: string;
   page: MenuDetails_menu_items_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetails_menu_items_children_children_children_children_children | null)[] | null;
 }
@@ -178,7 +175,6 @@ export interface MenuDetails_menu_items_children_children_children {
   level: number;
   name: string;
   page: MenuDetails_menu_items_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetails_menu_items_children_children_children_children | null)[] | null;
 }
@@ -191,7 +187,6 @@ export interface MenuDetails_menu_items_children_children {
   level: number;
   name: string;
   page: MenuDetails_menu_items_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetails_menu_items_children_children_children | null)[] | null;
 }
@@ -204,7 +199,6 @@ export interface MenuDetails_menu_items_children {
   level: number;
   name: string;
   page: MenuDetails_menu_items_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetails_menu_items_children_children | null)[] | null;
 }
@@ -217,7 +211,6 @@ export interface MenuDetails_menu_items {
   level: number;
   name: string;
   page: MenuDetails_menu_items_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetails_menu_items_children | null)[] | null;
 }

--- a/src/navigation/types/MenuDetailsFragment.ts
+++ b/src/navigation/types/MenuDetailsFragment.ts
@@ -140,7 +140,6 @@ export interface MenuDetailsFragment_items_children_children_children_children_c
   level: number;
   name: string;
   page: MenuDetailsFragment_items_children_children_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
 }
 
@@ -152,7 +151,6 @@ export interface MenuDetailsFragment_items_children_children_children_children_c
   level: number;
   name: string;
   page: MenuDetailsFragment_items_children_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetailsFragment_items_children_children_children_children_children_children | null)[] | null;
 }
@@ -165,7 +163,6 @@ export interface MenuDetailsFragment_items_children_children_children_children {
   level: number;
   name: string;
   page: MenuDetailsFragment_items_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetailsFragment_items_children_children_children_children_children | null)[] | null;
 }
@@ -178,7 +175,6 @@ export interface MenuDetailsFragment_items_children_children_children {
   level: number;
   name: string;
   page: MenuDetailsFragment_items_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetailsFragment_items_children_children_children_children | null)[] | null;
 }
@@ -191,7 +187,6 @@ export interface MenuDetailsFragment_items_children_children {
   level: number;
   name: string;
   page: MenuDetailsFragment_items_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetailsFragment_items_children_children_children | null)[] | null;
 }
@@ -204,7 +199,6 @@ export interface MenuDetailsFragment_items_children {
   level: number;
   name: string;
   page: MenuDetailsFragment_items_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetailsFragment_items_children_children | null)[] | null;
 }
@@ -217,7 +211,6 @@ export interface MenuDetailsFragment_items {
   level: number;
   name: string;
   page: MenuDetailsFragment_items_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuDetailsFragment_items_children | null)[] | null;
 }

--- a/src/navigation/types/MenuItemCreate.ts
+++ b/src/navigation/types/MenuItemCreate.ts
@@ -148,7 +148,6 @@ export interface MenuItemCreate_menuItemCreate_menuItem_menu_items_children_chil
   level: number;
   name: string;
   page: MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
 }
 
@@ -160,7 +159,6 @@ export interface MenuItemCreate_menuItemCreate_menuItem_menu_items_children_chil
   level: number;
   name: string;
   page: MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_children_children_children_children | null)[] | null;
 }
@@ -173,7 +171,6 @@ export interface MenuItemCreate_menuItemCreate_menuItem_menu_items_children_chil
   level: number;
   name: string;
   page: MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_children_children_children | null)[] | null;
 }
@@ -186,7 +183,6 @@ export interface MenuItemCreate_menuItemCreate_menuItem_menu_items_children_chil
   level: number;
   name: string;
   page: MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_children_children | null)[] | null;
 }
@@ -199,7 +195,6 @@ export interface MenuItemCreate_menuItemCreate_menuItem_menu_items_children_chil
   level: number;
   name: string;
   page: MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children_children | null)[] | null;
 }
@@ -212,7 +207,6 @@ export interface MenuItemCreate_menuItemCreate_menuItem_menu_items_children {
   level: number;
   name: string;
   page: MenuItemCreate_menuItemCreate_menuItem_menu_items_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemCreate_menuItemCreate_menuItem_menu_items_children_children | null)[] | null;
 }
@@ -225,7 +219,6 @@ export interface MenuItemCreate_menuItemCreate_menuItem_menu_items {
   level: number;
   name: string;
   page: MenuItemCreate_menuItemCreate_menuItem_menu_items_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemCreate_menuItemCreate_menuItem_menu_items_children | null)[] | null;
 }

--- a/src/navigation/types/MenuItemFragment.ts
+++ b/src/navigation/types/MenuItemFragment.ts
@@ -32,6 +32,5 @@ export interface MenuItemFragment {
   level: number;
   name: string;
   page: MenuItemFragment_page | null;
-  sortOrder: number | null;
   url: string | null;
 }

--- a/src/navigation/types/MenuItemNestedFragment.ts
+++ b/src/navigation/types/MenuItemNestedFragment.ts
@@ -140,7 +140,6 @@ export interface MenuItemNestedFragment_children_children_children_children_chil
   level: number;
   name: string;
   page: MenuItemNestedFragment_children_children_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
 }
 
@@ -152,7 +151,6 @@ export interface MenuItemNestedFragment_children_children_children_children_chil
   level: number;
   name: string;
   page: MenuItemNestedFragment_children_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemNestedFragment_children_children_children_children_children_children | null)[] | null;
 }
@@ -165,7 +163,6 @@ export interface MenuItemNestedFragment_children_children_children_children {
   level: number;
   name: string;
   page: MenuItemNestedFragment_children_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemNestedFragment_children_children_children_children_children | null)[] | null;
 }
@@ -178,7 +175,6 @@ export interface MenuItemNestedFragment_children_children_children {
   level: number;
   name: string;
   page: MenuItemNestedFragment_children_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemNestedFragment_children_children_children_children | null)[] | null;
 }
@@ -191,7 +187,6 @@ export interface MenuItemNestedFragment_children_children {
   level: number;
   name: string;
   page: MenuItemNestedFragment_children_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemNestedFragment_children_children_children | null)[] | null;
 }
@@ -204,7 +199,6 @@ export interface MenuItemNestedFragment_children {
   level: number;
   name: string;
   page: MenuItemNestedFragment_children_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemNestedFragment_children_children | null)[] | null;
 }
@@ -217,7 +211,6 @@ export interface MenuItemNestedFragment {
   level: number;
   name: string;
   page: MenuItemNestedFragment_page | null;
-  sortOrder: number | null;
   url: string | null;
   children: (MenuItemNestedFragment_children | null)[] | null;
 }

--- a/src/navigation/types/MenuItemUpdate.ts
+++ b/src/navigation/types/MenuItemUpdate.ts
@@ -40,7 +40,6 @@ export interface MenuItemUpdate_menuItemUpdate_menuItem {
   level: number;
   name: string;
   page: MenuItemUpdate_menuItemUpdate_menuItem_page | null;
-  sortOrder: number | null;
   url: string | null;
 }
 

--- a/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
+++ b/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
@@ -303,7 +303,9 @@ const OrderProductAddDialog: React.FC<OrderProductAddDialogProps> = props => {
                             </div>
                           </TableCell>
                           <TableCell className={classes.textRight}>
-                            <Money money={variant.price} />
+                            <Money
+                              money={variant.pricing.priceUndiscounted.net}
+                            />
                           </TableCell>
                         </TableRow>
                       )

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -10,6 +10,7 @@ import {
 } from "../types/globalTypes";
 import { OrderDetails_order } from "./types/OrderDetails";
 import { OrderList_orders_edges_node } from "./types/OrderList";
+import { SearchOrderVariant_search_edges_node } from "./types/SearchOrderVariant";
 
 export const clients: SearchCustomers_search_edges_node[] = [
   {
@@ -1163,7 +1164,9 @@ export const shippingMethods = [
   { country: "whole world", id: "s1", name: "DHL", price: {} },
   { country: "Afghanistan", id: "s2", name: "UPS" }
 ];
-export const orderLineSearch = (placeholderImage: string) => [
+export const orderLineSearch = (
+  placeholderImage: string
+): SearchOrderVariant_search_edges_node[] => [
   {
     __typename: "Product" as "Product",
     id: "UHJvZHVjdDo3Mg==",
@@ -1177,21 +1180,51 @@ export const orderLineSearch = (placeholderImage: string) => [
         __typename: "ProductVariant" as "ProductVariant",
         id: "UHJvZHVjdFZhcmlhbnQ6MjAy",
         name: "500ml",
-        price: { __typename: "Money" as "Money", amount: 3.0, currency: "USD" },
+        pricing: {
+          __typename: "VariantPricingInfo",
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            net: {
+              __typename: "Money" as "Money",
+              amount: 3.0,
+              currency: "USD"
+            }
+          }
+        },
         sku: "93855755"
       },
       {
         __typename: "ProductVariant" as "ProductVariant",
         id: "UHJvZHVjdFZhcmlhbnQ6MjAz",
         name: "1l",
-        price: { __typename: "Money" as "Money", amount: 5.0, currency: "USD" },
+        pricing: {
+          __typename: "VariantPricingInfo",
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            net: {
+              __typename: "Money" as "Money",
+              amount: 5.0,
+              currency: "USD"
+            }
+          }
+        },
         sku: "43226647"
       },
       {
         __typename: "ProductVariant" as "ProductVariant",
         id: "UHJvZHVjdFZhcmlhbnQ6MjA0",
         name: "2l",
-        price: { __typename: "Money" as "Money", amount: 7.0, currency: "USD" },
+        pricing: {
+          __typename: "VariantPricingInfo",
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            net: {
+              __typename: "Money" as "Money",
+              amount: 7.0,
+              currency: "USD"
+            }
+          }
+        },
         sku: "80884671"
       }
     ]
@@ -1209,21 +1242,51 @@ export const orderLineSearch = (placeholderImage: string) => [
         __typename: "ProductVariant" as "ProductVariant",
         id: "UHJvZHVjdFZhcmlhbnQ6MjEx",
         name: "500ml",
-        price: { __typename: "Money" as "Money", amount: 3.0, currency: "USD" },
+        pricing: {
+          __typename: "VariantPricingInfo",
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            net: {
+              __typename: "Money" as "Money",
+              amount: 3.0,
+              currency: "USD"
+            }
+          }
+        },
         sku: "43200242"
       },
       {
         __typename: "ProductVariant" as "ProductVariant",
         id: "UHJvZHVjdFZhcmlhbnQ6MjEy",
         name: "1l",
-        price: { __typename: "Money" as "Money", amount: 5.0, currency: "USD" },
+        pricing: {
+          __typename: "VariantPricingInfo",
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            net: {
+              __typename: "Money" as "Money",
+              amount: 5.0,
+              currency: "USD"
+            }
+          }
+        },
         sku: "79129513"
       },
       {
         __typename: "ProductVariant" as "ProductVariant",
         id: "UHJvZHVjdFZhcmlhbnQ6MjEz",
         name: "2l",
-        price: { __typename: "Money" as "Money", amount: 7.0, currency: "USD" },
+        pricing: {
+          __typename: "VariantPricingInfo",
+          priceUndiscounted: {
+            __typename: "TaxedMoney",
+            net: {
+              __typename: "Money" as "Money",
+              amount: 7.0,
+              currency: "USD"
+            }
+          }
+        },
         sku: "75799450"
       }
     ]

--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -291,7 +291,7 @@ export const TypedOrderDetailsQuery = TypedQuery<
 
 export const searchOrderVariant = gql`
   query SearchOrderVariant($first: Int!, $query: String!, $after: String) {
-    search: products(query: $query, first: $first, after: $after) {
+    search: products(first: $first, after: $after, filter: { search: $query }) {
       edges {
         node {
           id
@@ -303,9 +303,13 @@ export const searchOrderVariant = gql`
             id
             name
             sku
-            price {
-              amount
-              currency
+            pricing {
+              priceUndiscounted {
+                net {
+                  amount
+                  currency
+                }
+              }
             }
           }
         }

--- a/src/orders/types/SearchOrderVariant.ts
+++ b/src/orders/types/SearchOrderVariant.ts
@@ -11,10 +11,20 @@ export interface SearchOrderVariant_search_edges_node_thumbnail {
   url: string;
 }
 
-export interface SearchOrderVariant_search_edges_node_variants_price {
+export interface SearchOrderVariant_search_edges_node_variants_pricing_priceUndiscounted_net {
   __typename: "Money";
   amount: number;
   currency: string;
+}
+
+export interface SearchOrderVariant_search_edges_node_variants_pricing_priceUndiscounted {
+  __typename: "TaxedMoney";
+  net: SearchOrderVariant_search_edges_node_variants_pricing_priceUndiscounted_net;
+}
+
+export interface SearchOrderVariant_search_edges_node_variants_pricing {
+  __typename: "VariantPricingInfo";
+  priceUndiscounted: SearchOrderVariant_search_edges_node_variants_pricing_priceUndiscounted | null;
 }
 
 export interface SearchOrderVariant_search_edges_node_variants {
@@ -22,7 +32,7 @@ export interface SearchOrderVariant_search_edges_node_variants {
   id: string;
   name: string;
   sku: string;
-  price: SearchOrderVariant_search_edges_node_variants_price | null;
+  pricing: SearchOrderVariant_search_edges_node_variants_pricing | null;
 }
 
 export interface SearchOrderVariant_search_edges_node {

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -995,12 +995,14 @@ export const variant = (placeholderImage: string): ProductVariant => ({
           }
         ]
       },
-      value: {
-        __typename: "AttributeValue",
-        id: "ptav47282",
-        name: "portals",
-        slug: "portals"
-      }
+      values: [
+        {
+          __typename: "AttributeValue",
+          id: "ptav47282",
+          name: "portals",
+          slug: "portals"
+        }
+      ]
     },
     {
       __typename: "SelectedAttribute",
@@ -1037,12 +1039,14 @@ export const variant = (placeholderImage: string): ProductVariant => ({
           }
         ]
       },
-      value: {
-        __typename: "AttributeValue",
-        id: "ptav14907",
-        name: "Auto Loan Account",
-        slug: "Auto-Loan-Account"
-      }
+      values: [
+        {
+          __typename: "AttributeValue",
+          id: "ptav14907",
+          name: "Auto Loan Account",
+          slug: "Auto-Loan-Account"
+        }
+      ]
     }
   ],
   costPrice: {

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -167,7 +167,7 @@ export const fragmentVariant = gql`
           slug
         }
       }
-      value {
+      values {
         id
         name
         slug

--- a/src/products/types/ProductVariant.ts
+++ b/src/products/types/ProductVariant.ts
@@ -22,7 +22,7 @@ export interface ProductVariant_attributes_attribute {
   values: (ProductVariant_attributes_attribute_values | null)[] | null;
 }
 
-export interface ProductVariant_attributes_value {
+export interface ProductVariant_attributes_values {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
@@ -32,7 +32,7 @@ export interface ProductVariant_attributes_value {
 export interface ProductVariant_attributes {
   __typename: "SelectedAttribute";
   attribute: ProductVariant_attributes_attribute;
-  value: ProductVariant_attributes_value | null;
+  values: (ProductVariant_attributes_values | null)[];
 }
 
 export interface ProductVariant_costPrice {

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -22,7 +22,7 @@ export interface ProductVariantDetails_productVariant_attributes_attribute {
   values: (ProductVariantDetails_productVariant_attributes_attribute_values | null)[] | null;
 }
 
-export interface ProductVariantDetails_productVariant_attributes_value {
+export interface ProductVariantDetails_productVariant_attributes_values {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
@@ -32,7 +32,7 @@ export interface ProductVariantDetails_productVariant_attributes_value {
 export interface ProductVariantDetails_productVariant_attributes {
   __typename: "SelectedAttribute";
   attribute: ProductVariantDetails_productVariant_attributes_attribute;
-  value: ProductVariantDetails_productVariant_attributes_value | null;
+  values: (ProductVariantDetails_productVariant_attributes_values | null)[];
 }
 
 export interface ProductVariantDetails_productVariant_costPrice {

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -204,7 +204,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_attribu
   values: (SimpleProductUpdate_productVariantUpdate_productVariant_attributes_attribute_values | null)[] | null;
 }
 
-export interface SimpleProductUpdate_productVariantUpdate_productVariant_attributes_value {
+export interface SimpleProductUpdate_productVariantUpdate_productVariant_attributes_values {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
@@ -214,7 +214,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_attribu
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_attributes {
   __typename: "SelectedAttribute";
   attribute: SimpleProductUpdate_productVariantUpdate_productVariant_attributes_attribute;
-  value: SimpleProductUpdate_productVariantUpdate_productVariant_attributes_value | null;
+  values: (SimpleProductUpdate_productVariantUpdate_productVariant_attributes_values | null)[];
 }
 
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_costPrice {

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -31,7 +31,7 @@ export interface VariantCreate_productVariantCreate_productVariant_attributes_at
   values: (VariantCreate_productVariantCreate_productVariant_attributes_attribute_values | null)[] | null;
 }
 
-export interface VariantCreate_productVariantCreate_productVariant_attributes_value {
+export interface VariantCreate_productVariantCreate_productVariant_attributes_values {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
@@ -41,7 +41,7 @@ export interface VariantCreate_productVariantCreate_productVariant_attributes_va
 export interface VariantCreate_productVariantCreate_productVariant_attributes {
   __typename: "SelectedAttribute";
   attribute: VariantCreate_productVariantCreate_productVariant_attributes_attribute;
-  value: VariantCreate_productVariantCreate_productVariant_attributes_value | null;
+  values: (VariantCreate_productVariantCreate_productVariant_attributes_values | null)[];
 }
 
 export interface VariantCreate_productVariantCreate_productVariant_costPrice {

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -28,7 +28,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_attributes
   values: (VariantImageAssign_variantImageAssign_productVariant_attributes_attribute_values | null)[] | null;
 }
 
-export interface VariantImageAssign_variantImageAssign_productVariant_attributes_value {
+export interface VariantImageAssign_variantImageAssign_productVariant_attributes_values {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
@@ -38,7 +38,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_attributes
 export interface VariantImageAssign_variantImageAssign_productVariant_attributes {
   __typename: "SelectedAttribute";
   attribute: VariantImageAssign_variantImageAssign_productVariant_attributes_attribute;
-  value: VariantImageAssign_variantImageAssign_productVariant_attributes_value | null;
+  values: (VariantImageAssign_variantImageAssign_productVariant_attributes_values | null)[];
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant_costPrice {

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -28,7 +28,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_attrib
   values: (VariantImageUnassign_variantImageUnassign_productVariant_attributes_attribute_values | null)[] | null;
 }
 
-export interface VariantImageUnassign_variantImageUnassign_productVariant_attributes_value {
+export interface VariantImageUnassign_variantImageUnassign_productVariant_attributes_values {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
@@ -38,7 +38,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_attrib
 export interface VariantImageUnassign_variantImageUnassign_productVariant_attributes {
   __typename: "SelectedAttribute";
   attribute: VariantImageUnassign_variantImageUnassign_productVariant_attributes_attribute;
-  value: VariantImageUnassign_variantImageUnassign_productVariant_attributes_value | null;
+  values: (VariantImageUnassign_variantImageUnassign_productVariant_attributes_values | null)[];
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant_costPrice {

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -31,7 +31,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_attributes_at
   values: (VariantUpdate_productVariantUpdate_productVariant_attributes_attribute_values | null)[] | null;
 }
 
-export interface VariantUpdate_productVariantUpdate_productVariant_attributes_value {
+export interface VariantUpdate_productVariantUpdate_productVariant_attributes_values {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
@@ -41,7 +41,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_attributes_va
 export interface VariantUpdate_productVariantUpdate_productVariant_attributes {
   __typename: "SelectedAttribute";
   attribute: VariantUpdate_productVariantUpdate_productVariant_attributes_attribute;
-  value: VariantUpdate_productVariantUpdate_productVariant_attributes_value | null;
+  values: (VariantUpdate_productVariantUpdate_productVariant_attributes_values | null)[];
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant_costPrice {

--- a/src/products/utils/data.ts
+++ b/src/products/utils/data.ts
@@ -96,7 +96,7 @@ export function getAttributeInputFromVariant(
         },
         id: attribute.attribute.id,
         label: attribute.attribute.name,
-        value: maybe(() => attribute.value.slug, null)
+        value: maybe(() => attribute.values[0].slug, null)
       })),
     []
   );

--- a/src/searches/useCategorySearch.ts
+++ b/src/searches/useCategorySearch.ts
@@ -10,7 +10,11 @@ import {
 export const searchCategories = gql`
   ${pageInfoFragment}
   query SearchCategories($after: String, $first: Int!, $query: String!) {
-    search: categories(after: $after, first: $first, query: $query) {
+    search: categories(
+      after: $after
+      first: $first
+      filter: { search: $query }
+    ) {
       edges {
         node {
           id

--- a/src/searches/useCollectionSearch.ts
+++ b/src/searches/useCollectionSearch.ts
@@ -10,7 +10,11 @@ import {
 export const searchCollections = gql`
   ${pageInfoFragment}
   query SearchCollections($after: String, $first: Int!, $query: String!) {
-    search: collections(after: $after, first: $first, query: $query) {
+    search: collections(
+      after: $after
+      first: $first
+      filter: { search: $query }
+    ) {
       edges {
         node {
           id

--- a/src/searches/useCustomerSearch.ts
+++ b/src/searches/useCustomerSearch.ts
@@ -10,7 +10,11 @@ import {
 export const searchCustomers = gql`
   ${pageInfoFragment}
   query SearchCustomers($after: String, $first: Int!, $query: String!) {
-    search: customers(after: $after, first: $first, query: $query) {
+    search: customers(
+      after: $after
+      first: $first
+      filter: { search: $query }
+    ) {
       edges {
         node {
           id

--- a/src/searches/usePageSearch.ts
+++ b/src/searches/usePageSearch.ts
@@ -7,7 +7,7 @@ import { SearchPages, SearchPagesVariables } from "./types/SearchPages";
 export const searchPages = gql`
   ${pageInfoFragment}
   query SearchPages($after: String, $first: Int!, $query: String!) {
-    search: pages(after: $after, first: $first, query: $query) {
+    search: pages(after: $after, first: $first, filter: { search: $query }) {
       edges {
         node {
           id

--- a/src/searches/useProductSearch.ts
+++ b/src/searches/useProductSearch.ts
@@ -10,7 +10,7 @@ import {
 export const searchProducts = gql`
   ${pageInfoFragment}
   query SearchProducts($after: String, $first: Int!, $query: String!) {
-    search: products(after: $after, first: $first, query: $query) {
+    search: products(after: $after, first: $first, filter: { search: $query }) {
       edges {
         node {
           id

--- a/src/staff/views/StaffList/StaffList.tsx
+++ b/src/staff/views/StaffList/StaffList.tsx
@@ -143,8 +143,7 @@ export const StaffList: React.FC<StaffListProps> = ({ params }) => {
                   window.location.origin,
                   APP_MOUNT_URI === "/" ? "" : APP_MOUNT_URI,
                   newPasswordUrl().replace(/\?/, "")
-                ),
-                sendPasswordEmail: true
+                )
               }
             }
           });

--- a/src/storybook/stories/discounts/VoucherCreatePage.tsx
+++ b/src/storybook/stories/discounts/VoucherCreatePage.tsx
@@ -28,7 +28,7 @@ storiesOf("Views / Discounts / Voucher create", module)
         "code",
         "discountType",
         "endDate",
-        "minAmountSpent",
+        "minSpent",
         "name",
         "startDate",
         "type",

--- a/src/storybook/stories/discounts/VoucherDetailsPage.tsx
+++ b/src/storybook/stories/discounts/VoucherDetailsPage.tsx
@@ -53,7 +53,7 @@ storiesOf("Views / Discounts / Voucher details", module)
         "code",
         "discountType",
         "endDate",
-        "minAmountSpent",
+        "minSpent",
         "name",
         "startDate",
         "type",

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -480,6 +480,7 @@ export enum PaymentChargeStatusEnum {
 
 export enum PermissionEnum {
   IMPERSONATE_USERS = "IMPERSONATE_USERS",
+  MANAGE_CHECKOUTS = "MANAGE_CHECKOUTS",
   MANAGE_DISCOUNTS = "MANAGE_DISCOUNTS",
   MANAGE_GIFT_CARD = "MANAGE_GIFT_CARD",
   MANAGE_MENUS = "MANAGE_MENUS",
@@ -640,6 +641,7 @@ export enum WebhookErrorCode {
 
 export enum WebhookEventTypeEnum {
   ANY_EVENTS = "ANY_EVENTS",
+  CHECKOUT_QUANTITY_CHANGED = "CHECKOUT_QUANTITY_CHANGED",
   CUSTOMER_CREATED = "CUSTOMER_CREATED",
   ORDER_CANCELLED = "ORDER_CANCELLED",
   ORDER_CREATED = "ORDER_CREATED",
@@ -1168,7 +1170,6 @@ export interface StaffCreateInput {
   isActive?: boolean | null;
   note?: string | null;
   permissions?: (PermissionEnum | null)[] | null;
-  sendPasswordEmail?: boolean | null;
   redirectUrl?: string | null;
 }
 
@@ -1202,7 +1203,6 @@ export interface UserCreateInput {
   email?: string | null;
   isActive?: boolean | null;
   note?: string | null;
-  sendPasswordEmail?: boolean | null;
   redirectUrl?: string | null;
 }
 

--- a/src/webhooks/components/WebhookEvents/WebhookEvents.tsx
+++ b/src/webhooks/components/WebhookEvents/WebhookEvents.tsx
@@ -59,6 +59,10 @@ const WebhookEvents: React.FC<WebhookEventsProps> = ({
     [WebhookEventTypeEnum.PRODUCT_CREATED]: intl.formatMessage({
       defaultMessage: "Product created",
       description: "event"
+    }),
+    [WebhookEventTypeEnum.CHECKOUT_QUANTITY_CHANGED]: intl.formatMessage({
+      defaultMessage: "Changed quantity in checkout",
+      description: "event"
     })
   };
 


### PR DESCRIPTION
I want to merge this change because it uses up to date API fields instead of the deprecated ones.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
