### PR TITLE
Add missing filters to product list

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -556,6 +556,7 @@ type CategoryDelete {
 
 input CategoryFilterInput {
   search: String
+  ids: [ID]
 }
 
 input CategoryInput {
@@ -921,6 +922,7 @@ type CollectionDelete {
 input CollectionFilterInput {
   published: CollectionPublished
   search: String
+  ids: [ID]
 }
 
 input CollectionInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -66,7 +66,7 @@ input AccountInput {
 
 type AccountRegister {
   errors: [Error!]
-  requiresConfirmation: Boolean!
+  requiresConfirmation: Boolean
   accountErrors: [AccountError!]
   user: User
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -66,6 +66,7 @@ input AccountInput {
 
 type AccountRegister {
   errors: [Error!]
+  requiresConfirmation: Boolean!
   accountErrors: [AccountError!]
   user: User
 }
@@ -73,6 +74,7 @@ type AccountRegister {
 input AccountRegisterInput {
   email: String!
   password: String!
+  redirectUrl: String!
 }
 
 type AccountRequestDeletion {
@@ -287,7 +289,8 @@ input AttributeFilterInput {
 
 input AttributeInput {
   slug: String!
-  value: String!
+  value: String
+  values: [String]
 }
 
 enum AttributeInputTypeEnum {
@@ -1027,6 +1030,10 @@ enum ConfigurationTypeFieldEnum {
   BOOLEAN
   SECRET
   PASSWORD
+}
+
+type ConfirmAccount {
+  errors: [Error!]
 }
 
 type ConfirmEmailChange {
@@ -2080,6 +2087,13 @@ type Mutation {
   webhookCreate(input: WebhookCreateInput!): WebhookCreate
   webhookDelete(id: ID!): WebhookDelete
   webhookUpdate(id: ID!, input: WebhookUpdateInput!): WebhookUpdate
+  createWarehouse(input: WarehouseCreateInput!): WarehouseCreate
+  updateWarehouse(id: ID!, input: WarehouseUpdateInput!): WarehouseUpdate
+  deleteWarehouse(id: ID!): WarehouseDelete
+  createStock(input: StockInput!): StockCreate
+  updateStock(id: ID!, input: StockInput!): StockUpdate
+  deleteStock(id: ID!): StockDelete
+  bulkDeleteStock(ids: [ID]!): StockBulkDelete
   authorizationKeyAdd(input: AuthorizationKeyInput!, keyType: AuthorizationKeyType!): AuthorizationKeyAdd
   authorizationKeyDelete(keyType: AuthorizationKeyType!): AuthorizationKeyDelete
   staffNotificationRecipientCreate(input: StaffNotificationRecipientInput!): StaffNotificationRecipientCreate
@@ -2270,6 +2284,7 @@ type Mutation {
   checkoutUpdatePrivateMetadata(id: ID!, input: MetaInput!): CheckoutUpdatePrivateMeta
   checkoutClearPrivateMetadata(id: ID!, input: MetaPath!): CheckoutClearPrivateMeta
   requestPasswordReset(email: String!, redirectUrl: String!): RequestPasswordReset
+  confirmAccount(email: String!, token: String!): ConfirmAccount
   setPassword(token: String!, email: String!, password: String!): SetPassword
   passwordChange(newPassword: String!, oldPassword: String!): PasswordChange
   requestEmailChange(newEmail: String!, password: String!, redirectUrl: String!): RequestEmailChange
@@ -3082,6 +3097,7 @@ input ProductFilterInput {
   productType: ID
   search: String
   minimalPrice: PriceRangeInput
+  productTypes: [ID]
 }
 
 type ProductImage implements Node {
@@ -3349,15 +3365,15 @@ type ProductVariant implements Node {
   sku: String!
   product: Product!
   trackInventory: Boolean!
-  quantityAllocated: Int!
   weight: Weight
   privateMeta: [MetaStore]!
   meta: [MetaStore]!
-  quantity: Int!
-  stockQuantity: Int!
+  quantity: Int! @deprecated(reason: "This field will be removed in Saleor 2.11. Use the stock field instead.")
+  quantityAllocated: Int @deprecated(reason: "This field will be removed in Saleor 2.11. Use the stock field instead.")
+  stockQuantity: Int! @deprecated(reason: "This field will be removed in Saleor 2.11. Use the stock field instead.")
   priceOverride: Money
   pricing: VariantPricingInfo
-  isAvailable: Boolean
+  isAvailable: Boolean @deprecated(reason: "This field will be removed in Saleor 2.11. Use the stock field instead.")
   attributes: [SelectedAttribute!]!
   costPrice: Money
   margin: Int
@@ -3366,6 +3382,7 @@ type ProductVariant implements Node {
   images: [ProductImage]
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
   digitalContent: DigitalContent
+  stock(country: String): [Stock]
 }
 
 type ProductVariantBulkCreate {
@@ -3488,8 +3505,12 @@ type Query {
   webhooks(sortBy: WebhookSortingInput, filter: WebhookFilterInput, before: String, after: String, first: Int, last: Int): WebhookCountableConnection
   webhookEvents: [WebhookEvent]
   webhookSamplePayload(eventType: WebhookEventTypeEnum!): JSONString
+  warehouse(id: ID!): Warehouse
+  warehouses(filter: WarehouseFilterInput, before: String, after: String, first: Int, last: Int): WarehouseCountableConnection
   translations(kind: TranslatableKinds!, before: String, after: String, first: Int, last: Int): TranslatableItemConnection
   translation(id: ID!, kind: TranslatableKinds!): TranslatableItem
+  stock(id: ID!): Stock
+  stocks(filter: StockFilterInput, before: String, after: String, first: Int, last: Int): StockCountableConnection
   shop: Shop
   shippingZone(id: ID!): ShippingZone
   shippingZones(before: String, after: String, first: Int, last: Int): ShippingZoneCountableConnection
@@ -4134,9 +4155,79 @@ input StaffUserInput {
   search: String
 }
 
+type Stock implements Node {
+  warehouse: Warehouse!
+  productVariant: ProductVariant!
+  quantity: Int!
+  quantityAllocated: Int!
+  id: ID!
+  stockQuantity: Int!
+}
+
 enum StockAvailability {
   IN_STOCK
   OUT_OF_STOCK
+}
+
+type StockBulkDelete {
+  errors: [Error!]
+  count: Int!
+  stockError: [StockError!]
+}
+
+type StockCountableConnection {
+  pageInfo: PageInfo!
+  edges: [StockCountableEdge!]!
+  totalCount: Int
+}
+
+type StockCountableEdge {
+  node: Stock!
+  cursor: String!
+}
+
+type StockCreate {
+  errors: [Error!]
+  stockErrors: [StockError!]
+  stock: Stock
+}
+
+type StockDelete {
+  errors: [Error!]
+  stock: Stock
+}
+
+enum StockErorrCode {
+  ALREADY_EXISTS
+  GRAPHQL_ERROR
+  INVALID
+  NOT_FOUND
+  REQUIRED
+  UNIQUE
+}
+
+type StockError {
+  field: String
+  message: String
+  code: StockErorrCode
+}
+
+input StockFilterInput {
+  quantity: Float
+  quantityAllocated: Float
+  search: String
+}
+
+input StockInput {
+  productVariant: ID!
+  warehouse: ID!
+  quantity: Int
+}
+
+type StockUpdate {
+  errors: [Error!]
+  stockError: [StockError!]
+  stock: Stock
 }
 
 enum TaxRateType {
@@ -4524,6 +4615,90 @@ enum VoucherTypeEnum {
 type VoucherUpdate {
   errors: [Error!]
   voucher: Voucher
+}
+
+type Warehouse implements Node {
+  id: ID!
+  name: String!
+  companyName: String!
+  shippingZones(before: String, after: String, first: Int, last: Int): ShippingZoneCountableConnection!
+  address: Address!
+  email: String!
+}
+
+input WarehouseAddressInput {
+  streetAddress1: String!
+  streetAddress2: String
+  city: String!
+  cityArea: String
+  postalCode: String
+  country: CountryCode!
+  countryArea: String
+  phone: String
+}
+
+type WarehouseCountableConnection {
+  pageInfo: PageInfo!
+  edges: [WarehouseCountableEdge!]!
+  totalCount: Int
+}
+
+type WarehouseCountableEdge {
+  node: Warehouse!
+  cursor: String!
+}
+
+type WarehouseCreate {
+  errors: [Error!]
+  warehouseErrors: [WarehouseError!]
+  warehouse: Warehouse
+}
+
+input WarehouseCreateInput {
+  name: String!
+  companyName: String
+  shippingZones: [ID]
+  email: String
+  address: WarehouseAddressInput!
+}
+
+type WarehouseDelete {
+  errors: [Error!]
+  warehouseErrors: [WarehouseError!]
+  warehouse: Warehouse
+}
+
+type WarehouseError {
+  field: String
+  message: String
+  code: WarehouseErrorCode
+}
+
+enum WarehouseErrorCode {
+  ALREADY_EXISTS
+  GRAPHQL_ERROR
+  INVALID
+  NOT_FOUND
+  REQUIRED
+  UNIQUE
+}
+
+input WarehouseFilterInput {
+  search: String
+}
+
+type WarehouseUpdate {
+  errors: [Error!]
+  warehouseErrors: [WarehouseError!]
+  warehouse: Warehouse
+}
+
+input WarehouseUpdateInput {
+  name: String!
+  companyName: String
+  shippingZones: [ID]
+  email: String
+  address: WarehouseAddressInput
 }
 
 type Webhook implements Node {

--- a/schema.graphql
+++ b/schema.graphql
@@ -3276,6 +3276,7 @@ input ProductTypeFilterInput {
   search: String
   configurable: ProductTypeConfigurable
   productType: ProductTypeEnum
+  ids: [ID]
 }
 
 input ProductTypeInput {

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -47,7 +47,6 @@ const useStyles = makeStyles(
       },
       bottom: 0,
       gridColumn: 2,
-      height: 70,
       position: "sticky",
       zIndex: 10
     },

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -97,7 +97,13 @@ const Filter: React.FC<FilterProps> = props => {
   const isFilterActive = menu.some(filterElement => filterElement.active);
 
   return (
-    <ClickAwayListener onClickAway={() => setFilterMenuOpened(false)}>
+    <ClickAwayListener
+      onClickAway={event => {
+        if ((event.target as HTMLElement).getAttribute("role") !== "option") {
+          setFilterMenuOpened(false);
+        }
+      }}
+    >
       <div ref={anchor}>
         <ButtonBase
           className={classNames(classes.filterButton, classes.addFilterButton, {

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -1,4 +1,5 @@
 import ButtonBase from "@material-ui/core/ButtonBase";
+import ClickAwayListener from "@material-ui/core/ClickAwayListener";
 import Grow from "@material-ui/core/Grow";
 import Popper from "@material-ui/core/Popper";
 import { makeStyles } from "@material-ui/core/styles";
@@ -96,58 +97,61 @@ const Filter: React.FC<FilterProps> = props => {
   const isFilterActive = menu.some(filterElement => filterElement.active);
 
   return (
-    <div ref={anchor}>
-      <ButtonBase
-        className={classNames(classes.filterButton, classes.addFilterButton, {
-          [classes.addFilterButtonActive]: isFilterMenuOpened || isFilterActive
-        })}
-        onClick={() => setFilterMenuOpened(!isFilterMenuOpened)}
-      >
-        <Typography className={classes.addFilterText}>
-          <FormattedMessage defaultMessage="Filters" description="button" />
-        </Typography>
-        {isFilterActive && (
-          <>
-            <span className={classes.separator} />
-            <Typography className={classes.addFilterText}>
-              {menu.reduce(
-                (acc, filterElement) => acc + (filterElement.active ? 1 : 0),
-                0
-              )}
-            </Typography>
-          </>
-        )}
-      </ButtonBase>
-      <Popper
-        className={classes.popover}
-        open={isFilterMenuOpened}
-        anchorEl={anchor.current}
-        transition
-        disablePortal
-        placement="bottom-start"
-      >
-        {({ TransitionProps, placement }) => (
-          <Grow
-            {...TransitionProps}
-            style={{
-              transformOrigin:
-                placement === "bottom" ? "right top" : "right bottom"
-            }}
-          >
-            <FilterContent
-              currencySymbol={currencySymbol}
-              filters={data}
-              onClear={reset}
-              onFilterPropertyChange={dispatch}
-              onSubmit={() => {
-                onFilterAdd(data);
-                setFilterMenuOpened(false);
+    <ClickAwayListener onClickAway={() => setFilterMenuOpened(false)}>
+      <div ref={anchor}>
+        <ButtonBase
+          className={classNames(classes.filterButton, classes.addFilterButton, {
+            [classes.addFilterButtonActive]:
+              isFilterMenuOpened || isFilterActive
+          })}
+          onClick={() => setFilterMenuOpened(!isFilterMenuOpened)}
+        >
+          <Typography className={classes.addFilterText}>
+            <FormattedMessage defaultMessage="Filters" description="button" />
+          </Typography>
+          {isFilterActive && (
+            <>
+              <span className={classes.separator} />
+              <Typography className={classes.addFilterText}>
+                {menu.reduce(
+                  (acc, filterElement) => acc + (filterElement.active ? 1 : 0),
+                  0
+                )}
+              </Typography>
+            </>
+          )}
+        </ButtonBase>
+        <Popper
+          className={classes.popover}
+          open={isFilterMenuOpened}
+          anchorEl={anchor.current}
+          transition
+          disablePortal
+          placement="bottom-start"
+        >
+          {({ TransitionProps, placement }) => (
+            <Grow
+              {...TransitionProps}
+              style={{
+                transformOrigin:
+                  placement === "bottom" ? "right top" : "right bottom"
               }}
-            />
-          </Grow>
-        )}
-      </Popper>
-    </div>
+            >
+              <FilterContent
+                currencySymbol={currencySymbol}
+                filters={data}
+                onClear={reset}
+                onFilterPropertyChange={dispatch}
+                onSubmit={() => {
+                  onFilterAdd(data);
+                  setFilterMenuOpened(false);
+                }}
+              />
+            </Grow>
+          )}
+        </Popper>
+      </div>
+    </ClickAwayListener>
   );
 };
 Filter.displayName = "Filter";

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -132,6 +132,9 @@ const Filter: React.FC<FilterProps> = props => {
             flip: {
               enabled: false
             },
+            hide: {
+              enabled: false
+            },
             preventOverflow: {
               boundariesElement: "scrollParent",
               enabled: false

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -128,6 +128,15 @@ const Filter: React.FC<FilterProps> = props => {
           transition
           disablePortal
           placement="bottom-start"
+          modifiers={{
+            flip: {
+              enabled: false
+            },
+            preventOverflow: {
+              boundariesElement: "scrollParent",
+              enabled: false
+            }
+          }}
         >
           {({ TransitionProps, placement }) => (
             <Grow

--- a/src/components/Filter/FilterAutocompleteField.tsx
+++ b/src/components/Filter/FilterAutocompleteField.tsx
@@ -9,16 +9,13 @@ import { MultiAutocompleteChoiceType } from "../MultiAutocompleteSelectField";
 import Link from "../Link";
 import Checkbox from "../Checkbox";
 import Hr from "../Hr";
-import { IFilterElement } from "./types";
-import { FilterReducerAction } from "./reducer";
+import { FilterBaseFieldProps } from "./types";
 
-interface FilterAutocompleteFieldProps {
+interface FilterAutocompleteFieldProps extends FilterBaseFieldProps {
   displayValues: Record<string, MultiAutocompleteChoiceType[]>;
-  filterField: IFilterElement<string>;
   setDisplayValues: (
     values: Record<string, MultiAutocompleteChoiceType[]>
   ) => void;
-  onFilterPropertyChange: React.Dispatch<FilterReducerAction<string>>;
 }
 
 const useStyles = makeStyles(

--- a/src/components/Filter/FilterAutocompleteField.tsx
+++ b/src/components/Filter/FilterAutocompleteField.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import TextField from "@material-ui/core/TextField";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import { FormattedMessage } from "react-intl";
+
+import { toggle } from "@saleor/utils/lists";
+import { MultiAutocompleteChoiceType } from "../MultiAutocompleteSelectField";
+import Link from "../Link";
+import Checkbox from "../Checkbox";
+import Hr from "../Hr";
+import { IFilterElement } from "./types";
+import { FilterReducerAction } from "./reducer";
+
+interface FilterAutocompleteFieldProps {
+  displayValues: Record<string, MultiAutocompleteChoiceType[]>;
+  filterField: IFilterElement<string>;
+  setDisplayValues: (
+    values: Record<string, MultiAutocompleteChoiceType[]>
+  ) => void;
+  onFilterPropertyChange: React.Dispatch<FilterReducerAction<string>>;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    hr: {
+      backgroundColor: theme.palette.primary.light,
+      margin: theme.spacing(1, 0)
+    },
+    input: {
+      padding: "12px 0 9px 12px"
+    },
+    inputContainer: {
+      marginBottom: theme.spacing(1)
+    },
+    option: {
+      left: -theme.spacing(0.5),
+      position: "relative"
+    },
+    showMore: {
+      display: "inline-block",
+      marginTop: theme.spacing(1)
+    }
+  }),
+  { name: "FilterAutocompleteField" }
+);
+
+const FilterAutocompleteField: React.FC<FilterAutocompleteFieldProps> = ({
+  displayValues,
+  filterField,
+  setDisplayValues,
+  onFilterPropertyChange
+}) => {
+  const classes = useStyles({});
+
+  const fieldDisplayValues = displayValues[filterField.name];
+  const availableOptions = filterField.options.filter(option =>
+    fieldDisplayValues.every(
+      displayValue => displayValue.value !== option.value
+    )
+  );
+  const displayHr = !(
+    (fieldDisplayValues.length === 0 && availableOptions.length > 0) ||
+    (availableOptions.length === 0 && fieldDisplayValues.length > 0)
+  );
+
+  const handleChange = (option: MultiAutocompleteChoiceType) => {
+    onFilterPropertyChange({
+      payload: {
+        name: filterField.name,
+        update: {
+          value: toggle(option.value, filterField.value, (a, b) => a === b)
+        }
+      },
+      type: "set-property"
+    });
+
+    setDisplayValues({
+      ...displayValues,
+      [filterField.name]: toggle(
+        option,
+        fieldDisplayValues,
+        (a, b) => a.value === b.value
+      )
+    });
+  };
+
+  return (
+    <div>
+      <TextField
+        className={classes.inputContainer}
+        fullWidth
+        name={filterField.name + "_autocomplete"}
+        InputProps={{
+          classes: {
+            input: classes.input
+          }
+        }}
+        onChange={event => filterField.onSearchChange(event.target.value)}
+      />
+      {fieldDisplayValues.map(displayValue => (
+        <div className={classes.option} key={displayValue.value}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={filterField.value.includes(displayValue.value)}
+              />
+            }
+            label={displayValue.label}
+            name={filterField.name}
+            onChange={() => handleChange(displayValue)}
+          />
+        </div>
+      ))}
+      {displayHr && <Hr className={classes.hr} />}
+      {availableOptions.map(option => (
+        <div className={classes.option} key={option.value}>
+          <FormControlLabel
+            control={
+              <Checkbox checked={filterField.value.includes(option.value)} />
+            }
+            label={option.label}
+            name={filterField.name}
+            onChange={() => handleChange(option)}
+          />
+        </div>
+      ))}
+      {filterField.hasMore && (
+        <Link
+          className={classes.showMore}
+          underline
+          onClick={filterField.onFetchMore}
+        >
+          <FormattedMessage
+            defaultMessage="Show more"
+            description="search results"
+          />
+        </Link>
+      )}
+    </div>
+  );
+};
+
+FilterAutocompleteField.displayName = "FilterAutocompleteField";
+export default FilterAutocompleteField;

--- a/src/components/Filter/FilterAutocompleteField.tsx
+++ b/src/components/Filter/FilterAutocompleteField.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Typography from "@material-ui/core/Typography";
 import TextField from "@material-ui/core/TextField";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 import { FormattedMessage } from "react-intl";
@@ -30,6 +31,9 @@ const useStyles = makeStyles(
     inputContainer: {
       marginBottom: theme.spacing(1)
     },
+    noResults: {
+      marginTop: theme.spacing(1)
+    },
     option: {
       left: -theme.spacing(0.5),
       position: "relative"
@@ -56,9 +60,12 @@ const FilterAutocompleteField: React.FC<FilterAutocompleteFieldProps> = ({
       displayValue => displayValue.value !== option.value
     )
   );
+  const displayNoResults =
+    availableOptions.length === 0 && fieldDisplayValues.length === 0;
   const displayHr = !(
     (fieldDisplayValues.length === 0 && availableOptions.length > 0) ||
-    (availableOptions.length === 0 && fieldDisplayValues.length > 0)
+    (availableOptions.length === 0 && fieldDisplayValues.length > 0) ||
+    displayNoResults
   );
 
   const handleChange = (option: MultiAutocompleteChoiceType) => {
@@ -110,6 +117,11 @@ const FilterAutocompleteField: React.FC<FilterAutocompleteFieldProps> = ({
         </div>
       ))}
       {displayHr && <Hr className={classes.hr} />}
+      {displayNoResults && (
+        <Typography className={classes.noResults} color="textSecondary">
+          <FormattedMessage defaultMessage="No results" description="search" />
+        </Typography>
+      )}
       {availableOptions.map(option => (
         <div className={classes.option} key={option.value}>
           <FormControlLabel

--- a/src/components/Filter/FilterContent.tsx
+++ b/src/components/Filter/FilterContent.tsx
@@ -22,9 +22,11 @@ import FormSpacer from "../FormSpacer";
 import MultiAutocompleteSelectField, {
   MultiAutocompleteChoiceType
 } from "../MultiAutocompleteSelectField";
+import Link from "../Link";
 import { IFilter, FieldType, FilterType } from "./types";
 import Arrow from "./Arrow";
 import { FilterReducerAction } from "./reducer";
+import FilterAutocompleteField from "./FilterAutocompleteField";
 
 export interface FilterContentProps<T extends string = string> {
   currencySymbol: string;
@@ -428,51 +430,57 @@ const FilterContent: React.FC<FilterContentProps> = ({
                     ))}
                   {filterField.type === FieldType.autocomplete &&
                     filterField.multiple && (
-                      <MultiAutocompleteSelectField
-                        displayValues={
-                          autocompleteDisplayValues[filterField.name]
-                        }
-                        label={filterField.label}
-                        choices={filterField.options}
-                        name={filterField.name}
-                        value={filterField.value}
-                        // helperText={intl.formatMessage({
-                        //   defaultMessage:
-                        //     "*Optional. Adding product to collection helps users find it.",
-                        //   description: "field is optional"
-                        // })}
-                        onChange={createMultiAutocompleteSelectHandler(
-                          event =>
-                            onFilterPropertyChange({
-                              payload: {
-                                name: filterField.name,
-                                update: {
-                                  value: toggle(
-                                    event.target.value,
-                                    filterField.value,
-                                    (a, b) => a === b
-                                  )
-                                }
-                              },
-                              type: "set-property"
-                            }),
-                          value =>
-                            setAutocompleteDisplayValues({
-                              ...autocompleteDisplayValues,
-                              [filterField.name]: toggle(
-                                value[0],
-                                autocompleteDisplayValues[filterField.name],
-                                (a, b) => a.value === b.value
-                              )
-                            }),
-                          [],
-                          filterField.options
-                        )}
-                        fetchChoices={filterField.onSearchChange}
-                        loading={filterField.loading}
-                        data-tc={filterField.name}
-                        key={filterField.name}
+                      <FilterAutocompleteField
+                        displayValues={autocompleteDisplayValues}
+                        filterField={filterField}
+                        setDisplayValues={setAutocompleteDisplayValues}
+                        onFilterPropertyChange={onFilterPropertyChange}
                       />
+                      // <MultiAutocompleteSelectField
+                      //   displayValues={
+                      //     autocompleteDisplayValues[filterField.name]
+                      //   }
+                      //   label={filterField.label}
+                      //   choices={filterField.options}
+                      //   name={filterField.name}
+                      //   value={filterField.value}
+                      //   // helperText={intl.formatMessage({
+                      //   //   defaultMessage:
+                      //   //     "*Optional. Adding product to collection helps users find it.",
+                      //   //   description: "field is optional"
+                      //   // })}
+                      // onChange={createMultiAutocompleteSelectHandler(
+                      //   event =>
+                      //     onFilterPropertyChange({
+                      //       payload: {
+                      //         name: filterField.name,
+                      //         update: {
+                      //           value: toggle(
+                      //             event.target.value,
+                      //             filterField.value,
+                      //             (a, b) => a === b
+                      //           )
+                      //         }
+                      //       },
+                      //       type: "set-property"
+                      //     }),
+                      //   value =>
+                      //     setAutocompleteDisplayValues({
+                      //       ...autocompleteDisplayValues,
+                      //       [filterField.name]: toggle(
+                      //         value[0],
+                      //         autocompleteDisplayValues[filterField.name],
+                      //         (a, b) => a.value === b.value
+                      //       )
+                      //     }),
+                      //   [],
+                      //   filterField.options
+                      // )}
+                      //   fetchChoices={filterField.onSearchChange}
+                      //   loading={filterField.loading}
+                      //   data-tc={filterField.name}
+                      //   key={filterField.name}
+                      // />
                     )}
                 </div>
               )}

--- a/src/components/Filter/FilterContent.tsx
+++ b/src/components/Filter/FilterContent.tsx
@@ -436,51 +436,6 @@ const FilterContent: React.FC<FilterContentProps> = ({
                         setDisplayValues={setAutocompleteDisplayValues}
                         onFilterPropertyChange={onFilterPropertyChange}
                       />
-                      // <MultiAutocompleteSelectField
-                      //   displayValues={
-                      //     autocompleteDisplayValues[filterField.name]
-                      //   }
-                      //   label={filterField.label}
-                      //   choices={filterField.options}
-                      //   name={filterField.name}
-                      //   value={filterField.value}
-                      //   // helperText={intl.formatMessage({
-                      //   //   defaultMessage:
-                      //   //     "*Optional. Adding product to collection helps users find it.",
-                      //   //   description: "field is optional"
-                      //   // })}
-                      // onChange={createMultiAutocompleteSelectHandler(
-                      //   event =>
-                      //     onFilterPropertyChange({
-                      //       payload: {
-                      //         name: filterField.name,
-                      //         update: {
-                      //           value: toggle(
-                      //             event.target.value,
-                      //             filterField.value,
-                      //             (a, b) => a === b
-                      //           )
-                      //         }
-                      //       },
-                      //       type: "set-property"
-                      //     }),
-                      //   value =>
-                      //     setAutocompleteDisplayValues({
-                      //       ...autocompleteDisplayValues,
-                      //       [filterField.name]: toggle(
-                      //         value[0],
-                      //         autocompleteDisplayValues[filterField.name],
-                      //         (a, b) => a.value === b.value
-                      //       )
-                      //     }),
-                      //   [],
-                      //   filterField.options
-                      // )}
-                      //   fetchChoices={filterField.onSearchChange}
-                      //   loading={filterField.loading}
-                      //   data-tc={filterField.name}
-                      //   key={filterField.name}
-                      // />
                     )}
                 </div>
               )}

--- a/src/components/Filter/FilterContent.tsx
+++ b/src/components/Filter/FilterContent.tsx
@@ -11,22 +11,18 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 import { fade } from "@material-ui/core/styles/colorManipulator";
 import { buttonMessages } from "@saleor/intl";
 import { TextField } from "@material-ui/core";
-import { toggle } from "@saleor/utils/lists";
-import createMultiAutocompleteSelectHandler from "@saleor/utils/handlers/multiAutocompleteSelectChangeHandler";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import Hr from "../Hr";
 import Checkbox from "../Checkbox";
 import SingleSelectField from "../SingleSelectField";
 import { SingleAutocompleteChoiceType } from "../SingleAutocompleteSelectField";
 import FormSpacer from "../FormSpacer";
-import MultiAutocompleteSelectField, {
-  MultiAutocompleteChoiceType
-} from "../MultiAutocompleteSelectField";
-import Link from "../Link";
+import { MultiAutocompleteChoiceType } from "../MultiAutocompleteSelectField";
 import { IFilter, FieldType, FilterType } from "./types";
 import Arrow from "./Arrow";
 import { FilterReducerAction } from "./reducer";
 import FilterAutocompleteField from "./FilterAutocompleteField";
+import FilterOptionField from "./FilterOptionField";
 
 export interface FilterContentProps<T extends string = string> {
   currencySymbol: string;
@@ -341,61 +337,12 @@ const FilterContent: React.FC<FilterContentProps> = ({
                       </div>
                     </>
                   )}
-                  {filterField.type === FieldType.options &&
-                    (filterField.multiple ? (
-                      filterField.options.map(option => (
-                        <div className={classes.option} key={option.value}>
-                          <FormControlLabel
-                            control={
-                              <Checkbox
-                                checked={filterField.value.includes(
-                                  option.value
-                                )}
-                              />
-                            }
-                            label={option.label}
-                            name={filterField.name}
-                            onChange={() =>
-                              onFilterPropertyChange({
-                                payload: {
-                                  name: filterField.name,
-                                  update: {
-                                    value: toggle(
-                                      option.value,
-                                      filterField.value,
-                                      (a, b) => a === b
-                                    )
-                                  }
-                                },
-                                type: "set-property"
-                              })
-                            }
-                          />
-                        </div>
-                      ))
-                    ) : (
-                      <SingleSelectField
-                        choices={filterField.options}
-                        name={filterField.name}
-                        value={filterField.value[0]}
-                        InputProps={{
-                          classes: {
-                            input: classes.input
-                          }
-                        }}
-                        onChange={event =>
-                          onFilterPropertyChange({
-                            payload: {
-                              name: filterField.name,
-                              update: {
-                                value: [event.target.value]
-                              }
-                            },
-                            type: "set-property"
-                          })
-                        }
-                      />
-                    ))}
+                  {filterField.type === FieldType.options && (
+                    <FilterOptionField
+                      filterField={filterField}
+                      onFilterPropertyChange={onFilterPropertyChange}
+                    />
+                  )}
                   {filterField.type === FieldType.boolean &&
                     filterField.options.map(option => (
                       <div

--- a/src/components/Filter/FilterOptionField.tsx
+++ b/src/components/Filter/FilterOptionField.tsx
@@ -1,0 +1,74 @@
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Radio from "@material-ui/core/Radio";
+import React from "react";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import classNames from "classnames";
+
+import { toggle } from "@saleor/utils/lists";
+import Checkbox from "../Checkbox";
+import { FilterBaseFieldProps } from "./types";
+
+const useStyles = makeStyles(
+  theme => ({
+    option: {
+      left: -theme.spacing(0.5),
+      position: "relative"
+    },
+    optionRadio: {
+      left: -theme.spacing(0.25)
+    },
+    root: {}
+  }),
+  { name: "FilterOptionField" }
+);
+
+const FilterOptionField: React.FC<FilterBaseFieldProps> = ({
+  filterField,
+  onFilterPropertyChange
+}) => {
+  const classes = useStyles({});
+  const handleSelect = (value: string) =>
+    onFilterPropertyChange({
+      payload: {
+        name: filterField.name,
+        update: {
+          value: filterField.multiple
+            ? toggle(value, filterField.value, (a, b) => a === b)
+            : [value]
+        }
+      },
+      type: "set-property"
+    });
+
+  return (
+    <div className={classes.root}>
+      {filterField.options.map(option => (
+        <div
+          className={classNames(classes.option, {
+            [classes.optionRadio]: !filterField.multiple
+          })}
+          key={option.value}
+        >
+          <FormControlLabel
+            control={
+              filterField.multiple ? (
+                <Checkbox checked={filterField.value.includes(option.value)} />
+              ) : (
+                <Radio
+                  checked={filterField.value[0] === option.value}
+                  color="primary"
+                />
+              )
+            }
+            label={option.label}
+            name={filterField.name}
+            onChange={() => handleSelect(option.value)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+FilterOptionField.displayName = "FilterOptionField";
+export default FilterOptionField;

--- a/src/components/Filter/reducer.ts
+++ b/src/components/Filter/reducer.ts
@@ -26,7 +26,8 @@ function merge<T extends string>(
     if (!!prevFilter) {
       return {
         ...newFilter,
-        active: prevFilter.active
+        active: prevFilter.active,
+        value: prevFilter.value
       };
     }
 

--- a/src/components/Filter/types.ts
+++ b/src/components/Filter/types.ts
@@ -1,7 +1,8 @@
-import { FetchMoreProps } from "@saleor/types";
+import { FetchMoreProps, SearchPageProps } from "@saleor/types";
 import { MultiAutocompleteChoiceType } from "../MultiAutocompleteSelectField";
 
 export enum FieldType {
+  autocomplete,
   boolean,
   date,
   dateTime,
@@ -18,9 +19,10 @@ export interface IFilterElementMutableData<T extends string = string> {
   value: T[];
 }
 export interface IFilterElement<T extends string = string>
-  extends Partial<FetchMoreProps>,
-    IFilterElementMutableData {
+  extends IFilterElementMutableData,
+    Partial<FetchMoreProps & SearchPageProps> {
   autocomplete?: boolean;
+  displayValues?: MultiAutocompleteChoiceType[];
   label: string;
   name: T;
   type: FieldType;

--- a/src/components/Filter/types.ts
+++ b/src/components/Filter/types.ts
@@ -1,5 +1,6 @@
 import { FetchMoreProps, SearchPageProps } from "@saleor/types";
 import { MultiAutocompleteChoiceType } from "../MultiAutocompleteSelectField";
+import { FilterReducerAction } from "./reducer";
 
 export enum FieldType {
   autocomplete,
@@ -26,6 +27,11 @@ export interface IFilterElement<T extends string = string>
   label: string;
   name: T;
   type: FieldType;
+}
+
+export interface FilterBaseFieldProps<T extends string = string> {
+  filterField: IFilterElement<T>;
+  onFilterPropertyChange: React.Dispatch<FilterReducerAction<T>>;
 }
 
 export type IFilter<T extends string = string> = Array<IFilterElement<T>>;

--- a/src/components/Filter/types.ts
+++ b/src/components/Filter/types.ts
@@ -24,6 +24,7 @@ export interface IFilterElement<T extends string = string>
     Partial<FetchMoreProps & SearchPageProps> {
   autocomplete?: boolean;
   displayValues?: MultiAutocompleteChoiceType[];
+  group?: T;
   label: string;
   name: T;
   type: FieldType;

--- a/src/components/Filter/useFilter.ts
+++ b/src/components/Filter/useFilter.ts
@@ -17,12 +17,20 @@ function useFilter<T extends string>(initialFilter: IFilter<T>): UseFilter<T> {
   const reset = () =>
     dispatchFilterAction({
       payload: {
-        reset: initialFilter
+        new: initialFilter
       },
       type: "reset"
     });
 
-  useEffect(reset, [initialFilter]);
+  const refresh = () =>
+    dispatchFilterAction({
+      payload: {
+        new: initialFilter
+      },
+      type: "merge"
+    });
+
+  useEffect(refresh, [initialFilter]);
 
   return [data, dispatchFilterAction, reset];
 }

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -44,7 +44,7 @@ const Link: React.FC<LinkProps> = props => {
   return (
     <Typography
       component="a"
-      className={classNames({
+      className={classNames(className, {
         [classes.root]: true,
         [classes[color]]: true,
         [classes.underline]: underline

--- a/src/components/SaveButtonBar/SaveButtonBar.tsx
+++ b/src/components/SaveButtonBar/SaveButtonBar.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles(
       background: theme.palette.background.default,
       borderTop: "1px solid transparent",
       boxShadow: `0 -5px 5px 0 ${theme.palette.divider}`,
-      height: "100%",
+      height: 70,
       transition: `box-shadow ${theme.transitions.duration.shortest}ms`
     },
     spacer: {

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -41,17 +41,14 @@ export interface SingleAutocompleteSelectFieldProps
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const DebounceAutocomplete: React.ComponentType<
-  DebounceProps<string>
-> = Debounce;
+const DebounceAutocomplete: React.ComponentType<DebounceProps<
+  string
+>> = Debounce;
 
-const SingleAutocompleteSelectFieldComponent: React.FC<
-  SingleAutocompleteSelectFieldProps
-> = props => {
+const SingleAutocompleteSelectFieldComponent: React.FC<SingleAutocompleteSelectFieldProps> = props => {
   const {
-    choices,
-
     allowCustomValues,
+    choices,
     disabled,
     displayValue,
     emptyOption,
@@ -169,9 +166,11 @@ const SingleAutocompleteSelectFieldComponent: React.FC<
   );
 };
 
-const SingleAutocompleteSelectField: React.FC<
-  SingleAutocompleteSelectFieldProps
-> = ({ choices, fetchChoices, ...rest }) => {
+const SingleAutocompleteSelectField: React.FC<SingleAutocompleteSelectFieldProps> = ({
+  choices,
+  fetchChoices,
+  ...rest
+}) => {
   const [query, setQuery] = React.useState("");
   if (fetchChoices) {
     return (

--- a/src/discounts/components/VoucherListPage/filters.ts
+++ b/src/discounts/components/VoucherListPage/filters.ts
@@ -7,8 +7,7 @@ import {
 } from "@saleor/utils/filters/fields";
 import {
   VoucherDiscountType,
-  DiscountStatusEnum,
-  DiscountValueTypeEnum
+  DiscountStatusEnum
 } from "@saleor/types/globalTypes";
 import { MinMax, FilterOpts } from "@saleor/types";
 import { IFilter } from "@saleor/components/Filter";
@@ -118,11 +117,15 @@ export function createFilterStructure(
         [
           {
             label: intl.formatMessage(messages.fixed),
-            value: DiscountValueTypeEnum.FIXED
+            value: VoucherDiscountType.FIXED
           },
           {
             label: intl.formatMessage(messages.percentage),
-            value: DiscountValueTypeEnum.PERCENTAGE
+            value: VoucherDiscountType.PERCENTAGE
+          },
+          {
+            label: intl.formatMessage(messages.percentage),
+            value: VoucherDiscountType.SHIPPING
           }
         ]
       ),

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -48,7 +48,7 @@ const HomeSection = () => {
           onProductsOutOfStockClick={() =>
             navigate(
               productListUrl({
-                status: StockAvailability.OUT_OF_STOCK
+                stockStatus: StockAvailability.OUT_OF_STOCK
               })
             )
           }

--- a/src/hooks/debug/useOnMount.ts
+++ b/src/hooks/debug/useOnMount.ts
@@ -1,0 +1,8 @@
+import { useEffect } from "react";
+
+function useOnMount(name: string) {
+  // eslint-disable-next-line no-console
+  useEffect(() => console.log(`mounted node ${name}`), []);
+}
+
+export default useOnMount;

--- a/src/products/components/ProductListPage/filters.ts
+++ b/src/products/components/ProductListPage/filters.ts
@@ -15,6 +15,7 @@ export enum ProductFilterKeys {
   collections = "collections",
   status = "status",
   price = "price",
+  productType = "productType",
   stock = "stock"
 }
 
@@ -22,6 +23,7 @@ export interface ProductListFilterOpts {
   categories: FilterOpts<string[]> & AutocompleteFilterOpts;
   collections: FilterOpts<string[]> & AutocompleteFilterOpts;
   price: FilterOpts<MinMax>;
+  productType: FilterOpts<string[]> & AutocompleteFilterOpts;
   status: FilterOpts<ProductStatus>;
   stockStatus: FilterOpts<StockAvailability>;
 }
@@ -147,6 +149,24 @@ export function createFilterStructure(
         }
       ),
       active: opts.collections.active
+    },
+    {
+      ...createAutocompleteField(
+        ProductFilterKeys.productType,
+        intl.formatMessage(sectionNames.productTypes),
+        opts.productType.value,
+        opts.productType.displayValues,
+        true,
+        opts.productType.choices,
+        {
+          hasMore: opts.productType.hasMore,
+          initialSearch: "",
+          loading: opts.productType.loading,
+          onFetchMore: opts.productType.onFetchMore,
+          onSearchChange: opts.productType.onSearchChange
+        }
+      ),
+      active: opts.productType.active
     }
   ];
 }

--- a/src/products/components/ProductListPage/filters.ts
+++ b/src/products/components/ProductListPage/filters.ts
@@ -1,20 +1,26 @@
 import { defineMessages, IntlShape } from "react-intl";
 
-import { FilterOpts, MinMax } from "@saleor/types";
+import { FilterOpts, MinMax, AutocompleteFilterOpts } from "@saleor/types";
 import { StockAvailability } from "@saleor/types/globalTypes";
 import {
   createOptionsField,
-  createPriceField
+  createPriceField,
+  createAutocompleteField
 } from "@saleor/utils/filters/fields";
 import { IFilter } from "@saleor/components/Filter";
+import { sectionNames } from "@saleor/intl";
 
 export enum ProductFilterKeys {
+  categories = "categories",
+  collections = "collections",
   status = "status",
   price = "price",
   stock = "stock"
 }
 
 export interface ProductListFilterOpts {
+  categories: FilterOpts<string[]> & AutocompleteFilterOpts;
+  collections: FilterOpts<string[]> & AutocompleteFilterOpts;
   price: FilterOpts<MinMax>;
   status: FilterOpts<ProductStatus>;
   stockStatus: FilterOpts<StockAvailability>;
@@ -105,6 +111,42 @@ export function createFilterStructure(
         opts.price.value
       ),
       active: opts.price.active
+    },
+    {
+      ...createAutocompleteField(
+        ProductFilterKeys.categories,
+        intl.formatMessage(sectionNames.categories),
+        opts.categories.value,
+        opts.categories.displayValues,
+        true,
+        opts.categories.choices,
+        {
+          hasMore: opts.categories.hasMore,
+          initialSearch: "",
+          loading: opts.categories.loading,
+          onFetchMore: opts.categories.onFetchMore,
+          onSearchChange: opts.categories.onSearchChange
+        }
+      ),
+      active: opts.categories.active
+    },
+    {
+      ...createAutocompleteField(
+        ProductFilterKeys.collections,
+        intl.formatMessage(sectionNames.collections),
+        opts.collections.value,
+        opts.collections.displayValues,
+        true,
+        opts.collections.choices,
+        {
+          hasMore: opts.collections.hasMore,
+          initialSearch: "",
+          loading: opts.collections.loading,
+          onFetchMore: opts.collections.onFetchMore,
+          onSearchChange: opts.collections.onSearchChange
+        }
+      ),
+      active: opts.collections.active
     }
   ];
 }

--- a/src/products/components/ProductListPage/filters.ts
+++ b/src/products/components/ProductListPage/filters.ts
@@ -9,8 +9,10 @@ import {
 } from "@saleor/utils/filters/fields";
 import { IFilter } from "@saleor/components/Filter";
 import { sectionNames } from "@saleor/intl";
+import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocompleteSelectField";
 
 export enum ProductFilterKeys {
+  attributes = "attributes",
   categories = "categories",
   collections = "collections",
   status = "status",
@@ -20,6 +22,13 @@ export enum ProductFilterKeys {
 }
 
 export interface ProductListFilterOpts {
+  attributes: Array<
+    FilterOpts<string[]> & {
+      choices: MultiAutocompleteChoiceType[];
+      name: string;
+      slug: string;
+    }
+  >;
   categories: FilterOpts<string[]> & AutocompleteFilterOpts;
   collections: FilterOpts<string[]> & AutocompleteFilterOpts;
   price: FilterOpts<MinMax>;
@@ -167,6 +176,17 @@ export function createFilterStructure(
         }
       ),
       active: opts.productType.active
-    }
+    },
+    ...opts.attributes.map(attr => ({
+      ...createOptionsField(
+        attr.slug as any,
+        attr.name,
+        attr.value,
+        true,
+        attr.choices
+      ),
+      active: attr.active,
+      group: ProductFilterKeys.attributes
+    }))
   ];
 }

--- a/src/products/index.tsx
+++ b/src/products/index.tsx
@@ -5,6 +5,7 @@ import { Route, RouteComponentProps, Switch } from "react-router-dom";
 
 import { sectionNames } from "@saleor/intl";
 import { asSortParams } from "@saleor/utils/sort";
+import { getArrayQueryParam } from "@saleor/utils/urls";
 import { WindowTitle } from "../components/WindowTitle";
 import {
   productAddPath,
@@ -29,7 +30,12 @@ import ProductVariantCreateComponent from "./views/ProductVariantCreate";
 const ProductList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: ProductListUrlQueryParams = asSortParams(
-    qs,
+    {
+      ...qs,
+      categories: getArrayQueryParam(qs.categories),
+      collections: getArrayQueryParam(qs.collections),
+      productTypes: getArrayQueryParam(qs.productTypes)
+    },
     ProductListUrlSortField
   );
 

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -215,8 +215,12 @@ export const fragmentVariant = gql`
 `;
 
 const initialProductFilterDataQuery = gql`
-  query InitialProductFilterData($categories: [ID!], $collections: [ID!]) {
-    categories(first: 20, filter: { ids: $categories }) {
+  query InitialProductFilterData(
+    $categories: [ID!]
+    $collections: [ID!]
+    $productTypes: [ID!]
+  ) {
+    categories(first: 100, filter: { ids: $categories }) {
       edges {
         node {
           id
@@ -224,7 +228,15 @@ const initialProductFilterDataQuery = gql`
         }
       }
     }
-    collections(first: 20, filter: { ids: $collections }) {
+    collections(first: 100, filter: { ids: $collections }) {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+    productTypes(first: 100, filter: { ids: $productTypes }) {
       edges {
         node {
           id

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -1,5 +1,6 @@
 import gql from "graphql-tag";
 
+import makeQuery from "@saleor/hooks/makeQuery";
 import { pageInfoFragment, TypedQuery } from "../queries";
 import {
   AvailableInGridAttributes,
@@ -22,6 +23,10 @@ import {
   ProductVariantDetails,
   ProductVariantDetailsVariables
 } from "./types/ProductVariantDetails";
+import {
+  InitialProductFilterData,
+  InitialProductFilterDataVariables
+} from "./types/InitialProductFilterData";
 
 export const fragmentMoney = gql`
   fragment Money on Money {
@@ -208,6 +213,31 @@ export const fragmentVariant = gql`
     quantityAllocated
   }
 `;
+
+const initialProductFilterDataQuery = gql`
+  query InitialProductFilterData($categories: [ID!], $collections: [ID!]) {
+    categories(first: 20, filter: { ids: $categories }) {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+    collections(first: 20, filter: { ids: $collections }) {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+export const useInitialProductFilterDataQuery = makeQuery<
+  InitialProductFilterData,
+  InitialProductFilterDataVariables
+>(initialProductFilterDataQuery);
 
 const productListQuery = gql`
   ${productFragment}

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -220,6 +220,20 @@ const initialProductFilterDataQuery = gql`
     $collections: [ID!]
     $productTypes: [ID!]
   ) {
+    attributes(first: 100, filter: { filterableInDashboard: true }) {
+      edges {
+        node {
+          id
+          name
+          slug
+          values {
+            id
+            name
+            slug
+          }
+        }
+      }
+    }
     categories(first: 100, filter: { ids: $categories }) {
       edges {
         node {

--- a/src/products/types/InitialProductFilterData.ts
+++ b/src/products/types/InitialProductFilterData.ts
@@ -1,0 +1,49 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: InitialProductFilterData
+// ====================================================
+
+export interface InitialProductFilterData_categories_edges_node {
+  __typename: "Category";
+  id: string;
+  name: string;
+}
+
+export interface InitialProductFilterData_categories_edges {
+  __typename: "CategoryCountableEdge";
+  node: InitialProductFilterData_categories_edges_node;
+}
+
+export interface InitialProductFilterData_categories {
+  __typename: "CategoryCountableConnection";
+  edges: InitialProductFilterData_categories_edges[];
+}
+
+export interface InitialProductFilterData_collections_edges_node {
+  __typename: "Collection";
+  id: string;
+  name: string;
+}
+
+export interface InitialProductFilterData_collections_edges {
+  __typename: "CollectionCountableEdge";
+  node: InitialProductFilterData_collections_edges_node;
+}
+
+export interface InitialProductFilterData_collections {
+  __typename: "CollectionCountableConnection";
+  edges: InitialProductFilterData_collections_edges[];
+}
+
+export interface InitialProductFilterData {
+  categories: InitialProductFilterData_categories | null;
+  collections: InitialProductFilterData_collections | null;
+}
+
+export interface InitialProductFilterDataVariables {
+  categories?: string[] | null;
+  collections?: string[] | null;
+}

--- a/src/products/types/InitialProductFilterData.ts
+++ b/src/products/types/InitialProductFilterData.ts
@@ -38,12 +38,30 @@ export interface InitialProductFilterData_collections {
   edges: InitialProductFilterData_collections_edges[];
 }
 
+export interface InitialProductFilterData_productTypes_edges_node {
+  __typename: "ProductType";
+  id: string;
+  name: string;
+}
+
+export interface InitialProductFilterData_productTypes_edges {
+  __typename: "ProductTypeCountableEdge";
+  node: InitialProductFilterData_productTypes_edges_node;
+}
+
+export interface InitialProductFilterData_productTypes {
+  __typename: "ProductTypeCountableConnection";
+  edges: InitialProductFilterData_productTypes_edges[];
+}
+
 export interface InitialProductFilterData {
   categories: InitialProductFilterData_categories | null;
   collections: InitialProductFilterData_collections | null;
+  productTypes: InitialProductFilterData_productTypes | null;
 }
 
 export interface InitialProductFilterDataVariables {
   categories?: string[] | null;
   collections?: string[] | null;
+  productTypes?: string[] | null;
 }

--- a/src/products/types/InitialProductFilterData.ts
+++ b/src/products/types/InitialProductFilterData.ts
@@ -6,6 +6,31 @@
 // GraphQL query operation: InitialProductFilterData
 // ====================================================
 
+export interface InitialProductFilterData_attributes_edges_node_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface InitialProductFilterData_attributes_edges_node {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  slug: string | null;
+  values: (InitialProductFilterData_attributes_edges_node_values | null)[] | null;
+}
+
+export interface InitialProductFilterData_attributes_edges {
+  __typename: "AttributeCountableEdge";
+  node: InitialProductFilterData_attributes_edges_node;
+}
+
+export interface InitialProductFilterData_attributes {
+  __typename: "AttributeCountableConnection";
+  edges: InitialProductFilterData_attributes_edges[];
+}
+
 export interface InitialProductFilterData_categories_edges_node {
   __typename: "Category";
   id: string;
@@ -55,6 +80,7 @@ export interface InitialProductFilterData_productTypes {
 }
 
 export interface InitialProductFilterData {
+  attributes: InitialProductFilterData_attributes | null;
   categories: InitialProductFilterData_categories | null;
   collections: InitialProductFilterData_collections | null;
   productTypes: InitialProductFilterData_productTypes | null;

--- a/src/products/types/Product.ts
+++ b/src/products/types/Product.ts
@@ -135,7 +135,7 @@ export interface Product_variants {
   priceOverride: Product_variants_priceOverride | null;
   margin: number | null;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
   stockQuantity: number;
 }
 

--- a/src/products/types/ProductCreate.ts
+++ b/src/products/types/ProductCreate.ts
@@ -141,7 +141,7 @@ export interface ProductCreate_productCreate_product_variants {
   priceOverride: ProductCreate_productCreate_product_variants_priceOverride | null;
   margin: number | null;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
   stockQuantity: number;
 }
 

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -135,7 +135,7 @@ export interface ProductDetails_product_variants {
   priceOverride: ProductDetails_product_variants_priceOverride | null;
   margin: number | null;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
   stockQuantity: number;
 }
 

--- a/src/products/types/ProductImageCreate.ts
+++ b/src/products/types/ProductImageCreate.ts
@@ -141,7 +141,7 @@ export interface ProductImageCreate_productImageCreate_product_variants {
   priceOverride: ProductImageCreate_productImageCreate_product_variants_priceOverride | null;
   margin: number | null;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
   stockQuantity: number;
 }
 

--- a/src/products/types/ProductImageUpdate.ts
+++ b/src/products/types/ProductImageUpdate.ts
@@ -141,7 +141,7 @@ export interface ProductImageUpdate_productImageUpdate_product_variants {
   priceOverride: ProductImageUpdate_productImageUpdate_product_variants_priceOverride | null;
   margin: number | null;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
   stockQuantity: number;
 }
 

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -141,7 +141,7 @@ export interface ProductUpdate_productUpdate_product_variants {
   priceOverride: ProductUpdate_productUpdate_product_variants_priceOverride | null;
   margin: number | null;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
   stockQuantity: number;
 }
 

--- a/src/products/types/ProductVariant.ts
+++ b/src/products/types/ProductVariant.ts
@@ -100,5 +100,5 @@ export interface ProductVariant {
   product: ProductVariant_product;
   sku: string;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
 }

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -100,7 +100,7 @@ export interface ProductVariantDetails_productVariant {
   product: ProductVariantDetails_productVariant_product;
   sku: string;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
 }
 
 export interface ProductVariantDetails {

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -141,7 +141,7 @@ export interface SimpleProductUpdate_productUpdate_product_variants {
   priceOverride: SimpleProductUpdate_productUpdate_product_variants_priceOverride | null;
   margin: number | null;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
   stockQuantity: number;
 }
 
@@ -282,7 +282,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant {
   product: SimpleProductUpdate_productVariantUpdate_productVariant_product;
   sku: string;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
 }
 
 export interface SimpleProductUpdate_productVariantUpdate {

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -109,7 +109,7 @@ export interface VariantCreate_productVariantCreate_productVariant {
   product: VariantCreate_productVariantCreate_productVariant_product;
   sku: string;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
 }
 
 export interface VariantCreate_productVariantCreate {

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -106,7 +106,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant {
   product: VariantImageAssign_variantImageAssign_productVariant_product;
   sku: string;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
 }
 
 export interface VariantImageAssign_variantImageAssign {

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -106,7 +106,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant {
   product: VariantImageUnassign_variantImageUnassign_productVariant_product;
   sku: string;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
 }
 
 export interface VariantImageUnassign_variantImageUnassign {

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -109,7 +109,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant {
   product: VariantUpdate_productVariantUpdate_productVariant_product;
   sku: string;
   quantity: number;
-  quantityAllocated: number;
+  quantityAllocated: number | null;
 }
 
 export interface VariantUpdate_productVariantUpdate {

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -9,7 +9,8 @@ import {
   Filters,
   Pagination,
   Sort,
-  TabActionDialog
+  TabActionDialog,
+  FiltersWithMultipleValues
 } from "../types";
 
 const productSection = "/products/";
@@ -30,7 +31,12 @@ export enum ProductListUrlFiltersEnum {
   stockStatus = "stockStatus",
   query = "query"
 }
-export type ProductListUrlFilters = Filters<ProductListUrlFiltersEnum>;
+export enum ProductListUrlFiltersWithMultipleValues {
+  categories = "categories",
+  collections = "collections"
+}
+export type ProductListUrlFilters = Filters<ProductListUrlFiltersEnum> &
+  FiltersWithMultipleValues<ProductListUrlFiltersWithMultipleValues>;
 export enum ProductListUrlSortField {
   attribute = "attribute",
   name = "name",

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -10,7 +10,8 @@ import {
   Pagination,
   Sort,
   TabActionDialog,
-  FiltersWithMultipleValues
+  FiltersWithMultipleValues,
+  FiltersAsDictWithMultipleValues
 } from "../types";
 
 const productSection = "/products/";
@@ -36,8 +37,14 @@ export enum ProductListUrlFiltersWithMultipleValues {
   collections = "collections",
   productTypes = "productTypes"
 }
+export enum ProductListUrlFiltersAsDictWithMultipleValues {
+  attributes = "attributes"
+}
 export type ProductListUrlFilters = Filters<ProductListUrlFiltersEnum> &
-  FiltersWithMultipleValues<ProductListUrlFiltersWithMultipleValues>;
+  FiltersWithMultipleValues<ProductListUrlFiltersWithMultipleValues> &
+  FiltersAsDictWithMultipleValues<
+    ProductListUrlFiltersAsDictWithMultipleValues
+  >;
 export enum ProductListUrlSortField {
   attribute = "attribute",
   name = "name",

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -33,7 +33,8 @@ export enum ProductListUrlFiltersEnum {
 }
 export enum ProductListUrlFiltersWithMultipleValues {
   categories = "categories",
-  collections = "collections"
+  collections = "collections",
+  productTypes = "productTypes"
 }
 export type ProductListUrlFilters = Filters<ProductListUrlFiltersEnum> &
   FiltersWithMultipleValues<ProductListUrlFiltersWithMultipleValues>;

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -82,11 +82,6 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
   );
   const intl = useIntl();
   const { data: initialFilterData } = useInitialProductFilterDataQuery({
-    skip: !(
-      !!params.categories ||
-      !!params.collections ||
-      !!params.productTypes
-    ),
     variables: {
       categories: params.categories,
       collections: params.collections,
@@ -196,6 +191,7 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
 
   const filterOpts = getFilterOpts(
     params,
+    maybe(() => initialFilterData.attributes.edges.map(edge => edge.node), []),
     {
       initial: maybe(
         () => initialFilterData.categories.edges.map(edge => edge.node),

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -32,6 +32,7 @@ import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandl
 import createFilterHandlers from "@saleor/utils/handlers/filterHandlers";
 import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
+import useProductTypeSearch from "@saleor/searches/useProductTypeSearch";
 import ProductListPage from "../../components/ProductListPage";
 import {
   TypedProductBulkDeleteMutation,
@@ -81,17 +82,34 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
   );
   const intl = useIntl();
   const { data: initialFilterData } = useInitialProductFilterDataQuery({
-    skip: !(!!params.categories || !!params.collections),
+    skip: !(
+      !!params.categories ||
+      !!params.collections ||
+      !!params.productTypes
+    ),
     variables: {
       categories: params.categories,
-      collections: params.collections
+      collections: params.collections,
+      productTypes: params.productTypes
     }
   });
   const searchCategories = useCategorySearch({
-    variables: DEFAULT_INITIAL_SEARCH_DATA
+    variables: {
+      ...DEFAULT_INITIAL_SEARCH_DATA,
+      first: 5
+    }
   });
   const searchCollections = useCollectionSearch({
-    variables: DEFAULT_INITIAL_SEARCH_DATA
+    variables: {
+      ...DEFAULT_INITIAL_SEARCH_DATA,
+      first: 5
+    }
+  });
+  const searchProductTypes = useProductTypeSearch({
+    variables: {
+      ...DEFAULT_INITIAL_SEARCH_DATA,
+      first: 5
+    }
   });
 
   React.useEffect(
@@ -191,6 +209,13 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
         []
       ),
       search: searchCollections
+    },
+    {
+      initial: maybe(
+        () => initialFilterData.productTypes.edges.map(edge => edge.node),
+        []
+      ),
+      search: searchProductTypes
     }
   );
 

--- a/src/products/views/ProductList/__snapshots__/filters.test.ts.snap
+++ b/src/products/views/ProductList/__snapshots__/filters.test.ts.snap
@@ -3,11 +3,53 @@
 exports[`Filtering URL params should not be empty if active filters are present 1`] = `
 Object {
   "attributes": Object {
+    "author": Array [
+      "john-doe",
+      false,
+    ],
+    "box-size": Array [
+      "100g",
+      "500g",
+    ],
+    "brand": Array [
+      "saleor",
+      false,
+    ],
+    "candy-box-size": Array [
+      "100g",
+      "500g",
+    ],
+    "coffee-genre": Array [
+      "arabica",
+      false,
+    ],
+    "collar": Array [
+      "round",
+      "polo",
+    ],
+    "color": Array [
+      "blue",
+      false,
+    ],
+    "cover": Array [
+      "soft",
+      "middle-soft",
+    ],
+    "flavor": Array [
+      "sour",
+      false,
+    ],
+    "language": Array [
+      "english",
+      false,
+    ],
+    "publisher": Array [
+      "mirumee-press",
+      false,
+    ],
     "size": Array [
-      Array [
-        "xs",
-        "m",
-      ],
+      "xs",
+      "m",
     ],
   },
   "categories": Array [
@@ -26,4 +68,4 @@ Object {
 }
 `;
 
-exports[`Filtering URL params should not be empty if active filters are present 2`] = `"status=published&stockStatus=IN_STOCK&priceFrom=10&priceTo=20&categories%5B0%5D=878752&collections%5B0%5D=Q29sbGVjdGlvbjoc&productTypes%5B0%5D=UHJvZHVjdFR5cGU6MQ%3D%3D&attributes%5Bsize%5D%5B0%5D%5B0%5D=xs&attributes%5Bsize%5D%5B0%5D%5B1%5D=m"`;
+exports[`Filtering URL params should not be empty if active filters are present 2`] = `"status=published&stockStatus=IN_STOCK&priceFrom=10&priceTo=20&categories%5B0%5D=878752&collections%5B0%5D=Q29sbGVjdGlvbjoc&productTypes%5B0%5D=UHJvZHVjdFR5cGU6MQ%3D%3D&attributes%5Bauthor%5D%5B0%5D=john-doe&attributes%5Bauthor%5D%5B1%5D=false&attributes%5Bbox-size%5D%5B0%5D=100g&attributes%5Bbox-size%5D%5B1%5D=500g&attributes%5Bbrand%5D%5B0%5D=saleor&attributes%5Bbrand%5D%5B1%5D=false&attributes%5Bcandy-box-size%5D%5B0%5D=100g&attributes%5Bcandy-box-size%5D%5B1%5D=500g&attributes%5Bcoffee-genre%5D%5B0%5D=arabica&attributes%5Bcoffee-genre%5D%5B1%5D=false&attributes%5Bcollar%5D%5B0%5D=round&attributes%5Bcollar%5D%5B1%5D=polo&attributes%5Bcolor%5D%5B0%5D=blue&attributes%5Bcolor%5D%5B1%5D=false&attributes%5Bcover%5D%5B0%5D=soft&attributes%5Bcover%5D%5B1%5D=middle-soft&attributes%5Bflavor%5D%5B0%5D=sour&attributes%5Bflavor%5D%5B1%5D=false&attributes%5Blanguage%5D%5B0%5D=english&attributes%5Blanguage%5D%5B1%5D=false&attributes%5Bpublisher%5D%5B0%5D=mirumee-press&attributes%5Bpublisher%5D%5B1%5D=false&attributes%5Bsize%5D%5B0%5D=xs&attributes%5Bsize%5D%5B1%5D=m"`;

--- a/src/products/views/ProductList/__snapshots__/filters.test.ts.snap
+++ b/src/products/views/ProductList/__snapshots__/filters.test.ts.snap
@@ -2,6 +2,12 @@
 
 exports[`Filtering URL params should not be empty if active filters are present 1`] = `
 Object {
+  "categories": Array [
+    "878752",
+  ],
+  "collections": Array [
+    "Q29sbGVjdGlvbjoc",
+  ],
   "priceFrom": "10",
   "priceTo": "20",
   "status": "published",
@@ -9,4 +15,4 @@ Object {
 }
 `;
 
-exports[`Filtering URL params should not be empty if active filters are present 2`] = `"status=published&stockStatus=IN_STOCK&priceFrom=10&priceTo=20"`;
+exports[`Filtering URL params should not be empty if active filters are present 2`] = `"status=published&stockStatus=IN_STOCK&priceFrom=10&priceTo=20&categories%5B0%5D=878752&collections%5B0%5D=Q29sbGVjdGlvbjoc"`;

--- a/src/products/views/ProductList/__snapshots__/filters.test.ts.snap
+++ b/src/products/views/ProductList/__snapshots__/filters.test.ts.snap
@@ -2,6 +2,14 @@
 
 exports[`Filtering URL params should not be empty if active filters are present 1`] = `
 Object {
+  "attributes": Object {
+    "size": Array [
+      Array [
+        "xs",
+        "m",
+      ],
+    ],
+  },
   "categories": Array [
     "878752",
   ],
@@ -10,9 +18,12 @@ Object {
   ],
   "priceFrom": "10",
   "priceTo": "20",
+  "productTypes": Array [
+    "UHJvZHVjdFR5cGU6MQ==",
+  ],
   "status": "published",
   "stockStatus": "IN_STOCK",
 }
 `;
 
-exports[`Filtering URL params should not be empty if active filters are present 2`] = `"status=published&stockStatus=IN_STOCK&priceFrom=10&priceTo=20&categories%5B0%5D=878752&collections%5B0%5D=Q29sbGVjdGlvbjoc"`;
+exports[`Filtering URL params should not be empty if active filters are present 2`] = `"status=published&stockStatus=IN_STOCK&priceFrom=10&priceTo=20&categories%5B0%5D=878752&collections%5B0%5D=Q29sbGVjdGlvbjoc&productTypes%5B0%5D=UHJvZHVjdFR5cGU6MQ%3D%3D&attributes%5Bsize%5D%5B0%5D%5B0%5D=xs&attributes%5Bsize%5D%5B0%5D%5B1%5D=m"`;

--- a/src/products/views/ProductList/filters.test.ts
+++ b/src/products/views/ProductList/filters.test.ts
@@ -2,20 +2,13 @@ import { createIntl } from "react-intl";
 import { stringify as stringifyQs } from "qs";
 
 import { ProductListUrlFilters } from "@saleor/products/urls";
-import {
-  createFilterStructure,
-  ProductStatus
-} from "@saleor/products/components/ProductListPage";
+import { createFilterStructure } from "@saleor/products/components/ProductListPage";
 import { getFilterQueryParams } from "@saleor/utils/filters";
 import { getExistingKeys, setFilterOptsStatus } from "@test/filters";
 import { config } from "@test/intl";
 import { StockAvailability } from "@saleor/types/globalTypes";
-import { categories } from "@saleor/categories/fixtures";
-import { fetchMoreProps, searchPageProps } from "@saleor/fixtures";
-import { collections } from "@saleor/collections/fixtures";
-import { productTypes } from "@saleor/productTypes/fixtures";
-import { attributes } from "@saleor/attributes/fixtures";
 import { getFilterVariables, getFilterQueryParam } from "./filters";
+import { productListFilterOpts } from "./fixtures";
 
 describe("Filtering query params", () => {
   it("should be empty object if no params given", () => {
@@ -41,81 +34,7 @@ describe("Filtering query params", () => {
 describe("Filtering URL params", () => {
   const intl = createIntl(config);
 
-  const filters = createFilterStructure(intl, {
-    attributes: attributes.map(attr => ({
-      active: false,
-      choices: attr.values.map(val => ({
-        label: val.name,
-        value: val.slug
-      })),
-      name: attr.name,
-      slug: attr.slug,
-      value: [attr.values[0].slug, attr.values[2].slug]
-    })),
-    categories: {
-      ...fetchMoreProps,
-      ...searchPageProps,
-      active: false,
-      choices: categories.slice(5).map(category => ({
-        label: category.name,
-        value: category.id
-      })),
-      displayValues: [
-        {
-          label: categories[5].name,
-          value: categories[5].id
-        }
-      ],
-      value: [categories[5].id]
-    },
-    collections: {
-      ...fetchMoreProps,
-      ...searchPageProps,
-      active: false,
-      choices: collections.slice(5).map(category => ({
-        label: category.name,
-        value: category.id
-      })),
-      displayValues: [
-        {
-          label: collections[5].name,
-          value: collections[5].id
-        }
-      ],
-      value: [collections[5].id]
-    },
-    price: {
-      active: false,
-      value: {
-        max: "20",
-        min: "10"
-      }
-    },
-    productType: {
-      ...fetchMoreProps,
-      ...searchPageProps,
-      active: false,
-      choices: productTypes.slice(3).map(category => ({
-        label: category.name,
-        value: category.id
-      })),
-      displayValues: [
-        {
-          label: productTypes[3].name,
-          value: productTypes[3].id
-        }
-      ],
-      value: [productTypes[4].id]
-    },
-    status: {
-      active: false,
-      value: ProductStatus.PUBLISHED
-    },
-    stockStatus: {
-      active: false,
-      value: StockAvailability.IN_STOCK
-    }
-  });
+  const filters = createFilterStructure(intl, productListFilterOpts);
 
   it("should be empty if no active filters", () => {
     const filterQueryParams = getFilterQueryParams(

--- a/src/products/views/ProductList/filters.test.ts
+++ b/src/products/views/ProductList/filters.test.ts
@@ -10,6 +10,9 @@ import { getFilterQueryParams } from "@saleor/utils/filters";
 import { getExistingKeys, setFilterOptsStatus } from "@test/filters";
 import { config } from "@test/intl";
 import { StockAvailability } from "@saleor/types/globalTypes";
+import { categories } from "@saleor/categories/fixtures";
+import { fetchMoreProps, searchPageProps } from "@saleor/fixtures";
+import { collections } from "@saleor/collections/fixtures";
 import { getFilterVariables, getFilterQueryParam } from "./filters";
 
 describe("Filtering query params", () => {
@@ -37,6 +40,38 @@ describe("Filtering URL params", () => {
   const intl = createIntl(config);
 
   const filters = createFilterStructure(intl, {
+    categories: {
+      ...fetchMoreProps,
+      ...searchPageProps,
+      active: false,
+      choices: categories.slice(5).map(category => ({
+        label: category.name,
+        value: category.id
+      })),
+      displayValues: [
+        {
+          label: categories[5].name,
+          value: categories[5].id
+        }
+      ],
+      value: [categories[5].id]
+    },
+    collections: {
+      ...fetchMoreProps,
+      ...searchPageProps,
+      active: false,
+      choices: collections.slice(5).map(category => ({
+        label: category.name,
+        value: category.id
+      })),
+      displayValues: [
+        {
+          label: collections[5].name,
+          value: collections[5].id
+        }
+      ],
+      value: [collections[5].id]
+    },
     price: {
       active: false,
       value: {

--- a/src/products/views/ProductList/filters.test.ts
+++ b/src/products/views/ProductList/filters.test.ts
@@ -14,6 +14,7 @@ import { categories } from "@saleor/categories/fixtures";
 import { fetchMoreProps, searchPageProps } from "@saleor/fixtures";
 import { collections } from "@saleor/collections/fixtures";
 import { productTypes } from "@saleor/productTypes/fixtures";
+import { attributes } from "@saleor/attributes/fixtures";
 import { getFilterVariables, getFilterQueryParam } from "./filters";
 
 describe("Filtering query params", () => {
@@ -41,6 +42,16 @@ describe("Filtering URL params", () => {
   const intl = createIntl(config);
 
   const filters = createFilterStructure(intl, {
+    attributes: attributes.map(attr => ({
+      active: false,
+      choices: attr.values.map(val => ({
+        label: val.name,
+        value: val.slug
+      })),
+      name: attr.name,
+      slug: attr.slug,
+      value: [attr.values[0].slug, attr.values[2].slug]
+    })),
     categories: {
       ...fetchMoreProps,
       ...searchPageProps,

--- a/src/products/views/ProductList/filters.test.ts
+++ b/src/products/views/ProductList/filters.test.ts
@@ -13,6 +13,7 @@ import { StockAvailability } from "@saleor/types/globalTypes";
 import { categories } from "@saleor/categories/fixtures";
 import { fetchMoreProps, searchPageProps } from "@saleor/fixtures";
 import { collections } from "@saleor/collections/fixtures";
+import { productTypes } from "@saleor/productTypes/fixtures";
 import { getFilterVariables, getFilterQueryParam } from "./filters";
 
 describe("Filtering query params", () => {
@@ -78,6 +79,22 @@ describe("Filtering URL params", () => {
         max: "20",
         min: "10"
       }
+    },
+    productType: {
+      ...fetchMoreProps,
+      ...searchPageProps,
+      active: false,
+      choices: productTypes.slice(3).map(category => ({
+        label: category.name,
+        value: category.id
+      })),
+      displayValues: [
+        {
+          label: productTypes[3].name,
+          value: productTypes[3].id
+        }
+      ],
+      value: [productTypes[4].id]
     },
     status: {
       active: false,

--- a/src/products/views/ProductList/filters.ts
+++ b/src/products/views/ProductList/filters.ts
@@ -4,6 +4,19 @@ import {
   ProductListFilterOpts,
   ProductStatus
 } from "@saleor/products/components/ProductListPage";
+import { UseSearchResult } from "@saleor/hooks/makeSearch";
+import {
+  SearchCategories,
+  SearchCategoriesVariables
+} from "@saleor/searches/types/SearchCategories";
+import {
+  InitialProductFilterData_categories_edges_node,
+  InitialProductFilterData_collections_edges_node
+} from "@saleor/products/types/InitialProductFilterData";
+import {
+  SearchCollections,
+  SearchCollectionsVariables
+} from "@saleor/searches/types/SearchCollections";
 import { IFilterElement } from "../../../components/Filter";
 import {
   ProductFilterInput,
@@ -14,20 +27,87 @@ import {
   createFilterUtils,
   getGteLteVariables,
   getMinMaxQueryParam,
-  getSingleEnumValueQueryParam
+  getSingleEnumValueQueryParam,
+  dedupeFilter,
+  getMultipleValueQueryParam
 } from "../../../utils/filters";
 import {
   ProductListUrlFilters,
   ProductListUrlFiltersEnum,
-  ProductListUrlQueryParams
+  ProductListUrlQueryParams,
+  ProductListUrlFiltersWithMultipleValues
 } from "../../urls";
 
 export const PRODUCT_FILTERS_KEY = "productFilters";
 
 export function getFilterOpts(
-  params: ProductListUrlFilters
+  params: ProductListUrlFilters,
+  categories: {
+    initial: InitialProductFilterData_categories_edges_node[];
+    search: UseSearchResult<SearchCategories, SearchCategoriesVariables>;
+  },
+  collections: {
+    initial: InitialProductFilterData_collections_edges_node[];
+    search: UseSearchResult<SearchCollections, SearchCollectionsVariables>;
+  }
 ): ProductListFilterOpts {
   return {
+    categories: {
+      active: !!params.categories,
+      choices: maybe(
+        () =>
+          categories.search.result.data.search.edges.map(edge => ({
+            label: edge.node.name,
+            value: edge.node.id
+          })),
+        []
+      ),
+      displayValues: maybe(
+        () =>
+          categories.initial.map(category => ({
+            label: category.name,
+            value: category.id
+          })),
+        []
+      ),
+      hasMore: maybe(
+        () => categories.search.result.data.search.pageInfo.hasNextPage,
+        false
+      ),
+      initialSearch: "",
+      loading: categories.search.result.loading,
+      onFetchMore: categories.search.loadMore,
+      onSearchChange: categories.search.search,
+      value: maybe(() => dedupeFilter(params.categories), [])
+    },
+    collections: {
+      active: !!params.collections,
+      choices: maybe(
+        () =>
+          collections.search.result.data.search.edges.map(edge => ({
+            label: edge.node.name,
+            value: edge.node.id
+          })),
+        []
+      ),
+      displayValues: maybe(
+        () =>
+          collections.initial.map(category => ({
+            label: category.name,
+            value: category.id
+          })),
+        []
+      ),
+      hasMore: maybe(
+        () => collections.search.result.data.search.pageInfo.hasNextPage,
+        false
+      ),
+      initialSearch: "",
+      loading: collections.search.result.loading,
+      onFetchMore: collections.search.loadMore,
+      onSearchChange: collections.search.search,
+      value: maybe(() => dedupeFilter(params.collections), [])
+    },
     price: {
       active: maybe(
         () =>
@@ -54,6 +134,8 @@ export function getFilterVariables(
   params: ProductListUrlFilters
 ): ProductFilterInput {
   return {
+    categories: params.categories !== undefined ? params.categories : null,
+    collections: params.collections !== undefined ? params.collections : null,
     isPublished:
       params.status !== undefined
         ? params.status === ProductStatus.PUBLISHED
@@ -76,6 +158,18 @@ export function getFilterQueryParam(
   const { name } = filter;
 
   switch (name) {
+    case ProductFilterKeys.categories:
+      return getMultipleValueQueryParam(
+        filter,
+        ProductListUrlFiltersWithMultipleValues.categories
+      );
+
+    case ProductFilterKeys.collections:
+      return getMultipleValueQueryParam(
+        filter,
+        ProductListUrlFiltersWithMultipleValues.collections
+      );
+
     case ProductFilterKeys.price:
       return getMinMaxQueryParam(
         filter,

--- a/src/products/views/ProductList/filters.ts
+++ b/src/products/views/ProductList/filters.ts
@@ -129,7 +129,7 @@ export function getFilterOpts(
               })),
             []
           )
-        : undefined,
+        : [],
       hasMore: maybe(
         () => collections.search.result.data.search.pageInfo.hasNextPage,
         false

--- a/src/products/views/ProductList/filters.ts
+++ b/src/products/views/ProductList/filters.ts
@@ -215,8 +215,8 @@ export function getFilterVariables(
       gte: parseFloat(params.priceFrom),
       lte: parseFloat(params.priceTo)
     }),
-    productType:
-      params.productTypes !== undefined ? params.productTypes[0] : null,
+    productTypes:
+      params.productTypes !== undefined ? params.productTypes : null,
     search: params.query,
     stockAvailability:
       params.stockStatus !== undefined
@@ -232,21 +232,16 @@ export function getFilterQueryParam(
   const { active, group, name, value } = filter;
 
   if (!!group) {
-    if (active) {
-      return {
-        [group]:
-          params && params[group]
-            ? {
-                ...params[group],
-                [name]: [...params[group], value]
-              }
-            : {
-                [name]: [value]
-              }
-      };
-    }
+    const rest = params && params[group] ? params[group] : undefined;
 
-    return {};
+    return {
+      [group]: active
+        ? {
+            ...(rest === undefined ? {} : rest),
+            [name]: value
+          }
+        : rest
+    };
   }
 
   switch (name) {

--- a/src/products/views/ProductList/filters.ts
+++ b/src/products/views/ProductList/filters.ts
@@ -34,8 +34,7 @@ import {
   getMinMaxQueryParam,
   getSingleEnumValueQueryParam,
   dedupeFilter,
-  getMultipleValueQueryParam,
-  getSingleValueQueryParam
+  getMultipleValueQueryParam
 } from "../../../utils/filters";
 import {
   ProductListUrlFilters,

--- a/src/products/views/ProductList/fixtures.ts
+++ b/src/products/views/ProductList/fixtures.ts
@@ -1,0 +1,86 @@
+import {
+  ProductListFilterOpts,
+  ProductStatus
+} from "@saleor/products/components/ProductListPage";
+import { attributes } from "@saleor/attributes/fixtures";
+import { fetchMoreProps, searchPageProps } from "@saleor/fixtures";
+import { categories } from "@saleor/categories/fixtures";
+import { collections } from "@saleor/collections/fixtures";
+import { productTypes } from "@saleor/productTypes/fixtures";
+import { StockAvailability } from "@saleor/types/globalTypes";
+
+export const productListFilterOpts: ProductListFilterOpts = {
+  attributes: attributes.map(attr => ({
+    active: false,
+    choices: attr.values.map(val => ({
+      label: val.name,
+      value: val.slug
+    })),
+    name: attr.name,
+    slug: attr.slug,
+    value: [attr.values[0].slug, attr.values.length > 2 && attr.values[2].slug]
+  })),
+  categories: {
+    ...fetchMoreProps,
+    ...searchPageProps,
+    active: false,
+    choices: categories.slice(5).map(category => ({
+      label: category.name,
+      value: category.id
+    })),
+    displayValues: [
+      {
+        label: categories[5].name,
+        value: categories[5].id
+      }
+    ],
+    value: [categories[5].id]
+  },
+  collections: {
+    ...fetchMoreProps,
+    ...searchPageProps,
+    active: false,
+    choices: collections.slice(5).map(category => ({
+      label: category.name,
+      value: category.id
+    })),
+    displayValues: [
+      {
+        label: collections[5].name,
+        value: collections[5].id
+      }
+    ],
+    value: [collections[5].id]
+  },
+  price: {
+    active: false,
+    value: {
+      max: "20",
+      min: "10"
+    }
+  },
+  productType: {
+    ...fetchMoreProps,
+    ...searchPageProps,
+    active: false,
+    choices: productTypes.slice(3).map(category => ({
+      label: category.name,
+      value: category.id
+    })),
+    displayValues: [
+      {
+        label: productTypes[3].name,
+        value: productTypes[3].id
+      }
+    ],
+    value: [productTypes[4].id]
+  },
+  status: {
+    active: false,
+    value: ProductStatus.PUBLISHED
+  },
+  stockStatus: {
+    active: false,
+    value: StockAvailability.IN_STOCK
+  }
+};

--- a/src/storybook/stories/products/ProductListPage.tsx
+++ b/src/storybook/stories/products/ProductListPage.tsx
@@ -7,7 +7,7 @@ import { products as productListFixture } from "@saleor/products/fixtures";
 import { ProductListUrlSortField } from "@saleor/products/urls";
 import { attributes } from "@saleor/productTypes/fixtures";
 import { ListViews } from "@saleor/types";
-import { StockAvailability } from "@saleor/types/globalTypes";
+import { productListFilterOpts } from "@saleor/products/views/ProductList/fixtures";
 import {
   fetchMoreProps,
   filterPageProps,
@@ -16,8 +16,7 @@ import {
   sortPageProps
 } from "../../../fixtures";
 import ProductListPage, {
-  ProductListPageProps,
-  ProductStatus
+  ProductListPageProps
 } from "../../../products/components/ProductListPage";
 import Decorator from "../../Decorator";
 
@@ -38,23 +37,7 @@ const props: ProductListPageProps = {
   activeAttributeSortId: undefined,
   availableInGridAttributes: attributes,
   defaultSettings: defaultListSettings[ListViews.PRODUCT_LIST],
-  filterOpts: {
-    price: {
-      active: false,
-      value: {
-        max: "30",
-        min: "10"
-      }
-    },
-    status: {
-      active: false,
-      value: ProductStatus.PUBLISHED
-    },
-    stockStatus: {
-      active: false,
-      value: StockAvailability.IN_STOCK
-    }
-  },
+  filterOpts: productListFilterOpts,
   gridAttributes: attributes,
   products,
   settings: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,9 @@ export type Filters<TFilters extends string> = Partial<
 export type FiltersWithMultipleValues<TFilters extends string> = Partial<
   Record<TFilters, string[]>
 >;
+export type FiltersAsDictWithMultipleValues<TFilters extends string> = Partial<
+  Record<TFilters, Record<string, string[]>>
+>;
 export type Search = Partial<{
   query: string;
 }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { MutationResult } from "react-apollo";
 import { User_permissions } from "./auth/types/User";
 import { ConfirmButtonTransitionState } from "./components/ConfirmButton";
 import { IFilter } from "./components/Filter";
+import { MultiAutocompleteChoiceType } from "./components/MultiAutocompleteSelectField";
 
 export interface UserError {
   field: string;
@@ -175,4 +176,11 @@ export type MinMax = Record<"min" | "max", string>;
 export interface FilterOpts<T> {
   active: boolean;
   value: T;
+}
+
+export interface AutocompleteFilterOpts
+  extends FetchMoreProps,
+    SearchPageProps {
+  choices: MultiAutocompleteChoiceType[];
+  displayValues: MultiAutocompleteChoiceType[];
 }

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1028,6 +1028,7 @@ export interface ProductTypeFilterInput {
   search?: string | null;
   configurable?: ProductTypeConfigurable | null;
   productType?: ProductTypeEnum | null;
+  ids?: (string | null)[] | null;
 }
 
 export interface ProductTypeInput {

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -711,7 +711,8 @@ export interface AttributeFilterInput {
 
 export interface AttributeInput {
   slug: string;
-  value: string;
+  value?: string | null;
+  values?: (string | null)[] | null;
 }
 
 export interface AttributeSortingInput {
@@ -1016,6 +1017,7 @@ export interface ProductFilterInput {
   productType?: string | null;
   search?: string | null;
   minimalPrice?: PriceRangeInput | null;
+  productTypes?: (string | null)[] | null;
 }
 
 export interface ProductOrder {

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -755,6 +755,7 @@ export interface CatalogueInput {
 
 export interface CategoryFilterInput {
   search?: string | null;
+  ids?: (string | null)[] | null;
 }
 
 export interface CategoryInput {
@@ -788,6 +789,7 @@ export interface CollectionCreateInput {
 export interface CollectionFilterInput {
   published?: CollectionPublished | null;
   search?: string | null;
+  ids?: (string | null)[] | null;
 }
 
 export interface CollectionInput {

--- a/src/utils/filters/fields.ts
+++ b/src/utils/filters/fields.ts
@@ -1,6 +1,6 @@
 import { IFilterElement, FieldType } from "@saleor/components/Filter";
 import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocompleteSelectField";
-import { MinMax } from "@saleor/types";
+import { MinMax, FetchMoreProps, SearchPageProps } from "@saleor/types";
 
 export function createPriceField<T extends string>(
   name: T,
@@ -61,6 +61,28 @@ export function createOptionsField<T extends string>(
     name,
     options,
     type: FieldType.options,
+    value: defaultValue
+  };
+}
+
+export function createAutocompleteField<T extends string>(
+  name: T,
+  label: string,
+  defaultValue: string[],
+  displayValues: MultiAutocompleteChoiceType[],
+  multiple: boolean,
+  options: MultiAutocompleteChoiceType[],
+  opts: FetchMoreProps & SearchPageProps
+): IFilterElement<T> {
+  return {
+    ...opts,
+    active: false,
+    displayValues,
+    label,
+    multiple,
+    name,
+    options,
+    type: FieldType.autocomplete,
     value: defaultValue
   };
 }

--- a/src/utils/filters/filters.ts
+++ b/src/utils/filters/filters.ts
@@ -48,7 +48,7 @@ export function getFilterQueryParams<
   return filter.reduce(
     (acc, filterField) => ({
       ...acc,
-      ...getFilterQueryParam(filterField)
+      ...getFilterQueryParam(filterField, acc)
     }),
     {} as TUrlFilters
   );

--- a/src/utils/filters/filters.ts
+++ b/src/utils/filters/filters.ts
@@ -34,12 +34,16 @@ export function dedupeFilter<T>(array: T[]): T[] {
   return Array.from(new Set(array));
 }
 
+export type GetFilterQueryParam<
+  TFilterKeys extends string,
+  TFilters extends object
+> = (filter: IFilterElement<TFilterKeys>, params?: object) => TFilters;
 export function getFilterQueryParams<
   TFilterKeys extends string,
   TUrlFilters extends object
 >(
   filter: IFilter<TFilterKeys>,
-  getFilterQueryParam: (filter: IFilterElement<TFilterKeys>) => TUrlFilters
+  getFilterQueryParam: GetFilterQueryParam<TFilterKeys, TUrlFilters>
 ): TUrlFilters {
   return filter.reduce(
     (acc, filterField) => ({

--- a/src/utils/filters/filters.ts
+++ b/src/utils/filters/filters.ts
@@ -1,3 +1,5 @@
+import isArray from "lodash-es/isArray";
+
 import { IFilterElement, IFilter } from "@saleor/components/Filter";
 import { findValueInEnum } from "@saleor/misc";
 
@@ -25,6 +27,10 @@ function createFilterUtils<
 }
 
 export function dedupeFilter<T>(array: T[]): T[] {
+  if (!isArray(array)) {
+    return [array];
+  }
+
   return Array.from(new Set(array));
 }
 
@@ -107,6 +113,23 @@ export function getMultipleEnumValueQueryParam<
 
   return {
     [key]: value.map(val => findValueInEnum(val, haystack))
+  };
+}
+
+export function getMultipleValueQueryParam<
+  TKey extends string,
+  TUrlKey extends string
+>(param: IFilterElement<TKey>, key: TUrlKey) {
+  const { active, value } = param;
+
+  if (!active) {
+    return {
+      [key]: undefined
+    };
+  }
+
+  return {
+    [key]: value
   };
 }
 

--- a/src/utils/handlers/filterHandlers.ts
+++ b/src/utils/handlers/filterHandlers.ts
@@ -1,14 +1,10 @@
-import { IFilter, IFilterElement } from "@saleor/components/Filter";
+import { IFilter } from "@saleor/components/Filter";
 import { UseNavigatorResult } from "@saleor/hooks/useNavigator";
 import { Sort, Pagination, ActiveTab, Search } from "@saleor/types";
-import { getFilterQueryParams } from "../filters";
+import { getFilterQueryParams, GetFilterQueryParam } from "../filters";
 
 type RequiredParams = ActiveTab & Search & Sort & Pagination;
 type CreateUrl = (params: RequiredParams) => string;
-type GetFilterQueryParam<
-  TFilterKeys extends string,
-  TFilters extends object
-> = (filter: IFilterElement<TFilterKeys>) => TFilters;
 type CreateFilterHandlers<TFilterKeys extends string> = [
   (filter: IFilter<TFilterKeys>) => void,
   () => void,

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,7 +1,20 @@
 import { stringify } from "qs";
+import isArray from "lodash-es/isArray";
 
 export function stringifyQs(params: object): string {
   return stringify(params, {
     indices: false
   });
+}
+
+export function getArrayQueryParam(param: string | string[]): string[] {
+  if (!param) {
+    return undefined;
+  }
+
+  if (isArray(param)) {
+    return param;
+  }
+
+  return [param];
 }


### PR DESCRIPTION
I want to merge this change because it adds filtering by categories, collections, product types and attributes.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
