### PR TITLE
Throw error when API_URI is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add table sorting - #292 by @dominik-zeglen
 - Unify dialog handling - #296 by @dominik-zeglen
 - Stop using deprecated fields - #357 by @dominik-zeglen
+- Throw error when API_URI is not set - #375 by @dominik-zeglen
 
 ## 2.0.0
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { SearchVariables } from "./hooks/makeSearch";
 import { ListSettings, ListViews } from "./types";
 
 export const APP_MOUNT_URI = process.env.APP_MOUNT_URI || "/";
-export const API_URI = process.env.API_URI || "/graphql/";
+export const API_URI = process.env.API_URI;
 
 export const DEFAULT_INITIAL_SEARCH_DATA: SearchVariables = {
   after: null,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,10 @@ module.exports = (env, argv) => {
   let fileLoaderPath;
   let output;
 
+  if(!process.env.API_URI) {
+    throw new Error("Environment variable API_URI not set")
+  }
+
   if (!devMode) {
     const publicPath = process.env.STATIC_URL || "/";
     output = {


### PR DESCRIPTION
I want to merge this change because it resolves #102 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted to `.pot` file.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
