### PR TITLE
Add "Ready to capture" to the "Status" order filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Do not store errors in form component - #410 by @dominik-zeglen
 - Handle rich text editor content error - #395 by @dominik-zeglen
 - Fix crashing views - #422 by @dominik-zeglen
+- Add "Ready to capture" to the "Status" order filter - #430 by @dominik-zeglen
 
 ## 2.0.0
 

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3697,6 +3697,14 @@
   "src_dot_readOnly": {
     "string": "Saleor runs in read-only mode. Changes not saved."
   },
+  "src_dot_readyToCapture": {
+    "context": "order status",
+    "string": "Ready to capture"
+  },
+  "src_dot_readyToFulfill": {
+    "context": "order status",
+    "string": "Ready to fulfill"
+  },
   "src_dot_refunded": {
     "context": "payment status",
     "string": "Fully refunded"

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -38,10 +38,7 @@ const HomeSection = () => {
           onOrdersToFulfillClick={() =>
             navigate(
               orderListUrl({
-                status: [
-                  OrderStatusFilter.UNFULFILLED,
-                  OrderStatusFilter.PARTIALLY_FULFILLED
-                ]
+                status: [OrderStatusFilter.READY_TO_FULFILL]
               })
             )
           }

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -132,6 +132,14 @@ export const orderStatusMessages = defineMessages({
     defaultMessage: "Partially fulfilled",
     description: "order status"
   },
+  readyToCapture: {
+    defaultMessage: "Ready to capture",
+    description: "order status"
+  },
+  readyToFulfill: {
+    defaultMessage: "Ready to fulfill",
+    description: "order status"
+  },
   unfulfilled: {
     defaultMessage: "Unfulfilled",
     description: "order status"

--- a/src/orders/components/OrderListPage/filters.ts
+++ b/src/orders/components/OrderListPage/filters.ts
@@ -77,6 +77,14 @@ export function createFilterStructure(
           {
             label: intl.formatMessage(orderStatusMessages.unfulfilled),
             value: OrderStatusFilter.UNFULFILLED
+          },
+          {
+            label: intl.formatMessage(orderStatusMessages.readyToCapture),
+            value: OrderStatusFilter.READY_TO_CAPTURE
+          },
+          {
+            label: intl.formatMessage(orderStatusMessages.readyToFulfill),
+            value: OrderStatusFilter.READY_TO_FULFILL
           }
         ]
       ),

--- a/src/orders/views/OrderList/filters.ts
+++ b/src/orders/views/OrderList/filters.ts
@@ -6,8 +6,7 @@ import {
 import { IFilterElement } from "../../../components/Filter";
 import {
   OrderFilterInput,
-  OrderStatusFilter,
-  OrderStatus
+  OrderStatusFilter
 } from "../../../types/globalTypes";
 import {
   createFilterTabUtils,
@@ -96,7 +95,7 @@ export function getFilterQueryParam(
       return getMultipleEnumValueQueryParam(
         filter,
         OrderListUrlFiltersWithMultipleValuesEnum.status,
-        OrderStatus
+        OrderStatusFilter
       );
 
     case OrderFilterKeys.customer:


### PR DESCRIPTION
Resolves #73 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
