### PR TITLE
Display validation errors on NewPassword page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix crashing views - #422 by @dominik-zeglen
 - Add "Ready to capture" to the "Status" order filter - #430 by @dominik-zeglen
 - Reset state after closing - #456 by @dominik-zeglen
+- Password validation errors are not shown - #471 by @gabmartinez
 
 ## 2.0.0
 

--- a/src/auth/components/NewPasswordPage/NewPasswordPage.stories.tsx
+++ b/src/auth/components/NewPasswordPage/NewPasswordPage.stories.tsx
@@ -9,8 +9,8 @@ storiesOf("Views / Authentication / Set up a new password", module)
   .addDecorator(CardDecorator)
   .addDecorator(Decorator)
   .add("default", () => (
-    <NewPasswordPage disabled={false} onSubmit={() => undefined} />
+    <NewPasswordPage error={null} disabled={false} onSubmit={() => undefined} />
   ))
   .add("loading", () => (
-    <NewPasswordPage disabled={true} onSubmit={() => undefined} />
+    <NewPasswordPage error={null} disabled={true} onSubmit={() => undefined} />
   ));

--- a/src/auth/components/NewPasswordPage/NewPasswordPage.stories.tsx
+++ b/src/auth/components/NewPasswordPage/NewPasswordPage.stories.tsx
@@ -3,14 +3,26 @@ import React from "react";
 
 import CardDecorator from "@saleor/storybook//CardDecorator";
 import Decorator from "@saleor/storybook//Decorator";
+import { AccountErrorCode } from "@saleor/types/globalTypes";
 import NewPasswordPage from "./NewPasswordPage";
 
 storiesOf("Views / Authentication / Set up a new password", module)
   .addDecorator(CardDecorator)
   .addDecorator(Decorator)
   .add("default", () => (
-    <NewPasswordPage error={null} disabled={false} onSubmit={() => undefined} />
+    <NewPasswordPage errors={[]} disabled={false} onSubmit={() => undefined} />
   ))
   .add("loading", () => (
-    <NewPasswordPage error={null} disabled={true} onSubmit={() => undefined} />
+    <NewPasswordPage errors={[]} disabled={true} onSubmit={() => undefined} />
+  ))
+  .add("too short error", () => (
+    <NewPasswordPage
+      errors={["password"].map(field => ({
+        __typename: "AccountError",
+        code: AccountErrorCode.PASSWORD_TOO_SHORT,
+        field
+      }))}
+      disabled={false}
+      onSubmit={() => undefined}
+    />
   ));

--- a/src/auth/components/NewPasswordPage/NewPasswordPage.tsx
+++ b/src/auth/components/NewPasswordPage/NewPasswordPage.tsx
@@ -7,6 +7,8 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import Form from "@saleor/components/Form";
 import FormSpacer from "@saleor/components/FormSpacer";
+import { SetPassword_setPassword_errors } from "@saleor/auth/types/SetPassword";
+import getAccountErrorMessage from "@saleor/utils/errors/account";
 
 const useStyles = makeStyles(
   theme => ({
@@ -34,7 +36,7 @@ export interface NewPasswordPageFormData {
 }
 export interface NewPasswordPageProps {
   disabled: boolean;
-  error: string;
+  errors: SetPassword_setPassword_errors[];
   onSubmit: (data: NewPasswordPageFormData) => void;
 }
 
@@ -44,10 +46,14 @@ const initialForm: NewPasswordPageFormData = {
 };
 
 const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
-  const { disabled, error, onSubmit } = props;
+  const { disabled, errors, onSubmit } = props;
 
   const classes = useStyles(props);
   const intl = useIntl();
+  const error = getAccountErrorMessage(
+    errors.find(err => err.field === "password"),
+    intl
+  );
 
   return (
     <Form initial={initialForm} onSubmit={onSubmit}>

--- a/src/auth/components/NewPasswordPage/NewPasswordPage.tsx
+++ b/src/auth/components/NewPasswordPage/NewPasswordPage.tsx
@@ -9,11 +9,20 @@ import Form from "@saleor/components/Form";
 import FormSpacer from "@saleor/components/FormSpacer";
 
 const useStyles = makeStyles(
-  {
+  theme => ({
+    errorText: {
+      color: theme.palette.error.contrastText
+    },
+    panel: {
+      background: theme.palette.error.main,
+      borderRadius: theme.spacing(),
+      marginBottom: theme.spacing(3),
+      padding: theme.spacing(1.5)
+    },
     submit: {
       width: "100%"
     }
-  },
+  }),
   {
     name: "NewPasswordPage"
   }
@@ -25,6 +34,7 @@ export interface NewPasswordPageFormData {
 }
 export interface NewPasswordPageProps {
   disabled: boolean;
+  error: string;
   onSubmit: (data: NewPasswordPageFormData) => void;
 }
 
@@ -34,7 +44,7 @@ const initialForm: NewPasswordPageFormData = {
 };
 
 const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
-  const { disabled, onSubmit } = props;
+  const { disabled, error, onSubmit } = props;
 
   const classes = useStyles(props);
   const intl = useIntl();
@@ -47,6 +57,13 @@ const NewPasswordPage: React.FC<NewPasswordPageProps> = props => {
 
         return (
           <>
+            {!!error && (
+              <div className={classes.panel}>
+                <Typography variant="caption" className={classes.errorText}>
+                  {error}
+                </Typography>
+              </div>
+            )}
             <Typography>
               <FormattedMessage defaultMessage="Please set up a new password." />
             </Typography>

--- a/src/auth/views/NewPassword.tsx
+++ b/src/auth/views/NewPassword.tsx
@@ -8,18 +8,12 @@ import NewPasswordPage, {
   NewPasswordPageFormData
 } from "../components/NewPasswordPage";
 import { SetPasswordMutation } from "../mutations";
-import {
-  SetPassword,
-  SetPassword_setPassword_errors
-} from "../types/SetPassword";
+import { SetPassword } from "../types/SetPassword";
 import { NewPasswordUrlQueryParams } from "../urls";
 
 const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
   const navigate = useNavigator();
   const { loginByToken } = useUser();
-  const [errors, setErrors] = React.useState<
-    SetPassword_setPassword_errors[]
-  >();
 
   const params: NewPasswordUrlQueryParams = parseQs(location.search.substr(1));
 
@@ -27,8 +21,6 @@ const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
     if (data.setPassword.errors.length === 0) {
       loginByToken(data.setPassword.token, data.setPassword.user);
       navigate("/", true);
-    } else {
-      setErrors(data.setPassword.errors);
     }
   };
 
@@ -46,7 +38,7 @@ const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
 
         return (
           <NewPasswordPage
-            errors={errors}
+            errors={setPasswordOpts.data?.setPassword.errors || []}
             disabled={setPasswordOpts.loading}
             onSubmit={handleSubmit}
           />

--- a/src/auth/views/NewPassword.tsx
+++ b/src/auth/views/NewPassword.tsx
@@ -4,6 +4,9 @@ import { RouteComponentProps } from "react-router";
 
 import useNavigator from "@saleor/hooks/useNavigator";
 import useUser from "@saleor/hooks/useUser";
+import { useIntl } from "react-intl";
+import { commonMessages } from "@saleor/intl";
+import getAccountErrorMessage from "@saleor/utils/errors/account";
 import NewPasswordPage, {
   NewPasswordPageFormData
 } from "../components/NewPasswordPage";
@@ -14,6 +17,8 @@ import { NewPasswordUrlQueryParams } from "../urls";
 const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
   const navigate = useNavigator();
   const { loginByToken } = useUser();
+  const [error, setError] = React.useState<string>();
+  const intl = useIntl();
 
   const params: NewPasswordUrlQueryParams = parseQs(location.search.substr(1));
 
@@ -21,6 +26,15 @@ const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
     if (data.setPassword.errors.length === 0) {
       loginByToken(data.setPassword.token, data.setPassword.user);
       navigate("/", true);
+    } else {
+      const error = data.setPassword.errors.find(
+        err => err.field === "password"
+      );
+      if (error) {
+        setError(getAccountErrorMessage(error, intl));
+      } else {
+        setError(intl.formatMessage(commonMessages.somethingWentWrong));
+      }
     }
   };
 
@@ -38,6 +52,7 @@ const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
 
         return (
           <NewPasswordPage
+            error={error}
             disabled={setPasswordOpts.loading}
             onSubmit={handleSubmit}
           />

--- a/src/auth/views/NewPassword.tsx
+++ b/src/auth/views/NewPassword.tsx
@@ -4,21 +4,22 @@ import { RouteComponentProps } from "react-router";
 
 import useNavigator from "@saleor/hooks/useNavigator";
 import useUser from "@saleor/hooks/useUser";
-import { useIntl } from "react-intl";
-import { commonMessages } from "@saleor/intl";
-import getAccountErrorMessage from "@saleor/utils/errors/account";
 import NewPasswordPage, {
   NewPasswordPageFormData
 } from "../components/NewPasswordPage";
 import { SetPasswordMutation } from "../mutations";
-import { SetPassword } from "../types/SetPassword";
+import {
+  SetPassword,
+  SetPassword_setPassword_errors
+} from "../types/SetPassword";
 import { NewPasswordUrlQueryParams } from "../urls";
 
 const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
   const navigate = useNavigator();
   const { loginByToken } = useUser();
-  const [error, setError] = React.useState<string>();
-  const intl = useIntl();
+  const [errors, setErrors] = React.useState<
+    SetPassword_setPassword_errors[]
+  >();
 
   const params: NewPasswordUrlQueryParams = parseQs(location.search.substr(1));
 
@@ -27,14 +28,7 @@ const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
       loginByToken(data.setPassword.token, data.setPassword.user);
       navigate("/", true);
     } else {
-      const error = data.setPassword.errors.find(
-        err => err.field === "password"
-      );
-      if (error) {
-        setError(getAccountErrorMessage(error, intl));
-      } else {
-        setError(intl.formatMessage(commonMessages.somethingWentWrong));
-      }
+      setErrors(data.setPassword.errors);
     }
   };
 
@@ -52,7 +46,7 @@ const NewPassword: React.FC<RouteComponentProps> = ({ location }) => {
 
         return (
           <NewPasswordPage
-            error={error}
+            errors={errors}
             disabled={setPasswordOpts.loading}
             onSubmit={handleSubmit}
           />


### PR DESCRIPTION
I want to merge this change because it displays the validation errors on the New Password Page.

fix #468 
<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
