### PR TITLE
Reset pagination when guest change the sorting of the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add "Ready to capture" to the "Status" order filter - #430 by @dominik-zeglen
 - Reset state after closing - #456 by @dominik-zeglen
 - Password validation errors are not shown - #471 by @gabmartinez
+- Reset pagination when guest change the sorting of the list - #474 by @gabmartinez
 
 ## 2.0.0
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import packageInfo from "../package.json";
 import { SearchVariables } from "./hooks/makeSearch";
-import { ListSettings, ListViews } from "./types";
+import { ListSettings, ListViews, Pagination } from "./types";
 
 export const APP_MOUNT_URI = process.env.APP_MOUNT_URI || "/";
 export const API_URI = process.env.API_URI;
@@ -9,6 +9,11 @@ export const DEFAULT_INITIAL_SEARCH_DATA: SearchVariables = {
   after: null,
   first: 20,
   query: ""
+};
+
+export const DEFAULT_INITIAL_PAGINATION_DATA: Pagination = {
+  after: undefined,
+  before: undefined
 };
 
 export const PAGINATE_BY = 20;

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -13,7 +13,8 @@ import SaveFilterTabDialog, {
 import {
   defaultListSettings,
   ProductListColumns,
-  DEFAULT_INITIAL_SEARCH_DATA
+  DEFAULT_INITIAL_SEARCH_DATA,
+  DEFAULT_INITIAL_PAGINATION_DATA
 } from "@saleor/config";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useListSettings from "@saleor/hooks/useListSettings";
@@ -112,8 +113,7 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
       navigate(
         productListUrl({
           ...params,
-          after: undefined,
-          before: undefined
+          ...DEFAULT_INITIAL_PAGINATION_DATA
         }),
         true
       ),
@@ -172,7 +172,8 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
       productListUrl({
         ...params,
         ...getSortUrlVariables(field, params),
-        attributeId
+        attributeId,
+        ...DEFAULT_INITIAL_PAGINATION_DATA
       })
     );
 

--- a/src/utils/handlers/sortHandler.ts
+++ b/src/utils/handlers/sortHandler.ts
@@ -1,5 +1,6 @@
 import { UseNavigatorResult } from "@saleor/hooks/useNavigator";
 import { Sort } from "@saleor/types";
+import { DEFAULT_INITIAL_PAGINATION_DATA } from "@saleor/config";
 import { getSortUrlVariables } from "../sort";
 
 type CreateUrl<T extends string> = (params: Sort<T>) => string;
@@ -13,7 +14,8 @@ function createSortHandler<T extends string>(
     navigate(
       createUrl({
         ...params,
-        ...getSortUrlVariables(field, params)
+        ...getSortUrlVariables(field, params),
+        ...DEFAULT_INITIAL_PAGINATION_DATA
       }),
       true
     );


### PR DESCRIPTION
I want to merge this change because reset the pagination when the guest changes the sorting of the list.

<!-- Please mention all relevant issue numbers. -->
Fix #427 

### Screenshots
#### Initial load first page and sorted by name column desc
<img src="https://user-images.githubusercontent.com/24206382/78995736-0c585f00-7b11-11ea-9311-143e1bcdc912.png" height="150">

#### Change paginator next page and sorted by name column desc
<img src="https://user-images.githubusercontent.com/24206382/78995868-517c9100-7b11-11ea-8067-b9227aa57fa4.png" height="150">

#### Change sorting by email column and redirect to the first page
<img src="https://user-images.githubusercontent.com/24206382/78995905-6ce79c00-7b11-11ea-846f-0581264c1a29.png" height="150">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
