### PR TITLE
Display Is Published column correctly in main Product Listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add "Ready to capture" to the "Status" order filter - #430 by @dominik-zeglen
 - Reset state after closing - #456 by @dominik-zeglen
 - Password validation errors are not shown - #471 by @gabmartinez
+- Display Is Published column correctly in main Product Listing - #475 by @gabmartinez
 
 ## 2.0.0
 

--- a/src/products/components/ProductList/ProductList.tsx
+++ b/src/products/components/ProductList/ProductList.tsx
@@ -105,7 +105,6 @@ interface ProductListProps
 export const ProductList: React.FC<ProductListProps> = props => {
   const {
     activeAttributeSortId,
-
     settings,
     disabled,
     isChecked,
@@ -322,13 +321,13 @@ export const ProductList: React.FC<ProductListProps> = props => {
                     <TableCell
                       className={classes.colPublished}
                       data-tc="isPublished"
-                      data-tc-is-published={maybe(() => product.isAvailable)}
+                      data-tc-is-published={maybe(() => product.isPublished)}
                     >
                       {product &&
-                      maybe(() => product.isAvailable !== undefined) ? (
+                      maybe(() => product.isPublished !== undefined) ? (
                         <StatusLabel
                           label={
-                            product.isAvailable
+                            product.isPublished
                               ? intl.formatMessage({
                                   defaultMessage: "Published",
                                   description: "product status"
@@ -338,7 +337,7 @@ export const ProductList: React.FC<ProductListProps> = props => {
                                   description: "product status"
                                 })
                           }
-                          status={product.isAvailable ? "success" : "error"}
+                          status={product.isPublished ? "success" : "error"}
                         />
                       ) : (
                         <Skeleton />

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -324,7 +324,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo2NA==",
     isAvailable: true,
-    isPublished: true,
+    isPublished: false,
     name: "Light Speed Yellow Paint",
     productType: {
       __typename: "ProductType",
@@ -346,7 +346,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo2NQ==",
     isAvailable: true,
-    isPublished: true,
+    isPublished: false,
     name: "Hyperspace Turquoise Paint",
     productType: {
       __typename: "ProductType",
@@ -568,7 +568,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3OQ==",
     isAvailable: true,
-    isPublished: true,
+    isPublished: false,
     name: "Bean Juice",
     productType: {
       __typename: "ProductType",
@@ -864,7 +864,7 @@ export const products = (
     },
     id: "UHJvZHVjdDoxMTU=",
     isAvailable: true,
-    isPublished: true,
+    isPublished: false,
     name: "Black Hoodie",
     productType: {
       __typename: "ProductType",
@@ -975,7 +975,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo4NQ==",
     isAvailable: true,
-    isPublished: true,
+    isPublished: false,
     name: "Colored Parrot Cushion",
     productType: {
       __typename: "ProductType",

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -302,6 +302,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo2MQ==",
     isAvailable: true,
+    isPublished: true,
     name: "Nebula Night Sky Paint",
     productType: {
       __typename: "ProductType",
@@ -323,6 +324,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo2NA==",
     isAvailable: true,
+    isPublished: true,
     name: "Light Speed Yellow Paint",
     productType: {
       __typename: "ProductType",
@@ -344,6 +346,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo2NQ==",
     isAvailable: true,
+    isPublished: true,
     name: "Hyperspace Turquoise Paint",
     productType: {
       __typename: "ProductType",
@@ -380,6 +383,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3NQ==",
     isAvailable: true,
+    isPublished: true,
     name: "Pineapple Juice",
     productType: {
       __typename: "ProductType",
@@ -416,6 +420,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3Ng==",
     isAvailable: true,
+    isPublished: true,
     name: "Coconut Juice",
     productType: {
       __typename: "ProductType",
@@ -452,6 +457,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3Mg==",
     isAvailable: true,
+    isPublished: true,
     name: "Apple Juice",
     productType: {
       __typename: "ProductType",
@@ -488,6 +494,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3MQ==",
     isAvailable: true,
+    isPublished: true,
     name: "Orange Juice",
     productType: {
       __typename: "ProductType",
@@ -524,6 +531,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3NA==",
     isAvailable: true,
+    isPublished: true,
     name: "Banana Juice",
     productType: {
       __typename: "ProductType",
@@ -560,6 +568,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3OQ==",
     isAvailable: true,
+    isPublished: true,
     name: "Bean Juice",
     productType: {
       __typename: "ProductType",
@@ -596,6 +605,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3Mw==",
     isAvailable: true,
+    isPublished: true,
     name: "Carrot Juice",
     productType: {
       __typename: "ProductType",
@@ -632,6 +642,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo3OA==",
     isAvailable: true,
+    isPublished: true,
     name: "Green Juice",
     productType: {
       __typename: "ProductType",
@@ -668,6 +679,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo4OQ==",
     isAvailable: true,
+    isPublished: true,
     name: "Code Division T-shirt",
     productType: {
       __typename: "ProductType",
@@ -704,6 +716,7 @@ export const products = (
     },
     id: "UHJvZHVjdDoxMDc=",
     isAvailable: true,
+    isPublished: true,
     name: "Polo Shirt",
     productType: {
       __typename: "ProductType",
@@ -740,6 +753,7 @@ export const products = (
     },
     id: "UHJvZHVjdDoxMDg=",
     isAvailable: true,
+    isPublished: true,
     name: "Polo Shirt",
     productType: {
       __typename: "ProductType",
@@ -776,6 +790,7 @@ export const products = (
     },
     id: "UHJvZHVjdDoxMDk=",
     isAvailable: true,
+    isPublished: true,
     name: "Polo Shirt",
     productType: {
       __typename: "ProductType",
@@ -812,6 +827,7 @@ export const products = (
     },
     id: "UHJvZHVjdDoxMTA=",
     isAvailable: true,
+    isPublished: true,
     name: "Polo Shirt",
     productType: {
       __typename: "ProductType",
@@ -848,6 +864,7 @@ export const products = (
     },
     id: "UHJvZHVjdDoxMTU=",
     isAvailable: true,
+    isPublished: true,
     name: "Black Hoodie",
     productType: {
       __typename: "ProductType",
@@ -884,6 +901,7 @@ export const products = (
     },
     id: "UHJvZHVjdDoxMTY=",
     isAvailable: true,
+    isPublished: true,
     name: "Blue Hoodie",
     productType: {
       __typename: "ProductType",
@@ -920,6 +938,7 @@ export const products = (
     },
     id: "UHJvZHVjdDoxMTc=",
     isAvailable: true,
+    isPublished: true,
     name: "Mustard Hoodie",
     productType: {
       __typename: "ProductType",
@@ -956,6 +975,7 @@ export const products = (
     },
     id: "UHJvZHVjdDo4NQ==",
     isAvailable: true,
+    isPublished: true,
     name: "Colored Parrot Cushion",
     productType: {
       __typename: "ProductType",

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -53,6 +53,7 @@ export const productFragment = gql`
       url
     }
     isAvailable
+    isPublished
     basePrice {
       ...Money
     }

--- a/src/products/types/ProductList.ts
+++ b/src/products/types/ProductList.ts
@@ -48,6 +48,7 @@ export interface ProductList_products_edges_node {
   name: string;
   thumbnail: ProductList_products_edges_node_thumbnail | null;
   isAvailable: boolean | null;
+  isPublished: boolean | null;
   basePrice: ProductList_products_edges_node_basePrice | null;
   productType: ProductList_products_edges_node_productType;
   attributes: ProductList_products_edges_node_attributes[];

--- a/src/storybook/stories/products/ProductListPage.tsx
+++ b/src/storybook/stories/products/ProductListPage.tsx
@@ -58,4 +58,10 @@ storiesOf("Views / Products / Product list", module)
       disabled={true}
     />
   ))
+  .add("published", () => (
+    <ProductListPage
+      {...props}
+      products={products.filter(product => product.isPublished)}
+    />
+  ))
   .add("no data", () => <ProductListPage {...props} products={[]} />);

--- a/src/storybook/stories/products/ProductListPage.tsx
+++ b/src/storybook/stories/products/ProductListPage.tsx
@@ -64,4 +64,10 @@ storiesOf("Views / Products / Product list", module)
       products={products.filter(product => product.isPublished)}
     />
   ))
+  .add("not published", () => (
+    <ProductListPage
+      {...props}
+      products={products.filter(product => !product.isPublished)}
+    />
+  ))
   .add("no data", () => <ProductListPage {...props} products={[]} />);


### PR DESCRIPTION
I want to merge this change because use the isPublished instead of isAvailabled property in the main Product Listing.

<!-- Please mention all relevant issue numbers. -->
resolve #426

### Screenshots
#### Main Product Listing
<img src="https://user-images.githubusercontent.com/24206382/79031066-68030680-7b6a-11ea-82c7-9ae48d66d9fa.png" height="150">

#### Collection Product Listing
<img src="https://user-images.githubusercontent.com/24206382/79031068-6a656080-7b6a-11ea-937f-3251b98f707d.png" height="150">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
