### PR TITLE
Columns dialog clean attribute ids before send it to GridAttributes operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add "Ready to capture" to the "Status" order filter - #430 by @dominik-zeglen
 - Reset state after closing - #456 by @dominik-zeglen
 - Password validation errors are not shown - #471 by @gabmartinez
+- Filter column ids before send it to GridAttributes operation - #476 by @gabmartinez
 
 ## 2.0.0
 

--- a/src/products/components/ProductListPage/utils.ts
+++ b/src/products/components/ProductListPage/utils.ts
@@ -1,5 +1,3 @@
-import { ProductListColumns } from "@saleor/config";
-
 const prefix = "attribute";
 
 export function getAttributeColumnValue(id: string) {
@@ -12,10 +10,4 @@ export function isAttributeColumnValue(value: string) {
 
 export function getAttributeIdFromColumnValue(value: string) {
   return value.substr(prefix.length + 1);
-}
-
-export function filterColumnIds(columns: ProductListColumns[]) {
-  return columns
-    .filter(isAttributeColumnValue)
-    .map(getAttributeIdFromColumnValue);
 }

--- a/src/products/components/ProductListPage/utils.ts
+++ b/src/products/components/ProductListPage/utils.ts
@@ -1,3 +1,5 @@
+import { ProductListColumns } from "@saleor/config";
+
 const prefix = "attribute";
 
 export function getAttributeColumnValue(id: string) {
@@ -10,4 +12,10 @@ export function isAttributeColumnValue(value: string) {
 
 export function getAttributeIdFromColumnValue(value: string) {
   return value.substr(prefix.length + 1);
+}
+
+export function filterColumnIds(columns: ProductListColumns[]) {
+  return columns
+    .filter(isAttributeColumnValue)
+    .map(getAttributeIdFromColumnValue);
 }

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -33,10 +33,7 @@ import createFilterHandlers from "@saleor/utils/handlers/filterHandlers";
 import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import useProductTypeSearch from "@saleor/searches/useProductTypeSearch";
-import {
-  getAttributeIdFromColumnValue,
-  isAttributeColumnValue
-} from "@saleor/products/components/ProductListPage/utils";
+import { filterColumnIds } from "@saleor/products/components/ProductListPage/utils";
 import ProductListPage from "../../components/ProductListPage";
 import {
   TypedProductBulkDeleteMutation,
@@ -219,18 +216,9 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
     }
   );
 
-  const columnIdsFilter = columns => {
-    columns = columns.filter(column => isAttributeColumnValue(column));
-    columns.forEach(
-      (attribute, index, arr) =>
-        (arr[index] = getAttributeIdFromColumnValue(attribute))
-    );
-    return columns;
-  };
-
   return (
     <AvailableInGridAttributesQuery
-      variables={{ first: 6, ids: columnIdsFilter(settings.columns) }}
+      variables={{ first: 6, ids: filterColumnIds(settings.columns) }}
     >
       {attributes => (
         <TypedProductListQuery displayLoader variables={queryVariables}>

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -33,6 +33,10 @@ import createFilterHandlers from "@saleor/utils/handlers/filterHandlers";
 import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import useProductTypeSearch from "@saleor/searches/useProductTypeSearch";
+import {
+  getAttributeIdFromColumnValue,
+  isAttributeColumnValue
+} from "@saleor/products/components/ProductListPage/utils";
 import ProductListPage from "../../components/ProductListPage";
 import {
   TypedProductBulkDeleteMutation,
@@ -215,9 +219,18 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
     }
   );
 
+  const columnIdsFilter = columns => {
+    columns = columns.filter(column => isAttributeColumnValue(column));
+    columns.forEach(
+      (attribute, index, arr) =>
+        (arr[index] = getAttributeIdFromColumnValue(attribute))
+    );
+    return columns;
+  };
+
   return (
     <AvailableInGridAttributesQuery
-      variables={{ first: 6, ids: settings.columns }}
+      variables={{ first: 6, ids: columnIdsFilter(settings.columns) }}
     >
       {attributes => (
         <TypedProductListQuery displayLoader variables={queryVariables}>

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -33,7 +33,10 @@ import createFilterHandlers from "@saleor/utils/handlers/filterHandlers";
 import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import useProductTypeSearch from "@saleor/searches/useProductTypeSearch";
-import { filterColumnIds } from "@saleor/products/components/ProductListPage/utils";
+import {
+  getAttributeIdFromColumnValue,
+  isAttributeColumnValue
+} from "@saleor/products/components/ProductListPage/utils";
 import ProductListPage from "../../components/ProductListPage";
 import {
   TypedProductBulkDeleteMutation,
@@ -215,6 +218,12 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
       search: searchProductTypes
     }
   );
+
+  function filterColumnIds(columns: ProductListColumns[]) {
+    return columns
+      .filter(isAttributeColumnValue)
+      .map(getAttributeIdFromColumnValue);
+  }
 
   return (
     <AvailableInGridAttributesQuery


### PR DESCRIPTION
I want to merge this change because it resolves the issue that was sending invalid ids to GridAttributes operation and it was getting an error from the API and frozen the dialog to add/remove columns.

<!-- Please mention all relevant issue numbers. -->
Fix #478 

### Screenshots

#### Sending Invalid ids before the changes
<img src="https://user-images.githubusercontent.com/24206382/79031464-c4ffbc00-7b6c-11ea-8df8-da77db3c9332.png" height="150">

#### Sending valid ids after the changes
<img src="https://user-images.githubusercontent.com/24206382/79031463-c335f880-7b6c-11ea-91bd-e114be83e763.png" height="150">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
