### PR TITLE
Update gql types

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4,28 +4,28 @@ schema {
 }
 
 type AccountAddressCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
   address: Address
 }
 
 type AccountDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
@@ -39,7 +39,7 @@ type AccountError {
 enum AccountErrorCode {
   ACTIVATE_OWN_ACCOUNT
   ACTIVATE_SUPERUSER_ACCOUNT
-  ASSIGN_NON_STAFF_MEMBER
+  CANNOT_ADD_AND_REMOVE
   DEACTIVATE_OWN_ACCOUNT
   DEACTIVATE_SUPERUSER_ACCOUNT
   DELETE_NON_STAFF_USER
@@ -49,7 +49,12 @@ enum AccountErrorCode {
   GRAPHQL_ERROR
   INVALID
   INVALID_PASSWORD
+  LEFT_NOT_MANAGEABLE_PERMISSION
+  INVALID_CREDENTIALS
   NOT_FOUND
+  OUT_OF_SCOPE_USER
+  OUT_OF_SCOPE_GROUP
+  OUT_OF_SCOPE_PERMISSION
   PASSWORD_ENTIRELY_NUMERIC
   PASSWORD_TOO_COMMON
   PASSWORD_TOO_SHORT
@@ -66,7 +71,7 @@ input AccountInput {
 }
 
 type AccountRegister {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   requiresConfirmation: Boolean
   accountErrors: [AccountError!]!
   user: User
@@ -79,24 +84,24 @@ input AccountRegisterInput {
 }
 
 type AccountRequestDeletion {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
 }
 
 type AccountSetDefaultAddress {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
 }
 
 type AccountUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
 
 type AccountUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
@@ -119,14 +124,14 @@ type Address implements Node {
 }
 
 type AddressCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
   address: Address
 }
 
 type AddressDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
   address: Address
@@ -147,7 +152,7 @@ input AddressInput {
 }
 
 type AddressSetDefault {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
 }
@@ -158,7 +163,7 @@ enum AddressTypeEnum {
 }
 
 type AddressUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
   address: Address
@@ -185,7 +190,7 @@ type AddressValidationData {
 }
 
 type AssignNavigation {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   menu: Menu
   menuErrors: [MenuError!]!
 }
@@ -212,9 +217,9 @@ type Attribute implements Node & ObjectWithMetadata {
 }
 
 type AttributeAssign {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productType: ProductType
-  productErrors: [ProductError!]!
+  productErrors: [ProductAttributeError!]!
 }
 
 input AttributeAssignInput {
@@ -223,19 +228,19 @@ input AttributeAssignInput {
 }
 
 type AttributeBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type AttributeClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   attribute: Attribute
 }
 
 type AttributeClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   attribute: Attribute
 }
@@ -252,7 +257,7 @@ type AttributeCountableEdge {
 }
 
 type AttributeCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   attribute: Attribute
   productErrors: [ProductError!]!
 }
@@ -272,7 +277,7 @@ input AttributeCreateInput {
 }
 
 type AttributeDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   attribute: Attribute
 }
@@ -302,7 +307,7 @@ enum AttributeInputTypeEnum {
 }
 
 type AttributeReorderValues {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   attribute: Attribute
   productErrors: [ProductError!]!
 }
@@ -334,7 +339,8 @@ type AttributeTranslatableContent implements Node {
 }
 
 type AttributeTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   attribute: Attribute
 }
 
@@ -350,13 +356,13 @@ enum AttributeTypeEnum {
 }
 
 type AttributeUnassign {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productType: ProductType
   productErrors: [ProductError!]!
 }
 
 type AttributeUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   attribute: Attribute
   productErrors: [ProductError!]!
 }
@@ -376,13 +382,13 @@ input AttributeUpdateInput {
 }
 
 type AttributeUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   attribute: Attribute
 }
 
 type AttributeUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   attribute: Attribute
 }
@@ -397,13 +403,13 @@ type AttributeValue implements Node {
 }
 
 type AttributeValueBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type AttributeValueCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   attribute: Attribute
   productErrors: [ProductError!]!
   attributeValue: AttributeValue
@@ -414,7 +420,7 @@ input AttributeValueCreateInput {
 }
 
 type AttributeValueDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   attribute: Attribute
   productErrors: [ProductError!]!
   attributeValue: AttributeValue
@@ -433,7 +439,8 @@ type AttributeValueTranslatableContent implements Node {
 }
 
 type AttributeValueTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   attributeValue: AttributeValue
 }
 
@@ -451,7 +458,7 @@ enum AttributeValueType {
 }
 
 type AttributeValueUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   attribute: Attribute
   productErrors: [ProductError!]!
   attributeValue: AttributeValue
@@ -463,14 +470,14 @@ type AuthorizationKey {
 }
 
 type AuthorizationKeyAdd {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   authorizationKey: AuthorizationKey
   shop: Shop
   shopErrors: [ShopError!]!
 }
 
 type AuthorizationKeyDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   authorizationKey: AuthorizationKey
   shop: Shop
   shopErrors: [ShopError!]!
@@ -529,19 +536,19 @@ type Category implements Node & ObjectWithMetadata {
 }
 
 type CategoryBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type CategoryClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   category: Category
 }
 
 type CategoryClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   category: Category
 }
@@ -558,13 +565,13 @@ type CategoryCountableEdge {
 }
 
 type CategoryCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   category: Category
 }
 
 type CategoryDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   category: Category
 }
@@ -607,7 +614,8 @@ type CategoryTranslatableContent implements Node {
 }
 
 type CategoryTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   category: Category
 }
 
@@ -622,19 +630,19 @@ type CategoryTranslation implements Node {
 }
 
 type CategoryUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   category: Category
 }
 
 type CategoryUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   category: Category
 }
 
 type CategoryUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   category: Category
 }
@@ -670,31 +678,31 @@ type Checkout implements Node & ObjectWithMetadata {
 }
 
 type CheckoutAddPromoCode {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutBillingAddressUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
 
 type CheckoutClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
 
 type CheckoutComplete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   confirmationNeeded: Boolean!
   checkoutErrors: [CheckoutError!]!
@@ -712,7 +720,7 @@ type CheckoutCountableEdge {
 }
 
 type CheckoutCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   created: Boolean
   checkoutErrors: [CheckoutError!]!
   checkout: Checkout
@@ -726,19 +734,19 @@ input CheckoutCreateInput {
 }
 
 type CheckoutCustomerAttach {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutCustomerDetach {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutEmailUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
@@ -790,7 +798,7 @@ type CheckoutLineCountableEdge {
 }
 
 type CheckoutLineDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
@@ -801,50 +809,50 @@ input CheckoutLineInput {
 }
 
 type CheckoutLinesAdd {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutLinesUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutPaymentCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   payment: Payment
   paymentErrors: [PaymentError!]!
 }
 
 type CheckoutRemovePromoCode {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutShippingAddressUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutShippingMethodUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkout: Checkout
   checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
 
 type CheckoutUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
@@ -874,31 +882,31 @@ type Collection implements Node & ObjectWithMetadata {
 }
 
 type CollectionAddProducts {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   collection: Collection
   productErrors: [ProductError!]!
 }
 
 type CollectionBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type CollectionBulkPublish {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type CollectionClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   collection: Collection
 }
 
 type CollectionClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   collection: Collection
 }
@@ -915,7 +923,7 @@ type CollectionCountableEdge {
 }
 
 type CollectionCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   collection: Collection
 }
@@ -934,7 +942,7 @@ input CollectionCreateInput {
 }
 
 type CollectionDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   collection: Collection
 }
@@ -963,13 +971,13 @@ enum CollectionPublished {
 }
 
 type CollectionRemoveProducts {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   collection: Collection
   productErrors: [ProductError!]!
 }
 
 type CollectionReorderProducts {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   collection: Collection
   productErrors: [ProductError!]!
 }
@@ -997,7 +1005,8 @@ type CollectionTranslatableContent implements Node {
 }
 
 type CollectionTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   collection: Collection
 }
 
@@ -1012,19 +1021,19 @@ type CollectionTranslation implements Node {
 }
 
 type CollectionUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   collection: Collection
 }
 
 type CollectionUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   collection: Collection
 }
 
 type CollectionUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   collection: Collection
 }
@@ -1050,11 +1059,13 @@ enum ConfigurationTypeFieldEnum {
 }
 
 type ConfirmAccount {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  user: User
+  accountErrors: [AccountError!]!
 }
 
 type ConfirmEmailChange {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
 }
@@ -1320,7 +1331,8 @@ type CountryDisplay {
 
 type CreateToken {
   token: String
-  errors: [Error]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -1333,19 +1345,19 @@ type CreditCard {
 }
 
 type CustomerBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   accountErrors: [AccountError!]!
 }
 
 type CustomerCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
 
 type CustomerDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
@@ -1396,7 +1408,7 @@ input CustomerInput {
 }
 
 type CustomerUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
@@ -1418,13 +1430,13 @@ input DateTimeRangeInput {
 scalar Decimal
 
 type DeleteMetadata {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   metadataErrors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type DeletePrivateMetadata {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   metadataErrors: [MetadataError!]!
   item: ObjectWithMetadata
 }
@@ -1456,14 +1468,14 @@ type DigitalContentCountableEdge {
 }
 
 type DigitalContentCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   variant: ProductVariant
   content: DigitalContent
   productErrors: [ProductError!]!
 }
 
 type DigitalContentDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   variant: ProductVariant
   productErrors: [ProductError!]!
 }
@@ -1476,7 +1488,7 @@ input DigitalContentInput {
 }
 
 type DigitalContentUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   variant: ProductVariant
   content: DigitalContent
   productErrors: [ProductError!]!
@@ -1500,7 +1512,7 @@ type DigitalContentUrl implements Node {
 }
 
 type DigitalContentUrlCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   digitalContentUrl: DigitalContentUrl
 }
@@ -1517,6 +1529,7 @@ type DiscountError {
 
 enum DiscountErrorCode {
   ALREADY_EXISTS
+  GRAPHQL_ERROR
   INVALID
   NOT_FOUND
   REQUIRED
@@ -1541,19 +1554,19 @@ type Domain {
 }
 
 type DraftOrderBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   orderErrors: [OrderError!]!
 }
 
 type DraftOrderComplete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderErrors: [OrderError!]!
 }
 
 type DraftOrderCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   orderErrors: [OrderError!]!
   order: Order
 }
@@ -1571,7 +1584,7 @@ input DraftOrderCreateInput {
 }
 
 type DraftOrderDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   orderErrors: [OrderError!]!
   order: Order
 }
@@ -1588,34 +1601,34 @@ input DraftOrderInput {
 }
 
 type DraftOrderLineDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderLine: OrderLine
   orderErrors: [OrderError!]!
 }
 
 type DraftOrderLineUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderErrors: [OrderError!]!
   orderLine: OrderLine
 }
 
 type DraftOrderLinesBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   orderErrors: [OrderError!]!
 }
 
 type DraftOrderLinesCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderLines: [OrderLine!]
   orderErrors: [OrderError!]!
 }
 
 type DraftOrderUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   orderErrors: [OrderError!]!
   order: Order
 }
@@ -1623,21 +1636,6 @@ type DraftOrderUpdate {
 type Error {
   field: String
   message: String
-}
-
-type ExtensionsError {
-  field: String
-  message: String
-  code: ExtensionsErrorCode!
-}
-
-enum ExtensionsErrorCode {
-  GRAPHQL_ERROR
-  INVALID
-  PLUGIN_MISCONFIGURED
-  NOT_FOUND
-  REQUIRED
-  UNIQUE
 }
 
 type Fulfillment implements Node & ObjectWithMetadata {
@@ -1655,7 +1653,7 @@ type Fulfillment implements Node & ObjectWithMetadata {
 }
 
 type FulfillmentCancel {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   fulfillment: Fulfillment
   order: Order
   orderErrors: [OrderError!]!
@@ -1666,17 +1664,17 @@ input FulfillmentCancelInput {
 }
 
 type FulfillmentClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   fulfillment: Fulfillment
 }
 
 type FulfillmentClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   fulfillment: Fulfillment
 }
 
 type FulfillmentCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   fulfillment: Fulfillment
   order: Order
   orderErrors: [OrderError!]!
@@ -1705,17 +1703,17 @@ enum FulfillmentStatus {
 }
 
 type FulfillmentUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   fulfillment: Fulfillment
 }
 
 type FulfillmentUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   fulfillment: Fulfillment
 }
 
 type FulfillmentUpdateTracking {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   fulfillment: Fulfillment
   order: Order
   orderErrors: [OrderError!]!
@@ -1752,7 +1750,7 @@ type GiftCard implements Node {
 }
 
 type GiftCardActivate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   giftCard: GiftCard
   giftCardErrors: [GiftCardError!]!
 }
@@ -1769,7 +1767,7 @@ type GiftCardCountableEdge {
 }
 
 type GiftCardCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   giftCardErrors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -1783,7 +1781,7 @@ input GiftCardCreateInput {
 }
 
 type GiftCardDeactivate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   giftCard: GiftCard
   giftCardErrors: [GiftCardError!]!
 }
@@ -1804,7 +1802,7 @@ enum GiftCardErrorCode {
 }
 
 type GiftCardUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   giftCardErrors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -1819,8 +1817,9 @@ input GiftCardUpdateInput {
 type Group implements Node {
   id: ID!
   name: String!
-  permissions: [PermissionDisplay]
+  permissions: [Permission]
   users: [User]
+  userCanManage: Boolean!
 }
 
 type GroupCountableConnection {
@@ -1835,7 +1834,7 @@ type GroupCountableEdge {
 }
 
 type HomepageCollectionUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shop: Shop
   shopErrors: [ShopError!]!
 }
@@ -1915,7 +1914,7 @@ type Menu implements Node {
 }
 
 type MenuBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   menuErrors: [MenuError!]!
 }
@@ -1932,7 +1931,7 @@ type MenuCountableEdge {
 }
 
 type MenuCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   menuErrors: [MenuError!]!
   menu: Menu
 }
@@ -1943,7 +1942,7 @@ input MenuCreateInput {
 }
 
 type MenuDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   menuErrors: [MenuError!]!
   menu: Menu
 }
@@ -1989,7 +1988,7 @@ type MenuItem implements Node {
 }
 
 type MenuItemBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   menuErrors: [MenuError!]!
 }
@@ -2006,7 +2005,7 @@ type MenuItemCountableEdge {
 }
 
 type MenuItemCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   menuErrors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -2022,7 +2021,7 @@ input MenuItemCreateInput {
 }
 
 type MenuItemDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   menuErrors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -2040,7 +2039,7 @@ input MenuItemInput {
 }
 
 type MenuItemMove {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   menu: Menu
   menuErrors: [MenuError!]!
 }
@@ -2064,7 +2063,8 @@ type MenuItemTranslatableContent implements Node {
 }
 
 type MenuItemTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   menuItem: MenuItem
 }
 
@@ -2075,7 +2075,7 @@ type MenuItemTranslation implements Node {
 }
 
 type MenuItemUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   menuErrors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -2095,7 +2095,7 @@ input MenuSortingInput {
 }
 
 type MenuUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   menuErrors: [MenuError!]!
   menu: Menu
 }
@@ -2167,10 +2167,6 @@ input MoveProductInput {
 }
 
 type Mutation {
-  wishlistAddProduct(productId: ID!): WishlistAddProductMutation
-  wishlistRemoveProduct(productId: ID!): WishlistRemoveProductMutation
-  wishlistAddVariant(variantId: ID!): WishlistAddProductVariantMutation
-  wishlistRemoveVariant(variantId: ID!): WishlistRemoveProductVariantMutation
   webhookCreate(input: WebhookCreateInput!): WebhookCreate
   webhookDelete(id: ID!): WebhookDelete
   webhookUpdate(id: ID!, input: WebhookUpdateInput!): WebhookUpdate
@@ -2195,10 +2191,10 @@ type Mutation {
   shippingPriceBulkDelete(ids: [ID]!): ShippingPriceBulkDelete
   shippingPriceUpdate(id: ID!, input: ShippingPriceInput!): ShippingPriceUpdate
   shippingPriceTranslate(id: ID!, input: NameTranslationInput!, languageCode: LanguageCodeEnum!): ShippingPriceTranslate
-  shippingZoneCreate(input: ShippingZoneInput!): ShippingZoneCreate
+  shippingZoneCreate(input: ShippingZoneCreateInput!): ShippingZoneCreate
   shippingZoneDelete(id: ID!): ShippingZoneDelete
   shippingZoneBulkDelete(ids: [ID]!): ShippingZoneBulkDelete
-  shippingZoneUpdate(id: ID!, input: ShippingZoneInput!): ShippingZoneUpdate
+  shippingZoneUpdate(id: ID!, input: ShippingZoneUpdateInput!): ShippingZoneUpdate
   attributeCreate(input: AttributeCreateInput!): AttributeCreate
   attributeDelete(id: ID!): AttributeDelete
   attributeBulkDelete(ids: [ID]!): AttributeBulkDelete
@@ -2320,10 +2316,10 @@ type Mutation {
   orderUpdateShipping(order: ID!, input: OrderUpdateShippingInput): OrderUpdateShipping
   orderVoid(id: ID!): OrderVoid
   orderBulkCancel(ids: [ID]!, restock: Boolean!): OrderBulkCancel
-  deleteMetadata(id: ID!, key: String!): DeleteMetadata
-  deletePrivateMetadata(id: ID!, key: String!): DeletePrivateMetadata
-  updateMetadata(id: ID!, input: MetadataInput!): UpdateMetadata
-  updatePrivateMetadata(id: ID!, input: MetadataInput!): UpdatePrivateMetadata
+  deleteMetadata(id: ID!, keys: [String!]!): DeleteMetadata
+  deletePrivateMetadata(id: ID!, keys: [String!]!): DeletePrivateMetadata
+  updateMetadata(id: ID!, input: [MetadataInput!]!): UpdateMetadata
+  updatePrivateMetadata(id: ID!, input: [MetadataInput!]!): UpdatePrivateMetadata
   assignNavigation(menu: ID, navigationType: NavigationType!): AssignNavigation
   menuCreate(input: MenuCreateInput!): MenuCreate
   menuDelete(id: ID!): MenuDelete
@@ -2399,7 +2395,7 @@ type Mutation {
   customerDelete(id: ID!): CustomerDelete
   customerBulkDelete(ids: [ID]!): CustomerBulkDelete
   staffCreate(input: StaffCreateInput!): StaffCreate
-  staffUpdate(id: ID!, input: StaffInput!): StaffUpdate
+  staffUpdate(id: ID!, input: StaffUpdateInput!): StaffUpdate
   staffDelete(id: ID!): StaffDelete
   staffBulkDelete(ids: [ID]!): StaffBulkDelete
   userAvatarUpdate(image: Upload!): UserAvatarUpdate
@@ -2417,10 +2413,8 @@ type Mutation {
   serviceAccountTokenCreate(input: ServiceAccountTokenInput!): ServiceAccountTokenCreate
   serviceAccountTokenDelete(id: ID!): ServiceAccountTokenDelete
   permissionGroupCreate(input: PermissionGroupCreateInput!): PermissionGroupCreate
-  permissionGroupUpdate(id: ID!, input: PermissionGroupInput!): PermissionGroupUpdate
+  permissionGroupUpdate(id: ID!, input: PermissionGroupUpdateInput!): PermissionGroupUpdate
   permissionGroupDelete(id: ID!): PermissionGroupDelete
-  permissionGroupAssignUsers(id: ID!, users: [ID!]!): PermissionGroupAssignUsers
-  permissionGroupUnassignUsers(id: ID!, users: [ID!]!): PermissionGroupUnassignUsers
 }
 
 input NameTranslationInput {
@@ -2502,7 +2496,7 @@ enum OrderAction {
 }
 
 type OrderAddNote {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   event: OrderEvent
   orderErrors: [OrderError!]!
@@ -2513,30 +2507,30 @@ input OrderAddNoteInput {
 }
 
 type OrderBulkCancel {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   orderErrors: [OrderError!]!
 }
 
 type OrderCancel {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderErrors: [OrderError!]!
 }
 
 type OrderCapture {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderErrors: [OrderError!]!
 }
 
 type OrderClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
 }
 
 type OrderClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
 }
 
@@ -2695,13 +2689,13 @@ input OrderLineInput {
 }
 
 type OrderMarkAsPaid {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderErrors: [OrderError!]!
 }
 
 type OrderRefund {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderErrors: [OrderError!]!
 }
@@ -2738,7 +2732,7 @@ enum OrderStatusFilter {
 }
 
 type OrderUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   orderErrors: [OrderError!]!
   order: Order
 }
@@ -2750,17 +2744,17 @@ input OrderUpdateInput {
 }
 
 type OrderUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
 }
 
 type OrderUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
 }
 
 type OrderUpdateShipping {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderErrors: [OrderError!]!
 }
@@ -2770,7 +2764,7 @@ input OrderUpdateShippingInput {
 }
 
 type OrderVoid {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   order: Order
   orderErrors: [OrderError!]!
 }
@@ -2790,13 +2784,15 @@ type Page implements Node {
 }
 
 type PageBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
+  pageErrors: [PageError!]!
 }
 
 type PageBulkPublish {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
+  pageErrors: [PageError!]!
 }
 
 type PageCountableConnection {
@@ -2811,13 +2807,13 @@ type PageCountableEdge {
 }
 
 type PageCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   pageErrors: [PageError!]!
   page: Page
 }
 
 type PageDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   pageErrors: [PageError!]!
   page: Page
 }
@@ -2882,7 +2878,8 @@ type PageTranslatableContent implements Node {
 }
 
 type PageTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   page: PageTranslatableContent
 }
 
@@ -2905,13 +2902,13 @@ input PageTranslationInput {
 }
 
 type PageUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   pageErrors: [PageError!]!
   page: Page
 }
 
 type PasswordChange {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
 }
@@ -2940,7 +2937,7 @@ type Payment implements Node {
 }
 
 type PaymentCapture {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   payment: Payment
   paymentErrors: [PaymentError!]!
 }
@@ -2994,13 +2991,13 @@ input PaymentInput {
 }
 
 type PaymentRefund {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   payment: Payment
   paymentErrors: [PaymentError!]!
 }
 
 type PaymentSecureConfirm {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   payment: Payment
   paymentErrors: [PaymentError!]!
 }
@@ -3011,12 +3008,12 @@ type PaymentSource {
 }
 
 type PaymentVoid {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   payment: Payment
   paymentErrors: [PaymentError!]!
 }
 
-type PermissionDisplay {
+type Permission {
   code: PermissionEnum!
   name: String!
 }
@@ -3039,36 +3036,45 @@ enum PermissionEnum {
   MANAGE_CHECKOUTS
 }
 
-type PermissionGroupAssignUsers {
-  errors: [Error!]!
-  group: Group
-  accountErrors: [AccountError!]!
-}
-
 type PermissionGroupCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   group: Group
-  accountErrors: [AccountError!]!
+  permissionGroupErrors: [PermissionGroupError!]!
 }
 
 input PermissionGroupCreateInput {
+  addPermissions: [PermissionEnum!]
+  addUsers: [ID!]
   name: String!
-  permissions: [PermissionEnum!]
 }
 
 type PermissionGroupDelete {
-  errors: [Error!]!
-  accountErrors: [AccountError!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  permissionGroupErrors: [PermissionGroupError!]!
   group: Group
+}
+
+type PermissionGroupError {
+  field: String
+  message: String
+  code: PermissionGroupErrorCode!
+  permissions: [PermissionEnum!]
+  users: [ID!]
+}
+
+enum PermissionGroupErrorCode {
+  ASSIGN_NON_STAFF_MEMBER
+  CANNOT_ADD_AND_REMOVE
+  CANNOT_REMOVE_FROM_LAST_GROUP
+  LEFT_NOT_MANAGEABLE_PERMISSION
+  OUT_OF_SCOPE_PERMISSION
+  OUT_OF_SCOPE_USER
+  REQUIRED
+  UNIQUE
 }
 
 input PermissionGroupFilterInput {
   search: String
-}
-
-input PermissionGroupInput {
-  name: String
-  permissions: [PermissionEnum!]
 }
 
 enum PermissionGroupSortField {
@@ -3080,24 +3086,26 @@ input PermissionGroupSortingInput {
   field: PermissionGroupSortField!
 }
 
-type PermissionGroupUnassignUsers {
-  errors: [Error!]!
+type PermissionGroupUpdate {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   group: Group
-  accountErrors: [AccountError!]!
+  permissionGroupErrors: [PermissionGroupError!]!
 }
 
-type PermissionGroupUpdate {
-  errors: [Error!]!
-  group: Group
-  accountErrors: [AccountError!]!
+input PermissionGroupUpdateInput {
+  addPermissions: [PermissionEnum!]
+  addUsers: [ID!]
+  name: String
+  removePermissions: [PermissionEnum!]
+  removeUsers: [ID!]
 }
 
 type Plugin implements Node {
+  id: ID!
   name: String!
   description: String!
   active: Boolean!
   configuration: [ConfigurationItem]
-  id: ID!
 }
 
 type PluginCountableConnection {
@@ -3109,6 +3117,21 @@ type PluginCountableConnection {
 type PluginCountableEdge {
   node: Plugin!
   cursor: String!
+}
+
+type PluginError {
+  field: String
+  message: String
+  code: PluginErrorCode!
+}
+
+enum PluginErrorCode {
+  GRAPHQL_ERROR
+  INVALID
+  PLUGIN_MISCONFIGURED
+  NOT_FOUND
+  REQUIRED
+  UNIQUE
 }
 
 input PluginFilterInput {
@@ -3127,9 +3150,9 @@ input PluginSortingInput {
 }
 
 type PluginUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   plugin: Plugin
-  extensionsErrors: [ExtensionsError!]!
+  pluginsErrors: [PluginError!]!
 }
 
 input PluginUpdateInput {
@@ -3178,26 +3201,33 @@ type Product implements Node & ObjectWithMetadata {
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
 }
 
+type ProductAttributeError {
+  field: String
+  message: String
+  code: ProductErrorCode!
+  attributes: [ID!]
+}
+
 type ProductBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type ProductBulkPublish {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type ProductClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   product: Product
 }
 
 type ProductClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   product: Product
 }
@@ -3214,7 +3244,7 @@ type ProductCountableEdge {
 }
 
 type ProductCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   product: Product
 }
@@ -3242,7 +3272,7 @@ input ProductCreateInput {
 }
 
 type ProductDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   product: Product
 }
@@ -3290,13 +3320,13 @@ type ProductImage implements Node {
 }
 
 type ProductImageBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type ProductImageCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   product: Product
   image: ProductImage
   productErrors: [ProductError!]!
@@ -3309,21 +3339,21 @@ input ProductImageCreateInput {
 }
 
 type ProductImageDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   product: Product
   image: ProductImage
   productErrors: [ProductError!]!
 }
 
 type ProductImageReorder {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   product: Product
   images: [ProductImage]
   productErrors: [ProductError!]!
 }
 
 type ProductImageUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   product: Product
   image: ProductImage
   productErrors: [ProductError!]!
@@ -3394,7 +3424,8 @@ type ProductTranslatableContent implements Node {
 }
 
 type ProductTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   product: Product
 }
 
@@ -3429,19 +3460,19 @@ type ProductType implements Node & ObjectWithMetadata {
 }
 
 type ProductTypeBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type ProductTypeClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productType: ProductType
 }
@@ -3463,13 +3494,13 @@ type ProductTypeCountableEdge {
 }
 
 type ProductTypeCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productType: ProductType
 }
@@ -3499,7 +3530,7 @@ input ProductTypeInput {
 }
 
 type ProductTypeReorderAttributes {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productType: ProductType
   productErrors: [ProductError!]!
 }
@@ -3516,37 +3547,37 @@ input ProductTypeSortingInput {
 }
 
 type ProductTypeUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   product: Product
 }
 
 type ProductUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   product: Product
 }
 
 type ProductUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   product: Product
 }
@@ -3580,7 +3611,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
 }
 
 type ProductVariantBulkCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productVariants: [ProductVariant!]!
   bulkProductErrors: [BulkProductError!]!
@@ -3597,19 +3628,19 @@ input ProductVariantBulkCreateInput {
 }
 
 type ProductVariantBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   productErrors: [ProductError!]!
 }
 
 type ProductVariantClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
 type ProductVariantClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -3626,7 +3657,7 @@ type ProductVariantCountableEdge {
 }
 
 type ProductVariantCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -3644,7 +3675,7 @@ input ProductVariantCreateInput {
 }
 
 type ProductVariantDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -3660,19 +3691,19 @@ input ProductVariantInput {
 }
 
 type ProductVariantStocksCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productVariant: ProductVariant
   bulkStockErrors: [BulkStockError!]!
 }
 
 type ProductVariantStocksDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productVariant: ProductVariant
   stockErrors: [StockError!]!
 }
 
 type ProductVariantStocksUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productVariant: ProductVariant
   bulkStockErrors: [BulkStockError!]!
 }
@@ -3685,7 +3716,8 @@ type ProductVariantTranslatableContent implements Node {
 }
 
 type ProductVariantTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   productVariant: ProductVariant
 }
 
@@ -3696,19 +3728,19 @@ type ProductVariantTranslation implements Node {
 }
 
 type ProductVariantUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
 type ProductVariantUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
 type ProductVariantUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -3804,13 +3836,13 @@ enum ReportingPeriod {
 }
 
 type RequestEmailChange {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
 }
 
 type RequestPasswordReset {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
 }
 
@@ -3828,14 +3860,15 @@ type Sale implements Node {
 }
 
 type SaleAddCatalogues {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   sale: Sale
   discountErrors: [DiscountError!]!
 }
 
 type SaleBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
+  discountErrors: [DiscountError!]!
 }
 
 type SaleCountableConnection {
@@ -3850,13 +3883,13 @@ type SaleCountableEdge {
 }
 
 type SaleCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   discountErrors: [DiscountError!]!
   sale: Sale
 }
 
 type SaleDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   discountErrors: [DiscountError!]!
   sale: Sale
 }
@@ -3880,7 +3913,7 @@ input SaleInput {
 }
 
 type SaleRemoveCatalogues {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   sale: Sale
   discountErrors: [DiscountError!]!
 }
@@ -3906,7 +3939,8 @@ type SaleTranslatableContent implements Node {
 }
 
 type SaleTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   sale: Sale
 }
 
@@ -3922,7 +3956,7 @@ enum SaleType {
 }
 
 type SaleUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   discountErrors: [DiscountError!]!
   sale: Sale
 }
@@ -3942,7 +3976,7 @@ type ServiceAccount implements Node & ObjectWithMetadata {
   name: String
   created: DateTime
   isActive: Boolean
-  permissions: [PermissionDisplay]
+  permissions: [Permission]
   tokens: [ServiceAccountToken]
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
@@ -3951,7 +3985,7 @@ type ServiceAccount implements Node & ObjectWithMetadata {
 }
 
 type ServiceAccountClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
@@ -3968,14 +4002,14 @@ type ServiceAccountCountableEdge {
 }
 
 type ServiceAccountCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   authToken: String
   accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
 
 type ServiceAccountDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
@@ -4008,14 +4042,14 @@ type ServiceAccountToken implements Node {
 }
 
 type ServiceAccountTokenCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   authToken: String
   accountErrors: [AccountError!]!
   serviceAccountToken: ServiceAccountToken
 }
 
 type ServiceAccountTokenDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   serviceAccountToken: ServiceAccountToken
 }
@@ -4026,28 +4060,29 @@ input ServiceAccountTokenInput {
 }
 
 type ServiceAccountUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
 
 type ServiceAccountUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
 
 type SetPassword {
   token: String
-  errors: [Error]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  accountErrors: [AccountError!]!
   user: User
-  accountErrors: [AccountError!]
 }
 
 type ShippingError {
   field: String
   message: String
   code: ShippingErrorCode!
+  warehouses: [ID!]
 }
 
 enum ShippingErrorCode {
@@ -4058,6 +4093,7 @@ enum ShippingErrorCode {
   NOT_FOUND
   REQUIRED
   UNIQUE
+  CANNOT_ADD_AND_REMOVE
 }
 
 type ShippingMethod implements Node {
@@ -4091,20 +4127,20 @@ enum ShippingMethodTypeEnum {
 }
 
 type ShippingPriceBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   shippingErrors: [ShippingError!]!
 }
 
 type ShippingPriceCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shippingZone: ShippingZone
   shippingErrors: [ShippingError!]!
   shippingMethod: ShippingMethod
 }
 
 type ShippingPriceDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shippingMethod: ShippingMethod
   shippingZone: ShippingZone
   shippingErrors: [ShippingError!]!
@@ -4122,12 +4158,13 @@ input ShippingPriceInput {
 }
 
 type ShippingPriceTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   shippingMethod: ShippingMethod
 }
 
 type ShippingPriceUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shippingZone: ShippingZone
   shippingErrors: [ShippingError!]!
   shippingMethod: ShippingMethod
@@ -4144,7 +4181,7 @@ type ShippingZone implements Node {
 }
 
 type ShippingZoneBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   shippingErrors: [ShippingError!]!
 }
@@ -4161,27 +4198,36 @@ type ShippingZoneCountableEdge {
 }
 
 type ShippingZoneCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shippingZone: ShippingZone
   shippingErrors: [ShippingError!]!
 }
 
-type ShippingZoneDelete {
-  errors: [Error!]!
-  shippingErrors: [ShippingError!]!
-  shippingZone: ShippingZone
-}
-
-input ShippingZoneInput {
+input ShippingZoneCreateInput {
   name: String
   countries: [String]
   default: Boolean
+  addWarehouses: [ID]
+}
+
+type ShippingZoneDelete {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  shippingErrors: [ShippingError!]!
+  shippingZone: ShippingZone
 }
 
 type ShippingZoneUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shippingZone: ShippingZone
   shippingErrors: [ShippingError!]!
+}
+
+input ShippingZoneUpdateInput {
+  name: String
+  countries: [String]
+  default: Boolean
+  addWarehouses: [ID]
+  removeWarehouses: [ID]
 }
 
 type Shop {
@@ -4199,7 +4245,7 @@ type Shop {
   languages: [LanguageDisplay]!
   name: String!
   navigation: Navigation
-  permissions: [PermissionDisplay]!
+  permissions: [Permission]!
   phonePrefixes: [String]!
   headerText: String
   includeTaxesInPrices: Boolean!
@@ -4217,13 +4263,13 @@ type Shop {
 }
 
 type ShopAddressUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shop: Shop
   shopErrors: [ShopError!]!
 }
 
 type ShopDomainUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shop: Shop
   shopErrors: [ShopError!]!
 }
@@ -4245,7 +4291,7 @@ enum ShopErrorCode {
 }
 
 type ShopFetchTaxRates {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shop: Shop
   shopErrors: [ShopError!]!
 }
@@ -4267,8 +4313,9 @@ input ShopSettingsInput {
 }
 
 type ShopSettingsTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shop: Shop
+  translationErrors: [TranslationError!]!
 }
 
 input ShopSettingsTranslationInput {
@@ -4277,7 +4324,7 @@ input ShopSettingsTranslationInput {
 }
 
 type ShopSettingsUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shop: Shop
   shopErrors: [ShopError!]!
 }
@@ -4295,14 +4342,14 @@ input SiteDomainInput {
 }
 
 type StaffBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
-  accountErrors: [AccountError!]!
+  staffErrors: [StaffError!]!
 }
 
 type StaffCreate {
-  errors: [Error!]!
-  accountErrors: [AccountError!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  staffErrors: [StaffError!]!
   user: User
 }
 
@@ -4312,23 +4359,23 @@ input StaffCreateInput {
   email: String
   isActive: Boolean
   note: String
-  permissions: [PermissionEnum]
+  addGroups: [ID!]
   redirectUrl: String
 }
 
 type StaffDelete {
-  errors: [Error!]!
-  accountErrors: [AccountError!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  staffErrors: [StaffError!]!
   user: User
 }
 
-input StaffInput {
-  firstName: String
-  lastName: String
-  email: String
-  isActive: Boolean
-  note: String
-  permissions: [PermissionEnum]
+type StaffError {
+  field: String
+  message: String
+  code: AccountErrorCode!
+  permissions: [PermissionEnum!]
+  groups: [ID!]
+  users: [ID!]
 }
 
 enum StaffMemberStatus {
@@ -4344,13 +4391,13 @@ type StaffNotificationRecipient implements Node {
 }
 
 type StaffNotificationRecipientCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shopErrors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffNotificationRecipientDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shopErrors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
@@ -4362,15 +4409,25 @@ input StaffNotificationRecipientInput {
 }
 
 type StaffNotificationRecipientUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   shopErrors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffUpdate {
-  errors: [Error!]!
-  accountErrors: [AccountError!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  staffErrors: [StaffError!]!
   user: User
+}
+
+input StaffUpdateInput {
+  firstName: String
+  lastName: String
+  email: String
+  isActive: Boolean
+  note: String
+  addGroups: [ID!]
+  removeGroups: [ID!]
 }
 
 input StaffUserInput {
@@ -4534,6 +4591,18 @@ enum TranslatableKinds {
   VOUCHER
 }
 
+type TranslationError {
+  field: String
+  message: String
+  code: TranslationErrorCode!
+}
+
+enum TranslationErrorCode {
+  GRAPHQL_ERROR
+  NOT_FOUND
+  REQUIRED
+}
+
 input TranslationInput {
   seoTitle: String
   seoDescription: String
@@ -4545,13 +4614,13 @@ input TranslationInput {
 scalar UUID
 
 type UpdateMetadata {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   metadataErrors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type UpdatePrivateMetadata {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   metadataErrors: [MetadataError!]!
   item: ObjectWithMetadata
 }
@@ -4578,39 +4647,41 @@ type User implements Node & ObjectWithMetadata {
   checkout: Checkout
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  permissions: [PermissionDisplay]
+  permissions: [Permission] @deprecated(reason: "Will be removed in Saleor 2.11.Use the `userPermissions` instead.")
+  userPermissions: [UserPermission]
+  permissionGroups: [Group]
+  editableGroups: [Group]
   avatar(size: Int): Image
   events: [CustomerEvent]
   storedPaymentSources: [PaymentSource]
-  wishlist(before: String, after: String, first: Int, last: Int): WishlistItemCountableConnection
 }
 
 type UserAvatarDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
 }
 
 type UserAvatarUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   user: User
   accountErrors: [AccountError!]!
 }
 
 type UserBulkSetActive {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
   accountErrors: [AccountError!]!
 }
 
 type UserClearMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
 
 type UserClearPrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
@@ -4637,6 +4708,12 @@ input UserCreateInput {
   redirectUrl: String
 }
 
+type UserPermission {
+  code: PermissionEnum!
+  name: String!
+  sourcePermissionGroups(userId: ID!): [Group!]
+}
+
 enum UserSortField {
   FIRST_NAME
   LAST_NAME
@@ -4650,13 +4727,13 @@ input UserSortingInput {
 }
 
 type UserUpdateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
 
 type UserUpdatePrivateMeta {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   accountErrors: [AccountError!]!
   user: User
 }
@@ -4668,14 +4745,14 @@ type VAT {
 }
 
 type VariantImageAssign {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productVariant: ProductVariant
   image: ProductImage
   productErrors: [ProductError!]!
 }
 
 type VariantImageUnassign {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   productVariant: ProductVariant
   image: ProductImage
   productErrors: [ProductError!]!
@@ -4718,14 +4795,15 @@ type Voucher implements Node {
 }
 
 type VoucherAddCatalogues {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   voucher: Voucher
   discountErrors: [DiscountError!]!
 }
 
 type VoucherBulkDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   count: Int!
+  discountErrors: [DiscountError!]!
 }
 
 type VoucherCountableConnection {
@@ -4740,13 +4818,13 @@ type VoucherCountableEdge {
 }
 
 type VoucherCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   discountErrors: [DiscountError!]!
   voucher: Voucher
 }
 
 type VoucherDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   discountErrors: [DiscountError!]!
   voucher: Voucher
 }
@@ -4785,7 +4863,7 @@ input VoucherInput {
 }
 
 type VoucherRemoveCatalogues {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   voucher: Voucher
   discountErrors: [DiscountError!]!
 }
@@ -4813,7 +4891,8 @@ type VoucherTranslatableContent implements Node {
 }
 
 type VoucherTranslate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
+  translationErrors: [TranslationError!]!
   voucher: Voucher
 }
 
@@ -4830,7 +4909,7 @@ enum VoucherTypeEnum {
 }
 
 type VoucherUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   discountErrors: [DiscountError!]!
   voucher: Voucher
 }
@@ -4868,7 +4947,7 @@ type WarehouseCountableEdge {
 }
 
 type WarehouseCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   warehouseErrors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -4883,7 +4962,7 @@ input WarehouseCreateInput {
 }
 
 type WarehouseDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   warehouseErrors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -4905,16 +4984,17 @@ enum WarehouseErrorCode {
 
 input WarehouseFilterInput {
   search: String
+  ids: [ID]
 }
 
 type WarehouseShippingZoneAssign {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   warehouse: Warehouse
   warehouseErrors: [WarehouseError!]!
 }
 
 type WarehouseShippingZoneUnassign {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   warehouse: Warehouse
   warehouseErrors: [WarehouseError!]!
 }
@@ -4929,7 +5009,7 @@ input WarehouseSortingInput {
 }
 
 type WarehouseUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   warehouseErrors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -4964,7 +5044,7 @@ type WebhookCountableEdge {
 }
 
 type WebhookCreate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   webhookErrors: [WebhookError!]!
   webhook: Webhook
 }
@@ -4979,7 +5059,7 @@ input WebhookCreateInput {
 }
 
 type WebhookDelete {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   webhook: Webhook
   webhookErrors: [WebhookError!]!
 }
@@ -5045,7 +5125,7 @@ input WebhookSortingInput {
 }
 
 type WebhookUpdate {
-  errors: [Error!]!
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes.")
   webhook: Webhook
   webhookErrors: [WebhookError!]!
 }
@@ -5071,68 +5151,6 @@ enum WeightUnitsEnum {
   LB
   OZ
   G
-}
-
-type Wishlist implements Node {
-  id: ID!
-  createdAt: DateTime!
-  items(before: String, after: String, first: Int, last: Int, id: ID): WishlistItemCountableConnection!
-}
-
-type WishlistAddProductMutation {
-  errors: [Error!]!
-  wishlist: [WishlistItem]
-  wishlistErrors: [WishlistError!]!
-}
-
-type WishlistAddProductVariantMutation {
-  errors: [Error!]!
-  wishlist: [WishlistItem]
-  wishlistErrors: [WishlistError!]!
-}
-
-type WishlistError {
-  field: String
-  message: String
-  code: WishlistErrorCode!
-}
-
-enum WishlistErrorCode {
-  GRAPHQL_ERROR
-  INVALID
-  NOT_FOUND
-  REQUIRED
-  UNIQUE
-}
-
-type WishlistItem implements Node {
-  id: ID!
-  wishlist: Wishlist!
-  product: Product!
-  variants(before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection!
-}
-
-type WishlistItemCountableConnection {
-  pageInfo: PageInfo!
-  edges: [WishlistItemCountableEdge!]!
-  totalCount: Int
-}
-
-type WishlistItemCountableEdge {
-  node: WishlistItem!
-  cursor: String!
-}
-
-type WishlistRemoveProductMutation {
-  errors: [Error!]!
-  wishlist: [WishlistItem]
-  wishlistErrors: [WishlistError!]!
-}
-
-type WishlistRemoveProductVariantMutation {
-  errors: [Error!]!
-  wishlist: [WishlistItem]
-  wishlistErrors: [WishlistError!]!
 }
 
 scalar _Any

--- a/src/auth/types/SetPassword.ts
+++ b/src/auth/types/SetPassword.ts
@@ -15,7 +15,7 @@ export interface SetPassword_setPassword_errors {
 }
 
 export interface SetPassword_setPassword_user_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }
@@ -37,7 +37,7 @@ export interface SetPassword_setPassword_user {
 
 export interface SetPassword_setPassword {
   __typename: "SetPassword";
-  errors: SetPassword_setPassword_errors[] | null;
+  errors: SetPassword_setPassword_errors[];
   token: string | null;
   user: SetPassword_setPassword_user | null;
 }

--- a/src/auth/types/TokenAuth.ts
+++ b/src/auth/types/TokenAuth.ts
@@ -15,7 +15,7 @@ export interface TokenAuth_tokenCreate_errors {
 }
 
 export interface TokenAuth_tokenCreate_user_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }
@@ -38,7 +38,7 @@ export interface TokenAuth_tokenCreate_user {
 export interface TokenAuth_tokenCreate {
   __typename: "CreateToken";
   token: string | null;
-  errors: (TokenAuth_tokenCreate_errors | null)[];
+  errors: TokenAuth_tokenCreate_errors[];
   user: TokenAuth_tokenCreate_user | null;
 }
 

--- a/src/auth/types/User.ts
+++ b/src/auth/types/User.ts
@@ -9,7 +9,7 @@ import { PermissionEnum } from "./../../types/globalTypes";
 // ====================================================
 
 export interface User_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/auth/types/VerifyToken.ts
+++ b/src/auth/types/VerifyToken.ts
@@ -9,7 +9,7 @@ import { PermissionEnum } from "./../../types/globalTypes";
 // ====================================================
 
 export interface VerifyToken_tokenVerify_user_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/components/Shop/types/ShopInfo.ts
+++ b/src/components/Shop/types/ShopInfo.ts
@@ -33,7 +33,7 @@ export interface ShopInfo_shop_languages {
 }
 
 export interface ShopInfo_shop_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -373,7 +373,7 @@ export const permissions: ShopInfo_shop_permissions[] = [
     name: "Manage webhooks."
   }
 ].map(perm => ({
-  __typename: "PermissionDisplay" as "PermissionDisplay",
+  __typename: "Permission" as "Permission",
   ...perm
 }));
 

--- a/src/products/types/ProductFragment.ts
+++ b/src/products/types/ProductFragment.ts
@@ -29,6 +29,7 @@ export interface ProductFragment {
   name: string;
   thumbnail: ProductFragment_thumbnail | null;
   isAvailable: boolean | null;
+  isPublished: boolean;
   basePrice: ProductFragment_basePrice | null;
   productType: ProductFragment_productType;
 }

--- a/src/products/types/ProductList.ts
+++ b/src/products/types/ProductList.ts
@@ -48,7 +48,7 @@ export interface ProductList_products_edges_node {
   name: string;
   thumbnail: ProductList_products_edges_node_thumbnail | null;
   isAvailable: boolean | null;
-  isPublished: boolean | null;
+  isPublished: boolean;
   basePrice: ProductList_products_edges_node_basePrice | null;
   productType: ProductList_products_edges_node_productType;
   attributes: ProductList_products_edges_node_attributes[];

--- a/src/services/fixtures.ts
+++ b/src/services/fixtures.ts
@@ -30,7 +30,7 @@ export const service: ServiceDetails_serviceAccount = {
   name: "Magento Importer",
   permissions: [
     {
-      __typename: "PermissionDisplay" as "PermissionDisplay",
+      __typename: "Permission" as "Permission",
       code: PermissionEnum.MANAGE_PRODUCTS,
       name: "Manage products."
     }

--- a/src/services/types/ServiceDetails.ts
+++ b/src/services/types/ServiceDetails.ts
@@ -9,7 +9,7 @@ import { PermissionEnum } from "./../../types/globalTypes";
 // ====================================================
 
 export interface ServiceDetails_serviceAccount_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/services/types/ServiceDetailsFragment.ts
+++ b/src/services/types/ServiceDetailsFragment.ts
@@ -9,7 +9,7 @@ import { PermissionEnum } from "./../../types/globalTypes";
 // ====================================================
 
 export interface ServiceDetailsFragment_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/services/types/ServiceUpdate.ts
+++ b/src/services/types/ServiceUpdate.ts
@@ -15,7 +15,7 @@ export interface ServiceUpdate_serviceAccountUpdate_errors {
 }
 
 export interface ServiceUpdate_serviceAccountUpdate_serviceAccount_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/shipping/mutations.ts
+++ b/src/shipping/mutations.ts
@@ -98,7 +98,7 @@ export const TypedUpdateDefaultWeightUnit = TypedMutation<
 const createShippingZone = gql`
   ${countryFragment}
   ${shippingErrorFragment}
-  mutation CreateShippingZone($input: ShippingZoneInput!) {
+  mutation CreateShippingZone($input: ShippingZoneCreateInput!) {
     shippingZoneCreate(input: $input) {
       errors: shippingErrors {
         ...ShippingErrorFragment
@@ -122,7 +122,7 @@ export const TypedCreateShippingZone = TypedMutation<
 const updateShippingZone = gql`
   ${countryFragment}
   ${shippingErrorFragment}
-  mutation UpdateShippingZone($id: ID!, $input: ShippingZoneInput!) {
+  mutation UpdateShippingZone($id: ID!, $input: ShippingZoneUpdateInput!) {
     shippingZoneUpdate(id: $id, input: $input) {
       errors: shippingErrors {
         ...ShippingErrorFragment

--- a/src/shipping/types/CreateShippingZone.ts
+++ b/src/shipping/types/CreateShippingZone.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ShippingZoneInput, ShippingErrorCode } from "./../../types/globalTypes";
+import { ShippingZoneCreateInput, ShippingErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CreateShippingZone
@@ -39,5 +39,5 @@ export interface CreateShippingZone {
 }
 
 export interface CreateShippingZoneVariables {
-  input: ShippingZoneInput;
+  input: ShippingZoneCreateInput;
 }

--- a/src/shipping/types/UpdateShippingZone.ts
+++ b/src/shipping/types/UpdateShippingZone.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ShippingZoneInput, ShippingErrorCode } from "./../../types/globalTypes";
+import { ShippingZoneUpdateInput, ShippingErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateShippingZone
@@ -40,5 +40,5 @@ export interface UpdateShippingZone {
 
 export interface UpdateShippingZoneVariables {
   id: string;
-  input: ShippingZoneInput;
+  input: ShippingZoneUpdateInput;
 }

--- a/src/staff/components/StaffAddMemberDialog/StaffAddMemberDialog.tsx
+++ b/src/staff/components/StaffAddMemberDialog/StaffAddMemberDialog.tsx
@@ -5,21 +5,19 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
-import Typography from "@material-ui/core/Typography";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
-import { ControlledCheckbox } from "@saleor/components/ControlledCheckbox";
 import Form from "@saleor/components/Form";
 import FormSpacer from "@saleor/components/FormSpacer";
 import { buttonMessages, commonMessages } from "@saleor/intl";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
-import { AccountErrorFragment } from "@saleor/customers/types/AccountErrorFragment";
 import { getFormErrors } from "@saleor/utils/errors";
-import getAccountErrorMessage from "@saleor/utils/errors/account";
+import { StaffErrorFragment } from "@saleor/staff/types/StaffErrorFragment";
+import getStaffErrorMessage from "@saleor/utils/errors/staff";
 
 export interface FormData {
   email: string;
@@ -59,7 +57,7 @@ const useStyles = makeStyles(
 
 interface StaffAddMemberDialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
-  errors: AccountErrorFragment[];
+  errors: StaffErrorFragment[];
   open: boolean;
   onClose: () => void;
   onConfirm: (data: FormData) => void;
@@ -92,10 +90,7 @@ const StaffAddMemberDialog: React.FC<StaffAddMemberDialogProps> = props => {
               <div className={classes.textFieldGrid}>
                 <TextField
                   error={!!formErrors.firstName}
-                  helperText={getAccountErrorMessage(
-                    formErrors.firstName,
-                    intl
-                  )}
+                  helperText={getStaffErrorMessage(formErrors.firstName, intl)}
                   label={intl.formatMessage(commonMessages.firstName)}
                   name="firstName"
                   type="text"
@@ -104,7 +99,7 @@ const StaffAddMemberDialog: React.FC<StaffAddMemberDialogProps> = props => {
                 />
                 <TextField
                   error={!!formErrors.lastName}
-                  helperText={getAccountErrorMessage(formErrors.lastName, intl)}
+                  helperText={getStaffErrorMessage(formErrors.lastName, intl)}
                   label={intl.formatMessage(commonMessages.lastName)}
                   name="lastName"
                   type="text"
@@ -116,28 +111,11 @@ const StaffAddMemberDialog: React.FC<StaffAddMemberDialogProps> = props => {
               <TextField
                 error={!!formErrors.email}
                 fullWidth
-                helperText={getAccountErrorMessage(formErrors.email, intl)}
+                helperText={getStaffErrorMessage(formErrors.email, intl)}
                 label={intl.formatMessage(commonMessages.email)}
                 name="email"
                 type="email"
                 value={data.email}
-                onChange={change}
-              />
-            </DialogContent>
-            <hr className={classes.hr} />
-            <DialogContent>
-              <Typography className={classes.sectionTitle}>
-                <FormattedMessage defaultMessage="Permissions" />
-              </Typography>
-              <Typography>
-                <FormattedMessage defaultMessage="Expand or restrict user’s permissions to access certain part of saleor system." />
-              </Typography>
-              <ControlledCheckbox
-                checked={data.fullAccess}
-                label={intl.formatMessage({
-                  defaultMessage: "User has full access"
-                })}
-                name="fullAccess"
                 onChange={change}
               />
             </DialogContent>

--- a/src/staff/mutations.ts
+++ b/src/staff/mutations.ts
@@ -26,13 +26,19 @@ import {
   ChangeStaffPasswordVariables
 } from "./types/ChangeStaffPassword";
 
+const staffErrorFragment = gql`
+  fragment StaffErrorFragment on StaffError {
+    code
+    field
+  }
+`;
 const staffMemberAddMutation = gql`
-  ${accountFragmentError}
+  ${staffErrorFragment}
   ${staffMemberDetailsFragment}
   mutation StaffMemberAdd($input: StaffCreateInput!) {
     staffCreate(input: $input) {
-      errors: accountErrors {
-        ...AccountErrorFragment
+      errors: staffErrors {
+        ...StaffErrorFragment
       }
       user {
         ...StaffMemberDetailsFragment
@@ -48,10 +54,10 @@ export const TypedStaffMemberAddMutation = TypedMutation<
 const staffMemberUpdateMutation = gql`
   ${accountFragmentError}
   ${staffMemberDetailsFragment}
-  mutation StaffMemberUpdate($id: ID!, $input: StaffInput!) {
+  mutation StaffMemberUpdate($id: ID!, $input: StaffUpdateInput!) {
     staffUpdate(id: $id, input: $input) {
-      errors: accountErrors {
-        ...AccountErrorFragment
+      errors: staffErrors {
+        ...StaffErrorFragment
       }
       user {
         ...StaffMemberDetailsFragment
@@ -65,11 +71,11 @@ export const TypedStaffMemberUpdateMutation = TypedMutation<
 >(staffMemberUpdateMutation);
 
 const staffMemberDeleteMutation = gql`
-  ${accountFragmentError}
+  ${staffErrorFragment}
   mutation StaffMemberDelete($id: ID!) {
     staffDelete(id: $id) {
-      errors: accountErrors {
-        ...AccountErrorFragment
+      errors: staffErrors {
+        ...StaffErrorFragment
       }
     }
   }

--- a/src/staff/types/StaffErrorFragment.ts
+++ b/src/staff/types/StaffErrorFragment.ts
@@ -1,0 +1,15 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { AccountErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: StaffErrorFragment
+// ====================================================
+
+export interface StaffErrorFragment {
+  __typename: "StaffError";
+  code: AccountErrorCode;
+  field: string | null;
+}

--- a/src/staff/types/StaffMemberAdd.ts
+++ b/src/staff/types/StaffMemberAdd.ts
@@ -9,7 +9,7 @@ import { StaffCreateInput, AccountErrorCode, PermissionEnum } from "./../../type
 // ====================================================
 
 export interface StaffMemberAdd_staffCreate_errors {
-  __typename: "AccountError";
+  __typename: "StaffError";
   code: AccountErrorCode;
   field: string | null;
 }
@@ -20,7 +20,7 @@ export interface StaffMemberAdd_staffCreate_user_avatar {
 }
 
 export interface StaffMemberAdd_staffCreate_user_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/staff/types/StaffMemberDelete.ts
+++ b/src/staff/types/StaffMemberDelete.ts
@@ -9,7 +9,7 @@ import { AccountErrorCode } from "./../../types/globalTypes";
 // ====================================================
 
 export interface StaffMemberDelete_staffDelete_errors {
-  __typename: "AccountError";
+  __typename: "StaffError";
   code: AccountErrorCode;
   field: string | null;
 }

--- a/src/staff/types/StaffMemberDetails.ts
+++ b/src/staff/types/StaffMemberDetails.ts
@@ -14,7 +14,7 @@ export interface StaffMemberDetails_user_avatar {
 }
 
 export interface StaffMemberDetails_user_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/staff/types/StaffMemberDetailsFragment.ts
+++ b/src/staff/types/StaffMemberDetailsFragment.ts
@@ -14,7 +14,7 @@ export interface StaffMemberDetailsFragment_avatar {
 }
 
 export interface StaffMemberDetailsFragment_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }

--- a/src/staff/types/StaffMemberUpdate.ts
+++ b/src/staff/types/StaffMemberUpdate.ts
@@ -2,14 +2,14 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { StaffInput, AccountErrorCode, PermissionEnum } from "./../../types/globalTypes";
+import { StaffUpdateInput, AccountErrorCode, PermissionEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: StaffMemberUpdate
 // ====================================================
 
 export interface StaffMemberUpdate_staffUpdate_errors {
-  __typename: "AccountError";
+  __typename: "StaffError";
   code: AccountErrorCode;
   field: string | null;
 }
@@ -20,7 +20,7 @@ export interface StaffMemberUpdate_staffUpdate_user_avatar {
 }
 
 export interface StaffMemberUpdate_staffUpdate_user_permissions {
-  __typename: "PermissionDisplay";
+  __typename: "Permission";
   code: PermissionEnum;
   name: string;
 }
@@ -48,5 +48,5 @@ export interface StaffMemberUpdate {
 
 export interface StaffMemberUpdateVariables {
   id: string;
-  input: StaffInput;
+  input: StaffUpdateInput;
 }

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -161,8 +161,7 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
                                         email: variables.email,
                                         firstName: variables.firstName,
                                         isActive: variables.isActive,
-                                        lastName: variables.lastName,
-                                        permissions: variables.permissions
+                                        lastName: variables.lastName
                                       }
                                     }
                                   })

--- a/src/staff/views/StaffList/StaffList.tsx
+++ b/src/staff/views/StaffList/StaffList.tsx
@@ -141,9 +141,6 @@ export const StaffList: React.FC<StaffListProps> = ({ params }) => {
                 email: variables.email,
                 firstName: variables.firstName,
                 lastName: variables.lastName,
-                permissions: variables.fullAccess
-                  ? maybe(() => shop.permissions.map(perm => perm.code))
-                  : undefined,
                 redirectUrl: urlJoin(
                   window.location.origin,
                   APP_MOUNT_URI === "/" ? "" : APP_MOUNT_URI,

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -9,7 +9,7 @@
 export enum AccountErrorCode {
   ACTIVATE_OWN_ACCOUNT = "ACTIVATE_OWN_ACCOUNT",
   ACTIVATE_SUPERUSER_ACCOUNT = "ACTIVATE_SUPERUSER_ACCOUNT",
-  ASSIGN_NON_STAFF_MEMBER = "ASSIGN_NON_STAFF_MEMBER",
+  CANNOT_ADD_AND_REMOVE = "CANNOT_ADD_AND_REMOVE",
   DEACTIVATE_OWN_ACCOUNT = "DEACTIVATE_OWN_ACCOUNT",
   DEACTIVATE_SUPERUSER_ACCOUNT = "DEACTIVATE_SUPERUSER_ACCOUNT",
   DELETE_NON_STAFF_USER = "DELETE_NON_STAFF_USER",
@@ -18,8 +18,13 @@ export enum AccountErrorCode {
   DELETE_SUPERUSER_ACCOUNT = "DELETE_SUPERUSER_ACCOUNT",
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
   INVALID = "INVALID",
+  INVALID_CREDENTIALS = "INVALID_CREDENTIALS",
   INVALID_PASSWORD = "INVALID_PASSWORD",
+  LEFT_NOT_MANAGEABLE_PERMISSION = "LEFT_NOT_MANAGEABLE_PERMISSION",
   NOT_FOUND = "NOT_FOUND",
+  OUT_OF_SCOPE_GROUP = "OUT_OF_SCOPE_GROUP",
+  OUT_OF_SCOPE_PERMISSION = "OUT_OF_SCOPE_PERMISSION",
+  OUT_OF_SCOPE_USER = "OUT_OF_SCOPE_USER",
   PASSWORD_ENTIRELY_NUMERIC = "PASSWORD_ENTIRELY_NUMERIC",
   PASSWORD_TOO_COMMON = "PASSWORD_TOO_COMMON",
   PASSWORD_TOO_SHORT = "PASSWORD_TOO_SHORT",
@@ -348,6 +353,7 @@ export enum CountryCode {
 
 export enum DiscountErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
+  GRAPHQL_ERROR = "GRAPHQL_ERROR",
   INVALID = "INVALID",
   NOT_FOUND = "NOT_FOUND",
   REQUIRED = "REQUIRED",
@@ -633,6 +639,7 @@ export enum ServiceAccountSortField {
 
 export enum ShippingErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
+  CANNOT_ADD_AND_REMOVE = "CANNOT_ADD_AND_REMOVE",
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
   INVALID = "INVALID",
   MAX_LESS_THAN_MIN = "MAX_LESS_THAN_MIN",
@@ -1247,10 +1254,19 @@ export interface ShippingPriceInput {
   shippingZone?: string | null;
 }
 
-export interface ShippingZoneInput {
+export interface ShippingZoneCreateInput {
   name?: string | null;
   countries?: (string | null)[] | null;
   default?: boolean | null;
+  addWarehouses?: (string | null)[] | null;
+}
+
+export interface ShippingZoneUpdateInput {
+  name?: string | null;
+  countries?: (string | null)[] | null;
+  default?: boolean | null;
+  addWarehouses?: (string | null)[] | null;
+  removeWarehouses?: (string | null)[] | null;
 }
 
 export interface ShopSettingsInput {
@@ -1280,17 +1296,18 @@ export interface StaffCreateInput {
   email?: string | null;
   isActive?: boolean | null;
   note?: string | null;
-  permissions?: (PermissionEnum | null)[] | null;
+  addGroups?: string[] | null;
   redirectUrl?: string | null;
 }
 
-export interface StaffInput {
+export interface StaffUpdateInput {
   firstName?: string | null;
   lastName?: string | null;
   email?: string | null;
   isActive?: boolean | null;
   note?: string | null;
-  permissions?: (PermissionEnum | null)[] | null;
+  addGroups?: string[] | null;
+  removeGroups?: string[] | null;
 }
 
 export interface StaffUserInput {

--- a/src/utils/errors/staff.ts
+++ b/src/utils/errors/staff.ts
@@ -1,0 +1,18 @@
+import { IntlShape } from "react-intl";
+import { StaffErrorFragment } from "@saleor/staff/types/StaffErrorFragment";
+import getAccountErrorMessage from "./account";
+
+function getStaffErrorMessage(
+  err: StaffErrorFragment,
+  intl: IntlShape
+): string {
+  return getAccountErrorMessage(
+    err && {
+      ...err,
+      __typename: "AccountError"
+    },
+    intl
+  );
+}
+
+export default getStaffErrorMessage;


### PR DESCRIPTION
I want to merge this change because it updates api types to be compatible with newest master.
Also removes "user has full access" because setting permissions when creating staff member is now unsupported.

Resolves #485

### Screenshots
<img width="702" alt="Screenshot 2020-04-20 at 13 46 08" src="https://user-images.githubusercontent.com/6833443/79748192-4eea1a80-830d-11ea-824d-8de8055fb15e.png">
<img width="731" alt="Screenshot 2020-04-20 at 13 10 53" src="https://user-images.githubusercontent.com/6833443/79748150-3b3eb400-830d-11ea-980e-f131a355c33b.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
