### PR TITLE
Better styles for group selection widget

### DIFF
--- a/src/components/AccountPermissionGroups/AccountPermissionGroups.stories.tsx
+++ b/src/components/AccountPermissionGroups/AccountPermissionGroups.stories.tsx
@@ -1,0 +1,71 @@
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import Decorator from "@saleor/storybook/Decorator";
+import { SearchPermissionGroups_search_edges_node } from "@saleor/searches/types/SearchPermissionGroups";
+import { AccountErrorCode } from "@saleor/types/globalTypes";
+import { StaffErrorFragment } from "@saleor/staff/types/StaffErrorFragment";
+import { MultiAutocompleteChoiceType } from "../MultiAutocompleteSelectField";
+import AccountPermissionGroups, { AccountPermissionGroupsProps } from ".";
+
+const availablePermissionGroups: SearchPermissionGroups_search_edges_node[] = [
+  {
+    __typename: "Group",
+    id: "R3JvdXA6MQ==",
+    name: "Unmanagable by user",
+    userCanManage: false
+  },
+  {
+    __typename: "Group",
+    id: "R3JvdXA6Mg==",
+    name: "Default group",
+    userCanManage: true
+  },
+  {
+    __typename: "Group",
+    id: "R3JvdXA6Mz==",
+    name: "Translators",
+    userCanManage: false
+  },
+  {
+    __typename: "Group",
+    id: "R3JvdXA6My==",
+    name: "CMS",
+    userCanManage: true
+  }
+];
+
+const displayValues: MultiAutocompleteChoiceType[] = [
+  { disabled: true, label: "Unmanagable by user", value: "R3JvdXA6MQ==" },
+  { disabled: false, label: "Default group", value: "R3JvdXA6Mg==" }
+];
+
+const formData = {
+  permissionGroups: ["R3JvdXA6MQ==", "R3JvdXA6Mg=="]
+};
+
+const errors: StaffErrorFragment[] = [
+  {
+    __typename: "StaffError",
+    code: AccountErrorCode.OUT_OF_SCOPE_GROUP,
+    field: "addGroups"
+  }
+];
+
+const props: AccountPermissionGroupsProps = {
+  availablePermissionGroups,
+  disabled: false,
+  displayValues,
+  errors: [],
+  formData,
+  hasMore: false,
+  initialSearch: "",
+  loading: false,
+  onChange: () => undefined,
+  onFetchMore: () => undefined,
+  onSearchChange: () => undefined
+};
+
+storiesOf("Generics / Account Permission Groups Widget", module)
+  .addDecorator(Decorator)
+  .add("default", () => <AccountPermissionGroups {...props} />)
+  .add("error", () => <AccountPermissionGroups {...props} errors={errors} />);

--- a/src/components/AccountPermissionGroups/AccountPermissionGroups.tsx
+++ b/src/components/AccountPermissionGroups/AccountPermissionGroups.tsx
@@ -12,7 +12,9 @@ import MultiAutocompleteSelectField, {
   MultiAutocompleteChoiceType
 } from "../MultiAutocompleteSelectField";
 
-interface AccountPermissionGroupsProps extends FetchMoreProps, SearchPageProps {
+export interface AccountPermissionGroupsProps
+  extends FetchMoreProps,
+    SearchPageProps {
   formData: {
     permissionGroups: string[];
   };

--- a/src/components/AccountPermissionGroups/AccountPermissionGroups.tsx
+++ b/src/components/AccountPermissionGroups/AccountPermissionGroups.tsx
@@ -42,6 +42,7 @@ const AccountPermissionGroups: React.FC<AccountPermissionGroupsProps> = props =>
   const intl = useIntl();
 
   const choices = availablePermissionGroups?.map(pg => ({
+    disabled: !pg.userCanManage,
     label: pg.name,
     value: pg.id
   }));

--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
@@ -53,10 +53,10 @@ const useStyles = makeStyles(
     },
     disabledChipInner: {
       "& svg": {
-        color: theme.palette.secondary.contrastText
+        color: theme.palette.grey[200]
       },
       alignItems: "center",
-      background: fade(theme.palette.secondary.main, 0.8),
+      background: fade(theme.palette.grey[400], 0.8),
       borderRadius: 18,
       color: theme.palette.primary.contrastText,
       display: "flex",
@@ -194,14 +194,14 @@ const MultiAutocompleteSelectFieldComponent: React.FC<MultiAutocompleteSelectFie
               <Typography className={classes.chipLabel}>
                 {value.label}
               </Typography>
-              {!value.disabled && (
-                <IconButton
-                  className={classes.chipClose}
-                  onClick={() => handleSelect(value.value)}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              )}
+
+              <IconButton
+                className={classes.chipClose}
+                disabled={value.disabled}
+                onClick={() => handleSelect(value.value)}
+              >
+                <CloseIcon fontSize="small" />
+              </IconButton>
             </div>
           </div>
         ))}

--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectFieldContent.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectFieldContent.tsx
@@ -251,6 +251,7 @@ const MultiAutocompleteSelectFieldContent: React.FC<MultiAutocompleteSelectField
                 >
                   <Checkbox
                     checked={false}
+                    disabled={suggestion.disabled}
                     className={classes.checkbox}
                     disableRipple
                   />


### PR DESCRIPTION
I want to merge this change because... styles were confusing.

**PR intended to be tested with API branch:** master

### Screenshots

![image](https://user-images.githubusercontent.com/5188636/80349222-3af36b00-886f-11ea-9236-873f3fc06687.png)

Unavailable choices are blocked now:
![image](https://user-images.githubusercontent.com/5188636/80353342-84df4f80-8875-11ea-876b-0fa5a05cc8c3.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
