### PR TITLE
Fix available stock card

### DIFF
--- a/src/products/components/ProductVariants/ProductVariants.tsx
+++ b/src/products/components/ProductVariants/ProductVariants.tsx
@@ -296,7 +296,10 @@ export const ProductVariants: React.FC<ProductVariantsProps> = props => {
               const isSelected = variant ? isChecked(variant.id) : false;
               const numAvailable =
                 variant && variant.stocks
-                  ? variant.stocks.reduce((acc, s) => acc + s.quantity, 0)
+                  ? variant.stocks.reduce(
+                      (acc, s) => acc + s.quantity - s.quantityAllocated,
+                      0
+                    )
                   : null;
 
               return (

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -1256,6 +1256,7 @@ export const variant = (placeholderImage: string): ProductVariant => ({
       __typename: "Stock",
       id: "1",
       quantity: 1,
+      quantityAllocated: 1,
       warehouse: {
         __typename: "Warehouse",
         id: "123",
@@ -1266,6 +1267,7 @@ export const variant = (placeholderImage: string): ProductVariant => ({
       __typename: "Stock",
       id: "2",
       quantity: 4,
+      quantityAllocated: 2,
       warehouse: {
         __typename: "Warehouse",
         id: "1234",

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -266,12 +266,14 @@ export const product: (
           __typename: "Stock",
           id: "1",
           quantity: 1,
+          quantityAllocated: 0,
           warehouse: warehouseList[0]
         },
         {
           __typename: "Stock",
           id: "2",
           quantity: 4,
+          quantityAllocated: 2,
           warehouse: warehouseList[1]
         }
       ],
@@ -301,6 +303,7 @@ export const product: (
           __typename: "Stock",
           id: "1",
           quantity: 13,
+          quantityAllocated: 2,
           warehouse: warehouseList[0]
         }
       ],

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -37,6 +37,7 @@ export const stockFragment = gql`
   fragment StockFragment on Stock {
     id
     quantity
+    quantityAllocated
     warehouse {
       id
       name

--- a/src/products/types/AddOrRemoveStocks.ts
+++ b/src/products/types/AddOrRemoveStocks.ts
@@ -25,6 +25,7 @@ export interface AddOrRemoveStocks_productVariantStocksCreate_productVariant_sto
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: AddOrRemoveStocks_productVariantStocksCreate_productVariant_stocks_warehouse;
 }
 
@@ -56,6 +57,7 @@ export interface AddOrRemoveStocks_productVariantStocksDelete_productVariant_sto
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: AddOrRemoveStocks_productVariantStocksDelete_productVariant_stocks_warehouse;
 }
 

--- a/src/products/types/Product.ts
+++ b/src/products/types/Product.ts
@@ -159,6 +159,7 @@ export interface Product_variants_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: Product_variants_stocks_warehouse;
 }
 

--- a/src/products/types/ProductCreate.ts
+++ b/src/products/types/ProductCreate.ts
@@ -165,6 +165,7 @@ export interface ProductCreate_productCreate_product_variants_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: ProductCreate_productCreate_product_variants_stocks_warehouse;
 }
 

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -159,6 +159,7 @@ export interface ProductDetails_product_variants_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: ProductDetails_product_variants_stocks_warehouse;
 }
 

--- a/src/products/types/ProductImageCreate.ts
+++ b/src/products/types/ProductImageCreate.ts
@@ -165,6 +165,7 @@ export interface ProductImageCreate_productImageCreate_product_variants_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: ProductImageCreate_productImageCreate_product_variants_stocks_warehouse;
 }
 

--- a/src/products/types/ProductImageUpdate.ts
+++ b/src/products/types/ProductImageUpdate.ts
@@ -165,6 +165,7 @@ export interface ProductImageUpdate_productImageUpdate_product_variants_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: ProductImageUpdate_productImageUpdate_product_variants_stocks_warehouse;
 }
 

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -165,6 +165,7 @@ export interface ProductUpdate_productUpdate_product_variants_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: ProductUpdate_productUpdate_product_variants_stocks_warehouse;
 }
 

--- a/src/products/types/ProductVariant.ts
+++ b/src/products/types/ProductVariant.ts
@@ -99,6 +99,7 @@ export interface ProductVariant_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: ProductVariant_stocks_warehouse;
 }
 

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -99,6 +99,7 @@ export interface ProductVariantDetails_productVariant_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: ProductVariantDetails_productVariant_stocks_warehouse;
 }
 

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -165,6 +165,7 @@ export interface SimpleProductUpdate_productUpdate_product_variants_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: SimpleProductUpdate_productUpdate_product_variants_stocks_warehouse;
 }
 
@@ -307,6 +308,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_stocks 
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: SimpleProductUpdate_productVariantUpdate_productVariant_stocks_warehouse;
 }
 
@@ -430,6 +432,7 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_s
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: SimpleProductUpdate_productVariantStocksCreate_productVariant_stocks_warehouse;
 }
 
@@ -552,6 +555,7 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_s
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: SimpleProductUpdate_productVariantStocksDelete_productVariant_stocks_warehouse;
 }
 
@@ -675,6 +679,7 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_s
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: SimpleProductUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse;
 }
 

--- a/src/products/types/StockFragment.ts
+++ b/src/products/types/StockFragment.ts
@@ -16,5 +16,6 @@ export interface StockFragment {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: StockFragment_warehouse;
 }

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -107,6 +107,7 @@ export interface VariantCreate_productVariantCreate_productVariant_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: VariantCreate_productVariantCreate_productVariant_stocks_warehouse;
 }
 

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -107,6 +107,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: VariantImageAssign_variantImageAssign_productVariant_stocks_warehouse;
 }
 

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -107,6 +107,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_stocks
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: VariantImageUnassign_variantImageUnassign_productVariant_stocks_warehouse;
 }
 

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -107,6 +107,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_stocks {
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: VariantUpdate_productVariantUpdate_productVariant_stocks_warehouse;
 }
 
@@ -230,6 +231,7 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_stocks 
   __typename: "Stock";
   id: string;
   quantity: number;
+  quantityAllocated: number;
   warehouse: VariantUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse;
 }
 


### PR DESCRIPTION
I want to merge this change because it now properly displays how how much stock is there in warehouse of each variant, considering allocated quantity.

**PR intended to be tested with API branch:** master

### Screenshots
<img width="885" alt="Screenshot 2020-04-29 at 19 12 13" src="https://user-images.githubusercontent.com/6833443/80625412-73e93680-8a4d-11ea-8a0c-f644a3e40ea6.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
