### PR TITLE
Add sku column to fulfillment cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add sku column to fulfillment cards - #538 by @dominik-zeglen
+
 ## 2.10.0
 
 - Fix minor bugs - #244 by @dominik-zeglen

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2532,6 +2532,10 @@
     "context": "cancelled fulfillment, section header",
     "string": "Cancelled ({quantity})"
   },
+  "src_dot_orders_dot_components_dot_OrderFulfillment_dot_693960049": {
+    "context": "ordered product sku",
+    "string": "SKU"
+  },
   "src_dot_orders_dot_components_dot_OrderFulfillment_dot_732594284": {
     "context": "button",
     "string": "Cancel Fulfillment"
@@ -2812,6 +2816,10 @@
   "src_dot_orders_dot_components_dot_OrderUnfulfilledItems_dot_2886647373": {
     "context": "section header",
     "string": "Unfulfilled ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderUnfulfilledItems_dot_693960049": {
+    "context": "ordered product sku",
+    "string": "SKU"
   },
   "src_dot_orders_dot_components_dot_OrderUnfulfilledItems_dot_878013594": {
     "context": "order line total price",

--- a/src/orders/components/OrderFulfillment/OrderFulfillment.tsx
+++ b/src/orders/components/OrderFulfillment/OrderFulfillment.tsx
@@ -43,6 +43,11 @@ const useStyles = makeStyles(
       textAlign: "center",
       width: 120
     },
+    colSku: {
+      textAlign: "right",
+      textOverflow: "ellipsis",
+      width: 120
+    },
     colTotal: {
       textAlign: "right",
       width: 120
@@ -165,6 +170,12 @@ const OrderFulfillment: React.FC<OrderFulfillmentProps> = props => {
                 />
               </span>
             </TableCell>
+            <TableCell className={classes.colSku}>
+              <FormattedMessage
+                defaultMessage="SKU"
+                description="ordered product sku"
+              />
+            </TableCell>
             <TableCell className={classes.colQuantity}>
               <FormattedMessage
                 defaultMessage="Quantity"
@@ -198,8 +209,11 @@ const OrderFulfillment: React.FC<OrderFulfillmentProps> = props => {
               >
                 {maybe(() => line.orderLine.productName) || <Skeleton />}
               </TableCellAvatar>
+              <TableCell className={classes.colSku}>
+                {line?.orderLine.productSku || <Skeleton />}
+              </TableCell>
               <TableCell className={classes.colQuantity}>
-                {maybe(() => line.quantity) || <Skeleton />}
+                {line?.quantity || <Skeleton />}
               </TableCell>
               <TableCell className={classes.colPrice}>
                 {maybe(() => line.orderLine.unitPrice.gross) ? (

--- a/src/orders/components/OrderUnfulfilledItems/OrderUnfulfilledItems.tsx
+++ b/src/orders/components/OrderUnfulfilledItems/OrderUnfulfilledItems.tsx
@@ -40,6 +40,11 @@ const useStyles = makeStyles(
       textAlign: "center",
       width: 120
     },
+    colSku: {
+      textAlign: "right",
+      textOverflow: "ellipsis",
+      width: 120
+    },
     colTotal: {
       textAlign: "right",
       width: 120
@@ -97,6 +102,12 @@ const OrderUnfulfilledItems: React.FC<OrderUnfulfilledItemsProps> = props => {
                 />
               </span>
             </TableCell>
+            <TableCell className={classes.colSku}>
+              <FormattedMessage
+                defaultMessage="SKU"
+                description="ordered product sku"
+              />
+            </TableCell>
             <TableCell className={classes.colQuantity}>
               <FormattedMessage
                 defaultMessage="Quantity"
@@ -130,6 +141,9 @@ const OrderUnfulfilledItems: React.FC<OrderUnfulfilledItemsProps> = props => {
               >
                 {maybe(() => line.productName) || <Skeleton />}
               </TableCellAvatar>
+              <TableCell className={classes.colSku}>
+                {line?.productSku || <Skeleton />}
+              </TableCell>
               <TableCell className={classes.colQuantity}>
                 {maybe(() => line.quantity - line.quantityFulfilled) || (
                   <Skeleton />


### PR DESCRIPTION
I want to merge this change because it adds SKU column to fulfillment sections.
Resolves #536

**PR intended to be tested with API branch:** master

### Screenshots
<img width="1680" alt="Screenshot 2020-05-25 at 12 04 48" src="https://user-images.githubusercontent.com/6833443/82802984-0c71ab80-9e80-11ea-9949-ee313fb4c635.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
