### PR TITLE
Add weight field and fix warehouse country selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add weight field and fix warehouse country selection - #597 by @dominik-zeglen
+
 ## 2.10.0
 
 - Fix minor bugs - #244 by @dominik-zeglen

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3606,6 +3606,14 @@
   "src_dot_products_dot_components_dot_ProductPricing_dot_3015886868": {
     "string": "Charge taxes for this item"
   },
+  "src_dot_products_dot_components_dot_ProductShipping_dot_1325966144": {
+    "context": "product shipping",
+    "string": "Shipping"
+  },
+  "src_dot_products_dot_components_dot_ProductShipping_dot_746695941": {
+    "context": "product weight",
+    "string": "Weight"
+  },
   "src_dot_products_dot_components_dot_ProductStocks_dot_2585918415": {
     "string": "SKU (Stock Keeping Unit)"
   },
@@ -3642,14 +3650,6 @@
   },
   "src_dot_products_dot_components_dot_ProductUpdatePage_dot_2706108815": {
     "string": "Add search engine title and description to make this product easier to find"
-  },
-  "src_dot_products_dot_components_dot_ProductVariantAttributes_dot_1536841622": {
-    "context": "product attribute error",
-    "string": "All attributes should have value"
-  },
-  "src_dot_products_dot_components_dot_ProductVariantAttributes_dot_258966189": {
-    "context": "product attribute error",
-    "string": "This variant already exists"
   },
   "src_dot_products_dot_components_dot_ProductVariantCreatePage_dot_2853608829": {
     "context": "button",
@@ -5032,6 +5032,10 @@
   "src_dot_utils_dot_errors_dot_attributeCannotBeAssigned": {
     "string": "This attribute cannot be assigned to this product type"
   },
+  "src_dot_utils_dot_errors_dot_attributeRequired": {
+    "context": "product attribute error",
+    "string": "All attributes should have value"
+  },
   "src_dot_utils_dot_errors_dot_attributeVariantsDisabled": {
     "string": "Variants are disabled in this product type"
   },
@@ -5135,6 +5139,10 @@
   },
   "src_dot_utils_dot_errors_dot_variantNoDigitalContent": {
     "string": "This variant does not have any digital content"
+  },
+  "src_dot_utils_dot_errors_dot_variantUnique": {
+    "context": "product attribute error",
+    "string": "This variant already exists"
   },
   "src_dot_vouchers": {
     "context": "vouchers section name",

--- a/src/components/Timeline/TimelineNote.tsx
+++ b/src/components/Timeline/TimelineNote.tsx
@@ -79,14 +79,16 @@ export const TimelineNote: React.FC<TimelineNoteProps> = props => {
 
   return (
     <div className={classes.root}>
-      <Avatar
-        className={classes.avatar}
-        style={{ background: palette[CRC.str(user.email) % palette.length] }}
-      >
-        <PersonIcon />
-      </Avatar>
+      {user && (
+        <Avatar
+          className={classes.avatar}
+          style={{ background: palette[CRC.str(user.email) % palette.length] }}
+        >
+          <PersonIcon />
+        </Avatar>
+      )}
       <div className={classes.title}>
-        <Typography>{user.email}</Typography>
+        <Typography>{user?.email}</Typography>
         <Typography>
           <DateTime date={date} />
         </Typography>

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -59,6 +59,10 @@ export function decimal(value: string | number) {
   return value;
 }
 
+export function weight(value: string) {
+  return value === "" ? null : parseFloat(value);
+}
+
 export const removeDoubleSlashes = (url: string) =>
   url.replace(/([^:]\/)\/+/g, "$1");
 

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -825,6 +825,30 @@ export const order = (placeholder: string): OrderDetails_order => ({
         email: "admin@example.com",
         id: "QWRkcmVzczoxNQ=="
       }
+    },
+    {
+      __typename: "OrderEvent",
+      amount: null,
+      date: "2019-09-17T13:22:24.376193+00:00",
+      email: null,
+      emailType: null,
+      id: "T3JkZXJFdmVudDo0",
+      message: "This is note",
+      quantity: null,
+      type: OrderEventsEnum.NOTE_ADDED,
+      user: null
+    },
+    {
+      __typename: "OrderEvent",
+      amount: null,
+      date: "2019-09-17T13:22:24.376193+00:00",
+      email: null,
+      emailType: null,
+      id: "T3JkZXJFdmVudDo1",
+      message: "This is note",
+      quantity: null,
+      type: OrderEventsEnum.NOTE_ADDED,
+      user: null
     }
   ],
   fulfillments: [

--- a/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
+++ b/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
@@ -105,7 +105,7 @@ const ProductTypeCreatePage: React.FC<ProductTypeCreatePageProps> = ({
               <ProductTypeShipping
                 disabled={disabled}
                 data={data}
-                defaultWeightUnit={defaultWeightUnit}
+                weightUnit={defaultWeightUnit}
                 onChange={change}
               />
             </div>

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -199,7 +199,7 @@ const ProductTypeDetailsPage: React.FC<ProductTypeDetailsPageProps> = ({
               <ProductTypeShipping
                 disabled={disabled}
                 data={data}
-                defaultWeightUnit={defaultWeightUnit}
+                weightUnit={productType?.weight?.unit || defaultWeightUnit}
                 onChange={change}
               />
             </div>

--- a/src/productTypes/components/ProductTypeShipping/ProductTypeShipping.tsx
+++ b/src/productTypes/components/ProductTypeShipping/ProductTypeShipping.tsx
@@ -6,21 +6,20 @@ import { useIntl } from "react-intl";
 
 import CardTitle from "@saleor/components/CardTitle";
 import { ControlledCheckbox } from "@saleor/components/ControlledCheckbox";
-import { WeightUnitsEnum } from "../../../types/globalTypes";
 
 interface ProductTypeShippingProps {
   data: {
     isShippingRequired: boolean;
     weight: number | null;
   };
-  defaultWeightUnit: WeightUnitsEnum;
+  weightUnit: string;
   disabled: boolean;
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
 const ProductTypeShipping: React.FC<ProductTypeShippingProps> = ({
   data,
-  defaultWeightUnit,
+  weightUnit,
   disabled,
   onChange
 }) => {
@@ -48,7 +47,7 @@ const ProductTypeShipping: React.FC<ProductTypeShippingProps> = ({
         {data.isShippingRequired && (
           <TextField
             disabled={disabled}
-            InputProps={{ endAdornment: defaultWeightUnit }}
+            InputProps={{ endAdornment: weightUnit }}
             label={intl.formatMessage({
               defaultMessage: "Weight"
             })}

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -43,6 +43,7 @@ import ProductDetailsForm from "../ProductDetailsForm";
 import ProductOrganization from "../ProductOrganization";
 import ProductPricing from "../ProductPricing";
 import ProductStocks, { ProductStockInput } from "../ProductStocks";
+import ProductShipping from "../ProductShipping/ProductShipping";
 
 interface FormData {
   basePrice: number;
@@ -59,6 +60,7 @@ interface FormData {
   sku: string;
   stockQuantity: number;
   trackInventory: boolean;
+  weight: string;
 }
 export interface ProductCreatePageSubmitData extends FormData {
   attributes: ProductAttributeInput[];
@@ -82,6 +84,7 @@ interface ProductCreatePageProps {
   }>;
   header: string;
   saveButtonBarState: ConfirmButtonTransitionState;
+  weightUnit: string;
   warehouses: SearchWarehouses_search_edges_node[];
   fetchCategories: (data: string) => void;
   fetchCollections: (data: string) => void;
@@ -107,6 +110,7 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
   warehouses,
   onBack,
   fetchProductTypes,
+  weightUnit,
   onSubmit
 }: ProductCreatePageProps) => {
   const intl = useIntl();
@@ -143,7 +147,8 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
     seoTitle: "",
     sku: null,
     stockQuantity: null,
-    trackInventory: false
+    trackInventory: false,
+    weight: ""
   };
 
   // Display values
@@ -242,6 +247,14 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
                 <CardSpacer />
                 {!!productType && !productType.hasVariants && (
                   <>
+                    <ProductShipping
+                      data={data}
+                      disabled={disabled}
+                      errors={errors}
+                      weightUnit={weightUnit}
+                      onChange={change}
+                    />
+                    <CardSpacer />
                     <ProductStocks
                       data={data}
                       disabled={disabled}

--- a/src/products/components/ProductShipping/ProductShipping.tsx
+++ b/src/products/components/ProductShipping/ProductShipping.tsx
@@ -1,0 +1,65 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import TextField from "@material-ui/core/TextField";
+import CardTitle from "@saleor/components/CardTitle";
+import Grid from "@saleor/components/Grid";
+import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
+import React from "react";
+import { useIntl } from "react-intl";
+import { ProductErrorFragment } from "@saleor/attributes/types/ProductErrorFragment";
+
+interface ProductShippingProps {
+  data: {
+    weight: string;
+  };
+  disabled: boolean;
+  errors: ProductErrorFragment[];
+  weightUnit: string;
+  onChange: (event: React.ChangeEvent<any>) => void;
+}
+
+const ProductShipping: React.FC<ProductShippingProps> = props => {
+  const { data, disabled, errors, weightUnit, onChange } = props;
+
+  const intl = useIntl();
+
+  const formErrors = getFormErrors(["weight"], errors);
+
+  return (
+    <Card>
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Shipping",
+          description: "product shipping"
+        })}
+      />
+      <CardContent>
+        <Grid variant="uniform">
+          <TextField
+            disabled={disabled}
+            label={intl.formatMessage({
+              defaultMessage: "Weight",
+              description: "product weight"
+            })}
+            error={!!formErrors.weight}
+            helperText={getProductErrorMessage(formErrors.weight, intl)}
+            name="weight"
+            value={data.weight}
+            onChange={onChange}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">{weightUnit}</InputAdornment>
+              ),
+              inputProps: {
+                min: 0
+              }
+            }}
+          />
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+};
+ProductShipping.displayName = "ProductShipping";
+export default ProductShipping;

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -50,8 +50,10 @@ import ProductOrganization from "../ProductOrganization";
 import ProductPricing from "../ProductPricing";
 import ProductVariants from "../ProductVariants";
 import ProductStocks, { ProductStockInput } from "../ProductStocks";
+import ProductShipping from "../ProductShipping/ProductShipping";
 
 export interface ProductUpdatePageProps extends ListActions {
+  defaultWeightUnit: string;
   errors: ProductErrorFragment[];
   placeholderImage: string;
   collections: SearchCollections_search_edges_node[];
@@ -89,6 +91,7 @@ export interface ProductUpdatePageSubmitData extends ProductUpdatePageFormData {
 }
 
 export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
+  defaultWeightUnit,
   disabled,
   categories: categoryChoiceList,
   collections: collectionChoiceList,
@@ -269,33 +272,43 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
                       toggleAll={toggleAll}
                     />
                   ) : (
-                    <ProductStocks
-                      data={data}
-                      disabled={disabled}
-                      errors={errors}
-                      stocks={stocks}
-                      warehouses={warehouses}
-                      onChange={(id, value) => {
-                        triggerChange();
-                        changeStockData(id, value);
-                      }}
-                      onFormDataChange={change}
-                      onWarehouseStockAdd={id => {
-                        triggerChange();
-                        addStock({
-                          data: null,
-                          id,
-                          label: warehouses.find(
-                            warehouse => warehouse.id === id
-                          ).name,
-                          value: "0"
-                        });
-                      }}
-                      onWarehouseStockDelete={id => {
-                        triggerChange();
-                        removeStock(id);
-                      }}
-                    />
+                    <>
+                      <ProductShipping
+                        data={data}
+                        disabled={disabled}
+                        errors={errors}
+                        weightUnit={product?.weight?.unit || defaultWeightUnit}
+                        onChange={change}
+                      />
+                      <CardSpacer />
+                      <ProductStocks
+                        data={data}
+                        disabled={disabled}
+                        errors={errors}
+                        stocks={stocks}
+                        warehouses={warehouses}
+                        onChange={(id, value) => {
+                          triggerChange();
+                          changeStockData(id, value);
+                        }}
+                        onFormDataChange={change}
+                        onWarehouseStockAdd={id => {
+                          triggerChange();
+                          addStock({
+                            data: null,
+                            id,
+                            label: warehouses.find(
+                              warehouse => warehouse.id === id
+                            ).name,
+                            value: "0"
+                          });
+                        }}
+                        onWarehouseStockDelete={id => {
+                          triggerChange();
+                          removeStock(id);
+                        }}
+                      />
+                    </>
                   )}
                   <CardSpacer />
                   <SeoForm

--- a/src/products/components/ProductVariantAttributes/ProductVariantAttributes.tsx
+++ b/src/products/components/ProductVariantAttributes/ProductVariantAttributes.tsx
@@ -2,7 +2,7 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import Typography from "@material-ui/core/Typography";
 import React from "react";
-import { IntlShape, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import CardTitle from "@saleor/components/CardTitle";
 import FormSpacer from "@saleor/components/FormSpacer";
@@ -14,7 +14,7 @@ import Skeleton from "@saleor/components/Skeleton";
 import { FormsetAtomicData, FormsetChange } from "@saleor/hooks/useFormset";
 import { commonMessages } from "@saleor/intl";
 import { VariantCreate_productVariantCreate_errors } from "@saleor/products/types/VariantCreate";
-import { ProductErrorCode } from "@saleor/types/globalTypes";
+import { getProductVariantAttributeErrorMessage } from "@saleor/utils/errors/product";
 import { ProductVariant_attributes_attribute_values } from "../../types/ProductVariant";
 
 export interface VariantAttributeInputData {
@@ -67,19 +67,6 @@ function getAttributeValueChoices(
   }));
 }
 
-function translateErrors(intl: IntlShape) {
-  return {
-    [ProductErrorCode.REQUIRED]: intl.formatMessage({
-      defaultMessage: "All attributes should have value",
-      description: "product attribute error"
-    }),
-    [ProductErrorCode.UNIQUE]: intl.formatMessage({
-      defaultMessage: "This variant already exists",
-      description: "product attribute error"
-    })
-  };
-}
-
 const ProductVariantAttributes: React.FC<ProductVariantAttributesProps> = ({
   attributes,
   disabled,
@@ -87,8 +74,6 @@ const ProductVariantAttributes: React.FC<ProductVariantAttributesProps> = ({
   onChange
 }) => {
   const intl = useIntl();
-
-  const translatedErrors = translateErrors(intl);
 
   return (
     <Card>
@@ -127,7 +112,7 @@ const ProductVariantAttributes: React.FC<ProductVariantAttributesProps> = ({
               .filter(error => error.field === "attributes")
               .map(error => (
                 <Typography color="error" key={error.code}>
-                  {translatedErrors[error.code]}
+                  {getProductVariantAttributeErrorMessage(error, intl)}
                 </Typography>
               ))}
           </>

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -18,6 +18,7 @@ import { ProductErrorFragment } from "@saleor/attributes/types/ProductErrorFragm
 import { SearchWarehouses_search_edges_node } from "@saleor/searches/types/SearchWarehouses";
 import { maybe } from "../../../misc";
 import { ProductVariantCreateData_product } from "../../types/ProductVariantCreateData";
+import ProductShipping from "../ProductShipping/ProductShipping";
 import ProductVariantAttributes, {
   VariantAttributeInputData
 } from "../ProductVariantAttributes";
@@ -32,6 +33,7 @@ interface ProductVariantCreatePageFormData {
   quantity: string;
   sku: string;
   trackInventory: boolean;
+  weight: string;
 }
 
 export interface ProductVariantCreatePageSubmitData
@@ -48,6 +50,7 @@ interface ProductVariantCreatePageProps {
   product: ProductVariantCreateData_product;
   saveButtonBarState: ConfirmButtonTransitionState;
   warehouses: SearchWarehouses_search_edges_node[];
+  weightUnit: string;
   onBack: () => void;
   onSubmit: (data: ProductVariantCreatePageSubmitData) => void;
   onVariantClick: (variantId: string) => void;
@@ -61,6 +64,7 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
   product,
   saveButtonBarState,
   warehouses,
+  weightUnit,
   onBack,
   onSubmit,
   onVariantClick
@@ -86,7 +90,8 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
     priceOverride: "",
     quantity: "0",
     sku: "",
-    trackInventory: true
+    trackInventory: true,
+    weight: ""
   };
 
   const handleSubmit = (data: ProductVariantCreatePageFormData) =>
@@ -134,6 +139,14 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
                   currencySymbol={currencySymbol}
                   costPrice={data.costPrice}
                   loading={disabled}
+                  onChange={change}
+                />
+                <CardSpacer />
+                <ProductShipping
+                  data={data}
+                  disabled={disabled}
+                  errors={errors}
+                  weightUnit={weightUnit}
                   onChange={change}
                 />
                 <CardSpacer />

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -21,6 +21,7 @@ import {
 import { WarehouseFragment } from "@saleor/warehouses/types/WarehouseFragment";
 import { maybe } from "../../../misc";
 import { ProductVariant } from "../../types/ProductVariant";
+import ProductShipping from "../ProductShipping/ProductShipping";
 import ProductVariantAttributes, {
   VariantAttributeInputData
 } from "../ProductVariantAttributes";
@@ -35,6 +36,7 @@ export interface ProductVariantPageFormData {
   priceOverride: string;
   sku: string;
   trackInventory: boolean;
+  weight: string;
 }
 
 export interface ProductVariantPageSubmitData
@@ -46,6 +48,7 @@ export interface ProductVariantPageSubmitData
 }
 
 interface ProductVariantPageProps {
+  defaultWeightUnit: string;
   variant?: ProductVariant;
   errors: VariantUpdate_productVariantUpdate_errors[];
   saveButtonBarState: ConfirmButtonTransitionState;
@@ -62,6 +65,7 @@ interface ProductVariantPageProps {
 }
 
 const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
+  defaultWeightUnit,
   errors,
   loading,
   header,
@@ -112,7 +116,8 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
     costPrice: maybe(() => variant.costPrice.amount.toString(), ""),
     priceOverride: maybe(() => variant.priceOverride.amount.toString(), ""),
     sku: maybe(() => variant.sku, ""),
-    trackInventory: variant?.trackInventory
+    trackInventory: variant?.trackInventory,
+    weight: variant?.weight?.value.toString() || ""
   };
 
   const handleSubmit = (data: ProductVariantPageFormData) => {
@@ -192,6 +197,14 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                       }
                       costPrice={data.costPrice}
                       loading={loading}
+                      onChange={change}
+                    />
+                    <CardSpacer />
+                    <ProductShipping
+                      data={data}
+                      disabled={loading}
+                      errors={errors}
+                      weightUnit={variant?.weight?.unit || defaultWeightUnit}
                       onChange={change}
                     />
                     <CardSpacer />

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -277,7 +277,12 @@ export const product: (
           warehouse: warehouseList[1]
         }
       ],
-      trackInventory: true
+      trackInventory: true,
+      weight: {
+        __typename: "Weight",
+        unit: "kg",
+        value: 3
+      }
     },
     {
       __typename: "ProductVariant",
@@ -307,9 +312,19 @@ export const product: (
           warehouse: warehouseList[0]
         }
       ],
-      trackInventory: false
+      trackInventory: false,
+      weight: {
+        __typename: "Weight",
+        unit: "kg",
+        value: 4
+      }
     }
-  ]
+  ],
+  weight: {
+    __typename: "Weight",
+    unit: "kg",
+    value: 5
+  }
 });
 export const products = (
   placeholderImage: string
@@ -1275,7 +1290,12 @@ export const variant = (placeholderImage: string): ProductVariant => ({
       }
     }
   ],
-  trackInventory: true
+  trackInventory: true,
+  weight: {
+    __typename: "Weight",
+    unit: "kg",
+    value: 6
+  }
 });
 export const variantImages = (placeholderImage: string) =>
   variant(placeholderImage).images;

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -206,6 +206,7 @@ export const simpleProductUpdateMutation = gql`
     $addStocks: [StockInput!]!
     $deleteStocks: [ID!]!
     $updateStocks: [StockInput!]!
+    $weight: WeightScalar
   ) {
     productUpdate(
       id: $id
@@ -220,6 +221,7 @@ export const simpleProductUpdateMutation = gql`
         name: $name
         basePrice: $basePrice
         seo: $seo
+        weight: $weight
       }
     ) {
       errors: productErrors {

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -295,6 +295,7 @@ export const productCreateMutation = gql`
     $seo: SeoInput
     $stocks: [StockInput!]!
     $trackInventory: Boolean!
+    $weight: WeightScalar
   ) {
     productCreate(
       input: {
@@ -312,6 +313,7 @@ export const productCreateMutation = gql`
         seo: $seo
         stocks: $stocks
         trackInventory: $trackInventory
+        weight: $weight
       }
     ) {
       errors: productErrors {
@@ -360,6 +362,7 @@ export const variantUpdateMutation = gql`
     $sku: String
     $trackInventory: Boolean!
     $stocks: [StockInput!]!
+    $weight: WeightScalar
   ) {
     productVariantUpdate(
       id: $id
@@ -369,6 +372,7 @@ export const variantUpdateMutation = gql`
         priceOverride: $priceOverride
         sku: $sku
         trackInventory: $trackInventory
+        weight: $weight
       }
     ) {
       errors: productErrors {

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -185,11 +185,19 @@ export const productFragmentDetails = gql`
         ...StockFragment
       }
       trackInventory
+      weight {
+        unit
+        value
+      }
     }
     productType {
       id
       name
       hasVariants
+    }
+    weight {
+      unit
+      value
     }
   }
 `;
@@ -253,6 +261,10 @@ export const fragmentVariant = gql`
       ...StockFragment
     }
     trackInventory
+    weight {
+      unit
+      value
+    }
   }
 `;
 

--- a/src/products/types/Product.ts
+++ b/src/products/types/Product.ts
@@ -163,6 +163,12 @@ export interface Product_variants_stocks {
   warehouse: Product_variants_stocks_warehouse;
 }
 
+export interface Product_variants_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface Product_variants {
   __typename: "ProductVariant";
   id: string;
@@ -172,6 +178,13 @@ export interface Product_variants {
   margin: number | null;
   stocks: (Product_variants_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: Product_variants_weight | null;
+}
+
+export interface Product_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
 }
 
 export interface Product {
@@ -195,4 +208,5 @@ export interface Product {
   pricing: Product_pricing | null;
   images: (Product_images | null)[] | null;
   variants: (Product_variants | null)[] | null;
+  weight: Product_weight | null;
 }

--- a/src/products/types/ProductCreate.ts
+++ b/src/products/types/ProductCreate.ts
@@ -169,6 +169,12 @@ export interface ProductCreate_productCreate_product_variants_stocks {
   warehouse: ProductCreate_productCreate_product_variants_stocks_warehouse;
 }
 
+export interface ProductCreate_productCreate_product_variants_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface ProductCreate_productCreate_product_variants {
   __typename: "ProductVariant";
   id: string;
@@ -178,6 +184,13 @@ export interface ProductCreate_productCreate_product_variants {
   margin: number | null;
   stocks: (ProductCreate_productCreate_product_variants_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: ProductCreate_productCreate_product_variants_weight | null;
+}
+
+export interface ProductCreate_productCreate_product_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
 }
 
 export interface ProductCreate_productCreate_product {
@@ -201,6 +214,7 @@ export interface ProductCreate_productCreate_product {
   pricing: ProductCreate_productCreate_product_pricing | null;
   images: (ProductCreate_productCreate_product_images | null)[] | null;
   variants: (ProductCreate_productCreate_product_variants | null)[] | null;
+  weight: ProductCreate_productCreate_product_weight | null;
 }
 
 export interface ProductCreate_productCreate {
@@ -228,4 +242,5 @@ export interface ProductCreateVariables {
   seo?: SeoInput | null;
   stocks: StockInput[];
   trackInventory: boolean;
+  weight?: any | null;
 }

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -163,6 +163,12 @@ export interface ProductDetails_product_variants_stocks {
   warehouse: ProductDetails_product_variants_stocks_warehouse;
 }
 
+export interface ProductDetails_product_variants_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface ProductDetails_product_variants {
   __typename: "ProductVariant";
   id: string;
@@ -172,6 +178,13 @@ export interface ProductDetails_product_variants {
   margin: number | null;
   stocks: (ProductDetails_product_variants_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: ProductDetails_product_variants_weight | null;
+}
+
+export interface ProductDetails_product_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
 }
 
 export interface ProductDetails_product {
@@ -195,6 +208,7 @@ export interface ProductDetails_product {
   pricing: ProductDetails_product_pricing | null;
   images: (ProductDetails_product_images | null)[] | null;
   variants: (ProductDetails_product_variants | null)[] | null;
+  weight: ProductDetails_product_weight | null;
 }
 
 export interface ProductDetails {

--- a/src/products/types/ProductImageCreate.ts
+++ b/src/products/types/ProductImageCreate.ts
@@ -169,6 +169,12 @@ export interface ProductImageCreate_productImageCreate_product_variants_stocks {
   warehouse: ProductImageCreate_productImageCreate_product_variants_stocks_warehouse;
 }
 
+export interface ProductImageCreate_productImageCreate_product_variants_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface ProductImageCreate_productImageCreate_product_variants {
   __typename: "ProductVariant";
   id: string;
@@ -178,6 +184,13 @@ export interface ProductImageCreate_productImageCreate_product_variants {
   margin: number | null;
   stocks: (ProductImageCreate_productImageCreate_product_variants_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: ProductImageCreate_productImageCreate_product_variants_weight | null;
+}
+
+export interface ProductImageCreate_productImageCreate_product_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
 }
 
 export interface ProductImageCreate_productImageCreate_product {
@@ -201,6 +214,7 @@ export interface ProductImageCreate_productImageCreate_product {
   pricing: ProductImageCreate_productImageCreate_product_pricing | null;
   images: (ProductImageCreate_productImageCreate_product_images | null)[] | null;
   variants: (ProductImageCreate_productImageCreate_product_variants | null)[] | null;
+  weight: ProductImageCreate_productImageCreate_product_weight | null;
 }
 
 export interface ProductImageCreate_productImageCreate {

--- a/src/products/types/ProductImageUpdate.ts
+++ b/src/products/types/ProductImageUpdate.ts
@@ -169,6 +169,12 @@ export interface ProductImageUpdate_productImageUpdate_product_variants_stocks {
   warehouse: ProductImageUpdate_productImageUpdate_product_variants_stocks_warehouse;
 }
 
+export interface ProductImageUpdate_productImageUpdate_product_variants_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface ProductImageUpdate_productImageUpdate_product_variants {
   __typename: "ProductVariant";
   id: string;
@@ -178,6 +184,13 @@ export interface ProductImageUpdate_productImageUpdate_product_variants {
   margin: number | null;
   stocks: (ProductImageUpdate_productImageUpdate_product_variants_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: ProductImageUpdate_productImageUpdate_product_variants_weight | null;
+}
+
+export interface ProductImageUpdate_productImageUpdate_product_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
 }
 
 export interface ProductImageUpdate_productImageUpdate_product {
@@ -201,6 +214,7 @@ export interface ProductImageUpdate_productImageUpdate_product {
   pricing: ProductImageUpdate_productImageUpdate_product_pricing | null;
   images: (ProductImageUpdate_productImageUpdate_product_images | null)[] | null;
   variants: (ProductImageUpdate_productImageUpdate_product_variants | null)[] | null;
+  weight: ProductImageUpdate_productImageUpdate_product_weight | null;
 }
 
 export interface ProductImageUpdate_productImageUpdate {

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -169,6 +169,12 @@ export interface ProductUpdate_productUpdate_product_variants_stocks {
   warehouse: ProductUpdate_productUpdate_product_variants_stocks_warehouse;
 }
 
+export interface ProductUpdate_productUpdate_product_variants_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface ProductUpdate_productUpdate_product_variants {
   __typename: "ProductVariant";
   id: string;
@@ -178,6 +184,13 @@ export interface ProductUpdate_productUpdate_product_variants {
   margin: number | null;
   stocks: (ProductUpdate_productUpdate_product_variants_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: ProductUpdate_productUpdate_product_variants_weight | null;
+}
+
+export interface ProductUpdate_productUpdate_product_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
 }
 
 export interface ProductUpdate_productUpdate_product {
@@ -201,6 +214,7 @@ export interface ProductUpdate_productUpdate_product {
   pricing: ProductUpdate_productUpdate_product_pricing | null;
   images: (ProductUpdate_productUpdate_product_images | null)[] | null;
   variants: (ProductUpdate_productUpdate_product_variants | null)[] | null;
+  weight: ProductUpdate_productUpdate_product_weight | null;
 }
 
 export interface ProductUpdate_productUpdate {

--- a/src/products/types/ProductVariant.ts
+++ b/src/products/types/ProductVariant.ts
@@ -103,6 +103,12 @@ export interface ProductVariant_stocks {
   warehouse: ProductVariant_stocks_warehouse;
 }
 
+export interface ProductVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface ProductVariant {
   __typename: "ProductVariant";
   id: string;
@@ -115,4 +121,5 @@ export interface ProductVariant {
   sku: string;
   stocks: (ProductVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: ProductVariant_weight | null;
 }

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -103,6 +103,12 @@ export interface ProductVariantDetails_productVariant_stocks {
   warehouse: ProductVariantDetails_productVariant_stocks_warehouse;
 }
 
+export interface ProductVariantDetails_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface ProductVariantDetails_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -115,6 +121,7 @@ export interface ProductVariantDetails_productVariant {
   sku: string;
   stocks: (ProductVariantDetails_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: ProductVariantDetails_productVariant_weight | null;
 }
 
 export interface ProductVariantDetails {

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -770,4 +770,5 @@ export interface SimpleProductUpdateVariables {
   addStocks: StockInput[];
   deleteStocks: string[];
   updateStocks: StockInput[];
+  weight?: any | null;
 }

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -169,6 +169,12 @@ export interface SimpleProductUpdate_productUpdate_product_variants_stocks {
   warehouse: SimpleProductUpdate_productUpdate_product_variants_stocks_warehouse;
 }
 
+export interface SimpleProductUpdate_productUpdate_product_variants_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface SimpleProductUpdate_productUpdate_product_variants {
   __typename: "ProductVariant";
   id: string;
@@ -178,6 +184,13 @@ export interface SimpleProductUpdate_productUpdate_product_variants {
   margin: number | null;
   stocks: (SimpleProductUpdate_productUpdate_product_variants_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: SimpleProductUpdate_productUpdate_product_variants_weight | null;
+}
+
+export interface SimpleProductUpdate_productUpdate_product_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
 }
 
 export interface SimpleProductUpdate_productUpdate_product {
@@ -201,6 +214,7 @@ export interface SimpleProductUpdate_productUpdate_product {
   pricing: SimpleProductUpdate_productUpdate_product_pricing | null;
   images: (SimpleProductUpdate_productUpdate_product_images | null)[] | null;
   variants: (SimpleProductUpdate_productUpdate_product_variants | null)[] | null;
+  weight: SimpleProductUpdate_productUpdate_product_weight | null;
 }
 
 export interface SimpleProductUpdate_productUpdate {
@@ -312,6 +326,12 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_stocks 
   warehouse: SimpleProductUpdate_productVariantUpdate_productVariant_stocks_warehouse;
 }
 
+export interface SimpleProductUpdate_productVariantUpdate_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface SimpleProductUpdate_productVariantUpdate_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -324,6 +344,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant {
   sku: string;
   stocks: (SimpleProductUpdate_productVariantUpdate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: SimpleProductUpdate_productVariantUpdate_productVariant_weight | null;
 }
 
 export interface SimpleProductUpdate_productVariantUpdate {
@@ -436,6 +457,12 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_s
   warehouse: SimpleProductUpdate_productVariantStocksCreate_productVariant_stocks_warehouse;
 }
 
+export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -448,6 +475,7 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant {
   sku: string;
   stocks: (SimpleProductUpdate_productVariantStocksCreate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: SimpleProductUpdate_productVariantStocksCreate_productVariant_weight | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksCreate {
@@ -559,6 +587,12 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_s
   warehouse: SimpleProductUpdate_productVariantStocksDelete_productVariant_stocks_warehouse;
 }
 
+export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -571,6 +605,7 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant {
   sku: string;
   stocks: (SimpleProductUpdate_productVariantStocksDelete_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: SimpleProductUpdate_productVariantStocksDelete_productVariant_weight | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksDelete {
@@ -683,6 +718,12 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_s
   warehouse: SimpleProductUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse;
 }
 
+export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -695,6 +736,7 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant {
   sku: string;
   stocks: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: SimpleProductUpdate_productVariantStocksUpdate_productVariant_weight | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksUpdate {

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -111,6 +111,12 @@ export interface VariantCreate_productVariantCreate_productVariant_stocks {
   warehouse: VariantCreate_productVariantCreate_productVariant_stocks_warehouse;
 }
 
+export interface VariantCreate_productVariantCreate_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface VariantCreate_productVariantCreate_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -123,6 +129,7 @@ export interface VariantCreate_productVariantCreate_productVariant {
   sku: string;
   stocks: (VariantCreate_productVariantCreate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: VariantCreate_productVariantCreate_productVariant_weight | null;
 }
 
 export interface VariantCreate_productVariantCreate {

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -111,6 +111,12 @@ export interface VariantImageAssign_variantImageAssign_productVariant_stocks {
   warehouse: VariantImageAssign_variantImageAssign_productVariant_stocks_warehouse;
 }
 
+export interface VariantImageAssign_variantImageAssign_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface VariantImageAssign_variantImageAssign_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -123,6 +129,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant {
   sku: string;
   stocks: (VariantImageAssign_variantImageAssign_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: VariantImageAssign_variantImageAssign_productVariant_weight | null;
 }
 
 export interface VariantImageAssign_variantImageAssign {

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -111,6 +111,12 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_stocks
   warehouse: VariantImageUnassign_variantImageUnassign_productVariant_stocks_warehouse;
 }
 
+export interface VariantImageUnassign_variantImageUnassign_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface VariantImageUnassign_variantImageUnassign_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -123,6 +129,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant {
   sku: string;
   stocks: (VariantImageUnassign_variantImageUnassign_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: VariantImageUnassign_variantImageUnassign_productVariant_weight | null;
 }
 
 export interface VariantImageUnassign_variantImageUnassign {

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -111,6 +111,12 @@ export interface VariantUpdate_productVariantUpdate_productVariant_stocks {
   warehouse: VariantUpdate_productVariantUpdate_productVariant_stocks_warehouse;
 }
 
+export interface VariantUpdate_productVariantUpdate_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface VariantUpdate_productVariantUpdate_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -123,6 +129,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant {
   sku: string;
   stocks: (VariantUpdate_productVariantUpdate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: VariantUpdate_productVariantUpdate_productVariant_weight | null;
 }
 
 export interface VariantUpdate_productVariantUpdate {
@@ -235,6 +242,12 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_stocks 
   warehouse: VariantUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse;
 }
 
+export interface VariantUpdate_productVariantStocksUpdate_productVariant_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
 export interface VariantUpdate_productVariantStocksUpdate_productVariant {
   __typename: "ProductVariant";
   id: string;
@@ -247,6 +260,7 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant {
   sku: string;
   stocks: (VariantUpdate_productVariantStocksUpdate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
+  weight: VariantUpdate_productVariantStocksUpdate_productVariant_weight | null;
 }
 
 export interface VariantUpdate_productVariantStocksUpdate {
@@ -337,4 +351,5 @@ export interface VariantUpdateVariables {
   sku?: string | null;
   trackInventory: boolean;
   stocks: StockInput[];
+  weight?: any | null;
 }

--- a/src/products/utils/data.ts
+++ b/src/products/utils/data.ts
@@ -181,6 +181,7 @@ export interface ProductUpdatePageFormData {
   seoTitle: string;
   sku: string;
   trackInventory: boolean;
+  weight: string;
 }
 
 export function getProductUpdatePageFormData(
@@ -210,7 +211,8 @@ export function getProductUpdatePageFormData(
           : undefined,
       ""
     ),
-    trackInventory: !!product?.variants[0]?.trackInventory
+    trackInventory: !!product?.variants[0]?.trackInventory,
+    weight: product?.weight?.value.toString() || ""
   };
 }
 

--- a/src/products/views/ProductCreate.tsx
+++ b/src/products/views/ProductCreate.tsx
@@ -10,7 +10,7 @@ import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import useProductTypeSearch from "@saleor/searches/useProductTypeSearch";
 import { useWarehouseList } from "@saleor/warehouses/queries";
-import { decimal, maybe } from "../../misc";
+import { decimal, maybe, weight } from "../../misc";
 import ProductCreatePage, {
   ProductCreatePageSubmitData
 } from "../components/ProductCreatePage";
@@ -95,7 +95,8 @@ export const ProductCreateView: React.FC = () => {
                 quantity: parseInt(stock.value, 0),
                 warehouse: stock.id
               })),
-              trackInventory: formData.trackInventory
+              trackInventory: formData.trackInventory,
+              weight: weight(formData.weight)
             }
           });
         };
@@ -157,6 +158,7 @@ export const ProductCreateView: React.FC = () => {
               warehouses={
                 warehouses.data?.warehouses.edges.map(edge => edge.node) || []
               }
+              weightUnit={shop?.defaultWeightUnit}
             />
           </>
         );

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -17,6 +17,7 @@ import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import NotFoundPage from "@saleor/components/NotFoundPage";
 import { useWarehouseList } from "@saleor/warehouses/queries";
+import useShop from "@saleor/hooks/useShop";
 import { getMutationState, maybe } from "../../../misc";
 import ProductUpdatePage from "../../components/ProductUpdatePage";
 import ProductUpdateOperations from "../../containers/ProductUpdateOperations";
@@ -75,6 +76,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
       first: 50
     }
   });
+  const shop = useShop();
 
   const [openModal, closeModal] = createDialogActionHandlers<
     ProductUrlDialog,
@@ -213,6 +215,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
                   <ProductUpdatePage
                     categories={categories}
                     collections={collections}
+                    defaultWeightUnit={shop?.defaultWeightUnit}
                     disabled={disableFormSave}
                     errors={errors}
                     fetchCategories={searchCategories}

--- a/src/products/views/ProductUpdate/handlers.ts
+++ b/src/products/views/ProductUpdate/handlers.ts
@@ -1,4 +1,4 @@
-import { decimal } from "@saleor/misc";
+import { decimal, weight } from "@saleor/misc";
 import { ProductUpdatePageSubmitData } from "@saleor/products/components/ProductUpdatePage";
 import { ProductDetails_product } from "@saleor/products/types/ProductDetails";
 import { ProductImageCreateVariables } from "@saleor/products/types/ProductImageCreate";
@@ -48,7 +48,8 @@ export function createUpdateHandler(
           sku: data.sku,
           trackInventory: data.trackInventory
         },
-        updateStocks: data.updateStocks.map(mapFormsetStockToStockInput)
+        updateStocks: data.updateStocks.map(mapFormsetStockToStockInput),
+        weight: weight(data.weight)
       });
     }
   };

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -9,7 +9,8 @@ import { commonMessages } from "@saleor/intl";
 import NotFoundPage from "@saleor/components/NotFoundPage";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import { useWarehouseList } from "@saleor/warehouses/queries";
-import { decimal } from "../../misc";
+import useShop from "@saleor/hooks/useShop";
+import { decimal, weight } from "../../misc";
 import ProductVariantDeleteDialog from "../components/ProductVariantDeleteDialog";
 import ProductVariantPage, {
   ProductVariantPageSubmitData
@@ -40,6 +41,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
   productId,
   params
 }) => {
+  const shop = useShop();
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
@@ -129,6 +131,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
                 <>
                   <WindowTitle title={data?.productVariant?.name} />
                   <ProductVariantPage
+                    defaultWeightUnit={shop?.defaultWeightUnit}
                     errors={errors}
                     saveButtonBarState={updateVariant.opts.status}
                     loading={disableFormSave}
@@ -161,7 +164,8 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
                         stocks: data.updateStocks.map(
                           mapFormsetStockToStockInput
                         ),
-                        trackInventory: data.trackInventory
+                        trackInventory: data.trackInventory,
+                        weight: weight(data.weight)
                       })
                     }
                     onVariantClick={variantId => {

--- a/src/products/views/ProductVariantCreate.tsx
+++ b/src/products/views/ProductVariantCreate.tsx
@@ -8,7 +8,7 @@ import useShop from "@saleor/hooks/useShop";
 import NotFoundPage from "@saleor/components/NotFoundPage";
 import { commonMessages } from "@saleor/intl";
 import { useWarehouseList } from "@saleor/warehouses/queries";
-import { decimal } from "../../misc";
+import { decimal, weight } from "../../misc";
 import ProductVariantCreatePage, {
   ProductVariantCreatePageSubmitData
 } from "../components/ProductVariantCreatePage";
@@ -82,7 +82,8 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
                         quantity: parseInt(stock.value, 0),
                         warehouse: stock.id
                       })),
-                      trackInventory: true
+                      trackInventory: true,
+                      weight: weight(formData.weight)
                     }
                   }
                 });
@@ -120,6 +121,7 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
                         edge => edge.node
                       ) || []
                     }
+                    weightUnit={shop?.defaultWeightUnit}
                   />
                 </>
               );

--- a/src/storybook/stories/products/ProductCreatePage.tsx
+++ b/src/storybook/stories/products/ProductCreatePage.tsx
@@ -34,6 +34,7 @@ storiesOf("Views / Products / Create product", module)
       onSubmit={() => undefined}
       saveButtonBarState="default"
       warehouses={warehouseList}
+      weightUnit="kg"
     />
   ))
   .add("When loading", () => (
@@ -55,6 +56,7 @@ storiesOf("Views / Products / Create product", module)
       onSubmit={() => undefined}
       saveButtonBarState="default"
       warehouses={undefined}
+      weightUnit="kg"
     />
   ))
   .add("form errors", () => (
@@ -82,5 +84,6 @@ storiesOf("Views / Products / Create product", module)
       onSubmit={() => undefined}
       saveButtonBarState="default"
       warehouses={warehouseList}
+      weightUnit="kg"
     />
   ));

--- a/src/storybook/stories/products/ProductUpdatePage.tsx
+++ b/src/storybook/stories/products/ProductUpdatePage.tsx
@@ -19,6 +19,7 @@ const props: ProductUpdatePageProps = {
   ...listActionsProps,
   categories: [product.category],
   collections,
+  defaultWeightUnit: "kg",
   disabled: false,
   errors: [],
   fetchCategories: () => undefined,

--- a/src/storybook/stories/products/ProductVariantCreatePage.tsx
+++ b/src/storybook/stories/products/ProductVariantCreatePage.tsx
@@ -15,6 +15,7 @@ storiesOf("Views / Products / Create product variant", module)
   .add("default", () => (
     <ProductVariantCreatePage
       currencySymbol="USD"
+      weightUnit="kg"
       disabled={false}
       errors={[]}
       header="Add variant"
@@ -29,6 +30,7 @@ storiesOf("Views / Products / Create product variant", module)
   .add("with errors", () => (
     <ProductVariantCreatePage
       currencySymbol="USD"
+      weightUnit="kg"
       disabled={false}
       errors={[
         {
@@ -59,6 +61,7 @@ storiesOf("Views / Products / Create product variant", module)
   .add("when loading data", () => (
     <ProductVariantCreatePage
       currencySymbol="USD"
+      weightUnit="kg"
       disabled={true}
       errors={[]}
       header="Add variant"
@@ -73,6 +76,7 @@ storiesOf("Views / Products / Create product variant", module)
   .add("add first variant", () => (
     <ProductVariantCreatePage
       currencySymbol="USD"
+      weightUnit="kg"
       disabled={false}
       errors={[]}
       header="Add variant"

--- a/src/storybook/stories/products/ProductVariantPage.tsx
+++ b/src/storybook/stories/products/ProductVariantPage.tsx
@@ -14,6 +14,7 @@ storiesOf("Views / Products / Product variant details", module)
   .addDecorator(Decorator)
   .add("when loaded data", () => (
     <ProductVariantPage
+      defaultWeightUnit="kg"
       header={variant.name || variant.sku}
       errors={[]}
       variant={variant}
@@ -29,6 +30,7 @@ storiesOf("Views / Products / Product variant details", module)
   ))
   .add("when loading data", () => (
     <ProductVariantPage
+      defaultWeightUnit="kg"
       header={undefined}
       errors={[]}
       loading={true}
@@ -45,6 +47,7 @@ storiesOf("Views / Products / Product variant details", module)
   ))
   .add("attribute errors", () => (
     <ProductVariantPage
+      defaultWeightUnit="kg"
       header={variant.name || variant.sku}
       variant={variant}
       onAdd={() => undefined}

--- a/src/utils/errors/product.ts
+++ b/src/utils/errors/product.ts
@@ -14,8 +14,15 @@ const messages = defineMessages({
   attributeCannotBeAssigned: {
     defaultMessage: "This attribute cannot be assigned to this product type"
   },
+  attributeRequired: {
+    defaultMessage: "All attributes should have value",
+    description: "product attribute error"
+  },
   attributeVariantsDisabled: {
     defaultMessage: "Variants are disabled in this product type"
+  },
+  duplicatedInputItem: {
+    defaultMessage: "Variant with these attributes already exists"
   },
   skuUnique: {
     defaultMessage: "SKUs must be unique",
@@ -23,6 +30,10 @@ const messages = defineMessages({
   },
   variantNoDigitalContent: {
     defaultMessage: "This variant does not have any digital content"
+  },
+  variantUnique: {
+    defaultMessage: "This variant already exists",
+    description: "product attribute error"
   }
 });
 
@@ -38,6 +49,8 @@ function getProductErrorMessage(
         return intl.formatMessage(messages.attributeCannotBeAssigned);
       case ProductErrorCode.ATTRIBUTE_VARIANTS_DISABLED:
         return intl.formatMessage(messages.attributeVariantsDisabled);
+      case ProductErrorCode.DUPLICATED_INPUT_ITEM:
+        return intl.formatMessage(messages.duplicatedInputItem);
       case ProductErrorCode.GRAPHQL_ERROR:
         return intl.formatMessage(commonErrorMessages.graphqlError);
       case ProductErrorCode.REQUIRED:
@@ -48,6 +61,24 @@ function getProductErrorMessage(
         return intl.formatMessage(commonErrorMessages.invalid);
       default:
         return intl.formatMessage(commonErrorMessages.unknownError);
+    }
+  }
+
+  return undefined;
+}
+
+export function getProductVariantAttributeErrorMessage(
+  err: Omit<ProductErrorFragment, "__typename"> | undefined,
+  intl: IntlShape
+): string {
+  if (err) {
+    switch (err.code) {
+      case ProductErrorCode.REQUIRED:
+        return intl.formatMessage(messages.attributeRequired);
+      case ProductErrorCode.UNIQUE:
+        return intl.formatMessage(messages.variantUnique);
+      default:
+        return getProductErrorMessage(err, intl);
     }
   }
 

--- a/src/warehouses/components/WarehouseDetailsPage/WarehouseDetailsPage.tsx
+++ b/src/warehouses/components/WarehouseDetailsPage/WarehouseDetailsPage.tsx
@@ -51,7 +51,9 @@ const WarehouseDetailsPage: React.FC<WarehouseDetailsPageProps> = ({
   onSubmit
 }) => {
   const intl = useIntl();
-  const [displayCountry, setDisplayCountry] = useStateFromProps("");
+  const [displayCountry, setDisplayCountry] = useStateFromProps(
+    warehouse?.address?.country.country || ""
+  );
 
   const {
     errors: validationErrors,


### PR DESCRIPTION
I want to merge this change because it adds weight to products, enabling shop user to properly set up weight-based shipping rates. It also fixes bug causing dashboard to crash if no author was given in order note, and always displays actual weight unit, not the shops default. 

**PR intended to be tested with API branch:** 2.10

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
