### PR TITLE
Reset modal state after closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update to newest schema - #638 by @dominik-zeglen
 - Fix missing save button - #636 by @dominik-zeglen
 - Fix user avatars - #639 by @dominik-zeglen
+- Reset modal state after closing - #644 by @dominik-zeglen
 
 ## 2.10.1
 

--- a/src/products/components/ProductExportDialog/ProductExportDialogInfo.tsx
+++ b/src/products/components/ProductExportDialog/ProductExportDialogInfo.tsx
@@ -190,6 +190,7 @@ const FieldAccordion: React.FC<AccordionProps & {
                     }
                   })
                 }
+                key={field}
               />
             ))}
             {selectedFields.length > maxChips && (
@@ -331,6 +332,7 @@ const ProductExportDialogInfo: React.FC<ProductExportDialogInfoProps> = ({
                       }
                     })
                   }
+                  key={attribute.value}
                 />
               ))}
               {selectedAttributes.length > maxChips && (


### PR DESCRIPTION
I want to merge this change because it resets product export modal to initial state after closing.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
