### PR TITLE
Fix updating product that has no variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Reset modal state after closing - #644 by @dominik-zeglen
 - Fix incorrect messages - #643 by @dominik-zeglen
 - Do not use devserver to run cypress tests - #650 by @dominik-zeglen
+- Fix updating product that has no variants - #649 by @dominik-zeglen
 
 ## 2.10.1
 

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -167,23 +167,33 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
   const hasVariants = maybe(() => product.productType.hasVariants, false);
 
   const handleSubmit = (data: ProductUpdatePageFormData) => {
-    const dataStocks = stocks.map(stock => stock.id);
-    const variantStocks = product.variants[0].stocks.map(
-      stock => stock.warehouse.id
-    );
-    const stockDiff = diff(variantStocks, dataStocks);
+    if (product.productType.hasVariants) {
+      onSubmit({
+        ...data,
+        addStocks: [],
+        attributes,
+        removeStocks: [],
+        updateStocks: []
+      });
+    } else {
+      const dataStocks = stocks.map(stock => stock.id);
+      const variantStocks = product.variants[0]?.stocks.map(
+        stock => stock.warehouse.id
+      );
+      const stockDiff = diff(variantStocks, dataStocks);
 
-    onSubmit({
-      ...data,
-      addStocks: stocks.filter(stock =>
-        stockDiff.added.some(addedStock => addedStock === stock.id)
-      ),
-      attributes,
-      removeStocks: stockDiff.removed,
-      updateStocks: stocks.filter(
-        stock => !stockDiff.added.some(addedStock => addedStock === stock.id)
-      )
-    });
+      onSubmit({
+        ...data,
+        addStocks: stocks.filter(stock =>
+          stockDiff.added.some(addedStock => addedStock === stock.id)
+        ),
+        attributes,
+        removeStocks: stockDiff.removed,
+        updateStocks: stocks.filter(
+          stock => !stockDiff.added.some(addedStock => addedStock === stock.id)
+        )
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
I want to merge this change because it fixes following bug:

1. Go to "Create Product" view.
2. Fill "name" and "description", select "product type" and save the product.
3. After product is saved, change visibility to "Visible" and hit "Save".
4. Observe errors in the console

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
