### PR TITLE
Do not use devserver to  run cypress tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,8 @@ jobs:
         env:
           API_URI: https://pwa.demo.saleor.rocks/graphql/
         with:
-          start: |
-            npm start
+          build: npm run build
+          start: npx http-server -a localhost -p 9000 build/dashboard
           wait-on: http://localhost:9000/
           wait-on-timeout: 120
       - uses: actions/upload-artifact@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix user avatars - #639 by @dominik-zeglen
 - Reset modal state after closing - #644 by @dominik-zeglen
 - Fix incorrect messages - #643 by @dominik-zeglen
+- Do not use devserver to run cypress tests - #650 by @dominik-zeglen
 
 ## 2.10.1
 


### PR DESCRIPTION
I want to merge this change because cypress tests were failing for some time because of devserver depleting CI resources.
They still don't work but at least they are executed :)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
