### PR TITLE
Add metadata to product view

### DIFF
--- a/src/components/Metadata/Metadata.tsx
+++ b/src/components/Metadata/Metadata.tsx
@@ -1,15 +1,16 @@
 import { ChangeEvent } from "@saleor/hooks/useForm";
+import { MetadataInput } from "@saleor/types/globalTypes";
 import { removeAtIndex, updateAtIndex } from "@saleor/utils/lists";
 import React from "react";
 
 import CardSpacer from "../CardSpacer";
 import MetadataCard, { MetadataCardProps } from "./MetadataCard";
-import { EventDataAction, EventDataField, MetadataItem } from "./types";
+import { EventDataAction, EventDataField } from "./types";
 import { getDataKey, parseEventData } from "./utils";
 
 export interface MetadataProps
   extends Omit<MetadataCardProps, "data" | "isPrivate"> {
-  data: Record<"metadata" | "privateMetadata", MetadataItem[]>;
+  data: Record<"metadata" | "privateMetadata", MetadataInput[]>;
 }
 
 const Metadata: React.FC<MetadataProps> = ({ data, onChange }) => {
@@ -25,6 +26,7 @@ const Metadata: React.FC<MetadataProps> = ({ data, onChange }) => {
           action === EventDataAction.update
             ? updateAtIndex(
                 {
+                  ...dataToUpdate[fieldIndex],
                   key:
                     field === EventDataField.name
                       ? value

--- a/src/components/Metadata/MetadataCard.tsx
+++ b/src/components/Metadata/MetadataCard.tsx
@@ -14,7 +14,8 @@ import Typography from "@material-ui/core/Typography";
 import ToggleIcon from "@material-ui/icons/ArrowDropDown";
 import DeleteIcon from "@material-ui/icons/Delete";
 import { FormChange } from "@saleor/hooks/useForm";
-import React from "react";
+import { MetadataInput } from "@saleor/types/globalTypes";
+import React, { useEffect } from "react";
 import SVG from "react-inlinesvg";
 import { useIntl } from "react-intl";
 import { FormattedMessage } from "react-intl";
@@ -22,10 +23,10 @@ import { FormattedMessage } from "react-intl";
 import CardTitle from "../CardTitle";
 import Skeleton from "../Skeleton";
 import useStyles from "./styles";
-import { EventDataAction, EventDataField, MetadataItem } from "./types";
+import { EventDataAction, EventDataField } from "./types";
 
 export interface MetadataCardProps {
-  data: MetadataItem[];
+  data: MetadataInput[];
   isPrivate: boolean;
   onChange: FormChange;
 }
@@ -40,8 +41,18 @@ const MetadataCard: React.FC<MetadataCardProps> = ({
   onChange
 }) => {
   const intl = useIntl();
-  const [expanded, setExpanded] = React.useState(data?.length === 0);
+  const loaded = React.useRef(false);
+  const [expanded, setExpanded] = React.useState(true);
   const classes = useStyles({});
+
+  useEffect(() => {
+    if (data !== undefined) {
+      loaded.current = true;
+      if (data.length > 0) {
+        setExpanded(false);
+      }
+    }
+  }, [data === undefined]);
 
   return (
     <Card

--- a/src/components/Metadata/types.ts
+++ b/src/components/Metadata/types.ts
@@ -1,4 +1,4 @@
-export type MetadataItem = Record<"key" | "value", string>;
+import { MetadataInput } from "@saleor/types/globalTypes";
 
 export enum EventDataAction {
   add = "add",
@@ -14,4 +14,8 @@ export interface EventData {
   field: EventDataField | null;
   fieldIndex: number | null;
   value: string;
+}
+export interface MetadataFormData {
+  metadata: MetadataInput[];
+  privateMetadata: MetadataInput[];
 }

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -134,3 +134,10 @@ export const pluginErrorFragment = gql`
     field
   }
 `;
+
+export const metadataErrorFragment = gql`
+  fragment MetadataErrorFragment on MetadataError {
+    code
+    field
+  }
+`;

--- a/src/fragments/metadata.ts
+++ b/src/fragments/metadata.ts
@@ -1,0 +1,16 @@
+import gql from "graphql-tag";
+
+export const metadataFragment = gql`
+  fragment MetadataItem on MetadataItem {
+    key
+    value
+  }
+  fragment Metadata on ObjectWithMetadata {
+    metadata {
+      ...MetadataItem
+    }
+    privateMetadata {
+      ...MetadataItem
+    }
+  }
+`;

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -1,5 +1,6 @@
 import gql from "graphql-tag";
 
+import { metadataFragment } from "./metadata";
 import { weightFragment } from "./weight";
 
 export const stockFragment = gql`
@@ -105,8 +106,10 @@ export const productFragmentDetails = gql`
   ${productVariantAttributesFragment}
   ${stockFragment}
   ${weightFragment}
+  ${metadataFragment}
   fragment Product on Product {
     ...ProductVariantAttributesFragment
+    ...Metadata
     name
     descriptionJson
     seoTitle

--- a/src/fragments/types/Metadata.ts
+++ b/src/fragments/types/Metadata.ts
@@ -1,0 +1,25 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: Metadata
+// ====================================================
+
+export interface Metadata_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface Metadata_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface Metadata {
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  metadata: (Metadata_metadata | null)[];
+  privateMetadata: (Metadata_privateMetadata | null)[];
+}

--- a/src/fragments/types/MetadataErrorFragment.ts
+++ b/src/fragments/types/MetadataErrorFragment.ts
@@ -1,0 +1,15 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { MetadataErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: MetadataErrorFragment
+// ====================================================
+
+export interface MetadataErrorFragment {
+  __typename: "MetadataError";
+  code: MetadataErrorCode;
+  field: string | null;
+}

--- a/src/fragments/types/MetadataItem.ts
+++ b/src/fragments/types/MetadataItem.ts
@@ -1,0 +1,13 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: MetadataItem
+// ====================================================
+
+export interface MetadataItem {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}

--- a/src/fragments/types/Product.ts
+++ b/src/fragments/types/Product.ts
@@ -93,6 +93,18 @@ export interface Product_pricing {
   priceRangeUndiscounted: Product_pricing_priceRangeUndiscounted | null;
 }
 
+export interface Product_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface Product_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface Product_category {
   __typename: "Category";
   id: string;
@@ -180,6 +192,8 @@ export interface Product {
   attributes: Product_attributes[];
   productType: Product_productType;
   pricing: Product_pricing | null;
+  metadata: (Product_metadata | null)[];
+  privateMetadata: (Product_privateMetadata | null)[];
   name: string;
   descriptionJson: any;
   seoTitle: string | null;

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -153,6 +153,13 @@ export const product: (
   isFeatured: false,
   isPublished: true,
   margin: { __typename: "Margin", start: 2, stop: 7 },
+  metadata: [
+    {
+      __typename: "MetadataItem",
+      key: "integration.id",
+      value: "100023123"
+    }
+  ],
   name: "Ergonomic Plastic Bacon",
   pricing: {
     __typename: "ProductPricingInfo",
@@ -186,6 +193,7 @@ export const product: (
       }
     }
   },
+  privateMetadata: [],
   productType: {
     __typename: "ProductType",
     hasVariants: true,

--- a/src/products/types/ProductCreate.ts
+++ b/src/products/types/ProductCreate.ts
@@ -99,6 +99,18 @@ export interface ProductCreate_productCreate_product_pricing {
   priceRangeUndiscounted: ProductCreate_productCreate_product_pricing_priceRangeUndiscounted | null;
 }
 
+export interface ProductCreate_productCreate_product_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ProductCreate_productCreate_product_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ProductCreate_productCreate_product_category {
   __typename: "Category";
   id: string;
@@ -186,6 +198,8 @@ export interface ProductCreate_productCreate_product {
   attributes: ProductCreate_productCreate_product_attributes[];
   productType: ProductCreate_productCreate_product_productType;
   pricing: ProductCreate_productCreate_product_pricing | null;
+  metadata: (ProductCreate_productCreate_product_metadata | null)[];
+  privateMetadata: (ProductCreate_productCreate_product_privateMetadata | null)[];
   name: string;
   descriptionJson: any;
   seoTitle: string | null;

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -93,6 +93,18 @@ export interface ProductDetails_product_pricing {
   priceRangeUndiscounted: ProductDetails_product_pricing_priceRangeUndiscounted | null;
 }
 
+export interface ProductDetails_product_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ProductDetails_product_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ProductDetails_product_category {
   __typename: "Category";
   id: string;
@@ -180,6 +192,8 @@ export interface ProductDetails_product {
   attributes: ProductDetails_product_attributes[];
   productType: ProductDetails_product_productType;
   pricing: ProductDetails_product_pricing | null;
+  metadata: (ProductDetails_product_metadata | null)[];
+  privateMetadata: (ProductDetails_product_privateMetadata | null)[];
   name: string;
   descriptionJson: any;
   seoTitle: string | null;

--- a/src/products/types/ProductImageCreate.ts
+++ b/src/products/types/ProductImageCreate.ts
@@ -99,6 +99,18 @@ export interface ProductImageCreate_productImageCreate_product_pricing {
   priceRangeUndiscounted: ProductImageCreate_productImageCreate_product_pricing_priceRangeUndiscounted | null;
 }
 
+export interface ProductImageCreate_productImageCreate_product_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ProductImageCreate_productImageCreate_product_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ProductImageCreate_productImageCreate_product_category {
   __typename: "Category";
   id: string;
@@ -186,6 +198,8 @@ export interface ProductImageCreate_productImageCreate_product {
   attributes: ProductImageCreate_productImageCreate_product_attributes[];
   productType: ProductImageCreate_productImageCreate_product_productType;
   pricing: ProductImageCreate_productImageCreate_product_pricing | null;
+  metadata: (ProductImageCreate_productImageCreate_product_metadata | null)[];
+  privateMetadata: (ProductImageCreate_productImageCreate_product_privateMetadata | null)[];
   name: string;
   descriptionJson: any;
   seoTitle: string | null;

--- a/src/products/types/ProductImageUpdate.ts
+++ b/src/products/types/ProductImageUpdate.ts
@@ -99,6 +99,18 @@ export interface ProductImageUpdate_productImageUpdate_product_pricing {
   priceRangeUndiscounted: ProductImageUpdate_productImageUpdate_product_pricing_priceRangeUndiscounted | null;
 }
 
+export interface ProductImageUpdate_productImageUpdate_product_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ProductImageUpdate_productImageUpdate_product_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ProductImageUpdate_productImageUpdate_product_category {
   __typename: "Category";
   id: string;
@@ -186,6 +198,8 @@ export interface ProductImageUpdate_productImageUpdate_product {
   attributes: ProductImageUpdate_productImageUpdate_product_attributes[];
   productType: ProductImageUpdate_productImageUpdate_product_productType;
   pricing: ProductImageUpdate_productImageUpdate_product_pricing | null;
+  metadata: (ProductImageUpdate_productImageUpdate_product_metadata | null)[];
+  privateMetadata: (ProductImageUpdate_productImageUpdate_product_privateMetadata | null)[];
   name: string;
   descriptionJson: any;
   seoTitle: string | null;

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -99,6 +99,18 @@ export interface ProductUpdate_productUpdate_product_pricing {
   priceRangeUndiscounted: ProductUpdate_productUpdate_product_pricing_priceRangeUndiscounted | null;
 }
 
+export interface ProductUpdate_productUpdate_product_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ProductUpdate_productUpdate_product_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ProductUpdate_productUpdate_product_category {
   __typename: "Category";
   id: string;
@@ -186,6 +198,8 @@ export interface ProductUpdate_productUpdate_product {
   attributes: ProductUpdate_productUpdate_product_attributes[];
   productType: ProductUpdate_productUpdate_product_productType;
   pricing: ProductUpdate_productUpdate_product_pricing | null;
+  metadata: (ProductUpdate_productUpdate_product_metadata | null)[];
+  privateMetadata: (ProductUpdate_productUpdate_product_privateMetadata | null)[];
   name: string;
   descriptionJson: any;
   seoTitle: string | null;

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -99,6 +99,18 @@ export interface SimpleProductUpdate_productUpdate_product_pricing {
   priceRangeUndiscounted: SimpleProductUpdate_productUpdate_product_pricing_priceRangeUndiscounted | null;
 }
 
+export interface SimpleProductUpdate_productUpdate_product_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface SimpleProductUpdate_productUpdate_product_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface SimpleProductUpdate_productUpdate_product_category {
   __typename: "Category";
   id: string;
@@ -186,6 +198,8 @@ export interface SimpleProductUpdate_productUpdate_product {
   attributes: SimpleProductUpdate_productUpdate_product_attributes[];
   productType: SimpleProductUpdate_productUpdate_product_productType;
   pricing: SimpleProductUpdate_productUpdate_product_pricing | null;
+  metadata: (SimpleProductUpdate_productUpdate_product_metadata | null)[];
+  privateMetadata: (SimpleProductUpdate_productUpdate_product_privateMetadata | null)[];
   name: string;
   descriptionJson: any;
   seoTitle: string | null;

--- a/src/products/utils/data.ts
+++ b/src/products/utils/data.ts
@@ -1,3 +1,4 @@
+import { MetadataFormData } from "@saleor/components/Metadata/types";
 import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocompleteSelectField";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
 import { ProductVariant } from "@saleor/fragments/types/ProductVariant";
@@ -10,6 +11,7 @@ import {
 } from "@saleor/products/types/ProductDetails";
 import { SearchProductTypes_search_edges_node_productAttributes } from "@saleor/searches/types/SearchProductTypes";
 import { StockInput } from "@saleor/types/globalTypes";
+import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import { RawDraftContentState } from "draft-js";
 
 import { ProductAttributeInput } from "../components/ProductAttributes";
@@ -168,7 +170,7 @@ export function getChoices(nodes: Node[]): SingleAutocompleteChoiceType[] {
   );
 }
 
-export interface ProductUpdatePageFormData {
+export interface ProductUpdatePageFormData extends MetadataFormData {
   basePrice: number;
   category: string | null;
   collections: string[];
@@ -198,7 +200,9 @@ export function getProductUpdatePageFormData(
     ),
     description: maybe(() => JSON.parse(product.descriptionJson)),
     isPublished: maybe(() => product.isPublished, false),
+    metadata: product?.metadata.map(mapMetadataItemToInput),
     name: maybe(() => product.name, ""),
+    privateMetadata: product?.privateMetadata.map(mapMetadataItemToInput),
     publicationDate: maybe(() => product.publicationDate, ""),
     seoDescription: maybe(() => product.seoDescription, ""),
     seoTitle: maybe(() => product.seoTitle, ""),

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -23,6 +23,10 @@ import {
 import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
+import {
+  useMetadataUpdate,
+  usePrivateMetadataUpdate
+} from "@saleor/utils/metadata/updateMetadata";
 import { useWarehouseList } from "@saleor/warehouses/queries";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -81,6 +85,8 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     }
   });
   const shop = useShop();
+  const [updateMetadata] = useMetadataUpdate({});
+  const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
 
   const { data, loading, refetch } = useProductDetails({
     displayLoader: true,
@@ -184,7 +190,9 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
   const handleSubmit = createUpdateHandler(
     product,
     variables => updateProduct({ variables }),
-    variables => updateSimpleProduct({ variables })
+    variables => updateSimpleProduct({ variables }),
+    variables => updateMetadata({ variables }),
+    variables => updatePrivateMetadata({ variables })
   );
   const handleImageUpload = createImageUploadHandler(id, variables =>
     createProductImage({ variables })

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -23,6 +23,7 @@ import {
 import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
+import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
 import {
   useMetadataUpdate,
   usePrivateMetadataUpdate
@@ -187,10 +188,13 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     deleteProductImage({ variables: { id } });
   const handleImageEdit = (imageId: string) => () =>
     navigate(productImageUrl(id, imageId));
-  const handleSubmit = createUpdateHandler(
+  const handleSubmit = createMetadataUpdateHandler(
     product,
-    variables => updateProduct({ variables }),
-    variables => updateSimpleProduct({ variables }),
+    createUpdateHandler(
+      product,
+      variables => updateProduct({ variables }),
+      variables => updateSimpleProduct({ variables })
+    ),
     variables => updateMetadata({ variables }),
     variables => updatePrivateMetadata({ variables })
   );

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -506,6 +506,12 @@ export enum MenuSortField {
   NAME = "NAME",
 }
 
+export enum MetadataErrorCode {
+  GRAPHQL_ERROR = "GRAPHQL_ERROR",
+  INVALID = "INVALID",
+  NOT_FOUND = "NOT_FOUND",
+}
+
 export enum OrderAction {
   CAPTURE = "CAPTURE",
   MARK_AS_PAID = "MARK_AS_PAID",
@@ -1184,6 +1190,11 @@ export interface MenuItemMoveInput {
 export interface MenuSortingInput {
   direction: OrderDirection;
   field: MenuSortField;
+}
+
+export interface MetadataInput {
+  key: string;
+  value: string;
 }
 
 export interface NameTranslationInput {

--- a/src/utils/handlers/metadataUpdateHandler.ts
+++ b/src/utils/handlers/metadataUpdateHandler.ts
@@ -1,0 +1,88 @@
+import { MetadataFormData } from "@saleor/components/Metadata/types";
+import { MetadataInput } from "@saleor/types/globalTypes";
+import { diff } from "fast-array-diff";
+import { MutationFetchResult } from "react-apollo";
+
+import {
+  UpdateMetadata,
+  UpdateMetadataVariables
+} from "../metadata/types/UpdateMetadata";
+import {
+  UpdatePrivateMetadata,
+  UpdatePrivateMetadataVariables
+} from "../metadata/types/UpdatePrivateMetadata";
+
+interface ObjectWithMetadata {
+  id: string;
+  metadata: MetadataInput[];
+  privateMetadata: MetadataInput[];
+}
+
+function createMetadataUpdateHandler<TData extends MetadataFormData, TError>(
+  initial: ObjectWithMetadata,
+  update: (data: TData) => Promise<TError[]>,
+  updateMetadata: (
+    variables: UpdateMetadataVariables
+  ) => Promise<MutationFetchResult<UpdateMetadata>>,
+  updatePrivateMetadata: (
+    variables: UpdatePrivateMetadataVariables
+  ) => Promise<MutationFetchResult<UpdatePrivateMetadata>>
+) {
+  return async (data: TData) => {
+    const errors = await update(data);
+
+    if (errors.length > 0) {
+      return errors;
+    }
+
+    if (errors.length === 0) {
+      if (data.metadata) {
+        const metaDiff = diff(
+          initial.metadata,
+          data.metadata,
+          (a, b) => a.key === b.key
+        );
+
+        const updateMetaResult = await updateMetadata({
+          id: initial.id,
+          input: data.metadata,
+          keysToDelete: metaDiff.removed.map(meta => meta.key)
+        });
+        const updateMetaErrors = [
+          ...(updateMetaResult.data.deleteMetadata.errors || []),
+          ...(updateMetaResult.data.updateMetadata.errors || [])
+        ];
+
+        if (updateMetaErrors.length > 0) {
+          return updateMetaErrors;
+        }
+      }
+      if (data.privateMetadata) {
+        const privateMetaDiff = diff(
+          initial.privateMetadata,
+          data.privateMetadata,
+          (a, b) => a.key === b.key
+        );
+
+        const updatePrivateMetaResult = await updatePrivateMetadata({
+          id: initial.id,
+          input: data.privateMetadata,
+          keysToDelete: privateMetaDiff.removed.map(meta => meta.key)
+        });
+
+        const updatePrivateMetaErrors = [
+          ...(updatePrivateMetaResult.data.deletePrivateMetadata.errors || []),
+          ...(updatePrivateMetaResult.data.updatePrivateMetadata.errors || [])
+        ];
+
+        if (updatePrivateMetaErrors.length > 0) {
+          return updatePrivateMetaErrors;
+        }
+      }
+    }
+
+    return [];
+  };
+}
+
+export default createMetadataUpdateHandler;

--- a/src/utils/maps.ts
+++ b/src/utils/maps.ts
@@ -1,7 +1,9 @@
 import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocompleteSelectField";
 import { ShopInfo_shop_countries } from "@saleor/components/Shop/types/ShopInfo";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
+import { MetadataItem } from "@saleor/fragments/types/MetadataItem";
 import { Node } from "@saleor/types";
+import { MetadataInput } from "@saleor/types/globalTypes";
 
 export function mapCountriesToChoices(
   countries: ShopInfo_shop_countries[]
@@ -19,4 +21,11 @@ export function mapNodeToChoice(
     label: node.name,
     value: node.id
   }));
+}
+
+export function mapMetadataItemToInput(item: MetadataItem): MetadataInput {
+  return {
+    key: item.key,
+    value: item.value
+  };
 }

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -1,0 +1,68 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { MetadataInput } from "./../../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UpdateMetadata
+// ====================================================
+
+export interface UpdateMetadata_updateMetadata_item_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdateMetadata_updateMetadata_item_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdateMetadata_updateMetadata_item {
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  metadata: (UpdateMetadata_updateMetadata_item_metadata | null)[];
+  privateMetadata: (UpdateMetadata_updateMetadata_item_privateMetadata | null)[];
+  id: string;
+}
+
+export interface UpdateMetadata_updateMetadata {
+  __typename: "UpdateMetadata";
+  item: UpdateMetadata_updateMetadata_item | null;
+}
+
+export interface UpdateMetadata_deleteMetadata_item_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdateMetadata_deleteMetadata_item_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdateMetadata_deleteMetadata_item {
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  metadata: (UpdateMetadata_deleteMetadata_item_metadata | null)[];
+  privateMetadata: (UpdateMetadata_deleteMetadata_item_privateMetadata | null)[];
+  id: string;
+}
+
+export interface UpdateMetadata_deleteMetadata {
+  __typename: "DeleteMetadata";
+  item: UpdateMetadata_deleteMetadata_item | null;
+}
+
+export interface UpdateMetadata {
+  updateMetadata: UpdateMetadata_updateMetadata | null;
+  deleteMetadata: UpdateMetadata_deleteMetadata | null;
+}
+
+export interface UpdateMetadataVariables {
+  id: string;
+  input: MetadataInput[];
+  keysToDelete: string[];
+}

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -2,34 +2,27 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { MetadataInput } from "./../../../types/globalTypes";
+import { MetadataInput, MetadataErrorCode } from "./../../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateMetadata
 // ====================================================
 
-export interface UpdateMetadata_updateMetadata_item_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface UpdateMetadata_updateMetadata_item_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface UpdateMetadata_updateMetadata_item {
-  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
-  metadata: (UpdateMetadata_updateMetadata_item_metadata | null)[];
-  privateMetadata: (UpdateMetadata_updateMetadata_item_privateMetadata | null)[];
-  id: string;
+export interface UpdateMetadata_updateMetadata_errors {
+  __typename: "MetadataError";
+  code: MetadataErrorCode;
+  field: string | null;
 }
 
 export interface UpdateMetadata_updateMetadata {
   __typename: "UpdateMetadata";
-  item: UpdateMetadata_updateMetadata_item | null;
+  errors: UpdateMetadata_updateMetadata_errors[];
+}
+
+export interface UpdateMetadata_deleteMetadata_errors {
+  __typename: "MetadataError";
+  code: MetadataErrorCode;
+  field: string | null;
 }
 
 export interface UpdateMetadata_deleteMetadata_item_metadata {
@@ -53,6 +46,7 @@ export interface UpdateMetadata_deleteMetadata_item {
 
 export interface UpdateMetadata_deleteMetadata {
   __typename: "DeleteMetadata";
+  errors: UpdateMetadata_deleteMetadata_errors[];
   item: UpdateMetadata_deleteMetadata_item | null;
 }
 

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -1,0 +1,62 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { MetadataInput, MetadataErrorCode } from "./../../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UpdatePrivateMetadata
+// ====================================================
+
+export interface UpdatePrivateMetadata_updatePrivateMetadata_errors {
+  __typename: "MetadataError";
+  code: MetadataErrorCode;
+  field: string | null;
+}
+
+export interface UpdatePrivateMetadata_updatePrivateMetadata {
+  __typename: "UpdatePrivateMetadata";
+  errors: UpdatePrivateMetadata_updatePrivateMetadata_errors[];
+}
+
+export interface UpdatePrivateMetadata_deletePrivateMetadata_errors {
+  __typename: "MetadataError";
+  code: MetadataErrorCode;
+  field: string | null;
+}
+
+export interface UpdatePrivateMetadata_deletePrivateMetadata_item_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdatePrivateMetadata_deletePrivateMetadata_item {
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  metadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_metadata | null)[];
+  privateMetadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata | null)[];
+  id: string;
+}
+
+export interface UpdatePrivateMetadata_deletePrivateMetadata {
+  __typename: "DeletePrivateMetadata";
+  errors: UpdatePrivateMetadata_deletePrivateMetadata_errors[];
+  item: UpdatePrivateMetadata_deletePrivateMetadata_item | null;
+}
+
+export interface UpdatePrivateMetadata {
+  updatePrivateMetadata: UpdatePrivateMetadata_updatePrivateMetadata | null;
+  deletePrivateMetadata: UpdatePrivateMetadata_deletePrivateMetadata | null;
+}
+
+export interface UpdatePrivateMetadataVariables {
+  id: string;
+  input: MetadataInput[];
+  keysToDelete: string[];
+}

--- a/src/utils/metadata/updateMetadata.ts
+++ b/src/utils/metadata/updateMetadata.ts
@@ -14,20 +14,21 @@ import {
 
 const updateMetadata = gql`
   ${metadataFragment}
+  ${metadataErrorFragment}
   mutation UpdateMetadata(
     $id: ID!
     $input: [MetadataInput!]!
     $keysToDelete: [String!]!
   ) {
     updateMetadata(id: $id, input: $input) {
-      item {
-        ...Metadata
-        ... on Node {
-          id
-        }
+      errors: metadataErrors {
+        ...MetadataErrorFragment
       }
     }
     deleteMetadata(id: $id, keys: $keysToDelete) {
+      errors: metadataErrors {
+        ...MetadataErrorFragment
+      }
       item {
         ...Metadata
         ... on Node {

--- a/src/utils/metadata/updateMetadata.ts
+++ b/src/utils/metadata/updateMetadata.ts
@@ -1,0 +1,74 @@
+import { metadataErrorFragment } from "@saleor/fragments/errors";
+import makeMutation from "@saleor/hooks/makeMutation";
+import gql from "graphql-tag";
+
+import { metadataFragment } from "../../fragments/metadata";
+import {
+  UpdateMetadata,
+  UpdateMetadataVariables
+} from "./types/UpdateMetadata";
+import {
+  UpdatePrivateMetadata,
+  UpdatePrivateMetadataVariables
+} from "./types/UpdatePrivateMetadata";
+
+const updateMetadata = gql`
+  ${metadataFragment}
+  mutation UpdateMetadata(
+    $id: ID!
+    $input: [MetadataInput!]!
+    $keysToDelete: [String!]!
+  ) {
+    updateMetadata(id: $id, input: $input) {
+      item {
+        ...Metadata
+        ... on Node {
+          id
+        }
+      }
+    }
+    deleteMetadata(id: $id, keys: $keysToDelete) {
+      item {
+        ...Metadata
+        ... on Node {
+          id
+        }
+      }
+    }
+  }
+`;
+export const useMetadataUpdate = makeMutation<
+  UpdateMetadata,
+  UpdateMetadataVariables
+>(updateMetadata);
+
+const updatePrivateMetadata = gql`
+  ${metadataFragment}
+  ${metadataErrorFragment}
+  mutation UpdatePrivateMetadata(
+    $id: ID!
+    $input: [MetadataInput!]!
+    $keysToDelete: [String!]!
+  ) {
+    updatePrivateMetadata(id: $id, input: $input) {
+      errors: metadataErrors {
+        ...MetadataErrorFragment
+      }
+    }
+    deletePrivateMetadata(id: $id, keys: $keysToDelete) {
+      errors: metadataErrors {
+        ...MetadataErrorFragment
+      }
+      item {
+        ...Metadata
+        ... on Node {
+          id
+        }
+      }
+    }
+  }
+`;
+export const usePrivateMetadataUpdate = makeMutation<
+  UpdatePrivateMetadata,
+  UpdatePrivateMetadataVariables
+>(updatePrivateMetadata);

--- a/src/utils/metadata/useMetadataChangeTrigger.ts
+++ b/src/utils/metadata/useMetadataChangeTrigger.ts
@@ -1,0 +1,28 @@
+import { FormChange } from "@saleor/hooks/useForm";
+import { useState } from "react";
+
+function useMetadataChangeTrigger() {
+  const [isMetadataModified, setMetadataModified] = useState(false);
+  const [isPrivateMetadataModified, setPrivateMetadataModified] = useState(
+    false
+  );
+
+  const makeChangeHandler: (
+    onChange: FormChange
+  ) => FormChange = onChange => event => {
+    if (event.target.name === "metadata") {
+      setMetadataModified(true);
+    } else {
+      setPrivateMetadataModified(true);
+    }
+    onChange(event);
+  };
+
+  return {
+    isMetadataModified,
+    isPrivateMetadataModified,
+    makeChangeHandler
+  };
+}
+
+export default useMetadataChangeTrigger;


### PR DESCRIPTION
I want to merge this change because it adds metadata editor to product view

**PR intended to be tested with API branch:** master

### Screenshots
<img width="1680" alt="Screenshot 2020-08-25 at 13 46 39" src="https://user-images.githubusercontent.com/6833443/91170615-6da45780-e6d9-11ea-9fe6-741276d169f3.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
