### PR TITLE
Add apps and permission groups to navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix user management modal actions - #637 by @eaglesemanation
 - Fix navigator button rendering on safari browser - #656 by @dominik-zeglen
 - Use hooks instead of containers with render props in product mutations - #667 by @dominik-zeglen
+- Add apps and permission groups to navigator - #678 by @dominik-zeglen
 
 ## 2.10.1
 

--- a/src/components/Navigator/modes/default/views.ts
+++ b/src/components/Navigator/modes/default/views.ts
@@ -1,3 +1,4 @@
+import { appsListUrl } from "@saleor/apps/urls";
 import { attributeListUrl } from "@saleor/attributes/urls";
 import { categoryListUrl } from "@saleor/categories/urls";
 import { collectionListUrl } from "@saleor/collections/urls";
@@ -8,6 +9,7 @@ import { sectionNames } from "@saleor/intl";
 import { menuListUrl } from "@saleor/navigation/urls";
 import { orderDraftListUrl, orderListUrl } from "@saleor/orders/urls";
 import { pageListUrl } from "@saleor/pages/urls";
+import { permissionGroupListUrl } from "@saleor/permissionGroups/urls";
 import { pluginListUrl } from "@saleor/plugins/urls";
 import { productListUrl } from "@saleor/products/urls";
 import { productTypeListUrl } from "@saleor/productTypes/urls";
@@ -32,6 +34,10 @@ function searchInViews(
   navigate: UseNavigatorResult
 ): QuickSearchActionInput[] {
   const views: View[] = [
+    {
+      label: intl.formatMessage(sectionNames.apps),
+      url: appsListUrl()
+    },
     {
       label: intl.formatMessage(sectionNames.attributes),
       url: attributeListUrl()
@@ -67,6 +73,10 @@ function searchInViews(
     {
       label: intl.formatMessage(sectionNames.pages),
       url: pageListUrl()
+    },
+    {
+      label: intl.formatMessage(sectionNames.permissionGroups),
+      url: permissionGroupListUrl()
     },
     {
       label: intl.formatMessage(sectionNames.plugins),


### PR DESCRIPTION
I want to merge this change because it adds navigator shortcut to apps and permission groups.

**PR intended to be tested with API branch:** master
### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
