### PR TITLE
Fix crashing attribute value creation

### DIFF
--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -166,7 +166,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
           <AttributeValueDeleteDialog
             attributeName={undefined}
             open={params.action === "remove-value"}
-            name={getStringOrPlaceholder(values[id].name)}
+            name={getStringOrPlaceholder(values[id]?.name)}
             confirmButtonState="default"
             onClose={closeModal}
             onConfirm={handleValueDelete}


### PR DESCRIPTION
I want to merge this change because it fixes the following bug:
1. Go to Configuration > Attributes > Create new attribute.
2. Fill in the default label. 
3. Click "Assign Value" and provide some value and click "Save".
4. Crash.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
