### PR TITLE
Add metadata to orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add metadata editor to creator views - #684 by @dominik-zeglen
 - Update product visibility card component - #679 by @AlicjaSzu
 - Update savebar design - #690 by @dominik-zeglen
+- Add metadata to orders - #688 by @dominik-zeglen
 
 ## 2.10.1
 

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -1,6 +1,7 @@
 import gql from "graphql-tag";
 
 import { fragmentAddress } from "./address";
+import { metadataFragment } from "./metadata";
 
 export const fragmentOrderEvent = gql`
   fragment OrderEventFragment on OrderEvent {
@@ -87,8 +88,10 @@ export const fragmentOrderDetails = gql`
   ${fragmentOrderLine}
   ${fulfillmentFragment}
   ${invoiceFragment}
+  ${metadataFragment}
   fragment OrderDetailsFragment on Order {
     id
+    ...MetadataFragment
     billingAddress {
       ...AddressFragment
     }

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -8,6 +8,18 @@ import { OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentCharg
 // GraphQL fragment: OrderDetailsFragment
 // ====================================================
 
+export interface OrderDetailsFragment_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderDetailsFragment_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderDetailsFragment_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -285,6 +297,8 @@ export interface OrderDetailsFragment_invoices {
 export interface OrderDetailsFragment {
   __typename: "Order";
   id: string;
+  metadata: (OrderDetailsFragment_metadata | null)[];
+  privateMetadata: (OrderDetailsFragment_privateMetadata | null)[];
   billingAddress: OrderDetailsFragment_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -235,7 +235,7 @@ export function hasErrors(errorList: UserError[] | null): boolean {
 export function getMutationState(
   called: boolean,
   loading: boolean,
-  ...errorList: UserError[][]
+  ...errorList: any[][]
 ): ConfirmButtonTransitionState {
   if (loading) {
     return "loading";

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1096,8 +1096,16 @@ export const order = (placeholder: string): OrderDetails_order => ({
       }
     }
   ],
+  metadata: [
+    {
+      __typename: "MetadataItem",
+      key: "integration.key",
+      value: "some-value"
+    }
+  ],
   number: "9",
   paymentStatus: PaymentChargeStatusEnum.NOT_CHARGED,
+  privateMetadata: [],
   shippingAddress: {
     __typename: "Address",
     city: "West Patriciastad",

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1264,8 +1264,10 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
       }
     }
   ],
+  metadata: [],
   number: "24",
   paymentStatus: null,
+  privateMetadata: [],
   shippingAddress: null,
   shippingMethod: null,
   shippingMethodName: null,

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -16,6 +16,18 @@ export interface FulfillOrder_orderFulfill_errors {
   orderLine: string | null;
 }
 
+export interface FulfillOrder_orderFulfill_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface FulfillOrder_orderFulfill_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface FulfillOrder_orderFulfill_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -293,6 +305,8 @@ export interface FulfillOrder_orderFulfill_order_invoices {
 export interface FulfillOrder_orderFulfill_order {
   __typename: "Order";
   id: string;
+  metadata: (FulfillOrder_orderFulfill_order_metadata | null)[];
+  privateMetadata: (FulfillOrder_orderFulfill_order_privateMetadata | null)[];
   billingAddress: FulfillOrder_orderFulfill_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -14,6 +14,18 @@ export interface OrderCancel_orderCancel_errors {
   field: string | null;
 }
 
+export interface OrderCancel_orderCancel_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderCancel_orderCancel_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderCancel_orderCancel_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderCancel_orderCancel_order_invoices {
 export interface OrderCancel_orderCancel_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderCancel_orderCancel_order_metadata | null)[];
+  privateMetadata: (OrderCancel_orderCancel_order_privateMetadata | null)[];
   billingAddress: OrderCancel_orderCancel_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -14,6 +14,18 @@ export interface OrderCapture_orderCapture_errors {
   field: string | null;
 }
 
+export interface OrderCapture_orderCapture_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderCapture_orderCapture_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderCapture_orderCapture_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderCapture_orderCapture_order_invoices {
 export interface OrderCapture_orderCapture_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderCapture_orderCapture_order_metadata | null)[];
+  privateMetadata: (OrderCapture_orderCapture_order_privateMetadata | null)[];
   billingAddress: OrderCapture_orderCapture_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -8,6 +8,18 @@ import { OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentCharg
 // GraphQL query operation: OrderDetails
 // ====================================================
 
+export interface OrderDetails_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderDetails_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderDetails_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -285,6 +297,8 @@ export interface OrderDetails_order_invoices {
 export interface OrderDetails_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderDetails_order_metadata | null)[];
+  privateMetadata: (OrderDetails_order_privateMetadata | null)[];
   billingAddress: OrderDetails_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -14,6 +14,18 @@ export interface OrderDraftCancel_draftOrderDelete_errors {
   field: string | null;
 }
 
+export interface OrderDraftCancel_draftOrderDelete_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderDraftCancel_draftOrderDelete_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderDraftCancel_draftOrderDelete_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderDraftCancel_draftOrderDelete_order_invoices {
 export interface OrderDraftCancel_draftOrderDelete_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderDraftCancel_draftOrderDelete_order_metadata | null)[];
+  privateMetadata: (OrderDraftCancel_draftOrderDelete_order_privateMetadata | null)[];
   billingAddress: OrderDraftCancel_draftOrderDelete_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -14,6 +14,18 @@ export interface OrderDraftFinalize_draftOrderComplete_errors {
   field: string | null;
 }
 
+export interface OrderDraftFinalize_draftOrderComplete_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderDraftFinalize_draftOrderComplete_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderDraftFinalize_draftOrderComplete_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderDraftFinalize_draftOrderComplete_order_invoices {
 export interface OrderDraftFinalize_draftOrderComplete_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderDraftFinalize_draftOrderComplete_order_metadata | null)[];
+  privateMetadata: (OrderDraftFinalize_draftOrderComplete_order_privateMetadata | null)[];
   billingAddress: OrderDraftFinalize_draftOrderComplete_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -14,6 +14,18 @@ export interface OrderDraftUpdate_draftOrderUpdate_errors {
   field: string | null;
 }
 
+export interface OrderDraftUpdate_draftOrderUpdate_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderDraftUpdate_draftOrderUpdate_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderDraftUpdate_draftOrderUpdate_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_invoices {
 export interface OrderDraftUpdate_draftOrderUpdate_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderDraftUpdate_draftOrderUpdate_order_metadata | null)[];
+  privateMetadata: (OrderDraftUpdate_draftOrderUpdate_order_privateMetadata | null)[];
   billingAddress: OrderDraftUpdate_draftOrderUpdate_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -14,6 +14,18 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_errors {
   field: string | null;
 }
 
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_invoices {
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderFulfillmentCancel_orderFulfillmentCancel_order_metadata | null)[];
+  privateMetadata: (OrderFulfillmentCancel_orderFulfillmentCancel_order_privateMetadata | null)[];
   billingAddress: OrderFulfillmentCancel_orderFulfillmentCancel_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -14,6 +14,18 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_e
   field: string | null;
 }
 
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_metadata | null)[];
+  privateMetadata: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_privateMetadata | null)[];
   billingAddress: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -14,6 +14,18 @@ export interface OrderLineDelete_draftOrderLineDelete_errors {
   field: string | null;
 }
 
+export interface OrderLineDelete_draftOrderLineDelete_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderLineDelete_draftOrderLineDelete_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderLineDelete_draftOrderLineDelete_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderLineDelete_draftOrderLineDelete_order_invoices {
 export interface OrderLineDelete_draftOrderLineDelete_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderLineDelete_draftOrderLineDelete_order_metadata | null)[];
+  privateMetadata: (OrderLineDelete_draftOrderLineDelete_order_privateMetadata | null)[];
   billingAddress: OrderLineDelete_draftOrderLineDelete_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -14,6 +14,18 @@ export interface OrderLineUpdate_draftOrderLineUpdate_errors {
   field: string | null;
 }
 
+export interface OrderLineUpdate_draftOrderLineUpdate_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderLineUpdate_draftOrderLineUpdate_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderLineUpdate_draftOrderLineUpdate_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderLineUpdate_draftOrderLineUpdate_order_invoices {
 export interface OrderLineUpdate_draftOrderLineUpdate_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderLineUpdate_draftOrderLineUpdate_order_metadata | null)[];
+  privateMetadata: (OrderLineUpdate_draftOrderLineUpdate_order_privateMetadata | null)[];
   billingAddress: OrderLineUpdate_draftOrderLineUpdate_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -14,6 +14,18 @@ export interface OrderLinesAdd_draftOrderLinesCreate_errors {
   field: string | null;
 }
 
+export interface OrderLinesAdd_draftOrderLinesCreate_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderLinesAdd_draftOrderLinesCreate_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderLinesAdd_draftOrderLinesCreate_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderLinesAdd_draftOrderLinesCreate_order_invoices {
 export interface OrderLinesAdd_draftOrderLinesCreate_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderLinesAdd_draftOrderLinesCreate_order_metadata | null)[];
+  privateMetadata: (OrderLinesAdd_draftOrderLinesCreate_order_privateMetadata | null)[];
   billingAddress: OrderLinesAdd_draftOrderLinesCreate_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -14,6 +14,18 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_errors {
   field: string | null;
 }
 
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_invoices {
 export interface OrderMarkAsPaid_orderMarkAsPaid_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderMarkAsPaid_orderMarkAsPaid_order_metadata | null)[];
+  privateMetadata: (OrderMarkAsPaid_orderMarkAsPaid_order_privateMetadata | null)[];
   billingAddress: OrderMarkAsPaid_orderMarkAsPaid_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -14,6 +14,18 @@ export interface OrderRefund_orderRefund_errors {
   field: string | null;
 }
 
+export interface OrderRefund_orderRefund_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderRefund_orderRefund_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderRefund_orderRefund_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderRefund_orderRefund_order_invoices {
 export interface OrderRefund_orderRefund_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderRefund_orderRefund_order_metadata | null)[];
+  privateMetadata: (OrderRefund_orderRefund_order_privateMetadata | null)[];
   billingAddress: OrderRefund_orderRefund_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -14,6 +14,18 @@ export interface OrderVoid_orderVoid_errors {
   field: string | null;
 }
 
+export interface OrderVoid_orderVoid_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderVoid_orderVoid_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface OrderVoid_orderVoid_order_billingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -291,6 +303,8 @@ export interface OrderVoid_orderVoid_order_invoices {
 export interface OrderVoid_orderVoid_order {
   __typename: "Order";
   id: string;
+  metadata: (OrderVoid_orderVoid_order_metadata | null)[];
+  privateMetadata: (OrderVoid_orderVoid_order_privateMetadata | null)[];
   billingAddress: OrderVoid_orderVoid_order_billingAddress | null;
   canFinalize: boolean;
   created: any;

--- a/src/storybook/stories/orders/OrderDetailsPage.tsx
+++ b/src/storybook/stories/orders/OrderDetailsPage.tsx
@@ -19,6 +19,7 @@ const order = orderFixture(placeholderImage);
 
 const props: Omit<OrderDetailsPageProps, "classes"> = {
   countries,
+  disabled: false,
   onBack: () => undefined,
   onBillingAddressEdit: undefined,
   onFulfillmentCancel: () => undefined,
@@ -36,7 +37,9 @@ const props: Omit<OrderDetailsPageProps, "classes"> = {
   onProductClick: undefined,
   onProfileView: () => undefined,
   onShippingAddressEdit: undefined,
+  onSubmit: () => undefined,
   order,
+  saveButtonBarState: "default",
   userPermissions: adminUserPermissions
 };
 


### PR DESCRIPTION
I want to merge this change because it adds metadata editor to order view.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
