### PR TITLE
Fix not closed modal with two confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update savebar design - #690 by @dominik-zeglen
 - Add metadata to orders - #688 by @dominik-zeglen
 - Add lazyload to locales - #692 by @eaglesemanation
+- Fix not closed address update modal with two confirmations - #699 by @orzechdev
 
 ## 2.10.1
 

--- a/src/orders/components/OrderAddressEditDialog/OrderAddressEditDialog.tsx
+++ b/src/orders/components/OrderAddressEditDialog/OrderAddressEditDialog.tsx
@@ -80,7 +80,7 @@ const OrderAddressEditDialog: React.FC<OrderAddressEditDialogProps> = props => {
   return (
     <Dialog onClose={onClose} open={open} classes={{ paper: classes.overflow }}>
       <Form initial={address} onSubmit={handleSubmit}>
-        {({ change, data, submit }) => {
+        {({ change, data }) => {
           const handleCountrySelect = createSingleAutocompleteSelectHandler(
             change,
             setCountryDisplayName,
@@ -118,7 +118,6 @@ const OrderAddressEditDialog: React.FC<OrderAddressEditDialogProps> = props => {
                   transitionState={confirmButtonState}
                   color="primary"
                   variant="contained"
-                  onClick={submit}
                   type="submit"
                 >
                   <FormattedMessage {...buttonMessages.confirm} />

--- a/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
+++ b/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
@@ -160,6 +160,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
           defaultMessage: "Order successfully updated"
         })
       });
+      closeModal();
     }
   };
   const handleDraftUpdate = (data: OrderDraftUpdate) => {


### PR DESCRIPTION
I want to merge this change because... it fixes not closing order address update modal and double submission of these addresses.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
