### PR TITLE
Add error info when fetching taxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix not closed address update modal with two confirmations - #699 by @orzechdev
 - Update schema with PositiveDecimal type - #695 by @AlicjaSzu
 - Restyle side menu - #697 by @dominik-zeglen
+- Add error info when fetching taxes - #701 by @dominik-zeglen
 
 ## 2.10.1
 

--- a/src/taxes/views/CountryList.tsx
+++ b/src/taxes/views/CountryList.tsx
@@ -35,6 +35,11 @@ export const CountryList: React.FC = () => {
           defaultMessage: "Successfully fetched tax rates"
         })
       });
+    } else {
+      notify({
+        status: "error",
+        text: intl.formatMessage(commonMessages.somethingWentWrong)
+      });
     }
   };
 


### PR DESCRIPTION
I want to merge this change because if error occurs while fetching tax rates, user will be informed now about this.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
