### PR TITLE
Fix updating order details on address change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update product stock management to newest design - #515 by @dominik-zeglen
 - Handle untracked products - #523 by @dominik-zeglen
 - Display correct error if there were no graphql errors - #525 by @dominik-zeglen
+- Fix updating order details on address change #711 - by @orzechdev
 
 ## 2.0.0
 

--- a/src/orders/mutations.ts
+++ b/src/orders/mutations.ts
@@ -1,4 +1,3 @@
-import { fragmentAddress } from "@saleor/fragments/address";
 import {
   invoiceErrorFragment,
   orderErrorFragment
@@ -282,7 +281,7 @@ export const TypedOrderAddNoteMutation = TypedMutation<
 >(orderAddNoteMutation);
 
 const orderUpdateMutation = gql`
-  ${fragmentAddress}
+  ${fragmentOrderDetails}
   ${orderErrorFragment}
   mutation OrderUpdate($id: ID!, $input: OrderUpdateInput!) {
     orderUpdate(id: $id, input: $input) {
@@ -290,14 +289,7 @@ const orderUpdateMutation = gql`
         ...OrderErrorFragment
       }
       order {
-        id
-        userEmail
-        billingAddress {
-          ...AddressFragment
-        }
-        shippingAddress {
-          ...AddressFragment
-        }
+        ...OrderDetailsFragment
       }
     }
   }

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { OrderUpdateInput, OrderErrorCode } from "./../../types/globalTypes";
+import { OrderUpdateInput, OrderErrorCode, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderUpdate
@@ -12,6 +12,18 @@ export interface OrderUpdate_orderUpdate_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+}
+
+export interface OrderUpdate_orderUpdate_order_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
 }
 
 export interface OrderUpdate_orderUpdate_order_billingAddress_country {
@@ -36,6 +48,145 @@ export interface OrderUpdate_orderUpdate_order_billingAddress {
   streetAddress2: string;
 }
 
+export interface OrderUpdate_orderUpdate_order_events_user {
+  __typename: "User";
+  id: string;
+  email: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_events {
+  __typename: "OrderEvent";
+  id: string;
+  amount: number | null;
+  date: any | null;
+  email: string | null;
+  emailType: OrderEventsEmailsEnum | null;
+  invoiceNumber: string | null;
+  message: string | null;
+  quantity: number | null;
+  type: OrderEventsEnum | null;
+  user: OrderUpdate_orderUpdate_order_events_user | null;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_product {
+  __typename: "Product";
+  isAvailableForPurchase: boolean | null;
+  isPublished: boolean;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant {
+  __typename: "ProductVariant";
+  product: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant_product;
+  quantityAvailable: number;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_unitPrice_gross {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_unitPrice_net {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_unitPrice {
+  __typename: "TaxedMoney";
+  gross: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_unitPrice_net;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_thumbnail {
+  __typename: "Image";
+  url: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine {
+  __typename: "OrderLine";
+  id: string;
+  isShippingRequired: boolean;
+  variant: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant | null;
+  productName: string;
+  productSku: string;
+  quantity: number;
+  quantityFulfilled: number;
+  unitPrice: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_unitPrice | null;
+  thumbnail: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_thumbnail | null;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_lines {
+  __typename: "FulfillmentLine";
+  id: string;
+  quantity: number;
+  orderLine: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine | null;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments_warehouse {
+  __typename: "Warehouse";
+  id: string;
+  name: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_fulfillments {
+  __typename: "Fulfillment";
+  id: string;
+  lines: (OrderUpdate_orderUpdate_order_fulfillments_lines | null)[] | null;
+  fulfillmentOrder: number;
+  status: FulfillmentStatus;
+  trackingNumber: string;
+  warehouse: OrderUpdate_orderUpdate_order_fulfillments_warehouse | null;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_variant_product {
+  __typename: "Product";
+  isAvailableForPurchase: boolean | null;
+  isPublished: boolean;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_variant {
+  __typename: "ProductVariant";
+  product: OrderUpdate_orderUpdate_order_lines_variant_product;
+  quantityAvailable: number;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_unitPrice_gross {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_unitPrice_net {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_unitPrice {
+  __typename: "TaxedMoney";
+  gross: OrderUpdate_orderUpdate_order_lines_unitPrice_gross;
+  net: OrderUpdate_orderUpdate_order_lines_unitPrice_net;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines_thumbnail {
+  __typename: "Image";
+  url: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_lines {
+  __typename: "OrderLine";
+  id: string;
+  isShippingRequired: boolean;
+  variant: OrderUpdate_orderUpdate_order_lines_variant | null;
+  productName: string;
+  productSku: string;
+  quantity: number;
+  quantityFulfilled: number;
+  unitPrice: OrderUpdate_orderUpdate_order_lines_unitPrice | null;
+  thumbnail: OrderUpdate_orderUpdate_order_lines_thumbnail | null;
+}
+
 export interface OrderUpdate_orderUpdate_order_shippingAddress_country {
   __typename: "CountryDisplay";
   code: string;
@@ -58,12 +209,126 @@ export interface OrderUpdate_orderUpdate_order_shippingAddress {
   streetAddress2: string;
 }
 
+export interface OrderUpdate_orderUpdate_order_shippingMethod {
+  __typename: "ShippingMethod";
+  id: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_shippingPrice_gross {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_shippingPrice {
+  __typename: "TaxedMoney";
+  gross: OrderUpdate_orderUpdate_order_shippingPrice_gross;
+}
+
+export interface OrderUpdate_orderUpdate_order_subtotal_gross {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_subtotal {
+  __typename: "TaxedMoney";
+  gross: OrderUpdate_orderUpdate_order_subtotal_gross;
+}
+
+export interface OrderUpdate_orderUpdate_order_total_gross {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_total_tax {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_total {
+  __typename: "TaxedMoney";
+  gross: OrderUpdate_orderUpdate_order_total_gross;
+  tax: OrderUpdate_orderUpdate_order_total_tax;
+}
+
+export interface OrderUpdate_orderUpdate_order_totalAuthorized {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_totalCaptured {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_user {
+  __typename: "User";
+  id: string;
+  email: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_availableShippingMethods_price {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_availableShippingMethods {
+  __typename: "ShippingMethod";
+  id: string;
+  name: string;
+  price: OrderUpdate_orderUpdate_order_availableShippingMethods_price | null;
+}
+
+export interface OrderUpdate_orderUpdate_order_discount {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderUpdate_orderUpdate_order_invoices {
+  __typename: "Invoice";
+  id: string;
+  number: string | null;
+  createdAt: any;
+  url: string | null;
+  status: JobStatusEnum;
+}
+
 export interface OrderUpdate_orderUpdate_order {
   __typename: "Order";
   id: string;
-  userEmail: string | null;
+  metadata: (OrderUpdate_orderUpdate_order_metadata | null)[];
+  privateMetadata: (OrderUpdate_orderUpdate_order_privateMetadata | null)[];
   billingAddress: OrderUpdate_orderUpdate_order_billingAddress | null;
+  canFinalize: boolean;
+  created: any;
+  customerNote: string;
+  events: (OrderUpdate_orderUpdate_order_events | null)[] | null;
+  fulfillments: (OrderUpdate_orderUpdate_order_fulfillments | null)[];
+  lines: (OrderUpdate_orderUpdate_order_lines | null)[];
+  number: string | null;
+  paymentStatus: PaymentChargeStatusEnum | null;
   shippingAddress: OrderUpdate_orderUpdate_order_shippingAddress | null;
+  shippingMethod: OrderUpdate_orderUpdate_order_shippingMethod | null;
+  shippingMethodName: string | null;
+  shippingPrice: OrderUpdate_orderUpdate_order_shippingPrice | null;
+  status: OrderStatus;
+  subtotal: OrderUpdate_orderUpdate_order_subtotal | null;
+  total: OrderUpdate_orderUpdate_order_total | null;
+  actions: (OrderAction | null)[];
+  totalAuthorized: OrderUpdate_orderUpdate_order_totalAuthorized | null;
+  totalCaptured: OrderUpdate_orderUpdate_order_totalCaptured | null;
+  user: OrderUpdate_orderUpdate_order_user | null;
+  userEmail: string | null;
+  availableShippingMethods: (OrderUpdate_orderUpdate_order_availableShippingMethods | null)[] | null;
+  discount: OrderUpdate_orderUpdate_order_discount | null;
+  invoices: (OrderUpdate_orderUpdate_order_invoices | null)[] | null;
 }
 
 export interface OrderUpdate_orderUpdate {


### PR DESCRIPTION
I want to merge this change because... it updates the order with latest order prices, shipping methods, etc. from backend on any changes in draft order addresses.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
