### PR TITLE
Pass missing isVisibleListing variable to mutation

### DIFF
--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -201,6 +201,7 @@ export const simpleProductUpdateMutation = gql`
     $deleteStocks: [ID!]!
     $updateStocks: [StockInput!]!
     $weight: WeightScalar
+    $visibleInListings: Boolean
   ) {
     productUpdate(
       id: $id
@@ -216,6 +217,7 @@ export const simpleProductUpdateMutation = gql`
         basePrice: $basePrice
         seo: $seo
         weight: $weight
+        visibleInListings: $visibleInListings
       }
     ) {
       errors: productErrors {

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -830,4 +830,5 @@ export interface SimpleProductUpdateVariables {
   deleteStocks: string[];
   updateStocks: StockInput[];
   weight?: any | null;
+  visibleInListings?: boolean | null;
 }


### PR DESCRIPTION
The simpleProductUpdate mutation doesn't pass the new value of `isVisibleListing` to backend