### PR TITLE
Fix strings containing "informations"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix return to previous page on screen size change - #710 by @orzechdev
 - Add variants reordering possibility - #716 by @orzechdev
 - Fix avatar change button - #719 by @orzechdev
+- Change plural form of "informations" to "information" strings across the app #722 by @mmarkusik
 
 ## 2.10.1
 

--- a/locale/ar.json
+++ b/locale/ar.json
@@ -2200,7 +2200,7 @@
     "string": "استوفى"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/az.json
+++ b/locale/az.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/bg.json
+++ b/locale/bg.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/bn.json
+++ b/locale/bn.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/ca.json
+++ b/locale/ca.json
@@ -2200,7 +2200,7 @@
     "string": "Completat"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/da.json
+++ b/locale/da.json
@@ -2200,7 +2200,7 @@
     "string": "Pakket"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/de.json
+++ b/locale/de.json
@@ -2200,7 +2200,7 @@
     "string": "Abgeschlossen"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2715,7 +2715,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/el.json
+++ b/locale/el.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/es_CO.json
+++ b/locale/es_CO.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/et.json
+++ b/locale/et.json
@@ -2200,7 +2200,7 @@
     "string": "Täidetud"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/hi.json
+++ b/locale/hi.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/hu.json
+++ b/locale/hu.json
@@ -2200,7 +2200,7 @@
     "string": "Teljesített"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/hy.json
+++ b/locale/hy.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/id.json
+++ b/locale/id.json
@@ -2200,7 +2200,7 @@
     "string": "Terpenuhi"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/is.json
+++ b/locale/is.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/ja.json
+++ b/locale/ja.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/ko.json
+++ b/locale/ko.json
@@ -2200,7 +2200,7 @@
     "string": "완료"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/nl.json
+++ b/locale/nl.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/pt.json
+++ b/locale/pt.json
@@ -2200,7 +2200,7 @@
     "string": "Completo"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/pt_BR.json
+++ b/locale/pt_BR.json
@@ -2200,7 +2200,7 @@
     "string": "Completo"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/ro.json
+++ b/locale/ro.json
@@ -2200,7 +2200,7 @@
     "string": "Livrată"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -2200,7 +2200,7 @@
     "string": "Исполнен"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/sk.json
+++ b/locale/sk.json
@@ -2200,7 +2200,7 @@
     "string": "Splnené"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/sl.json
+++ b/locale/sl.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/sq.json
+++ b/locale/sq.json
@@ -2200,7 +2200,7 @@
     "string": "I perfunduar"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/sr.json
+++ b/locale/sr.json
@@ -2200,7 +2200,7 @@
     "string": "Ispunjeno"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/sv.json
+++ b/locale/sv.json
@@ -2200,7 +2200,7 @@
     "string": "Fullbordad"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/th.json
+++ b/locale/th.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/tr.json
+++ b/locale/tr.json
@@ -2200,7 +2200,7 @@
     "string": "Tamamlanmış"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/uk.json
+++ b/locale/uk.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/zh-Hans.json
+++ b/locale/zh-Hans.json
@@ -2200,7 +2200,7 @@
     "string": "已完成"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/locale/zh-Hant.json
+++ b/locale/zh-Hant.json
@@ -2200,7 +2200,7 @@
     "string": "Fulfilled"
   },
   "src_dot_generalInformations": {
-    "string": "General Informations"
+    "string": "General Information"
   },
   "src_dot_home": {
     "context": "home section name",

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -40,7 +40,7 @@ export const commonMessages = defineMessages({
     defaultMessage: "First Name"
   },
   generalInformations: {
-    defaultMessage: "General Informations"
+    defaultMessage: "General Information"
   },
   lastName: {
     defaultMessage: "Last Name"


### PR DESCRIPTION
Noticed that we use "Informations" as plural, whereas it should come as "Information". Only changed like 175 places 💩 

- [x] Confirmed with @pwgryglak 

### Pull Request Checklist

1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
