### PR TITLE
Disable autocomplete for plugin auth key field and site settings auth field

### DIFF
--- a/src/plugins/components/PluginSecretFieldDialog/PluginSecretFieldDialog.tsx
+++ b/src/plugins/components/PluginSecretFieldDialog/PluginSecretFieldDialog.tsx
@@ -63,6 +63,7 @@ const PluginSecretFieldDialog: React.FC<PluginSecretFieldDialogProps> = ({
           <>
             <DialogContent>
               <TextField
+                autoComplete="off"
                 fullWidth
                 label={field && field.label}
                 name="value"

--- a/src/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.tsx
+++ b/src/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.tsx
@@ -70,6 +70,7 @@ const SiteSettingsKeyDialog: React.FC<SiteSettingsKeyDialogProps> = ({
               />
               <FormSpacer />
               <TextField
+                autoComplete="off"
                 error={!!formErrors.key}
                 fullWidth
                 label={intl.formatMessage({
@@ -83,6 +84,7 @@ const SiteSettingsKeyDialog: React.FC<SiteSettingsKeyDialogProps> = ({
               />
               <FormSpacer />
               <TextField
+                autoComplete="off"
                 error={!!formErrors.password}
                 fullWidth
                 label={intl.formatMessage({


### PR DESCRIPTION
[SALEOR-753](https://app.clickup.com/t/2549495/SALEOR-753)

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
