### PR TITLE
add autocomplete off to email field in site settings

### DIFF
--- a/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
+++ b/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
@@ -114,6 +114,7 @@ const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
           disabled={disabled}
           error={!!formErrors.customerSetPasswordUrl}
           fullWidth
+          autoComplete="off"
           name="customerSetPasswordUrl"
           label={intl.formatMessage({
             defaultMessage: "Customer password reset URL"

--- a/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
+++ b/src/siteSettings/components/SiteSettingsMailing/SiteSettingsMailing.tsx
@@ -115,6 +115,7 @@ const SiteSettingsMailing: React.FC<SiteSettingsMailingProps> = props => {
           error={!!formErrors.customerSetPasswordUrl}
           fullWidth
           autoComplete="off"
+          type="url"
           name="customerSetPasswordUrl"
           label={intl.formatMessage({
             defaultMessage: "Customer password reset URL"


### PR DESCRIPTION
[SALEOR-1133](https://app.clickup.com/t/2549495/SALEOR-1133)

I want to merge this change because the autocomplete in the email field is unnecessary.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
