### PR TITLE
Use regex instead of string to replace all "\n" occurences

### DIFF
--- a/src/components/Timeline/TimelineNote.tsx
+++ b/src/components/Timeline/TimelineNote.tsx
@@ -97,7 +97,7 @@ export const TimelineNote: React.FC<TimelineNoteProps> = props => {
         <CardContent className={classes.cardContent}>
           <Typography
             dangerouslySetInnerHTML={{
-              __html: message.replace("\n", "<br />")
+              __html: message.replace(/\n/, "<br />")
             }}
           />
         </CardContent>

--- a/src/components/Timeline/TimelineNote.tsx
+++ b/src/components/Timeline/TimelineNote.tsx
@@ -97,7 +97,7 @@ export const TimelineNote: React.FC<TimelineNoteProps> = props => {
         <CardContent className={classes.cardContent}>
           <Typography
             dangerouslySetInnerHTML={{
-              __html: message.replace(/\n/, "<br />")
+              __html: message.replace(/\n/g, "<br />")
             }}
           />
         </CardContent>


### PR DESCRIPTION
I want to merge this change because if message contains more than one `\n` symbols, only the first will be replaced, resulting in misformatted message.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
