### PR TITLE
Fix failing cypress test

### DIFF
--- a/cypress/elements/catalog/product-selectors.js
+++ b/cypress/elements/catalog/product-selectors.js
@@ -6,6 +6,7 @@ export const PRODUCTS_SELECTORS = {
   productTypeInput: "[data-test='product-type']",
   categoryInput: "[data-test='category']",
   categoryItem: "[data-test='singleautocomplete-select-option']",
+  autocompleteDropdown: "[data-test='autocomplete-dropdown']",
   firstCategoryItem: "#downshift-0-item-0",
   visibleRadioBtn: "[name='isPublished']",
   saveBtn: "[data-test='button-bar-confirm']",

--- a/cypress/integration/products.js
+++ b/cypress/integration/products.js
@@ -20,6 +20,9 @@ describe("Products", () => {
       .type("Visible test product")
       .get(PRODUCTS_SELECTORS.productTypeInput)
       .click()
+      .get(PRODUCTS_SELECTORS.autocompleteDropdown) // trying to fill autocomplete before dropdown will cause error
+      .get(PRODUCTS_SELECTORS.productTypeInput)
+      .click()
       .type("Cushion")
       .get(PRODUCTS_SELECTORS.categoryItem)
       .should("have.length", 1)

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectFieldContent.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectFieldContent.tsx
@@ -177,7 +177,11 @@ const SingleAutocompleteSelectFieldContent: React.FC<SingleAutocompleteSelectFie
 
   return (
     <Paper className={classes.root}>
-      <div className={classes.content} ref={anchor}>
+      <div
+        className={classes.content}
+        ref={anchor}
+        data-test="autocomplete-dropdown"
+      >
         {choices.length > 0 || displayCustomValue ? (
           <>
             {emptyOption && (


### PR DESCRIPTION
I want to merge this change because filling autocomplete field before visible dropdown caused cypress error.
Clickup: SALEOR-1197

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
