### PR TITLE
Add default variant indicator for variant nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Change plural form of "informations" to "information" strings across the app #722 by @mmarkusik
 - Fix misaligned rich text draft controls - #725 by @orzechdev
 - Allow taxes to be configured per product - #728 by @dominik-zeglen
+- Add default variant indicator for variant nav - #741 by @krzysztofwolski
 - Fix style of product type attributes empty table - #744 by @orzechdev
 - Fix order draft back button redirect - #753 by @orzechdev
 

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4516,6 +4516,10 @@
     "context": "button",
     "string": "Choose photos"
   },
+  "src_dot_products_dot_components_dot_ProductVariantNavigation_dot_1120495519": {
+    "context": "default variant label",
+    "string": "default"
+  },
   "src_dot_products_dot_components_dot_ProductVariantNavigation_dot_2153006789": {
     "context": "section header",
     "string": "Variants"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4516,9 +4516,9 @@
     "context": "button",
     "string": "Choose photos"
   },
-  "src_dot_products_dot_components_dot_ProductVariantNavigation_dot_1120495519": {
-    "context": "default variant label",
-    "string": "default"
+  "src_dot_products_dot_components_dot_ProductVariantNavigation_dot_1222345317": {
+    "context": "default product variant indicator",
+    "string": "Default"
   },
   "src_dot_products_dot_components_dot_ProductVariantNavigation_dot_2153006789": {
     "context": "section header",
@@ -4554,13 +4554,13 @@
     "context": "product variant inventory",
     "string": "Unavailable"
   },
-  "src_dot_products_dot_components_dot_ProductVariants_dot_1120495519": {
-    "context": "default variant label",
-    "string": "default"
-  },
   "src_dot_products_dot_components_dot_ProductVariants_dot_1134347598": {
     "context": "product variant price",
     "string": "Price"
+  },
+  "src_dot_products_dot_components_dot_ProductVariants_dot_1222345317": {
+    "context": "default product variant indicator",
+    "string": "Default"
   },
   "src_dot_products_dot_components_dot_ProductVariants_dot_1252282784": {
     "context": "product variant inventory",

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -253,6 +253,9 @@ export const fragmentVariant = gql`
           url
         }
       }
+      defaultVariant {
+        id
+      }
     }
     sku
     stocks {

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -99,6 +99,11 @@ export interface ProductVariant_product_variants {
   images: (ProductVariant_product_variants_images | null)[] | null;
 }
 
+export interface ProductVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface ProductVariant_product {
   __typename: "Product";
   id: string;
@@ -107,6 +112,7 @@ export interface ProductVariant_product {
   name: string;
   thumbnail: ProductVariant_product_thumbnail | null;
   variants: (ProductVariant_product_variants | null)[] | null;
+  defaultVariant: ProductVariant_product_defaultVariant | null;
 }
 
 export interface ProductVariant_stocks_warehouse {

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -112,7 +112,6 @@ export interface ProductVariant_product {
   name: string;
   thumbnail: ProductVariant_product_thumbnail | null;
   variants: (ProductVariant_product_variants | null)[] | null;
-  defaultVariant: ProductVariant_product_defaultVariant | null;
 }
 
 export interface ProductVariant_stocks_warehouse {

--- a/src/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
+++ b/src/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
@@ -17,7 +17,7 @@ import classNames from "classnames";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { maybe, renderCollection } from "../../../misc";
+import { renderCollection } from "../../../misc";
 import { ProductVariantCreateData_product_variants } from "../../types/ProductVariantCreateData";
 import { ProductVariantDetails_productVariant } from "../../types/ProductVariantDetails";
 
@@ -118,8 +118,8 @@ const ProductVariantNavigation: React.FC<ProductVariantNavigationProps> = props 
                   {isDefault && (
                     <span className={classes.defaultVariant}>
                       {intl.formatMessage({
-                        defaultMessage: "default",
-                        description: "default variant label"
+                        defaultMessage: "Default",
+                        description: "default product variant indicator"
                       })}
                     </span>
                   )}

--- a/src/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
+++ b/src/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
@@ -1,6 +1,7 @@
 import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import { makeStyles } from "@material-ui/core/styles";
+import { fade } from "@material-ui/core/styles/colorManipulator";
 import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
 import CardTitle from "@saleor/components/CardTitle";
@@ -27,6 +28,10 @@ const useStyles = makeStyles(
     },
     colName: {
       paddingLeft: 0
+    },
+    defaultVariant: {
+      color: fade(theme.palette.text.secondary, 0.6),
+      display: "block"
     },
     firstVariant: {
       width: 88
@@ -57,6 +62,7 @@ const useStyles = makeStyles(
 
 interface ProductVariantNavigationProps {
   current?: string;
+  defaultVariantId?: string;
   fallbackThumbnail: string;
   variants:
     | ProductVariantDetails_productVariant[]
@@ -69,6 +75,7 @@ interface ProductVariantNavigationProps {
 const ProductVariantNavigation: React.FC<ProductVariantNavigationProps> = props => {
   const {
     current,
+    defaultVariantId,
     fallbackThumbnail,
     variants,
     onAdd,
@@ -89,28 +96,37 @@ const ProductVariantNavigation: React.FC<ProductVariantNavigationProps> = props 
       />
       <ResponsiveTable>
         <SortableTableBody onSortEnd={onReorder}>
-          {renderCollection(variants, (variant, variantIndex) => (
-            <SortableTableRow
-              hover={!!variant}
-              key={variant ? variant.id : "skeleton"}
-              index={variantIndex || 0}
-              className={classNames(classes.link, {
-                [classes.tabActive]: variant && variant.id === current
-              })}
-              onClick={variant ? () => onRowClick(variant.id) : undefined}
-            >
-              <TableCellAvatar
-                className={classes.colAvatar}
-                thumbnail={maybe(
-                  () => variant.images[0].url,
-                  fallbackThumbnail
-                )}
-              />
-              <TableCell className={classes.colName}>
-                {variant ? variant.name || variant.sku : <Skeleton />}
-              </TableCell>
-            </SortableTableRow>
-          ))}
+          {renderCollection(variants, (variant, variantIndex) => {
+            const isDefault = variant && variant.id === defaultVariantId;
+            const isActive = variant && variant.id === current;
+            return (
+              <SortableTableRow
+                hover={!!variant}
+                key={variant ? variant.id : "skeleton"}
+                index={variantIndex || 0}
+                className={classNames(classes.link, {
+                  [classes.tabActive]: isActive
+                })}
+                onClick={variant ? () => onRowClick(variant.id) : undefined}
+              >
+                <TableCellAvatar
+                  className={classes.colAvatar}
+                  thumbnail={variant?.images[0]?.url || fallbackThumbnail}
+                />
+                <TableCell className={classes.colName}>
+                  {variant ? variant.name || variant.sku : <Skeleton />}
+                  {isDefault && (
+                    <span className={classes.defaultVariant}>
+                      {intl.formatMessage({
+                        defaultMessage: "default",
+                        description: "default variant label"
+                      })}
+                    </span>
+                  )}
+                </TableCell>
+              </SortableTableRow>
+            );
+          })}
           {onAdd ? (
             <TableRow>
               <TableCell colSpan={3}>

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -15,6 +15,7 @@ import useFormset, {
   FormsetChange,
   FormsetData
 } from "@saleor/hooks/useFormset";
+import { VariantUpdate_productVariantUpdate_errors } from "@saleor/products/types/VariantUpdate";
 import {
   getAttributeInputFromVariant,
   getStockInputFromVariant
@@ -54,13 +55,16 @@ export interface ProductVariantPageSubmitData
 }
 
 interface ProductVariantPageProps {
+  defaultVariantId?: string;
   defaultWeightUnit: string;
-  variant?: ProductVariant;
-  errors: ProductErrorWithAttributesFragment[];
-  saveButtonBarState: ConfirmButtonTransitionState;
+  errors:
+    | ProductErrorWithAttributesFragment[]
+    | VariantUpdate_productVariantUpdate_errors[];
+  header: string;
   loading?: boolean;
   placeholderImage?: string;
-  header: string;
+  saveButtonBarState: ConfirmButtonTransitionState;
+  variant?: ProductVariant;
   warehouses: WarehouseFragment[];
   onVariantReorder: ReorderAction;
   onAdd();
@@ -74,10 +78,11 @@ interface ProductVariantPageProps {
 }
 
 const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
+  defaultVariantId,
   defaultWeightUnit,
   errors,
-  loading,
   header,
+  loading,
   placeholderImage,
   saveButtonBarState,
   variant,
@@ -192,6 +197,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                   <div>
                     <ProductVariantNavigation
                       current={variant ? variant.id : undefined}
+                      defaultVariantId={defaultVariantId}
                       fallbackThumbnail={maybe(
                         () => variant.product.thumbnail.url
                       )}

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -176,7 +176,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
           {maybe(() => variant.product.name)}
         </AppHeader>
         <PageHeader title={header}>
-          {variant?.product?.defaultVariant.id !== variant?.id && (
+          {variant?.product?.defaultVariant?.id !== variant?.id && (
             <ProductVariantSetDefault
               onSetDefaultVariant={onSetDefaultVariant}
             />

--- a/src/products/components/ProductVariants/ProductVariants.tsx
+++ b/src/products/components/ProductVariants/ProductVariants.tsx
@@ -355,8 +355,8 @@ export const ProductVariants: React.FC<ProductVariantsProps> = props => {
                     {isDefault && (
                       <span className={classes.defaultVariant}>
                         {intl.formatMessage({
-                          defaultMessage: "default",
-                          description: "default variant label"
+                          defaultMessage: "Default",
+                          description: "default product variant indicator"
                         })}
                       </span>
                     )}

--- a/src/products/components/ProductVariants/ProductVariants.tsx
+++ b/src/products/components/ProductVariants/ProductVariants.tsx
@@ -399,7 +399,7 @@ export const ProductVariants: React.FC<ProductVariantsProps> = props => {
                     data-test="actions"
                     onClick={e => e.stopPropagation()}
                   >
-                    {variant?.id !== product?.defaultVariant.id && (
+                    {variant?.id !== product?.defaultVariant?.id && (
                       <ProductVariantSetDefault
                         onSetDefaultVariant={() => onSetDefaultVariant(variant)}
                       />

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -99,6 +99,11 @@ export interface ProductVariantDetails_productVariant_product_variants {
   images: (ProductVariantDetails_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface ProductVariantDetails_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface ProductVariantDetails_productVariant_product {
   __typename: "Product";
   id: string;
@@ -107,6 +112,7 @@ export interface ProductVariantDetails_productVariant_product {
   name: string;
   thumbnail: ProductVariantDetails_productVariant_product_thumbnail | null;
   variants: (ProductVariantDetails_productVariant_product_variants | null)[] | null;
+  defaultVariant: ProductVariantDetails_productVariant_product_defaultVariant | null;
 }
 
 export interface ProductVariantDetails_productVariant_stocks_warehouse {

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -107,7 +107,6 @@ export interface ProductVariantDetails_productVariant_product_defaultVariant {
 export interface ProductVariantDetails_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: ProductVariantDetails_productVariant_product_defaultVariant | null;
   images: (ProductVariantDetails_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: ProductVariantDetails_productVariant_product_thumbnail | null;

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -346,6 +346,11 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_product
   images: (SimpleProductUpdate_productVariantUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface SimpleProductUpdate_productVariantUpdate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
@@ -354,6 +359,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_product
   name: string;
   thumbnail: SimpleProductUpdate_productVariantUpdate_productVariant_product_thumbnail | null;
   variants: (SimpleProductUpdate_productVariantUpdate_productVariant_product_variants | null)[] | null;
+  defaultVariant: SimpleProductUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
 }
 
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_stocks_warehouse {
@@ -497,6 +503,11 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_p
   images: (SimpleProductUpdate_productVariantStocksCreate_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product {
   __typename: "Product";
   id: string;
@@ -505,6 +516,7 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_p
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_thumbnail | null;
   variants: (SimpleProductUpdate_productVariantStocksCreate_productVariant_product_variants | null)[] | null;
+  defaultVariant: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_defaultVariant | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_stocks_warehouse {
@@ -647,6 +659,11 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_p
   images: (SimpleProductUpdate_productVariantStocksDelete_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product {
   __typename: "Product";
   id: string;
@@ -655,6 +672,7 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_p
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_thumbnail | null;
   variants: (SimpleProductUpdate_productVariantStocksDelete_productVariant_product_variants | null)[] | null;
+  defaultVariant: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_defaultVariant | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_stocks_warehouse {
@@ -798,6 +816,11 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_p
   images: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product {
   __typename: "Product";
   id: string;
@@ -806,6 +829,7 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_p
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_thumbnail | null;
   variants: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_variants | null)[] | null;
+  defaultVariant: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse {

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -354,7 +354,6 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_product
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: SimpleProductUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantUpdate_productVariant_product_thumbnail | null;
@@ -511,7 +510,6 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_p
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksCreate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_thumbnail | null;
@@ -667,7 +665,6 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_p
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksDelete_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_thumbnail | null;
@@ -824,7 +821,6 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_p
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -114,7 +114,6 @@ export interface VariantCreate_productVariantCreate_productVariant_product_defau
 export interface VariantCreate_productVariantCreate_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: VariantCreate_productVariantCreate_productVariant_product_defaultVariant | null;
   images: (VariantCreate_productVariantCreate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantCreate_productVariantCreate_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -106,6 +106,11 @@ export interface VariantCreate_productVariantCreate_productVariant_product_varia
   images: (VariantCreate_productVariantCreate_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface VariantCreate_productVariantCreate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantCreate_productVariantCreate_productVariant_product {
   __typename: "Product";
   id: string;
@@ -114,6 +119,7 @@ export interface VariantCreate_productVariantCreate_productVariant_product {
   name: string;
   thumbnail: VariantCreate_productVariantCreate_productVariant_product_thumbnail | null;
   variants: (VariantCreate_productVariantCreate_productVariant_product_variants | null)[] | null;
+  defaultVariant: VariantCreate_productVariantCreate_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantCreate_productVariantCreate_productVariant_stocks_warehouse {

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -113,7 +113,6 @@ export interface VariantImageAssign_variantImageAssign_productVariant_product_de
 export interface VariantImageAssign_variantImageAssign_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: VariantImageAssign_variantImageAssign_productVariant_product_defaultVariant | null;
   images: (VariantImageAssign_variantImageAssign_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantImageAssign_variantImageAssign_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -105,6 +105,11 @@ export interface VariantImageAssign_variantImageAssign_productVariant_product_va
   images: (VariantImageAssign_variantImageAssign_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface VariantImageAssign_variantImageAssign_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantImageAssign_variantImageAssign_productVariant_product {
   __typename: "Product";
   id: string;
@@ -113,6 +118,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_product {
   name: string;
   thumbnail: VariantImageAssign_variantImageAssign_productVariant_product_thumbnail | null;
   variants: (VariantImageAssign_variantImageAssign_productVariant_product_variants | null)[] | null;
+  defaultVariant: VariantImageAssign_variantImageAssign_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant_stocks_warehouse {

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -113,7 +113,6 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_produc
 export interface VariantImageUnassign_variantImageUnassign_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: VariantImageUnassign_variantImageUnassign_productVariant_product_defaultVariant | null;
   images: (VariantImageUnassign_variantImageUnassign_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantImageUnassign_variantImageUnassign_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -105,6 +105,11 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_produc
   images: (VariantImageUnassign_variantImageUnassign_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface VariantImageUnassign_variantImageUnassign_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantImageUnassign_variantImageUnassign_productVariant_product {
   __typename: "Product";
   id: string;
@@ -113,6 +118,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_produc
   name: string;
   thumbnail: VariantImageUnassign_variantImageUnassign_productVariant_product_thumbnail | null;
   variants: (VariantImageUnassign_variantImageUnassign_productVariant_product_variants | null)[] | null;
+  defaultVariant: VariantImageUnassign_variantImageUnassign_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant_stocks_warehouse {

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -114,7 +114,6 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product_defau
 export interface VariantUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: VariantUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
   images: (VariantUpdate_productVariantUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantUpdate_productVariantUpdate_productVariant_product_thumbnail | null;
@@ -271,7 +270,6 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_product
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_product {
   __typename: "Product";
   id: string;
-  defaultVariant: VariantUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
   images: (VariantUpdate_productVariantStocksUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantUpdate_productVariantStocksUpdate_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -106,6 +106,11 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product_varia
   images: (VariantUpdate_productVariantUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface VariantUpdate_productVariantUpdate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
@@ -114,6 +119,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product {
   name: string;
   thumbnail: VariantUpdate_productVariantUpdate_productVariant_product_thumbnail | null;
   variants: (VariantUpdate_productVariantUpdate_productVariant_product_variants | null)[] | null;
+  defaultVariant: VariantUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant_stocks_warehouse {
@@ -257,6 +263,11 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_product
   images: (VariantUpdate_productVariantStocksUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
+export interface VariantUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_product {
   __typename: "Product";
   id: string;
@@ -265,6 +276,7 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_product
   name: string;
   thumbnail: VariantUpdate_productVariantStocksUpdate_productVariant_product_thumbnail | null;
   variants: (VariantUpdate_productVariantStocksUpdate_productVariant_product_variants | null)[] | null;
+  defaultVariant: VariantUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse {

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -201,7 +201,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
       <WindowTitle title={data?.productVariant?.name} />
       <ProductVariantPage
         defaultWeightUnit={shop?.defaultWeightUnit}
-        defaultVariantId={data?.productVariant.product.defaultVariant.id}
+        defaultVariantId={data?.productVariant.product.defaultVariant?.id}
         errors={errors}
         onSetDefaultVariant={onSetDefaultVariant}
         saveButtonBarState={updateVariantOpts.status}

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -201,6 +201,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
       <WindowTitle title={data?.productVariant?.name} />
       <ProductVariantPage
         defaultWeightUnit={shop?.defaultWeightUnit}
+        defaultVariantId={data?.productVariant.product.defaultVariant.id}
         errors={errors}
         onSetDefaultVariant={onSetDefaultVariant}
         saveButtonBarState={updateVariantOpts.status}


### PR DESCRIPTION
I want to merge this change because variant navigation at the variant details view was not marking the default variant.

Clickup: SALEOR-1162


### Screenshots
Implementation:
![image](https://user-images.githubusercontent.com/5188636/94843272-c07dd700-041c-11eb-9476-d9f2d1caf27e.png)

Design:
![image](https://user-images.githubusercontent.com/5188636/94843361-e1dec300-041c-11eb-9f4a-fdb012cd600e.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
