### PR TITLE
Fix Variant Details console errors

### DIFF
--- a/src/products/components/ProductShipping/ProductShipping.tsx
+++ b/src/products/components/ProductShipping/ProductShipping.tsx
@@ -49,7 +49,9 @@ const ProductShipping: React.FC<ProductShippingProps> = props => {
             onChange={onChange}
             InputProps={{
               endAdornment: (
-                <InputAdornment position="end">{weightUnit}</InputAdornment>
+                <InputAdornment position="end">
+                  {weightUnit || ""}
+                </InputAdornment>
               ),
               inputProps: {
                 min: 0

--- a/src/products/components/ProductVariantAttributes/ProductVariantAttributes.tsx
+++ b/src/products/components/ProductVariantAttributes/ProductVariantAttributes.tsx
@@ -52,7 +52,7 @@ function getAttributeValue(
   attributes: VariantAttributeInput[]
 ): string {
   const attribute = attributes.find(attr => attr.id === id);
-  return attribute.value;
+  return attribute?.value === null ? undefined : attribute.value;
 }
 
 function getAttributeValueChoices(

--- a/src/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
+++ b/src/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
@@ -90,7 +90,7 @@ const ProductVariantNavigation: React.FC<ProductVariantNavigationProps> = props 
             <SortableTableRow
               hover={!!variant}
               key={variant ? variant.id : "skeleton"}
-              index={variantIndex}
+              index={variantIndex || 0}
               className={classNames(classes.link, {
                 [classes.tabActive]: variant && variant.id === current
               })}


### PR DESCRIPTION
I want to merge this change because the console output at the Variant Details page was polluted with errors.

Clickup: SALEOR-1260


### Screenshots

Before:
![image](https://user-images.githubusercontent.com/5188636/94849902-641fb500-0426-11eb-9637-8f28cee7ec97.png)

![image](https://user-images.githubusercontent.com/5188636/94849947-7699ee80-0426-11eb-86e5-bbfa23c5b6a4.png)

After:
None 😎 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
