### PR TITLE
Fix style of product type attributes empty table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Change plural form of "informations" to "information" strings across the app #722 by @mmarkusik
 - Fix misaligned rich text draft controls - #725 by @orzechdev
 - Allow taxes to be configured per product - #728 by @dominik-zeglen
-
+- Fix style of product type attributes empty table - #744 by @orzechdev
 
 ## 2.10.1
 

--- a/src/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
+++ b/src/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
@@ -125,26 +125,28 @@ const ProductTypeAttributes: React.FC<ProductTypeAttributesProps> = props => {
           <col className={classes.colSlug} />
           <col className={classes.colAction} />
         </colgroup>
-        <TableHead
-          colSpan={numberOfColumns}
-          disabled={disabled}
-          dragRows
-          selected={selected}
-          items={attributes}
-          toggleAll={toggleAll}
-          toolbar={toolbar}
-        >
-          <TableCell className={classes.colName}>
-            <FormattedMessage defaultMessage="Attribute name" />
-          </TableCell>
-          <TableCell className={classes.colName}>
-            <FormattedMessage
-              defaultMessage="Slug"
-              description="attribute internal name"
-            />
-          </TableCell>
-          <TableCell />
-        </TableHead>
+        {attributes?.length > 0 && (
+          <TableHead
+            colSpan={numberOfColumns}
+            disabled={disabled}
+            dragRows
+            selected={selected}
+            items={attributes}
+            toggleAll={toggleAll}
+            toolbar={toolbar}
+          >
+            <TableCell className={classes.colName}>
+              <FormattedMessage defaultMessage="Attribute name" />
+            </TableCell>
+            <TableCell className={classes.colName}>
+              <FormattedMessage
+                defaultMessage="Slug"
+                description="attribute internal name"
+              />
+            </TableCell>
+            <TableCell />
+          </TableHead>
+        )}
         <SortableTableBody onSortEnd={onAttributeReorder}>
           {renderCollection(
             attributes,


### PR DESCRIPTION
I want to merge this change because... it displays just no attributes found message without table header when there are no attributes to display in the table.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
