### PR TITLE
Fix set default variant alert

### DIFF
--- a/src/hooks/useOnSetDefaultVariant.ts
+++ b/src/hooks/useOnSetDefaultVariant.ts
@@ -26,14 +26,19 @@ function useOnSetDefaultVariant(
           })
         );
       } else {
-        if (variant) {
+        const defaultVariant = data.productVariantSetDefault.product.variants.find(
+          variant =>
+            variant.id ===
+            data.productVariantSetDefault.product.defaultVariant.id
+        );
+        if (defaultVariant) {
           notify({
             status: "success",
             text: intl.formatMessage(
               {
                 defaultMessage: "Variant {name} has been set as default."
               },
-              { name: variant.name }
+              { name: defaultVariant.name }
             )
           });
         }

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -86,7 +86,7 @@ export interface ProductUpdatePageProps extends ListActions {
   onSeoClick?();
   onSubmit?(data: ProductUpdatePageSubmitData);
   onVariantAdd?();
-  onSetDefaultVariant();
+  onSetDefaultVariant(variant: ProductDetails_product_variants);
   onWarehouseConfigure();
 }
 


### PR DESCRIPTION
I want to merge this change because... it fixes the missing set default variant alert.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
