### PR TITLE
Fix order draft negative quantity

### DIFF
--- a/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
@@ -186,6 +186,9 @@ const OrderDraftDetailsProducts: React.FC<OrderDraftDetailsProductsProps> = prop
                               value={data.quantity}
                               onChange={debounce}
                               onBlur={submit}
+                              inputProps={{
+                                min: 1
+                              }}
                             />
                           )}
                         </DebounceForm>

--- a/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
@@ -164,25 +164,33 @@ const OrderDraftDetailsProducts: React.FC<OrderDraftDetailsProductsProps> = prop
                     initial={{ quantity: line.quantity }}
                     onSubmit={data => onOrderLineChange(line.id, data)}
                   >
-                    {({ change, data, hasChanged, submit }) => (
-                      <DebounceForm
-                        change={change}
-                        submit={hasChanged ? submit : undefined}
-                        time={200}
-                      >
-                        {debounce => (
-                          <TextField
-                            className={classes.quantityField}
-                            fullWidth
-                            name="quantity"
-                            type="number"
-                            value={data.quantity}
-                            onChange={debounce}
-                            onBlur={submit}
-                          />
-                        )}
-                      </DebounceForm>
-                    )}
+                    {({ change, data, hasChanged, submit }) => {
+                      const handleQuantityChange = event => {
+                        if (/^\d*(\.\d+)?$/.test(event.target.value)) {
+                          change(event);
+                        }
+                      };
+
+                      return (
+                        <DebounceForm
+                          change={handleQuantityChange}
+                          submit={hasChanged ? submit : undefined}
+                          time={200}
+                        >
+                          {debounce => (
+                            <TextField
+                              className={classes.quantityField}
+                              fullWidth
+                              name="quantity"
+                              type="number"
+                              value={data.quantity}
+                              onChange={debounce}
+                              onBlur={submit}
+                            />
+                          )}
+                        </DebounceForm>
+                      );
+                    }}
                   </Form>
                 ) : (
                   <Skeleton />

--- a/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
@@ -15,6 +15,7 @@ import Skeleton from "@saleor/components/Skeleton";
 import TableCellAvatar, {
   AVATAR_MARGIN
 } from "@saleor/components/TableCellAvatar";
+import createNonNegativeValueChangeHandler from "@saleor/utils/handlers/nonNegativeValueChangeHandler";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -165,11 +166,9 @@ const OrderDraftDetailsProducts: React.FC<OrderDraftDetailsProductsProps> = prop
                     onSubmit={data => onOrderLineChange(line.id, data)}
                   >
                     {({ change, data, hasChanged, submit }) => {
-                      const handleQuantityChange = event => {
-                        if (/^\d*(\.\d+)?$/.test(event.target.value)) {
-                          change(event);
-                        }
-                      };
+                      const handleQuantityChange = createNonNegativeValueChangeHandler(
+                        change
+                      );
 
                       return (
                         <DebounceForm

--- a/src/products/components/ProductPricing/ProductPricing.tsx
+++ b/src/products/components/ProductPricing/ProductPricing.tsx
@@ -37,6 +37,12 @@ const ProductPricing: React.FC<ProductPricingProps> = props => {
 
   const formErrors = getFormErrors(["basePrice"], errors);
 
+  const handlePriceChange = event => {
+    if (/^\d*(\.\d+)?$/.test(event.target.value)) {
+      onChange(event);
+    }
+  };
+
   return (
     <Card>
       <CardTitle
@@ -58,7 +64,7 @@ const ProductPricing: React.FC<ProductPricingProps> = props => {
             name="basePrice"
             value={data.basePrice}
             currencySymbol={currency}
-            onChange={onChange}
+            onChange={handlePriceChange}
             InputProps={{
               inputProps: {
                 min: 0

--- a/src/products/components/ProductPricing/ProductPricing.tsx
+++ b/src/products/components/ProductPricing/ProductPricing.tsx
@@ -5,6 +5,7 @@ import CardTitle from "@saleor/components/CardTitle";
 import PriceField from "@saleor/components/PriceField";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
+import createNonNegativeValueChangeHandler from "@saleor/utils/handlers/nonNegativeValueChangeHandler";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -37,11 +38,7 @@ const ProductPricing: React.FC<ProductPricingProps> = props => {
 
   const formErrors = getFormErrors(["basePrice"], errors);
 
-  const handlePriceChange = event => {
-    if (/^\d*(\.\d+)?$/.test(event.target.value)) {
-      onChange(event);
-    }
-  };
+  const handlePriceChange = createNonNegativeValueChangeHandler(onChange);
 
   return (
     <Card>

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -36,6 +36,12 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
 
   const formErrors = getFormErrors(["price", "cost_price"], errors);
 
+  const handlePriceChange = event => {
+    if (/^\d*(\.\d+)?$/.test(event.target.value)) {
+      onChange(event);
+    }
+  };
+
   return (
     <Card>
       <CardTitle
@@ -55,8 +61,13 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
               })}
               value={price}
               currencySymbol={currencySymbol}
-              onChange={onChange}
+              onChange={handlePriceChange}
               disabled={loading}
+              InputProps={{
+                inputProps: {
+                  min: "0"
+                }
+              }}
             />
           </div>
           <div>
@@ -76,8 +87,13 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
               }
               value={costPrice}
               currencySymbol={currencySymbol}
-              onChange={onChange}
+              onChange={handlePriceChange}
               disabled={loading}
+              InputProps={{
+                inputProps: {
+                  min: "0"
+                }
+              }}
             />
           </div>
         </div>

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -5,6 +5,7 @@ import CardTitle from "@saleor/components/CardTitle";
 import PriceField from "@saleor/components/PriceField";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
+import createNonNegativeValueChangeHandler from "@saleor/utils/handlers/nonNegativeValueChangeHandler";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -36,11 +37,7 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
 
   const formErrors = getFormErrors(["price", "cost_price"], errors);
 
-  const handlePriceChange = event => {
-    if (/^\d*(\.\d+)?$/.test(event.target.value)) {
-      onChange(event);
-    }
-  };
+  const handlePriceChange = createNonNegativeValueChangeHandler(onChange);
 
   return (
     <Card>

--- a/src/utils/handlers/nonNegativeValueChangeHandler.ts
+++ b/src/utils/handlers/nonNegativeValueChangeHandler.ts
@@ -1,0 +1,11 @@
+import { FormChange } from "@saleor/hooks/useForm";
+
+function createNonNegativeValueChangeHandler(change: FormChange) {
+  return (event: React.ChangeEvent<any>) => {
+    if (/^\d*(\.\d+)?$/.test(event.target.value)) {
+      change(event);
+    }
+  };
+}
+
+export default createNonNegativeValueChangeHandler;


### PR DESCRIPTION
I want to merge this change because... it prevents from setting negative quantity in order draft lines quantity.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
