### PR TITLE
Hide "set as default" option if variant is already default 

### DIFF
--- a/src/components/CardMenu/CardMenu.tsx
+++ b/src/components/CardMenu/CardMenu.tsx
@@ -12,6 +12,7 @@ import React from "react";
 const ITEM_HEIGHT = 48;
 
 export interface CardMenuItem {
+  disabled?: boolean;
   label: string;
   testId?: string;
   onSelect: () => void;
@@ -118,6 +119,7 @@ const CardMenu: React.FC<CardMenuProps> = props => {
                 >
                   {menuItems.map((menuItem, menuItemIndex) => (
                     <MenuItem
+                      disabled={menuItem.disabled}
                       onClick={() => handleMenuClick(menuItemIndex)}
                       key={menuItem.label}
                       data-test={menuItem.testId}

--- a/src/components/SeoForm/SeoForm.tsx
+++ b/src/components/SeoForm/SeoForm.tsx
@@ -202,7 +202,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
               }
               InputProps={{
                 inputProps: {
-                  maxlength: maxSlugLength
+                  maxLength: maxSlugLength
                 }
               }}
               helperText={getSlugHelperMessage()}
@@ -237,7 +237,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
               }
               InputProps={{
                 inputProps: {
-                  maxlength: maxTitleLength
+                  maxLength: maxTitleLength
                 }
               }}
               helperText={intl.formatMessage(seoFieldMessage)}
@@ -273,7 +273,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
               helperText={intl.formatMessage(seoFieldMessage)}
               InputProps={{
                 inputProps: {
-                  maxlength: maxDescriptionLength
+                  maxLength: maxDescriptionLength
                 }
               }}
               value={description}

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -234,6 +234,9 @@ export const fragmentVariant = gql`
     }
     product {
       id
+      defaultVariant {
+        id
+      }
       images {
         ...ProductImageFragment
       }

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -67,6 +67,11 @@ export interface ProductVariant_price {
   currency: string;
 }
 
+export interface ProductVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface ProductVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -97,6 +102,7 @@ export interface ProductVariant_product_variants {
 export interface ProductVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: ProductVariant_product_defaultVariant | null;
   images: (ProductVariant_product_images | null)[] | null;
   name: string;
   thumbnail: ProductVariant_product_thumbnail | null;

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -171,7 +171,11 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
           {maybe(() => variant.product.name)}
         </AppHeader>
         <PageHeader title={header}>
-          <ProductVariantSetDefault onSetDefaultVariant={onSetDefaultVariant} />
+          {variant?.product?.defaultVariant.id !== variant?.id && (
+            <ProductVariantSetDefault
+              onSetDefaultVariant={onSetDefaultVariant}
+            />
+          )}
         </PageHeader>
         <Form initial={initialForm} onSubmit={handleSubmit} confirmLeave>
           {({ change, data, hasChanged, submit, triggerChange }) => {

--- a/src/products/components/ProductVariants/ProductVariants.tsx
+++ b/src/products/components/ProductVariants/ProductVariants.tsx
@@ -402,9 +402,11 @@ export const ProductVariants: React.FC<ProductVariantsProps> = props => {
                     data-test="actions"
                     onClick={e => e.stopPropagation()}
                   >
-                    <ProductVariantSetDefault
-                      onSetDefaultVariant={() => onSetDefaultVariant(variant)}
-                    />
+                    {variant?.id !== product?.defaultVariant.id && (
+                      <ProductVariantSetDefault
+                        onSetDefaultVariant={() => onSetDefaultVariant(variant)}
+                      />
+                    )}
                   </TableCell>
                 </SortableTableRow>
               );

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -1557,6 +1557,10 @@ export const variant = (placeholderImage: string): ProductVariant => ({
   privateMetadata: [],
   product: {
     __typename: "Product" as "Product",
+    defaultVariant: {
+      __typename: "ProductVariant",
+      id: "var1"
+    },
     id: "prod1",
     images: [
       {

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -67,6 +67,11 @@ export interface ProductVariantDetails_productVariant_price {
   currency: string;
 }
 
+export interface ProductVariantDetails_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface ProductVariantDetails_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -97,6 +102,7 @@ export interface ProductVariantDetails_productVariant_product_variants {
 export interface ProductVariantDetails_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: ProductVariantDetails_productVariant_product_defaultVariant | null;
   images: (ProductVariantDetails_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: ProductVariantDetails_productVariant_product_thumbnail | null;

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -314,6 +314,11 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_price {
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantUpdate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -344,6 +349,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_product
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: SimpleProductUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantUpdate_productVariant_product_thumbnail | null;
@@ -459,6 +465,11 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_p
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -489,6 +500,7 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_p
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksCreate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_thumbnail | null;
@@ -603,6 +615,11 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_p
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -633,6 +650,7 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_p
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksDelete_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_thumbnail | null;
@@ -748,6 +766,11 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_p
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -778,6 +801,7 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_p
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -74,6 +74,11 @@ export interface VariantCreate_productVariantCreate_productVariant_price {
   currency: string;
 }
 
+export interface VariantCreate_productVariantCreate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantCreate_productVariantCreate_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -104,6 +109,7 @@ export interface VariantCreate_productVariantCreate_productVariant_product_varia
 export interface VariantCreate_productVariantCreate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantCreate_productVariantCreate_productVariant_product_defaultVariant | null;
   images: (VariantCreate_productVariantCreate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantCreate_productVariantCreate_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -73,6 +73,11 @@ export interface VariantImageAssign_variantImageAssign_productVariant_price {
   currency: string;
 }
 
+export interface VariantImageAssign_variantImageAssign_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantImageAssign_variantImageAssign_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -103,6 +108,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_product_va
 export interface VariantImageAssign_variantImageAssign_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantImageAssign_variantImageAssign_productVariant_product_defaultVariant | null;
   images: (VariantImageAssign_variantImageAssign_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantImageAssign_variantImageAssign_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -73,6 +73,11 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_price 
   currency: string;
 }
 
+export interface VariantImageUnassign_variantImageUnassign_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantImageUnassign_variantImageUnassign_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -103,6 +108,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_produc
 export interface VariantImageUnassign_variantImageUnassign_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantImageUnassign_variantImageUnassign_productVariant_product_defaultVariant | null;
   images: (VariantImageUnassign_variantImageUnassign_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantImageUnassign_variantImageUnassign_productVariant_product_thumbnail | null;

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -74,6 +74,11 @@ export interface VariantUpdate_productVariantUpdate_productVariant_price {
   currency: string;
 }
 
+export interface VariantUpdate_productVariantUpdate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantUpdate_productVariantUpdate_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -104,6 +109,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product_varia
 export interface VariantUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
   images: (VariantUpdate_productVariantUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantUpdate_productVariantUpdate_productVariant_product_thumbnail | null;
@@ -219,6 +225,11 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_price {
   currency: string;
 }
 
+export interface VariantUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
@@ -249,6 +260,7 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_product
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
   images: (VariantUpdate_productVariantStocksUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantUpdate_productVariantStocksUpdate_productVariant_product_thumbnail | null;


### PR DESCRIPTION
I want to merge this change because it disables "set as default" option if the variant already is default one.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
