### PR TITLE
Limit slug to 255 characters

### DIFF
--- a/src/components/SeoForm/SeoForm.tsx
+++ b/src/components/SeoForm/SeoForm.tsx
@@ -23,7 +23,7 @@ enum SeoField {
 }
 
 const SLUG_REGEX = /^[a-zA-Z0-9\-\_]+$/;
-const maxSlugLength = 15;
+const maxSlugLength = 255;
 const maxTitleLength = 70;
 const maxDescriptionLength = 300;
 

--- a/src/components/SeoForm/SeoForm.tsx
+++ b/src/components/SeoForm/SeoForm.tsx
@@ -23,6 +23,9 @@ enum SeoField {
 }
 
 const SLUG_REGEX = /^[a-zA-Z0-9\-\_]+$/;
+const maxSlugLength = 15;
+const maxTitleLength = 70;
+const maxDescriptionLength = 300;
 
 const useStyles = makeStyles(
   theme => ({
@@ -176,7 +179,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
         {expanded && (
           <div className={classes.container}>
             <TextField
-              error={!!getError(SeoField.slug)}
+              error={!!getError(SeoField.slug) || slug.length > maxSlugLength}
               name={SeoField.slug}
               label={
                 <div className={classes.labelContainer}>
@@ -189,7 +192,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
                         defaultMessage="{numberOfCharacters} of {maxCharacters} characters"
                         description="character limit"
                         values={{
-                          maxCharacters: 70,
+                          maxCharacters: maxSlugLength,
                           numberOfCharacters: slug?.length
                         }}
                       />
@@ -197,8 +200,13 @@ const SeoForm: React.FC<SeoFormProps> = props => {
                   )}
                 </div>
               }
+              InputProps={{
+                inputProps: {
+                  maxlength: maxSlugLength
+                }
+              }}
               helperText={getSlugHelperMessage()}
-              value={slug?.slice(0, 69)}
+              value={slug}
               disabled={loading || disabled}
               placeholder={slug || slugify(slugPlaceholder, { lower: true })}
               onChange={handleSlugChange}
@@ -206,6 +214,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
             />
             <FormSpacer />
             <TextField
+              error={title.length > maxTitleLength}
               name={SeoField.title}
               label={
                 <div className={classes.labelContainer}>
@@ -218,7 +227,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
                         defaultMessage="{numberOfCharacters} of {maxCharacters} characters"
                         description="character limit"
                         values={{
-                          maxCharacters: 70,
+                          maxCharacters: maxTitleLength,
                           numberOfCharacters: title.length
                         }}
                       />
@@ -226,8 +235,13 @@ const SeoForm: React.FC<SeoFormProps> = props => {
                   )}
                 </div>
               }
+              InputProps={{
+                inputProps: {
+                  maxlength: maxTitleLength
+                }
+              }}
               helperText={intl.formatMessage(seoFieldMessage)}
-              value={title?.slice(0, 69)}
+              value={title}
               disabled={loading || disabled}
               placeholder={titlePlaceholder}
               onChange={onChange}
@@ -235,6 +249,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
             />
             <FormSpacer />
             <TextField
+              error={description.length > maxDescriptionLength}
               name={SeoField.description}
               label={
                 <div className={classes.labelContainer}>
@@ -247,7 +262,7 @@ const SeoForm: React.FC<SeoFormProps> = props => {
                         defaultMessage="{numberOfCharacters} of {maxCharacters} characters"
                         description="character limit"
                         values={{
-                          maxCharacters: 300,
+                          maxCharacters: maxDescriptionLength,
                           numberOfCharacters: description.length
                         }}
                       />
@@ -256,7 +271,12 @@ const SeoForm: React.FC<SeoFormProps> = props => {
                 </div>
               }
               helperText={intl.formatMessage(seoFieldMessage)}
-              value={description?.slice(0, 299)}
+              InputProps={{
+                inputProps: {
+                  maxlength: maxDescriptionLength
+                }
+              }}
+              value={description}
               onChange={onChange}
               disabled={loading || disabled}
               fullWidth


### PR DESCRIPTION
I want to merge this change because it prevents user to save more than 255 characters in slug field. Applies to title and description too.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
