### PR TITLE
nav menu item sorting sends the whole new order to the backend

### DIFF
--- a/src/navigation/components/MenuDetailsPage/MenuDetailsPage.tsx
+++ b/src/navigation/components/MenuDetailsPage/MenuDetailsPage.tsx
@@ -72,9 +72,9 @@ const MenuDetailsPage: React.FC<MenuDetailsPageProps> = ({
     }
   };
 
-  const handleChange = (operation: TreeOperation) => {
+  const handleChange = (operation: TreeOperation[]) => {
     if (!!operation) {
-      setTreeOperations([...treeOperations, operation]);
+      setTreeOperations([...treeOperations, ...operation]);
     }
   };
 

--- a/src/navigation/components/MenuItems/MenuItems.tsx
+++ b/src/navigation/components/MenuItems/MenuItems.tsx
@@ -27,7 +27,7 @@ const NODE_MARGIN = 40;
 export interface MenuItemsProps {
   canUndo: boolean;
   items: MenuDetails_menu_items[];
-  onChange: (operation: TreeOperation) => void;
+  onChange: (operation: TreeOperation[]) => void;
   onItemAdd: () => void;
   onItemClick: (id: string, type: MenuItemType) => void;
   onItemEdit: (id: string) => void;


### PR DESCRIPTION
I want to merge this change to try and fix #654.
However I have figured out, that it's most likely a backend issue. The modifications here apply the new updated order for each item affected by the move, but it is still impossible to change the first item.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
