### PR TITLE
Dock savebar if there is nothing to save

### DIFF
--- a/src/components/AppLayout/AppActionContext.tsx
+++ b/src/components/AppLayout/AppActionContext.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 
-const AppActionContext = React.createContext<React.RefObject<HTMLDivElement>>(
-  undefined
-);
+interface AppAction {
+  anchor: React.RefObject<HTMLDivElement>;
+  docked: boolean;
+  setDocked: (docked: boolean) => void;
+}
+const AppActionContext = React.createContext<AppAction>({
+  anchor: undefined,
+  docked: true,
+  setDocked: () => undefined
+});
+export const useAppAction = () => React.useContext(AppActionContext);
 
 export default AppActionContext;

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -50,6 +50,9 @@ const useStyles = makeStyles(
       position: "sticky",
       zIndex: 10
     },
+    appActionDocked: {
+      position: "static"
+    },
     appLoader: {
       height: appLoaderHeight,
       marginBottom: theme.spacing(2),
@@ -313,6 +316,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const [appState, dispatchAppState] = useAppState();
   const { location } = useRouter();
   const [isNavigatorVisible, setNavigatorVisibility] = React.useState(false);
+  const [docked, setDocked] = React.useState(true);
 
   const menuStructure = createMenuStructure(intl);
   const configurationMenu = createConfigurationMenu(intl);
@@ -365,7 +369,13 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
         setVisibility={setNavigatorVisibility}
       />
       <AppHeaderContext.Provider value={appHeaderAnchor}>
-        <AppActionContext.Provider value={appActionAnchor}>
+        <AppActionContext.Provider
+          value={{
+            anchor: appActionAnchor,
+            docked,
+            setDocked
+          }}
+        >
           <div className={classes.root}>
             <div className={classes.sideBar}>
               <ResponsiveDrawer
@@ -533,7 +543,12 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                     : children}
                 </main>
               </div>
-              <div className={classes.appAction} ref={appActionAnchor} />
+              <div
+                className={classNames(classes.appAction, {
+                  [classes.appActionDocked]: docked
+                })}
+                ref={appActionAnchor}
+              />
             </div>
           </div>
         </AppActionContext.Provider>

--- a/src/components/SaveButtonBar/SaveButtonBar.tsx
+++ b/src/components/SaveButtonBar/SaveButtonBar.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { maybe } from "../../misc";
-import AppActionContext, { useAppAction } from "../AppLayout/AppActionContext";
+import { useAppAction } from "../AppLayout/AppActionContext";
 import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "../ConfirmButton/ConfirmButton";

--- a/src/components/SaveButtonBar/SaveButtonBar.tsx
+++ b/src/components/SaveButtonBar/SaveButtonBar.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { maybe } from "../../misc";
-import AppActionContext from "../AppLayout/AppActionContext";
+import AppActionContext, { useAppAction } from "../AppLayout/AppActionContext";
 import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "../ConfirmButton/ConfirmButton";
@@ -41,8 +41,12 @@ const useStyles = makeStyles(
       backgroundColor: theme.palette.error.main,
       color: theme.palette.error.contrastText
     },
+    paper: {
+      borderBottomLeftRadius: 0,
+      borderBottomRightRadius: 0
+    },
     root: {
-      height: 120
+      height: 70
     },
     spacer: {
       flex: "1"
@@ -76,67 +80,69 @@ export const SaveButtonBar: React.FC<SaveButtonBarProps> = props => {
   } = props;
   const classes = useStyles(props);
 
+  const appAction = useAppAction();
   const intl = useIntl();
   const scrollPosition = useWindowScroll();
+
+  React.useEffect(() => {
+    appAction.setDocked(disabled);
+
+    return () => appAction.setDocked(true);
+  }, [disabled]);
+
   const scrolledToBottom =
     scrollPosition.y + window.innerHeight >= document.body.scrollHeight;
-  const shouldDisplay = onDelete || !disabled;
 
-  return (
-    <AppActionContext.Consumer>
-      {anchor =>
-        anchor ? (
-          <Portal container={anchor.current}>
-            {shouldDisplay && (
-              <div className={classes.root} {...rest}>
-                <Container>
-                  <Card elevation={scrolledToBottom ? 0 : 16}>
-                    <CardContent className={classes.content}>
-                      {!!onDelete && (
-                        <Button
-                          variant="contained"
-                          onClick={onDelete}
-                          className={classes.deleteButton}
-                          data-test="button-bar-delete"
-                        >
-                          {labels && labels.delete
-                            ? labels.delete
-                            : intl.formatMessage(buttonMessages.delete)}
-                        </Button>
-                      )}
-                      <div className={classes.spacer} />
-                      <Button
-                        className={classes.cancelButton}
-                        variant="text"
-                        onClick={onCancel}
-                        data-test="button-bar-cancel"
-                      >
-                        {maybe(
-                          () => labels.cancel,
-                          intl.formatMessage(buttonMessages.back)
-                        )}
-                      </Button>
-                      <ConfirmButton
-                        disabled={disabled}
-                        onClick={onSave}
-                        transitionState={state}
-                        data-test="button-bar-confirm"
-                      >
-                        {maybe(
-                          () => labels.save,
-                          intl.formatMessage(buttonMessages.save)
-                        )}
-                      </ConfirmButton>
-                    </CardContent>
-                  </Card>
-                </Container>
-              </div>
-            )}
-          </Portal>
-        ) : null
-      }
-    </AppActionContext.Consumer>
-  );
+  return appAction.anchor ? (
+    <Portal container={appAction.anchor.current}>
+      <div className={classes.root} {...rest}>
+        <Container>
+          <Card
+            className={classes.paper}
+            elevation={!(appAction.docked || scrolledToBottom) ? 16 : 0}
+          >
+            <CardContent className={classes.content}>
+              {!!onDelete && (
+                <Button
+                  variant="contained"
+                  onClick={onDelete}
+                  className={classes.deleteButton}
+                  data-test="button-bar-delete"
+                >
+                  {labels && labels.delete
+                    ? labels.delete
+                    : intl.formatMessage(buttonMessages.delete)}
+                </Button>
+              )}
+              <div className={classes.spacer} />
+              <Button
+                className={classes.cancelButton}
+                variant="text"
+                onClick={onCancel}
+                data-test="button-bar-cancel"
+              >
+                {maybe(
+                  () => labels.cancel,
+                  intl.formatMessage(buttonMessages.back)
+                )}
+              </Button>
+              <ConfirmButton
+                disabled={disabled}
+                onClick={onSave}
+                transitionState={state}
+                data-test="button-bar-confirm"
+              >
+                {maybe(
+                  () => labels.save,
+                  intl.formatMessage(buttonMessages.save)
+                )}
+              </ConfirmButton>
+            </CardContent>
+          </Card>
+        </Container>
+      </div>
+    </Portal>
+  ) : null;
 };
 SaveButtonBar.displayName = "SaveButtonBar";
 export default SaveButtonBar;


### PR DESCRIPTION
I want to merge this change because it changes savebar behaviour.
If there is nothing to save it docks now at the bottom of the page.

**PR intended to be tested with API branch:** master

### Screenshots
Before:
<img width="1680" alt="Screenshot 2020-10-14 at 10 21 49" src="https://user-images.githubusercontent.com/6833443/95962814-2861f380-0e07-11eb-8f12-91425b8f64c0.png">
<img width="1680" alt="Screenshot 2020-10-14 at 10 21 56" src="https://user-images.githubusercontent.com/6833443/95962822-2bf57a80-0e07-11eb-907b-32993083a495.png">

After:
<img width="1680" alt="Screenshot 2020-10-14 at 10 21 16" src="https://user-images.githubusercontent.com/6833443/95962842-31eb5b80-0e07-11eb-87b8-9cc8c8782f5e.png">
<img width="1680" alt="Screenshot 2020-10-14 at 10 22 10" src="https://user-images.githubusercontent.com/6833443/95962844-331c8880-0e07-11eb-91f7-e5097d040b05.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
