### PR TITLE
Add manage product types and attributes permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add default variant indicator for variant nav - #741 by @krzysztofwolski
 - Fix style of product type attributes empty table - #744 by @orzechdev
 - Fix order draft back button redirect - #753 by @orzechdev
+- Add manage product types and attributes permission - #768 by @orzechdev
 
 ## 2.10.1
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -412,7 +412,7 @@ type Attribute implements Node & ObjectWithMetadata {
 type AttributeAssign {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productType: ProductType
-  productErrors: [ProductAttributeError!]!
+  productErrors: [ProductError!]!
 }
 
 input AttributeAssignInput {
@@ -2534,6 +2534,7 @@ enum MetadataErrorCode {
   GRAPHQL_ERROR
   INVALID
   NOT_FOUND
+  REQUIRED
 }
 
 input MetadataInput {
@@ -3116,8 +3117,8 @@ input OrderFulfillLineInput {
 }
 
 input OrderFulfillStockInput {
-  quantity: Int
-  warehouse: ID
+  quantity: Int!
+  warehouse: ID!
 }
 
 type OrderLine implements Node {
@@ -3490,6 +3491,7 @@ enum PermissionEnum {
   MANAGE_ORDERS
   MANAGE_PAGES
   MANAGE_PRODUCTS
+  MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES
   MANAGE_SHIPPING
   MANAGE_SETTINGS
   MANAGE_TRANSLATIONS
@@ -3664,13 +3666,6 @@ type Product implements Node & ObjectWithMetadata {
   collections: [Collection]
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   isAvailableForPurchase: Boolean
-}
-
-type ProductAttributeError {
-  field: String
-  message: String
-  code: ProductErrorCode!
-  attributes: [ID!]
 }
 
 type ProductBulkDelete {
@@ -4173,6 +4168,11 @@ type ProductVariantDelete {
   productVariant: ProductVariant
 }
 
+input ProductVariantFilterInput {
+  search: String
+  sku: [String]
+}
+
 input ProductVariantInput {
   attributes: [AttributeValueInput]
   costPrice: PositiveDecimal
@@ -4275,8 +4275,8 @@ type Query {
   products(filter: ProductFilterInput, sortBy: ProductOrder, stockAvailability: StockAvailability, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   productType(id: ID!): ProductType
   productTypes(filter: ProductTypeFilterInput, sortBy: ProductTypeSortingInput, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
-  productVariant(id: ID!): ProductVariant
-  productVariants(ids: [ID], before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
+  productVariant(id: ID, sku: String): ProductVariant
+  productVariants(ids: [ID], filter: ProductVariantFilterInput, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   reportProductSales(period: ReportingPeriod!, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   payment(id: ID!): Payment
   payments(before: String, after: String, first: Int, last: Int): PaymentCountableConnection

--- a/src/configuration/index.tsx
+++ b/src/configuration/index.tsx
@@ -44,7 +44,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuAttributes"
           }),
           icon: <Attributes fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PRODUCTS,
+          permission: PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
           title: intl.formatMessage(sectionNames.attributes),
           url: attributeListUrl()
         },
@@ -54,7 +54,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuProductTypes"
           }),
           icon: <ProductTypes fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PRODUCTS,
+          permission: PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
           title: intl.formatMessage(sectionNames.productTypes),
           url: productTypeListUrl()
         }

--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -346,6 +346,10 @@ export const permissions: ShopInfo_shop_permissions[] = [
     name: "Manage products."
   },
   {
+    code: PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+    name: "Manage product types and attributes."
+  },
+  {
     code: PermissionEnum.MANAGE_SETTINGS,
     name: "Manage settings."
   },
@@ -438,6 +442,11 @@ export const adminUserPermissions: User_userPermissions[] = [
     __typename: "UserPermission",
     code: PermissionEnum.MANAGE_PRODUCTS,
     name: "Manage products."
+  },
+  {
+    __typename: "UserPermission",
+    code: PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+    name: "Manage product types and attributes."
   },
   {
     __typename: "UserPermission",

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -99,11 +99,6 @@ export interface ProductVariant_product_variants {
   images: (ProductVariant_product_variants_images | null)[] | null;
 }
 
-export interface ProductVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface ProductVariant_product {
   __typename: "Product";
   id: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -191,7 +191,9 @@ const Routes: React.FC = () => {
                 component={ProductSection}
               />
               <SectionRoute
-                permissions={[PermissionEnum.MANAGE_PRODUCTS]}
+                permissions={[
+                  PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES
+                ]}
                 path="/product-types"
                 component={ProductTypesSection}
               />
@@ -231,7 +233,9 @@ const Routes: React.FC = () => {
                 component={NavigationSection}
               />
               <SectionRoute
-                permissions={[PermissionEnum.MANAGE_PRODUCTS]}
+                permissions={[
+                  PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES
+                ]}
                 path={attributeSection}
                 component={AttributeSection}
               />

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -99,19 +99,14 @@ export interface ProductVariantDetails_productVariant_product_variants {
   images: (ProductVariantDetails_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface ProductVariantDetails_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface ProductVariantDetails_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: ProductVariantDetails_productVariant_product_defaultVariant | null;
   images: (ProductVariantDetails_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: ProductVariantDetails_productVariant_product_thumbnail | null;
   variants: (ProductVariantDetails_productVariant_product_variants | null)[] | null;
-  defaultVariant: ProductVariantDetails_productVariant_product_defaultVariant | null;
 }
 
 export interface ProductVariantDetails_productVariant_stocks_warehouse {

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -346,19 +346,14 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_product
   images: (SimpleProductUpdate_productVariantUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface SimpleProductUpdate_productVariantUpdate_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: SimpleProductUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantUpdate_productVariant_product_thumbnail | null;
   variants: (SimpleProductUpdate_productVariantUpdate_productVariant_product_variants | null)[] | null;
-  defaultVariant: SimpleProductUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
 }
 
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_stocks_warehouse {
@@ -502,19 +497,14 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_p
   images: (SimpleProductUpdate_productVariantStocksCreate_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksCreate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_thumbnail | null;
   variants: (SimpleProductUpdate_productVariantStocksCreate_productVariant_product_variants | null)[] | null;
-  defaultVariant: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_defaultVariant | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_stocks_warehouse {
@@ -657,19 +647,14 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_p
   images: (SimpleProductUpdate_productVariantStocksDelete_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksDelete_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_thumbnail | null;
   variants: (SimpleProductUpdate_productVariantStocksDelete_productVariant_product_variants | null)[] | null;
-  defaultVariant: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_defaultVariant | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_stocks_warehouse {
@@ -813,19 +798,14 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_p
   images: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
   images: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_thumbnail | null;
   variants: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_variants | null)[] | null;
-  defaultVariant: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse {

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -106,19 +106,14 @@ export interface VariantCreate_productVariantCreate_productVariant_product_varia
   images: (VariantCreate_productVariantCreate_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface VariantCreate_productVariantCreate_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface VariantCreate_productVariantCreate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantCreate_productVariantCreate_productVariant_product_defaultVariant | null;
   images: (VariantCreate_productVariantCreate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantCreate_productVariantCreate_productVariant_product_thumbnail | null;
   variants: (VariantCreate_productVariantCreate_productVariant_product_variants | null)[] | null;
-  defaultVariant: VariantCreate_productVariantCreate_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantCreate_productVariantCreate_productVariant_stocks_warehouse {

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -105,19 +105,14 @@ export interface VariantImageAssign_variantImageAssign_productVariant_product_va
   images: (VariantImageAssign_variantImageAssign_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface VariantImageAssign_variantImageAssign_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface VariantImageAssign_variantImageAssign_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantImageAssign_variantImageAssign_productVariant_product_defaultVariant | null;
   images: (VariantImageAssign_variantImageAssign_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantImageAssign_variantImageAssign_productVariant_product_thumbnail | null;
   variants: (VariantImageAssign_variantImageAssign_productVariant_product_variants | null)[] | null;
-  defaultVariant: VariantImageAssign_variantImageAssign_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant_stocks_warehouse {

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -105,19 +105,14 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_produc
   images: (VariantImageUnassign_variantImageUnassign_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface VariantImageUnassign_variantImageUnassign_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantImageUnassign_variantImageUnassign_productVariant_product_defaultVariant | null;
   images: (VariantImageUnassign_variantImageUnassign_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantImageUnassign_variantImageUnassign_productVariant_product_thumbnail | null;
   variants: (VariantImageUnassign_variantImageUnassign_productVariant_product_variants | null)[] | null;
-  defaultVariant: VariantImageUnassign_variantImageUnassign_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant_stocks_warehouse {

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -106,19 +106,14 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product_varia
   images: (VariantUpdate_productVariantUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface VariantUpdate_productVariantUpdate_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface VariantUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
   images: (VariantUpdate_productVariantUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantUpdate_productVariantUpdate_productVariant_product_thumbnail | null;
   variants: (VariantUpdate_productVariantUpdate_productVariant_product_variants | null)[] | null;
-  defaultVariant: VariantUpdate_productVariantUpdate_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant_stocks_warehouse {
@@ -262,19 +257,14 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_product
   images: (VariantUpdate_productVariantStocksUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
-export interface VariantUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant {
-  __typename: "ProductVariant";
-  id: string;
-}
-
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_product {
   __typename: "Product";
   id: string;
+  defaultVariant: VariantUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
   images: (VariantUpdate_productVariantStocksUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnail: VariantUpdate_productVariantStocksUpdate_productVariant_product_thumbnail | null;
   variants: (VariantUpdate_productVariantStocksUpdate_productVariant_product_variants | null)[] | null;
-  defaultVariant: VariantUpdate_productVariantStocksUpdate_productVariant_product_defaultVariant | null;
 }
 
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse {

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -512,6 +512,7 @@ export enum MetadataErrorCode {
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
   INVALID = "INVALID",
   NOT_FOUND = "NOT_FOUND",
+  REQUIRED = "REQUIRED",
 }
 
 export enum OrderAction {
@@ -658,6 +659,7 @@ export enum PermissionEnum {
   MANAGE_PAGES = "MANAGE_PAGES",
   MANAGE_PLUGINS = "MANAGE_PLUGINS",
   MANAGE_PRODUCTS = "MANAGE_PRODUCTS",
+  MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES = "MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES",
   MANAGE_SERVICE_ACCOUNTS = "MANAGE_SERVICE_ACCOUNTS",
   MANAGE_SETTINGS = "MANAGE_SETTINGS",
   MANAGE_SHIPPING = "MANAGE_SHIPPING",
@@ -1244,8 +1246,8 @@ export interface OrderFulfillLineInput {
 }
 
 export interface OrderFulfillStockInput {
-  quantity?: number | null;
-  warehouse?: string | null;
+  quantity: number;
+  warehouse: string;
 }
 
 export interface OrderLineCreateInput {


### PR DESCRIPTION
I want to merge this change because... it updates permission list and restricts access to product types and attributes pages based on the new permission.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
