### PR TITLE
add cost price field

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4203,6 +4203,10 @@
     "context": "tabel column header",
     "string": "Selling Price"
   },
+  "src_dot_products_dot_components_dot_ProductVariantPrice_dot_2051669917": {
+    "context": "tabel column header",
+    "string": "Cost Price"
+  },
   "src_dot_products_dot_components_dot_ProductVariantPrice_dot_3211447524": {
     "context": "info text",
     "string": "Channels that don’t have assigned prices will use their parent channel to define the price. Price will be converted to channel’s currency"

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -58,6 +58,9 @@ export const channelListingProductVariantFragment = gql`
     price {
       ...Money
     }
+    costPrice {
+      ...Money
+    }
   }
 `;
 
@@ -81,6 +84,7 @@ export const productFragment = gql`
 `;
 
 export const productVariantAttributesFragment = gql`
+  ${fragmentMoney}
   fragment ProductVariantAttributesFragment on Product {
     id
     attributes {

--- a/src/fragments/types/ChannelListingProductVariantFragment.ts
+++ b/src/fragments/types/ChannelListingProductVariantFragment.ts
@@ -19,8 +19,15 @@ export interface ChannelListingProductVariantFragment_price {
   currency: string;
 }
 
+export interface ChannelListingProductVariantFragment_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ChannelListingProductVariantFragment {
   __typename: "ProductVariantChannelListing";
   channel: ChannelListingProductVariantFragment_channel;
   price: ChannelListingProductVariantFragment_price | null;
+  costPrice: ChannelListingProductVariantFragment_costPrice | null;
 }

--- a/src/fragments/types/Product.ts
+++ b/src/fragments/types/Product.ts
@@ -131,10 +131,17 @@ export interface Product_variants_channelListing_price {
   currency: string;
 }
 
+export interface Product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface Product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: Product_variants_channelListing_channel;
   price: Product_variants_channelListing_price | null;
+  costPrice: Product_variants_channelListing_costPrice | null;
 }
 
 export interface Product_variants {

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -110,10 +110,17 @@ export interface ProductVariant_channelListing_price {
   currency: string;
 }
 
+export interface ProductVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductVariant_channelListing_channel;
   price: ProductVariant_channelListing_price | null;
+  costPrice: ProductVariant_channelListing_costPrice | null;
 }
 
 export interface ProductVariant_stocks_warehouse {

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -10,12 +10,12 @@ import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocomplet
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import SeoForm from "@saleor/components/SeoForm";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import useFormset from "@saleor/hooks/useFormset";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import ProductVariantPrice from "@saleor/products/components/ProductVariantPrice";
-import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import {
   getChoices,
   ProductAttributeValueChoices,
@@ -72,7 +72,7 @@ export interface ProductCreatePageSubmitData extends FormData {
 }
 
 interface ProductCreatePageProps {
-  channelsErrors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  channelsErrors: ProductChannelListingErrorFragment[];
   errors: ProductErrorFragment[];
   allChannelsCount: number;
   currentChannels: ChannelData[];

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -21,7 +21,10 @@ import {
   ProductAttributeValueChoices,
   ProductType
 } from "@saleor/products/utils/data";
-import { validatePrice } from "@saleor/products/utils/validation";
+import {
+  validateCostPrice,
+  validatePrice
+} from "@saleor/products/utils/validation";
 import { SearchCategories_search_edges_node } from "@saleor/searches/types/SearchCategories";
 import { SearchCollections_search_edges_node } from "@saleor/searches/types/SearchCollections";
 import { SearchProductTypes_search_edges_node_productAttributes } from "@saleor/searches/types/SearchProductTypes";
@@ -233,7 +236,11 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
         const formDisabled =
           !productTypeChoice?.hasVariants &&
           (!data.sku ||
-            data.channelListing.some(channel => validatePrice(channel.price)));
+            data.channelListing.some(
+              channel =>
+                validatePrice(channel.price) ||
+                validateCostPrice(channel.costPrice)
+            ));
 
         return (
           <Container>

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -18,7 +18,10 @@ import { sectionNames } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import ProductVariantPrice from "@saleor/products/components/ProductVariantPrice";
 import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
-import { validatePrice } from "@saleor/products/utils/validation";
+import {
+  validateCostPrice,
+  validatePrice
+} from "@saleor/products/utils/validation";
 import { SearchCategories_search_edges_node } from "@saleor/searches/types/SearchCategories";
 import { SearchCollections_search_edges_node } from "@saleor/searches/types/SearchCollections";
 import { FetchMoreProps, ListActions } from "@saleor/types";
@@ -242,7 +245,11 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
         const formDisabled =
           !product?.productType.hasVariants &&
           (!data.sku ||
-            data.channelListing?.some(channel => validatePrice(channel.price)));
+            data.channelListing?.some(
+              channel =>
+                validatePrice(channel.price) ||
+                validateCostPrice(channel.costPrice)
+            ));
 
         return (
           <>

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -10,6 +10,7 @@ import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import SeoForm from "@saleor/components/SeoForm";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { WarehouseFragment } from "@saleor/fragments/types/WarehouseFragment";
 import useFormset from "@saleor/hooks/useFormset";
@@ -17,7 +18,6 @@ import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import ProductVariantPrice from "@saleor/products/components/ProductVariantPrice";
-import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import {
   validateCostPrice,
   validatePrice
@@ -60,7 +60,7 @@ import ProductStocks, { ProductStockInput } from "../ProductStocks";
 import ProductVariants from "../ProductVariants";
 
 export interface ProductUpdatePageProps extends ListActions {
-  channelsErrors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  channelsErrors: ProductChannelListingErrorFragment[];
   errors: ProductErrorFragment[];
   allChannelsCount: number;
   currentChannels: ChannelData[];

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -23,12 +23,9 @@ import ProductVariantAttributes, {
   VariantAttributeInputData
 } from "../ProductVariantAttributes";
 import ProductVariantNavigation from "../ProductVariantNavigation";
-// import ProductVariantPrice from "../ProductVariantPrice";
 
 interface ProductVariantCreatePageFormData {
-  costPrice: string;
   images: string[];
-  price: string;
   quantity: string;
   sku: string;
   trackInventory: boolean;
@@ -54,7 +51,6 @@ interface ProductVariantCreatePageProps {
 }
 
 const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
-  // currencySymbol,
   disabled,
   errors,
   header,
@@ -81,9 +77,7 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
   } = useFormset<null, string>([]);
 
   const initialForm: ProductVariantCreatePageFormData = {
-    costPrice: "",
-    images: maybe(() => product.images.map(image => image.id)),
-    price: "",
+    images: product?.images?.map(image => image.id),
     quantity: "0",
     sku: "",
     trackInventory: true
@@ -127,15 +121,6 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
                   errors={errors}
                   onChange={handleAttributeChange}
                 />
-                <CardSpacer />
-                {/* <ProductVariantPrice
-                  errors={errors}
-                  price={data.price}
-                  currencySymbol={currencySymbol}
-                  costPrice={data.costPrice}
-                  loading={disabled}
-                  onChange={change}
-                /> */}
                 <CardSpacer />
                 <ProductStocks
                   data={data}

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -7,13 +7,13 @@ import Form from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductVariant } from "@saleor/fragments/types/ProductVariant";
 import { WarehouseFragment } from "@saleor/fragments/types/WarehouseFragment";
 import useFormset, {
   FormsetChange,
   FormsetData
 } from "@saleor/hooks/useFormset";
-import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import { VariantUpdate_productVariantUpdate_errors } from "@saleor/products/types/VariantUpdate";
 import {
   getAttributeInputFromVariant,
@@ -54,7 +54,7 @@ export interface ProductVariantPageSubmitData
 interface ProductVariantPageProps {
   variant?: ProductVariant;
   channels: ChannelPriceData[];
-  channelErrors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  channelErrors: ProductChannelListingErrorFragment[];
   errors: VariantUpdate_productVariantUpdate_errors[];
   saveButtonBarState: ConfirmButtonTransitionState;
   loading?: boolean;

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -20,7 +20,10 @@ import {
   getStockInputFromVariant
 } from "@saleor/products/utils/data";
 import { createVariantChannelsChangeHandler } from "@saleor/products/utils/handlers";
-import { validatePrice } from "@saleor/products/utils/validation";
+import {
+  validateCostPrice,
+  validatePrice
+} from "@saleor/products/utils/validation";
 import { diff } from "fast-array-diff";
 import React from "react";
 
@@ -34,14 +37,8 @@ import ProductVariantImageSelectDialog from "../ProductVariantImageSelectDialog"
 import ProductVariantNavigation from "../ProductVariantNavigation";
 import ProductVariantPrice from "../ProductVariantPrice";
 
-export interface ProductVariantChannelData {
-  id: string;
-  currency: string;
-  name: string;
-  price: number;
-}
 export interface ProductVariantPageFormData {
-  channelListing: ProductVariantChannelData[];
+  channelListing: ChannelPriceData[];
   sku: string;
   trackInventory: boolean;
 }
@@ -161,8 +158,10 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
               set,
               triggerChange
             );
-            const formDisabled = data.channelListing?.some(channel =>
-              validatePrice(channel.price)
+            const formDisabled = data.channelListing?.some(
+              channel =>
+                validatePrice(channel.price) ||
+                validateCostPrice(channel.costPrice)
             );
             return (
               <>

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -178,7 +178,6 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                             })
                           }
                           disabled={loading}
-                          required
                           hint={
                             costPriceError
                               ? getProductErrorMessage(

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -8,12 +8,12 @@ import {
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import { makeStyles } from "@material-ui/core/styles";
+import { ChannelPriceArgs, ChannelPriceData } from "@saleor/channels/utils";
 import CardTitle from "@saleor/components/CardTitle";
 import PriceField from "@saleor/components/PriceField";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
 import { renderCollection } from "@saleor/misc";
-import { ProductVariantChannelData } from "@saleor/products/components/ProductVariantPage";
 import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import { getFormErrors } from "@saleor/utils/errors";
 import getProductErrorMessage from "@saleor/utils/errors/product";
@@ -33,6 +33,7 @@ const useStyles = makeStyles(
     },
     colPrice: {
       textAlign: "right",
+      verticalAlign: "top",
       width: 200
     },
     colType: {
@@ -58,10 +59,10 @@ const useStyles = makeStyles(
 );
 
 interface ProductVariantPriceProps {
-  ProductVariantChannelListings: ProductVariantChannelData[];
+  ProductVariantChannelListings: ChannelPriceData[];
   errors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
   loading?: boolean;
-  onChange: (id: string, price: number) => void;
+  onChange: (id: string, data: ChannelPriceArgs) => void;
 }
 
 const numberOfColumns = 2;
@@ -75,7 +76,7 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
   } = props;
   const classes = useStyles(props);
   const intl = useIntl();
-  const formErrors = getFormErrors(["price"], errors);
+  const formErrors = getFormErrors(["price", "costPrice"], errors);
 
   return (
     <Card>
@@ -108,12 +109,12 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                   description="tabel column header"
                 />
               </TableCell>
-              {/* <TableCell className={classes.colType}>
+              <TableCell className={classes.colType}>
                 <FormattedMessage
                   defaultMessage="Cost Price"
                   description="tabel column header"
                 />
-              </TableCell> */}
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -121,6 +122,9 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
               ProductVariantChannelListings,
               (listing, index) => {
                 const error = formErrors.price?.channels?.find(
+                  id => id === listing.id
+                );
+                const costPriceError = formErrors.costPrice?.channels?.find(
                   id => id === listing.id
                 );
                 return (
@@ -135,9 +139,13 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                             defaultMessage: "Price"
                           })}
                           name={`${listing.id}-channel-price`}
-                          value={listing.price || ""}
+                          value={listing.price === null ? "" : listing.price}
                           currencySymbol={listing.currency}
-                          onChange={e => onChange(listing.id, e.target.value)}
+                          onChange={e =>
+                            onChange(listing.id, {
+                              price: e.target.value
+                            })
+                          }
                           disabled={loading}
                           required
                           hint={
@@ -150,24 +158,40 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                         <Skeleton />
                       )}
                     </TableCell>
-                    {/* FIXME: Waiting for costPrice */}
-                    {/* <TableCell className={classes.colPrice}>
-                    {listing?.channel ? (
-                      <PriceField
-                        className={classes.input}
-                        error={false}
-                        name={`${listing.id}-channel-price`}
-                        value={listing.price}
-                        currencySymbol={listing.currency}
-                        onChange={e =>
-                          onChange(listing.id, e.target.value)
-                        }
-                        disabled={loading}
-                      />
-                    ) : (
-                      <Skeleton />
-                    )}
-                  </TableCell> */}
+                    <TableCell className={classes.colPrice}>
+                      {listing ? (
+                        <PriceField
+                          className={classes.input}
+                          error={!!costPriceError?.length}
+                          label={intl.formatMessage({
+                            defaultMessage: "Cost Price",
+                            description: "tabel column header"
+                          })}
+                          name={`${listing.id}-channel-costPrice`}
+                          value={
+                            listing.costPrice === null ? "" : listing.costPrice
+                          }
+                          currencySymbol={listing.currency}
+                          onChange={e =>
+                            onChange(listing.id, {
+                              costPrice: e.target.value
+                            })
+                          }
+                          disabled={loading}
+                          required
+                          hint={
+                            costPriceError
+                              ? getProductErrorMessage(
+                                  formErrors.costPrice,
+                                  intl
+                                )
+                              : ""
+                          }
+                        />
+                      ) : (
+                        <Skeleton />
+                      )}
+                    </TableCell>
                   </TableRow>
                 );
               },

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -13,8 +13,8 @@ import CardTitle from "@saleor/components/CardTitle";
 import PriceField from "@saleor/components/PriceField";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { renderCollection } from "@saleor/misc";
-import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import { getFormErrors } from "@saleor/utils/errors";
 import getProductErrorMessage from "@saleor/utils/errors/product";
 import React from "react";
@@ -60,7 +60,7 @@ const useStyles = makeStyles(
 
 interface ProductVariantPriceProps {
   ProductVariantChannelListings: ChannelPriceData[];
-  errors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  errors: ProductChannelListingErrorFragment[];
   loading?: boolean;
   onChange: (id: string, data: ChannelPriceArgs) => void;
 }

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -298,6 +298,11 @@ export const product: (
             id: "123",
             name: "Channel1"
           },
+          costPrice: {
+            __typename: "Money",
+            amount: 10,
+            currency: "USD"
+          },
           price: {
             __typename: "Money",
             amount: 1,
@@ -311,6 +316,11 @@ export const product: (
             currencyCode: "USD",
             id: "124",
             name: "Channel2"
+          },
+          costPrice: {
+            __typename: "Money",
+            amount: 10,
+            currency: "USD"
           },
           price: {
             __typename: "Money",
@@ -1818,6 +1828,11 @@ export const variant = (placeholderImage: string): ProductVariant => ({
         id: "test1",
         name: "Test channel"
       },
+      costPrice: {
+        __typename: "Money",
+        amount: 10,
+        currency: "USD"
+      },
       price: {
         __typename: "Money",
         amount: 10,
@@ -1831,6 +1846,11 @@ export const variant = (placeholderImage: string): ProductVariant => ({
         currencyCode: "USD",
         id: "test2",
         name: "Test channel other"
+      },
+      costPrice: {
+        __typename: "Money",
+        amount: 10,
+        currency: "USD"
       },
       price: {
         __typename: "Money",

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -591,7 +591,7 @@ export const ProductChannelListingUpdateMutation = gql`
       product {
         ...Product
       }
-      productChannelListingErrors {
+      errors: productChannelListingErrors {
         ...ProductChannelListingErrorFragment
       }
     }
@@ -614,7 +614,7 @@ export const ProductVariantChannelListingUpdateMutation = gql`
       variant {
         ...ProductVariant
       }
-      productChannelListingErrors {
+      errors: productChannelListingErrors {
         ...ProductChannelListingErrorFragment
       }
     }

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -176,6 +176,13 @@ const productVariantCreateQuery = gql`
         sortOrder
         url
       }
+      channelListing {
+        channel {
+          id
+          name
+          currencyCode
+        }
+      }
       name
       productType {
         id

--- a/src/products/types/ProductChannelListingUpdate.ts
+++ b/src/products/types/ProductChannelListingUpdate.ts
@@ -172,7 +172,7 @@ export interface ProductChannelListingUpdate_productChannelListingUpdate_product
   variants: (ProductChannelListingUpdate_productChannelListingUpdate_product_variants | null)[] | null;
 }
 
-export interface ProductChannelListingUpdate_productChannelListingUpdate_productChannelListingErrors {
+export interface ProductChannelListingUpdate_productChannelListingUpdate_errors {
   __typename: "ProductChannelListingError";
   code: ProductErrorCode;
   field: string | null;
@@ -183,7 +183,7 @@ export interface ProductChannelListingUpdate_productChannelListingUpdate_product
 export interface ProductChannelListingUpdate_productChannelListingUpdate {
   __typename: "ProductChannelListingUpdate";
   product: ProductChannelListingUpdate_productChannelListingUpdate_product | null;
-  productChannelListingErrors: ProductChannelListingUpdate_productChannelListingUpdate_productChannelListingErrors[];
+  errors: ProductChannelListingUpdate_productChannelListingUpdate_errors[];
 }
 
 export interface ProductChannelListingUpdate {

--- a/src/products/types/ProductChannelListingUpdate.ts
+++ b/src/products/types/ProductChannelListingUpdate.ts
@@ -131,10 +131,17 @@ export interface ProductChannelListingUpdate_productChannelListingUpdate_product
   currency: string;
 }
 
+export interface ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing_channel;
   price: ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing_price | null;
+  costPrice: ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductChannelListingUpdate_productChannelListingUpdate_product_variants {

--- a/src/products/types/ProductCreate.ts
+++ b/src/products/types/ProductCreate.ts
@@ -137,10 +137,17 @@ export interface ProductCreate_productCreate_product_variants_channelListing_pri
   currency: string;
 }
 
+export interface ProductCreate_productCreate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductCreate_productCreate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductCreate_productCreate_product_variants_channelListing_channel;
   price: ProductCreate_productCreate_product_variants_channelListing_price | null;
+  costPrice: ProductCreate_productCreate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductCreate_productCreate_product_variants {

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -131,10 +131,17 @@ export interface ProductDetails_product_variants_channelListing_price {
   currency: string;
 }
 
+export interface ProductDetails_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductDetails_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductDetails_product_variants_channelListing_channel;
   price: ProductDetails_product_variants_channelListing_price | null;
+  costPrice: ProductDetails_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductDetails_product_variants {

--- a/src/products/types/ProductImageCreate.ts
+++ b/src/products/types/ProductImageCreate.ts
@@ -137,10 +137,17 @@ export interface ProductImageCreate_productImageCreate_product_variants_channelL
   currency: string;
 }
 
+export interface ProductImageCreate_productImageCreate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductImageCreate_productImageCreate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductImageCreate_productImageCreate_product_variants_channelListing_channel;
   price: ProductImageCreate_productImageCreate_product_variants_channelListing_price | null;
+  costPrice: ProductImageCreate_productImageCreate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductImageCreate_productImageCreate_product_variants {

--- a/src/products/types/ProductImageUpdate.ts
+++ b/src/products/types/ProductImageUpdate.ts
@@ -137,10 +137,17 @@ export interface ProductImageUpdate_productImageUpdate_product_variants_channelL
   currency: string;
 }
 
+export interface ProductImageUpdate_productImageUpdate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductImageUpdate_productImageUpdate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductImageUpdate_productImageUpdate_product_variants_channelListing_channel;
   price: ProductImageUpdate_productImageUpdate_product_variants_channelListing_price | null;
+  costPrice: ProductImageUpdate_productImageUpdate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductImageUpdate_productImageUpdate_product_variants {

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -137,10 +137,17 @@ export interface ProductUpdate_productUpdate_product_variants_channelListing_pri
   currency: string;
 }
 
+export interface ProductUpdate_productUpdate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductUpdate_productUpdate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductUpdate_productUpdate_product_variants_channelListing_channel;
   price: ProductUpdate_productUpdate_product_variants_channelListing_price | null;
+  costPrice: ProductUpdate_productUpdate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductUpdate_productUpdate_product_variants {

--- a/src/products/types/ProductVariantChannelListingUpdate.ts
+++ b/src/products/types/ProductVariantChannelListingUpdate.ts
@@ -152,7 +152,7 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
   trackInventory: boolean;
 }
 
-export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors {
+export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_errors {
   __typename: "ProductChannelListingError";
   code: ProductErrorCode;
   field: string | null;
@@ -163,7 +163,7 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
 export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate {
   __typename: "ProductVariantChannelListingUpdate";
   variant: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant | null;
-  productChannelListingErrors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  errors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_errors[];
 }
 
 export interface ProductVariantChannelListingUpdate {

--- a/src/products/types/ProductVariantChannelListingUpdate.ts
+++ b/src/products/types/ProductVariantChannelListingUpdate.ts
@@ -112,10 +112,17 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
   currency: string;
 }
 
+export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing_channel;
   price: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing_price | null;
+  costPrice: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing_costPrice | null;
 }
 
 export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_stocks_warehouse {

--- a/src/products/types/ProductVariantCreateData.ts
+++ b/src/products/types/ProductVariantCreateData.ts
@@ -13,6 +13,18 @@ export interface ProductVariantCreateData_product_images {
   url: string;
 }
 
+export interface ProductVariantCreateData_product_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+  currencyCode: string;
+}
+
+export interface ProductVariantCreateData_product_channelListing {
+  __typename: "ProductChannelListing";
+  channel: ProductVariantCreateData_product_channelListing_channel;
+}
+
 export interface ProductVariantCreateData_product_productType_variantAttributes_values {
   __typename: "AttributeValue";
   id: string;
@@ -58,6 +70,7 @@ export interface ProductVariantCreateData_product {
   __typename: "Product";
   id: string;
   images: (ProductVariantCreateData_product_images | null)[] | null;
+  channelListing: ProductVariantCreateData_product_channelListing[] | null;
   name: string;
   productType: ProductVariantCreateData_product_productType;
   thumbnail: ProductVariantCreateData_product_thumbnail | null;

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -110,10 +110,17 @@ export interface ProductVariantDetails_productVariant_channelListing_price {
   currency: string;
 }
 
+export interface ProductVariantDetails_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductVariantDetails_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductVariantDetails_productVariant_channelListing_channel;
   price: ProductVariantDetails_productVariant_channelListing_price | null;
+  costPrice: ProductVariantDetails_productVariant_channelListing_costPrice | null;
 }
 
 export interface ProductVariantDetails_productVariant_stocks_warehouse {

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -137,10 +137,17 @@ export interface SimpleProductUpdate_productUpdate_product_variants_channelListi
   currency: string;
 }
 
+export interface SimpleProductUpdate_productUpdate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productUpdate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productUpdate_product_variants_channelListing_channel;
   price: SimpleProductUpdate_productUpdate_product_variants_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productUpdate_product_variants_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productUpdate_product_variants {
@@ -287,10 +294,17 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_channel
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantUpdate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productVariantUpdate_productVariant_channelListing_channel;
   price: SimpleProductUpdate_productVariantUpdate_productVariant_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productVariantUpdate_productVariant_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_stocks_warehouse {
@@ -437,10 +451,17 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_c
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing_channel;
   price: SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_stocks_warehouse {
@@ -586,10 +607,17 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_c
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing_channel;
   price: SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_stocks_warehouse {
@@ -736,10 +764,17 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_c
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing_channel;
   price: SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse {

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -118,10 +118,17 @@ export interface VariantCreate_productVariantCreate_productVariant_channelListin
   currency: string;
 }
 
+export interface VariantCreate_productVariantCreate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantCreate_productVariantCreate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantCreate_productVariantCreate_productVariant_channelListing_channel;
   price: VariantCreate_productVariantCreate_productVariant_channelListing_price | null;
+  costPrice: VariantCreate_productVariantCreate_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantCreate_productVariantCreate_productVariant_stocks_warehouse {

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -118,10 +118,17 @@ export interface VariantImageAssign_variantImageAssign_productVariant_channelLis
   currency: string;
 }
 
+export interface VariantImageAssign_variantImageAssign_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantImageAssign_variantImageAssign_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantImageAssign_variantImageAssign_productVariant_channelListing_channel;
   price: VariantImageAssign_variantImageAssign_productVariant_channelListing_price | null;
+  costPrice: VariantImageAssign_variantImageAssign_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant_stocks_warehouse {

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -118,10 +118,17 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_channe
   currency: string;
 }
 
+export interface VariantImageUnassign_variantImageUnassign_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantImageUnassign_variantImageUnassign_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantImageUnassign_variantImageUnassign_productVariant_channelListing_channel;
   price: VariantImageUnassign_variantImageUnassign_productVariant_channelListing_price | null;
+  costPrice: VariantImageUnassign_variantImageUnassign_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant_stocks_warehouse {

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -118,10 +118,17 @@ export interface VariantUpdate_productVariantUpdate_productVariant_channelListin
   currency: string;
 }
 
+export interface VariantUpdate_productVariantUpdate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantUpdate_productVariantUpdate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantUpdate_productVariantUpdate_productVariant_channelListing_channel;
   price: VariantUpdate_productVariantUpdate_productVariant_channelListing_price | null;
+  costPrice: VariantUpdate_productVariantUpdate_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant_stocks_warehouse {
@@ -268,10 +275,17 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_channel
   currency: string;
 }
 
+export interface VariantUpdate_productVariantStocksUpdate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantUpdate_productVariantStocksUpdate_productVariant_channelListing_channel;
   price: VariantUpdate_productVariantStocksUpdate_productVariant_channelListing_price | null;
+  costPrice: VariantUpdate_productVariantStocksUpdate_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse {

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -1,4 +1,4 @@
-import { ChannelData } from "@saleor/channels/utils";
+import { ChannelData, ChannelPriceArgs } from "@saleor/channels/utils";
 import { FormChange } from "@saleor/hooks/useForm";
 import { FormsetChange, FormsetData } from "@saleor/hooks/useFormset";
 import { maybe } from "@saleor/misc";
@@ -11,6 +11,13 @@ import {
   ProductAttributeValueChoices,
   ProductType
 } from "./data";
+
+const setPrice = (price: string, initialPrice: number) =>
+  typeof price === "string"
+    ? price
+      ? parseInt(price, 10)
+      : null
+    : initialPrice;
 
 export function createAttributeChangeHandler(
   changeAttributeData: FormsetChange<string[]>,
@@ -53,7 +60,8 @@ export function createChannelsPriceChangeHandler(
   updateChannels: (data: ChannelData[]) => void,
   triggerChange: () => void
 ) {
-  return (id: string, price: number) => {
+  return (id: string, priceData: ChannelPriceArgs) => {
+    const { costPrice, price } = priceData;
     const channelIndex = channelListing.findIndex(channel => channel.id === id);
     const channel = channelListing[channelIndex];
 
@@ -61,7 +69,8 @@ export function createChannelsPriceChangeHandler(
       ...channelListing.slice(0, channelIndex),
       {
         ...channel,
-        price
+        costPrice: setPrice(costPrice, channel.costPrice),
+        price: setPrice(price, channel.price)
       },
       ...channelListing.slice(channelIndex + 1)
     ];
@@ -100,7 +109,8 @@ export function createVariantChannelsChangeHandler(
   setData: (data: ProductVariantPageFormData) => void,
   triggerChange: () => void
 ) {
-  return (id: string, price: number) => {
+  return (id: string, priceData: ChannelPriceArgs) => {
+    const { costPrice, price } = priceData;
     const { channelListing } = data;
     const channelIndex = channelListing.findIndex(channel => channel.id === id);
     const channel = channelListing[channelIndex];
@@ -109,7 +119,8 @@ export function createVariantChannelsChangeHandler(
       ...channelListing.slice(0, channelIndex),
       {
         ...channel,
-        price
+        costPrice: setPrice(costPrice, channel.costPrice),
+        price: setPrice(price, channel.price)
       },
       ...channelListing.slice(channelIndex + 1)
     ];

--- a/src/products/utils/validation.ts
+++ b/src/products/utils/validation.ts
@@ -2,3 +2,6 @@ export const validatePrice = (price: string | number) =>
   price === "" ||
   price === null ||
   (typeof price === "string" ? parseInt(price, 10) : price) < 0;
+
+export const validateCostPrice = (price: string | number) =>
+  (typeof price === "string" && price !== "" ? parseInt(price, 10) : price) < 0;

--- a/src/products/views/ProductCreate/ProductCreate.tsx
+++ b/src/products/views/ProductCreate/ProductCreate.tsx
@@ -190,7 +190,7 @@ export const ProductCreateView: React.FC = () => {
         }
         channelsErrors={
           updateVariantChannelsOpts.data?.productVariantChannelListingUpdate
-            ?.productChannelListingErrors
+            ?.errors
         }
         errors={[
           ...(productCreateOpts.data?.productCreate.errors || []),

--- a/src/products/views/ProductCreate/handlers.ts
+++ b/src/products/views/ProductCreate/handlers.ts
@@ -35,7 +35,6 @@ const getSimpleProductVariables = (
 ) => ({
   input: {
     attributes: [],
-    costPrice: formData.basePrice,
     product: productId,
     sku: formData.sku,
     stocks: formData.stocks?.map(stock => ({
@@ -97,23 +96,16 @@ export function createHandler(
       const variantErrors = result[1].data.productVariantCreate.errors;
       const variantId = result[1].data.productVariantCreate.productVariant.id;
       if (variantErrors.length === 0 && variantId) {
-        const variantPrices = formData.channelListing
-          .map(
-            listing =>
-              listing.price !== null && {
-                channelId: listing.id,
-                price: listing.price
-              }
-          )
-          .filter(Boolean);
-        if (variantPrices.length) {
-          updateVariantChannels({
-            variables: {
-              id: variantId,
-              input: variantPrices
-            }
-          });
-        }
+        updateVariantChannels({
+          variables: {
+            id: variantId,
+            input: formData.channelListing.map(listing => ({
+              channelId: listing.id,
+              costPrice: listing.costPrice,
+              price: listing.price
+            }))
+          }
+        });
       }
     } else {
       updateChannels(getChannelsVariables(productId, formData.channelListing));

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -135,10 +135,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
 
   const [updateChannels, updateChannelsOpts] = useProductChannelListingUpdate({
     onCompleted: data => {
-      if (
-        data.productChannelListingUpdate.productChannelListingErrors.length ===
-        0
-      ) {
+      if (data.productChannelListingUpdate.errors.length === 0) {
         const updatedProductChannelsChoices: ChannelData[] = createSortedChannelsDataFromProduct(
           data.productChannelListingUpdate.product
         );
@@ -299,10 +296,9 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     ...(productVariantCreateOpts?.data?.productVariantCreate.errors || [])
   ];
   const channelsErrors = [
-    ...(updateChannelsOpts?.data?.productChannelListingUpdate
-      ?.productChannelListingErrors || []),
+    ...(updateChannelsOpts?.data?.productChannelListingUpdate?.errors || []),
     ...(updateVariantChannelsOpts?.data?.productVariantChannelListingUpdate
-      ?.productChannelListingErrors || [])
+      ?.errors || [])
   ];
   return product === null ? (
     <NotFoundPage onBack={handleBack} />

--- a/src/products/views/ProductUpdate/handlers.ts
+++ b/src/products/views/ProductUpdate/handlers.ts
@@ -1,11 +1,11 @@
 import { createChannelsDataFromProduct } from "@saleor/channels/utils";
 import { BulkStockErrorFragment } from "@saleor/fragments/types/BulkStockErrorFragment";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { StockErrorFragment } from "@saleor/fragments/types/StockErrorFragment";
 import { ProductUpdatePageSubmitData } from "@saleor/products/components/ProductUpdatePage";
 import {
   ProductChannelListingUpdate,
-  ProductChannelListingUpdate_productChannelListingUpdate_productChannelListingErrors,
   ProductChannelListingUpdateVariables
 } from "@saleor/products/types/ProductChannelListingUpdate";
 import { ProductDetails_product } from "@saleor/products/types/ProductDetails";
@@ -17,7 +17,6 @@ import {
 } from "@saleor/products/types/ProductUpdate";
 import {
   ProductVariantChannelListingUpdate,
-  ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors,
   ProductVariantChannelListingUpdateVariables
 } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import {
@@ -127,8 +126,7 @@ export function createUpdateHandler(
       | ProductErrorFragment
       | StockErrorFragment
       | BulkStockErrorFragment
-      | ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors
-      | ProductChannelListingUpdate_productChannelListingUpdate_productChannelListingErrors
+      | ProductChannelListingErrorFragment
     >;
 
     if (product.productType.hasVariants) {

--- a/src/products/views/ProductUpdate/handlers.ts
+++ b/src/products/views/ProductUpdate/handlers.ts
@@ -45,7 +45,6 @@ const getSimpleProductVariables = (
   deleteStocks: data.removeStocks,
   productVariantId: productId,
   productVariantInput: {
-    costPrice: data.basePrice,
     sku: data.sku,
     trackInventory: data.trackInventory
   },
@@ -80,6 +79,13 @@ const getChannelsVariables = (
     }
   };
 };
+
+const getVariantChannelsInput = (data: ProductUpdatePageSubmitData) =>
+  data.channelListing.map(listing => ({
+    channelId: listing.id,
+    costPrice: listing.costPrice,
+    price: listing.price
+  }));
 
 export function createUpdateHandler(
   product: ProductDetails_product,
@@ -156,10 +162,7 @@ export function createUpdateHandler(
           updateVariantChannels({
             variables: {
               id: variantId,
-              input: data.channelListing.map(listing => ({
-                channelId: listing.id,
-                price: listing.price
-              }))
+              input: getVariantChannelsInput(data)
             }
           });
           updateChannels({
@@ -186,10 +189,7 @@ export function createUpdateHandler(
         updateVariantChannels({
           variables: {
             id: product.variants[0].id,
-            input: data.channelListing.map(listing => ({
-              channelId: listing.id,
-              price: listing.price
-            }))
+            input: getVariantChannelsInput(data)
           }
         });
       }

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -80,10 +80,13 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
     variant: ProductVariantDetails_productVariant
   ) => {
     if (
-      data.channelListing.some(
-        (channel, index) =>
-          channel.price !== variant.channelListing[index]?.price.amount
-      )
+      data.channelListing.some((channel, index) => {
+        const variantChannel = variant.channelListing[index];
+        return (
+          channel.price !== variantChannel?.price.amount ||
+          channel.price !== variantChannel?.costPrice.amount
+        );
+      })
     ) {
       updateChannels({
         variables: {
@@ -169,8 +172,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
                     channels={channels}
                     channelErrors={
                       updateChannelsOpts?.data
-                        ?.productVariantChannelListingUpdate
-                        ?.productChannelListingErrors || []
+                        ?.productVariantChannelListingUpdate?.errors || []
                     }
                     saveButtonBarState={updateVariant.opts.status}
                     loading={disableFormSave}

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -90,6 +90,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
           id: variant.id,
           input: data.channelListing.map(listing => ({
             channelId: listing.id,
+            costPrice: listing.costPrice,
             price: listing.price
           }))
         }

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -80,11 +80,13 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
     variant: ProductVariantDetails_productVariant
   ) => {
     if (
-      data.channelListing.some((channel, index) => {
-        const variantChannel = variant.channelListing[index];
+      data.channelListing.some(channel => {
+        const variantChannel = variant.channelListing.find(
+          variantChannel => variantChannel.channel.id === channel.id
+        );
         return (
-          channel.price !== variantChannel?.price.amount ||
-          channel.price !== variantChannel?.costPrice.amount
+          channel.price !== variantChannel?.price?.amount ||
+          channel.costPrice !== variantChannel?.costPrice?.amount
         );
       })
     ) {

--- a/src/storybook/stories/products/ProductVariantCreatePage.tsx
+++ b/src/storybook/stories/products/ProductVariantCreatePage.tsx
@@ -9,12 +9,20 @@ import { product as productFixture } from "../../../products/fixtures";
 import Decorator from "../../Decorator";
 
 const product = productFixture(placeholderImage);
+const channels = product.channelListing.map(listing => ({
+  costPrice: null,
+  currency: listing.channel.currencyCode,
+  id: listing.channel.id,
+  name: listing.channel.name,
+  price: null
+}));
 
 storiesOf("Views / Products / Create product variant", module)
   .addDecorator(Decorator)
   .add("default", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       disabled={false}
       errors={[]}
       header="Add variant"
@@ -28,7 +36,8 @@ storiesOf("Views / Products / Create product variant", module)
   ))
   .add("with errors", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       disabled={false}
       errors={[
         {
@@ -58,7 +67,8 @@ storiesOf("Views / Products / Create product variant", module)
   ))
   .add("when loading data", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       disabled={true}
       errors={[]}
       header="Add variant"
@@ -72,7 +82,8 @@ storiesOf("Views / Products / Create product variant", module)
   ))
   .add("add first variant", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       disabled={false}
       errors={[]}
       header="Add variant"


### PR DESCRIPTION
I want to merge this change because...
it adds ability to set the cost price for a variant. Cost prices are rendered next to regular selling prices in the "Pricing" box on the following pages:
- simple product page
- variant page in configurable product
- variant creator

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** feature/multichannel-multicurrency

### Screenshots
<img width="1295" alt="Screenshot 2020-10-16 at 11 14 54" src="https://user-images.githubusercontent.com/10812388/96240377-203dbb80-0fa1-11eb-8847-ca67712cf35e.png">
<img width="1279" alt="Screenshot 2020-10-16 at 11 15 14" src="https://user-images.githubusercontent.com/10812388/96240385-2469d900-0fa1-11eb-9bdc-2e3ee59fc885.png">
<img width="964" alt="Screenshot 2020-10-16 at 11 15 37" src="https://user-images.githubusercontent.com/10812388/96240399-292e8d00-0fa1-11eb-8bc1-2ef7d4b7a21a.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
