### PR TITLE
add cost price field

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -208,10 +208,6 @@
     "context": "vat not included in order price",
     "string": "does not apply"
   },
-  "productExportFieldAvailability": {
-    "context": "product field",
-    "string": "Available for purchase"
-  },
   "productExportFieldCategory": {
     "context": "product field",
     "string": "Category"
@@ -227,10 +223,6 @@
   "productExportFieldName": {
     "context": "product field",
     "string": "Name"
-  },
-  "productExportFieldPrice": {
-    "context": "product field",
-    "string": "Cost Price"
   },
   "productExportFieldProductImages": {
     "context": "product field",
@@ -251,10 +243,6 @@
   "productExportFieldVariantImages": {
     "context": "product field",
     "string": "Variant Images"
-  },
-  "productExportFieldVariantPrice": {
-    "context": "product field",
-    "string": "Variant Price"
   },
   "productExportFieldVariantSku": {
     "context": "product field",
@@ -341,6 +329,10 @@
   "saleDetailsUnassignProduct": {
     "context": "unassign product from sale, button",
     "string": "Unassign"
+  },
+  "shippingZoneDetailsDialogsDeleteShippingMethod": {
+    "context": "delete shipping method",
+    "string": "Are you sure you want to delete {name}?"
   },
   "shippingZoneDetailsDialogsDeleteShippingZone": {
     "context": "delete shipping zone",
@@ -1418,14 +1410,6 @@
   "src_dot_collections_dot_views_dot_942133001": {
     "context": "dialog title",
     "string": "Delete image"
-  },
-  "src_dot_collections_dot_views_dot_CollectionList_dot_1547167026": {
-    "context": "publish collections",
-    "string": "Publish"
-  },
-  "src_dot_collections_dot_views_dot_CollectionList_dot_2237014112": {
-    "context": "unpublish collections",
-    "string": "Unpublish"
   },
   "src_dot_collections_dot_views_dot_CollectionList_dot_2491832187": {
     "string": "{counter,plural,one{Are you sure you want to delete this collection?} other{Are you sure you want to delete {displayQuantity} collections?}}"
@@ -3124,21 +3108,12 @@
   "src_dot_orders_dot_components_dot_OrderDraftDetailsProducts_dot_1895667608": {
     "string": "Product"
   },
-  "src_dot_orders_dot_components_dot_OrderDraftDetailsProducts_dot_270371448": {
-    "string": "Product is out of stock"
-  },
   "src_dot_orders_dot_components_dot_OrderDraftDetailsProducts_dot_2796503714": {
     "context": "quantity of ordered products",
     "string": "Quantity"
   },
-  "src_dot_orders_dot_components_dot_OrderDraftDetailsProducts_dot_2963336581": {
-    "string": "Product is unavailable to purchase"
-  },
   "src_dot_orders_dot_components_dot_OrderDraftDetailsProducts_dot_546865199": {
     "string": "No Products added to Order"
-  },
-  "src_dot_orders_dot_components_dot_OrderDraftDetailsProducts_dot_59548500": {
-    "string": "Product is hidden"
   },
   "src_dot_orders_dot_components_dot_OrderDraftDetailsProducts_dot_878013594": {
     "context": "total price of ordered products",
@@ -4815,6 +4790,10 @@
     "context": "tabel column header",
     "string": "Selling Price"
   },
+  "src_dot_products_dot_components_dot_ProductVariantPrice_dot_2051669917": {
+    "context": "tabel column header",
+    "string": "Cost Price"
+  },
   "src_dot_products_dot_components_dot_ProductVariantPrice_dot_3211447524": {
     "context": "info text",
     "string": "Channels that don’t have assigned prices will use their parent channel to define the price. Price will be converted to channel’s currency"
@@ -5028,6 +5007,10 @@
     "context": "shipping section name",
     "string": "Shipping Methods"
   },
+  "src_dot_shipping_dot_components_dot_DeleteShippingRateDialog_dot_1502359905": {
+    "context": "dialog header",
+    "string": "Delete Shipping Method"
+  },
   "src_dot_shipping_dot_components_dot_OrderValue_dot_1063111824": {
     "context": "max price in channel",
     "string": "Max. value"
@@ -5061,6 +5044,24 @@
   "src_dot_shipping_dot_components_dot_OrderValue_dot_882649212": {
     "context": "checkbox label",
     "string": "There are no value limits"
+  },
+  "src_dot_shipping_dot_components_dot_OrderWeight_dot_1064401942": {
+    "context": "info text",
+    "string": "This rate will apply to all orders"
+  },
+  "src_dot_shipping_dot_components_dot_OrderWeight_dot_2935375344": {
+    "string": "Min. Order Weight"
+  },
+  "src_dot_shipping_dot_components_dot_OrderWeight_dot_3721863048": {
+    "context": "card title",
+    "string": "Order weight"
+  },
+  "src_dot_shipping_dot_components_dot_OrderWeight_dot_882649212": {
+    "context": "checkbox label",
+    "string": "There are no value limits"
+  },
+  "src_dot_shipping_dot_components_dot_OrderWeight_dot_959089677": {
+    "string": "Max. Order Weight"
   },
   "src_dot_shipping_dot_components_dot_PricingCard_dot_1099355007": {
     "context": "pricing card title",
@@ -5232,6 +5233,10 @@
   "src_dot_shipping_dot_components_dot_ShippingZonesList_dot_655374584": {
     "string": "No shipping zones found"
   },
+  "src_dot_shipping_dot_price": {
+    "context": "error message",
+    "string": "Maximum price cannot be lower than minimum"
+  },
   "src_dot_shipping_dot_views_dot_1005071028": {
     "string": "Are you sure you want to delete {shippingZoneName} shipping zone?"
   },
@@ -5270,6 +5275,10 @@
   },
   "src_dot_shipping_dot_views_dot_WeightRatesUpdate_dot_3014453080": {
     "string": "Manage Channels Availability"
+  },
+  "src_dot_shipping_dot_weight": {
+    "context": "error message",
+    "string": "Maximum weight cannot be lower than minimum"
   },
   "src_dot_show": {
     "context": "button",

--- a/src/channels/utils.ts
+++ b/src/channels/utils.ts
@@ -18,8 +18,8 @@ export interface ChannelData {
   name: string;
   publicationDate: string | null;
   currency: string;
-  price: number;
-  costPrice: number;
+  price: string;
+  costPrice: string;
   availableForPurchase: string;
   isAvailableForPurchase: boolean;
   visibleInListings: boolean;
@@ -29,8 +29,8 @@ export interface ChannelPriceData {
   id: string;
   name: string;
   currency: string;
-  price: number | null;
-  costPrice?: number | null;
+  price: string;
+  costPrice?: string;
 }
 
 interface IChannelPriceArgs {
@@ -45,31 +45,31 @@ export type ChannelPriceArgs = RequireOnlyOne<
 export interface ChannelVoucherData {
   id: string;
   name: string;
-  discountValue: number | null;
+  discountValue: string;
   currency: string;
-  minSpent: number | null;
+  minSpent: string;
 }
 
 export interface ChannelSaleData {
   id: string;
   name: string;
-  discountValue: number | null;
+  discountValue: string;
   currency: string;
 }
 
 export const createVoucherChannels = (data?: Channels_channels[]) =>
   data?.map(channel => ({
     currency: channel.currencyCode,
-    discountValue: null,
+    discountValue: "",
     id: channel.id,
-    minSpent: null,
+    minSpent: "",
     name: channel.name
   }));
 
 export const createSaleChannels = (data?: Channels_channels[]) =>
   data?.map(channel => ({
     currency: channel.currencyCode,
-    discountValue: null,
+    discountValue: "",
     id: channel.id,
     name: channel.name
   }));
@@ -79,18 +79,18 @@ export const createVariantChannels = (
 ): ChannelPriceData[] => {
   if (data) {
     const productChannels = data?.product.channelListing.map(listing => ({
-      costPrice: null,
+      costPrice: "",
       currency: listing.channel.currencyCode,
       id: listing.channel.id,
       name: listing.channel.name,
-      price: null
+      price: ""
     }));
     const variantChannels = data?.channelListing.map(listing => ({
-      costPrice: listing.costPrice?.amount || null,
+      costPrice: listing.costPrice?.amount.toString() || "",
       currency: listing.channel.currencyCode,
       id: listing.channel.id,
       name: listing.channel.name,
-      price: listing.price.amount
+      price: listing.price.amount.toString()
     }));
     return uniqBy([...variantChannels, ...productChannels], obj => obj.id);
   }
@@ -188,16 +188,16 @@ export const createChannelsDataFromVoucher = (
 ) =>
   voucherData?.channelListing?.map(option => ({
     currency: option.channel.currencyCode || option?.minSpent?.currency || "",
-    discountValue: option.discountValue,
+    discountValue: option.discountValue.toString() || "",
     id: option.channel.id,
-    minSpent: option?.minSpent?.amount || null,
+    minSpent: option?.minSpent?.amount.toString() || "",
     name: option.channel.name
   })) || [];
 
 export const createChannelsDataFromSale = (saleData?: SaleDetails_sale) =>
   saleData?.channelListing?.map(option => ({
     currency: option.channel.currencyCode || "",
-    discountValue: option.discountValue,
+    discountValue: option.discountValue.toString() || "",
     id: option.channel.id,
     name: option.channel.name
   })) || [];
@@ -213,13 +213,13 @@ export const createChannelsDataFromProduct = (
     const costPrice = variantChannel?.costPrice;
     return {
       availableForPurchase: option?.availableForPurchase,
-      costPrice: costPrice ? costPrice.amount : null,
+      costPrice: costPrice ? costPrice.amount.toString() : "",
       currency: price ? price.currency : "",
       id: option.channel.id,
       isAvailableForPurchase: !!option?.isAvailableForPurchase,
       isPublished: option.isPublished,
       name: option.channel.name,
-      price: price ? price.amount : null,
+      price: price ? price.amount.toString() : "",
       publicationDate: option.publicationDate,
       visibleInListings: !!option.visibleInListings
     };

--- a/src/discounts/components/SaleValue/SaleValue.tsx
+++ b/src/discounts/components/SaleValue/SaleValue.tsx
@@ -101,17 +101,13 @@ const SaleValue: React.FC<SaleValueProps> = ({
                                   )
                                 : ""
                             }
-                            name={"value"}
+                            name="value"
                             onChange={e => onChange(listing.id, e.target.value)}
                             label={intl.formatMessage({
                               defaultMessage: "Discount Value",
                               description: "sale discount"
                             })}
-                            value={
-                              listing.discountValue !== null
-                                ? listing.discountValue
-                                : ""
-                            }
+                            value={listing.discountValue || ""}
                             type="number"
                             fullWidth
                             inputProps={{

--- a/src/discounts/components/VoucherRequirements/VoucherRequirements.tsx
+++ b/src/discounts/components/VoucherRequirements/VoucherRequirements.tsx
@@ -152,11 +152,7 @@ const VoucherRequirements = ({
                                 }
                                 label={minimalOrderValueText}
                                 name="minSpent"
-                                value={
-                                  listing.minSpent !== null
-                                    ? listing.minSpent
-                                    : ""
-                                }
+                                value={listing.minSpent || ""}
                                 onChange={e =>
                                   onChannelChange(listing.id, {
                                     minSpent: e.target.value

--- a/src/discounts/components/VoucherValue/VoucherValue.tsx
+++ b/src/discounts/components/VoucherValue/VoucherValue.tsx
@@ -130,11 +130,7 @@ const VoucherValue: React.FC<VoucherValueProps> = props => {
                             label={intl.formatMessage({
                               defaultMessage: "Discount Value"
                             })}
-                            value={
-                              listing.discountValue !== null
-                                ? listing.discountValue
-                                : ""
-                            }
+                            value={listing.discountValue || ""}
                             type="number"
                             fullWidth
                             inputProps={{

--- a/src/discounts/handlers.ts
+++ b/src/discounts/handlers.ts
@@ -28,9 +28,9 @@ export function createChannelsChangeHandler(
       {
         ...channel,
         ...(minSpent !== undefined
-          ? { minSpent: minSpent ? parseInt(minSpent, 10) : null }
+          ? { minSpent }
           : {
-              discountValue: discountValue ? parseInt(discountValue, 10) : null
+              discountValue
             })
       },
       ...channelListing.slice(channelIndex + 1)
@@ -53,7 +53,7 @@ export function createSaleChannelsChangeHandler(
       ...channelListing.slice(0, channelIndex),
       {
         ...channel,
-        discountValue: !discountValue ? null : parseInt(discountValue, 10)
+        discountValue
       },
       ...channelListing.slice(channelIndex + 1)
     ];

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -62,6 +62,9 @@ export const channelListingProductVariantFragment = gql`
     price {
       ...Money
     }
+    costPrice {
+      ...Money
+    }
   }
 `;
 

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -88,6 +88,7 @@ export const productFragment = gql`
 `;
 
 export const productVariantAttributesFragment = gql`
+  ${fragmentMoney}
   fragment ProductVariantAttributesFragment on Product {
     id
     attributes {
@@ -136,7 +137,6 @@ export const productVariantAttributesFragment = gql`
 
 export const productFragmentDetails = gql`
   ${fragmentProductImage}
-  ${fragmentMoney}
   ${productVariantAttributesFragment}
   ${stockFragment}
   ${weightFragment}

--- a/src/fragments/types/ChannelListingProductVariantFragment.ts
+++ b/src/fragments/types/ChannelListingProductVariantFragment.ts
@@ -19,8 +19,15 @@ export interface ChannelListingProductVariantFragment_price {
   currency: string;
 }
 
+export interface ChannelListingProductVariantFragment_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ChannelListingProductVariantFragment {
   __typename: "ProductVariantChannelListing";
   channel: ChannelListingProductVariantFragment_channel;
   price: ChannelListingProductVariantFragment_price | null;
+  costPrice: ChannelListingProductVariantFragment_costPrice | null;
 }

--- a/src/fragments/types/Product.ts
+++ b/src/fragments/types/Product.ts
@@ -155,10 +155,17 @@ export interface Product_variants_channelListing_price {
   currency: string;
 }
 
+export interface Product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface Product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: Product_variants_channelListing_channel;
   price: Product_variants_channelListing_price | null;
+  costPrice: Product_variants_channelListing_costPrice | null;
 }
 
 export interface Product_variants {

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -130,10 +130,17 @@ export interface ProductVariant_channelListing_price {
   currency: string;
 }
 
+export interface ProductVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductVariant_channelListing_channel;
   price: ProductVariant_channelListing_price | null;
+  costPrice: ProductVariant_channelListing_costPrice | null;
 }
 
 export interface ProductVariant_stocks_warehouse {

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -11,13 +11,13 @@ import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocomplet
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import SeoForm from "@saleor/components/SeoForm";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductErrorWithAttributesFragment } from "@saleor/fragments/types/ProductErrorWithAttributesFragment";
 import { TaxTypeFragment } from "@saleor/fragments/types/TaxTypeFragment";
 import useFormset from "@saleor/hooks/useFormset";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import ProductVariantPrice from "@saleor/products/components/ProductVariantPrice";
-import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import {
   getAttributeInputFromProductType,
   getChoices,
@@ -82,7 +82,7 @@ export interface ProductCreatePageSubmitData extends FormData {
 
 interface ProductCreatePageProps {
   errors: ProductErrorWithAttributesFragment[];
-  channelsErrors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  channelsErrors: ProductChannelListingErrorFragment[];
   allChannelsCount: number;
   currentChannels: ChannelData[];
   collections: SearchCollections_search_edges_node[];

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -23,7 +23,10 @@ import {
   getChoices,
   ProductType
 } from "@saleor/products/utils/data";
-import { validatePrice } from "@saleor/products/utils/validation";
+import {
+  validateCostPrice,
+  validatePrice
+} from "@saleor/products/utils/validation";
 import { SearchCategories_search_edges_node } from "@saleor/searches/types/SearchCategories";
 import { SearchCollections_search_edges_node } from "@saleor/searches/types/SearchCollections";
 import { SearchProductTypes_search_edges_node_productAttributes } from "@saleor/searches/types/SearchProductTypes";
@@ -280,7 +283,11 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
         const formDisabled =
           !productTypeChoice?.hasVariants &&
           (!data.sku ||
-            data.channelListing.some(channel => validatePrice(channel.price)));
+            data.channelListing.some(
+              channel =>
+                validatePrice(channel.price) ||
+                validateCostPrice(channel.costPrice)
+            ));
 
         return (
           <Container>

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -11,6 +11,7 @@ import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import SeoForm from "@saleor/components/SeoForm";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductErrorWithAttributesFragment } from "@saleor/fragments/types/ProductErrorWithAttributesFragment";
 import { TaxTypeFragment } from "@saleor/fragments/types/TaxTypeFragment";
 import { WarehouseFragment } from "@saleor/fragments/types/WarehouseFragment";
@@ -19,7 +20,6 @@ import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import ProductVariantPrice from "@saleor/products/components/ProductVariantPrice";
-import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import {
   validateCostPrice,
   validatePrice
@@ -65,7 +65,7 @@ import ProductVariants from "../ProductVariants";
 export interface ProductUpdatePageProps extends ListActions {
   defaultWeightUnit: string;
   errors: ProductErrorWithAttributesFragment[];
-  channelsErrors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  channelsErrors: ProductChannelListingErrorFragment[];
   allChannelsCount: number;
   currentChannels: ChannelData[];
   channelChoices: SingleAutocompleteChoiceType[];

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -20,7 +20,10 @@ import { sectionNames } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import ProductVariantPrice from "@saleor/products/components/ProductVariantPrice";
 import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
-import { validatePrice } from "@saleor/products/utils/validation";
+import {
+  validateCostPrice,
+  validatePrice
+} from "@saleor/products/utils/validation";
 import { SearchCategories_search_edges_node } from "@saleor/searches/types/SearchCategories";
 import { SearchCollections_search_edges_node } from "@saleor/searches/types/SearchCollections";
 import { FetchMoreProps, ListActions, ReorderAction } from "@saleor/types";
@@ -288,7 +291,11 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
         const formDisabled =
           !product?.productType.hasVariants &&
           (!data.sku ||
-            data.channelListing?.some(channel => validatePrice(channel.price)));
+            data.channelListing.some(
+              channel =>
+                validatePrice(channel.price) ||
+                validateCostPrice(channel.costPrice)
+            ));
 
         return (
           <>

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -27,12 +27,9 @@ import ProductVariantAttributes, {
   VariantAttributeInputData
 } from "../ProductVariantAttributes";
 import ProductVariantNavigation from "../ProductVariantNavigation";
-// import ProductVariantPrice from "../ProductVariantPrice";
 
 interface ProductVariantCreatePageFormData extends MetadataFormData {
-  costPrice: string;
   images: string[];
-  price: string;
   quantity: string;
   sku: string;
   trackInventory: boolean;
@@ -46,7 +43,6 @@ export interface ProductVariantCreatePageSubmitData
 }
 
 interface ProductVariantCreatePageProps {
-  currencySymbol: string;
   disabled: boolean;
   errors: ProductErrorWithAttributesFragment[];
   header: string;
@@ -62,7 +58,6 @@ interface ProductVariantCreatePageProps {
 }
 
 const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
-  // currencySymbol,
   disabled,
   errors,
   header,
@@ -95,10 +90,8 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
   } = useMetadataChangeTrigger();
 
   const initialForm: ProductVariantCreatePageFormData = {
-    costPrice: "",
     images: product?.images.map(image => image.id),
     metadata: [],
-    price: "",
     privateMetadata: [],
     quantity: "0",
     sku: "",
@@ -146,13 +139,6 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
                   errors={errors}
                   onChange={handleAttributeChange}
                 />
-                <CardSpacer />
-                {/* <ProductVariantPrice
-                  errors={errors}
-                  currencySymbol={currencySymbol}
-                  loading={disabled}
-                  onChange={change}
-                /> */}
                 <CardSpacer />
                 <ProductShipping
                   data={data}

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -53,7 +53,7 @@ export interface ProductVariantCreatePageSubmitData
 
 interface ProductVariantCreatePageProps {
   channels: ChannelPriceData[];
-  channelErrors: ProductChannelListingErrorFragment[];
+  channelErrors: ProductChannelListingErrorFragment[] | undefined;
   disabled: boolean;
   errors: ProductErrorWithAttributesFragment[];
   header: string;
@@ -70,7 +70,7 @@ interface ProductVariantCreatePageProps {
 
 const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
   channels,
-  channelErrors,
+  channelErrors = [],
   disabled,
   errors,
   header,

--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreator.stories.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreator.stories.tsx
@@ -90,7 +90,7 @@ const props: ProductVariantCreatorContentProps = {
     currency: listing.discountedPrice.currency,
     id: listing.channel.id,
     name: listing.channel.name,
-    price: listing.discountedPrice.amount
+    price: listing.discountedPrice?.amount.toString() || ""
   })),
   data: {
     ...data,

--- a/src/products/components/ProductVariantCreatorPage/fixtures.ts
+++ b/src/products/components/ProductVariantCreatorPage/fixtures.ts
@@ -10,9 +10,9 @@ import {
 } from "./form";
 
 export const channels: ChannelPriceData[] = [
-  { currency: "USD", id: "channel-1", name: "Channel1", price: 1 },
-  { currency: "USD", id: "channel-2", name: "Channel2", price: 2 },
-  { currency: "USD", id: "channel-3", name: "Channel3", price: 3 }
+  { currency: "USD", id: "channel-1", name: "Channel1", price: "1" },
+  { currency: "USD", id: "channel-2", name: "Channel2", price: "2" },
+  { currency: "USD", id: "channel-3", name: "Channel3", price: "3" }
 ];
 
 export const attributes = [

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -9,6 +9,7 @@ import { MetadataFormData } from "@saleor/components/Metadata";
 import Metadata from "@saleor/components/Metadata/Metadata";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductErrorWithAttributesFragment } from "@saleor/fragments/types/ProductErrorWithAttributesFragment";
 import { ProductVariant } from "@saleor/fragments/types/ProductVariant";
 import { WarehouseFragment } from "@saleor/fragments/types/WarehouseFragment";
@@ -16,7 +17,6 @@ import useFormset, {
   FormsetChange,
   FormsetData
 } from "@saleor/hooks/useFormset";
-import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import { VariantUpdate_productVariantUpdate_errors } from "@saleor/products/types/VariantUpdate";
 import {
   getAttributeInputFromVariant,
@@ -68,7 +68,7 @@ interface ProductVariantPageProps {
     | VariantUpdate_productVariantUpdate_errors[];
   header: string;
   channels: ChannelPriceData[];
-  channelErrors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  channelErrors: ProductChannelListingErrorFragment[];
   loading?: boolean;
   placeholderImage?: string;
   saveButtonBarState: ConfirmButtonTransitionState;

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -23,7 +23,10 @@ import {
   getStockInputFromVariant
 } from "@saleor/products/utils/data";
 import { createVariantChannelsChangeHandler } from "@saleor/products/utils/handlers";
-import { validatePrice } from "@saleor/products/utils/validation";
+import {
+  validateCostPrice,
+  validatePrice
+} from "@saleor/products/utils/validation";
 import { ReorderAction } from "@saleor/types";
 import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -42,14 +45,8 @@ import ProductVariantNavigation from "../ProductVariantNavigation";
 import ProductVariantPrice from "../ProductVariantPrice";
 import ProductVariantSetDefault from "../ProductVariantSetDefault";
 
-export interface ProductVariantChannelData {
-  id: string;
-  currency: string;
-  name: string;
-  price: number;
-}
 export interface ProductVariantPageFormData extends MetadataFormData {
-  channelListing: ProductVariantChannelData[];
+  channelListing: ChannelPriceData[];
   sku: string;
   trackInventory: boolean;
   weight: string;
@@ -206,8 +203,10 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
               set,
               triggerChange
             );
-            const formDisabled = data.channelListing?.some(channel =>
-              validatePrice(channel.price)
+            const formDisabled = data.channelListing?.some(
+              channel =>
+                validatePrice(channel.price) ||
+                validateCostPrice(channel.costPrice)
             );
             return (
               <>

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -121,12 +121,13 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
             {renderCollection(
               ProductVariantChannelListings,
               (listing, index) => {
-                const error = formErrors.price?.channels?.find(
+                const priceError = formErrors.price?.channels?.find(
                   id => id === listing.id
                 );
                 const costPriceError = formErrors.costPrice?.channels?.find(
                   id => id === listing.id
                 );
+
                 return (
                   <TableRow key={listing?.id || `skeleton-${index}`}>
                     <TableCell>{listing?.name || <Skeleton />}</TableCell>
@@ -134,22 +135,23 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                       {listing ? (
                         <PriceField
                           className={classes.input}
-                          error={!!error?.length}
+                          error={!!priceError?.length}
                           label={intl.formatMessage({
                             defaultMessage: "Price"
                           })}
                           name={`${listing.id}-channel-price`}
-                          value={listing.price === null ? "" : listing.price}
+                          value={listing.price || ""}
                           currencySymbol={listing.currency}
                           onChange={e =>
                             onChange(listing.id, {
+                              costPrice: listing.costPrice,
                               price: e.target.value
                             })
                           }
                           disabled={loading}
                           required
                           hint={
-                            error
+                            priceError
                               ? getProductErrorMessage(formErrors.price, intl)
                               : ""
                           }
@@ -168,13 +170,12 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                             description: "tabel column header"
                           })}
                           name={`${listing.id}-channel-costPrice`}
-                          value={
-                            listing.costPrice === null ? "" : listing.costPrice
-                          }
+                          value={listing.costPrice || ""}
                           currencySymbol={listing.currency}
                           onChange={e =>
                             onChange(listing.id, {
-                              costPrice: e.target.value
+                              costPrice: e.target.value,
+                              price: listing.price
                             })
                           }
                           disabled={loading}

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -8,12 +8,12 @@ import {
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import { makeStyles } from "@material-ui/core/styles";
+import { ChannelPriceArgs, ChannelPriceData } from "@saleor/channels/utils";
 import CardTitle from "@saleor/components/CardTitle";
 import PriceField from "@saleor/components/PriceField";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
 import { renderCollection } from "@saleor/misc";
-import { ProductVariantChannelData } from "@saleor/products/components/ProductVariantPage";
 import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import { getFormErrors } from "@saleor/utils/errors";
 import getProductErrorMessage from "@saleor/utils/errors/product";
@@ -33,6 +33,7 @@ const useStyles = makeStyles(
     },
     colPrice: {
       textAlign: "right",
+      verticalAlign: "top",
       width: 200
     },
     colType: {
@@ -58,10 +59,10 @@ const useStyles = makeStyles(
 );
 
 interface ProductVariantPriceProps {
-  ProductVariantChannelListings: ProductVariantChannelData[];
+  ProductVariantChannelListings: ChannelPriceData[];
   errors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
   loading?: boolean;
-  onChange: (id: string, price: number) => void;
+  onChange: (id: string, data: ChannelPriceArgs) => void;
 }
 
 const numberOfColumns = 2;
@@ -75,7 +76,7 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
   } = props;
   const classes = useStyles(props);
   const intl = useIntl();
-  const formErrors = getFormErrors(["price"], errors);
+  const formErrors = getFormErrors(["price", "costPrice"], errors);
 
   return (
     <Card>
@@ -108,12 +109,12 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                   description="tabel column header"
                 />
               </TableCell>
-              {/* <TableCell className={classes.colType}>
+              <TableCell className={classes.colType}>
                 <FormattedMessage
                   defaultMessage="Cost Price"
                   description="tabel column header"
                 />
-              </TableCell> */}
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -121,6 +122,9 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
               ProductVariantChannelListings,
               (listing, index) => {
                 const error = formErrors.price?.channels?.find(
+                  id => id === listing.id
+                );
+                const costPriceError = formErrors.costPrice?.channels?.find(
                   id => id === listing.id
                 );
                 return (
@@ -135,9 +139,13 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                             defaultMessage: "Price"
                           })}
                           name={`${listing.id}-channel-price`}
-                          value={listing.price || ""}
+                          value={listing.price === null ? "" : listing.price}
                           currencySymbol={listing.currency}
-                          onChange={e => onChange(listing.id, e.target.value)}
+                          onChange={e =>
+                            onChange(listing.id, {
+                              price: e.target.value
+                            })
+                          }
                           disabled={loading}
                           required
                           hint={
@@ -150,24 +158,40 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                         <Skeleton />
                       )}
                     </TableCell>
-                    {/* FIXME: Waiting for costPrice */}
-                    {/* <TableCell className={classes.colPrice}>
-                    {listing?.channel ? (
-                      <PriceField
-                        className={classes.input}
-                        error={false}
-                        name={`${listing.id}-channel-price`}
-                        value={listing.price}
-                        currencySymbol={listing.currency}
-                        onChange={e =>
-                          onChange(listing.id, e.target.value)
-                        }
-                        disabled={loading}
-                      />
-                    ) : (
-                      <Skeleton />
-                    )}
-                  </TableCell> */}
+                    <TableCell className={classes.colPrice}>
+                      {listing ? (
+                        <PriceField
+                          className={classes.input}
+                          error={!!costPriceError?.length}
+                          label={intl.formatMessage({
+                            defaultMessage: "Cost Price",
+                            description: "tabel column header"
+                          })}
+                          name={`${listing.id}-channel-costPrice`}
+                          value={
+                            listing.costPrice === null ? "" : listing.costPrice
+                          }
+                          currencySymbol={listing.currency}
+                          onChange={e =>
+                            onChange(listing.id, {
+                              costPrice: e.target.value
+                            })
+                          }
+                          disabled={loading}
+                          required
+                          hint={
+                            costPriceError
+                              ? getProductErrorMessage(
+                                  formErrors.costPrice,
+                                  intl
+                                )
+                              : ""
+                          }
+                        />
+                      ) : (
+                        <Skeleton />
+                      )}
+                    </TableCell>
                   </TableRow>
                 );
               },

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -13,8 +13,8 @@ import CardTitle from "@saleor/components/CardTitle";
 import PriceField from "@saleor/components/PriceField";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { renderCollection } from "@saleor/misc";
-import { ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors } from "@saleor/products/types/ProductVariantChannelListingUpdate";
 import { getFormErrors } from "@saleor/utils/errors";
 import getProductErrorMessage from "@saleor/utils/errors/product";
 import React from "react";
@@ -60,7 +60,7 @@ const useStyles = makeStyles(
 
 interface ProductVariantPriceProps {
   ProductVariantChannelListings: ChannelPriceData[];
-  errors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  errors: ProductChannelListingErrorFragment[];
   loading?: boolean;
   onChange: (id: string, data: ChannelPriceArgs) => void;
 }
@@ -178,7 +178,6 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
                             })
                           }
                           disabled={loading}
-                          required
                           hint={
                             costPriceError
                               ? getProductErrorMessage(

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -326,6 +326,11 @@ export const product: (
             id: "123",
             name: "Channel1"
           },
+          costPrice: {
+            __typename: "Money",
+            amount: 10,
+            currency: "USD"
+          },
           price: {
             __typename: "Money",
             amount: 1,
@@ -339,6 +344,11 @@ export const product: (
             currencyCode: "USD",
             id: "124",
             name: "Channel2"
+          },
+          costPrice: {
+            __typename: "Money",
+            amount: 10,
+            currency: "USD"
           },
           price: {
             __typename: "Money",
@@ -1857,6 +1867,11 @@ export const variant = (placeholderImage: string): ProductVariant => ({
         id: "test1",
         name: "Test channel"
       },
+      costPrice: {
+        __typename: "Money",
+        amount: 10,
+        currency: "USD"
+      },
       price: {
         __typename: "Money",
         amount: 10,
@@ -1870,6 +1885,11 @@ export const variant = (placeholderImage: string): ProductVariant => ({
         currencyCode: "USD",
         id: "test2",
         name: "Test channel other"
+      },
+      costPrice: {
+        __typename: "Money",
+        amount: 10,
+        currency: "USD"
       },
       price: {
         __typename: "Money",

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -530,7 +530,7 @@ export const ProductChannelListingUpdateMutation = gql`
       product {
         ...Product
       }
-      productChannelListingErrors {
+      errors: productChannelListingErrors {
         ...ProductChannelListingErrorFragment
       }
     }
@@ -571,7 +571,7 @@ export const ProductVariantChannelListingUpdateMutation = gql`
       variant {
         ...ProductVariant
       }
-      productChannelListingErrors {
+      errors: productChannelListingErrors {
         ...ProductChannelListingErrorFragment
       }
     }

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -295,8 +295,8 @@ export const useAvailableInGridAttributesQuery = makeQuery<
 const createMultipleVariantsData = gql`
   ${productVariantAttributesFragment}
   ${warehouseFragment}
-  query CreateMultipleVariantsData($id: ID!, $channel: String) {
-    product(id: $id, channel: $channel) {
+  query CreateMultipleVariantsData($id: ID!) {
+    product(id: $id) {
       ...ProductVariantAttributesFragment
     }
     warehouses(first: 20) {

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -193,6 +193,13 @@ const productVariantCreateQuery = gql`
         sortOrder
         url
       }
+      channelListing {
+        channel {
+          id
+          name
+          currencyCode
+        }
+      }
       name
       productType {
         id

--- a/src/products/types/CreateMultipleVariantsData.ts
+++ b/src/products/types/CreateMultipleVariantsData.ts
@@ -108,5 +108,4 @@ export interface CreateMultipleVariantsData {
 
 export interface CreateMultipleVariantsDataVariables {
   id: string;
-  channel?: string | null;
 }

--- a/src/products/types/ProductChannelListingUpdate.ts
+++ b/src/products/types/ProductChannelListingUpdate.ts
@@ -155,10 +155,17 @@ export interface ProductChannelListingUpdate_productChannelListingUpdate_product
   currency: string;
 }
 
+export interface ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing_channel;
   price: ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing_price | null;
+  costPrice: ProductChannelListingUpdate_productChannelListingUpdate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductChannelListingUpdate_productChannelListingUpdate_product_variants {

--- a/src/products/types/ProductChannelListingUpdate.ts
+++ b/src/products/types/ProductChannelListingUpdate.ts
@@ -214,7 +214,7 @@ export interface ProductChannelListingUpdate_productChannelListingUpdate_product
   taxType: ProductChannelListingUpdate_productChannelListingUpdate_product_taxType | null;
 }
 
-export interface ProductChannelListingUpdate_productChannelListingUpdate_productChannelListingErrors {
+export interface ProductChannelListingUpdate_productChannelListingUpdate_errors {
   __typename: "ProductChannelListingError";
   code: ProductErrorCode;
   field: string | null;
@@ -225,7 +225,7 @@ export interface ProductChannelListingUpdate_productChannelListingUpdate_product
 export interface ProductChannelListingUpdate_productChannelListingUpdate {
   __typename: "ProductChannelListingUpdate";
   product: ProductChannelListingUpdate_productChannelListingUpdate_product | null;
-  productChannelListingErrors: ProductChannelListingUpdate_productChannelListingUpdate_productChannelListingErrors[];
+  errors: ProductChannelListingUpdate_productChannelListingUpdate_errors[];
 }
 
 export interface ProductChannelListingUpdate {

--- a/src/products/types/ProductCreate.ts
+++ b/src/products/types/ProductCreate.ts
@@ -162,10 +162,17 @@ export interface ProductCreate_productCreate_product_variants_channelListing_pri
   currency: string;
 }
 
+export interface ProductCreate_productCreate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductCreate_productCreate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductCreate_productCreate_product_variants_channelListing_channel;
   price: ProductCreate_productCreate_product_variants_channelListing_price | null;
+  costPrice: ProductCreate_productCreate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductCreate_productCreate_product_variants {

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -155,10 +155,17 @@ export interface ProductDetails_product_variants_channelListing_price {
   currency: string;
 }
 
+export interface ProductDetails_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductDetails_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductDetails_product_variants_channelListing_channel;
   price: ProductDetails_product_variants_channelListing_price | null;
+  costPrice: ProductDetails_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductDetails_product_variants {

--- a/src/products/types/ProductImageCreate.ts
+++ b/src/products/types/ProductImageCreate.ts
@@ -161,10 +161,17 @@ export interface ProductImageCreate_productImageCreate_product_variants_channelL
   currency: string;
 }
 
+export interface ProductImageCreate_productImageCreate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductImageCreate_productImageCreate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductImageCreate_productImageCreate_product_variants_channelListing_channel;
   price: ProductImageCreate_productImageCreate_product_variants_channelListing_price | null;
+  costPrice: ProductImageCreate_productImageCreate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductImageCreate_productImageCreate_product_variants {

--- a/src/products/types/ProductImageUpdate.ts
+++ b/src/products/types/ProductImageUpdate.ts
@@ -161,10 +161,17 @@ export interface ProductImageUpdate_productImageUpdate_product_variants_channelL
   currency: string;
 }
 
+export interface ProductImageUpdate_productImageUpdate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductImageUpdate_productImageUpdate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductImageUpdate_productImageUpdate_product_variants_channelListing_channel;
   price: ProductImageUpdate_productImageUpdate_product_variants_channelListing_price | null;
+  costPrice: ProductImageUpdate_productImageUpdate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductImageUpdate_productImageUpdate_product_variants {

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -162,10 +162,17 @@ export interface ProductUpdate_productUpdate_product_variants_channelListing_pri
   currency: string;
 }
 
+export interface ProductUpdate_productUpdate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductUpdate_productUpdate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductUpdate_productUpdate_product_variants_channelListing_channel;
   price: ProductUpdate_productUpdate_product_variants_channelListing_price | null;
+  costPrice: ProductUpdate_productUpdate_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductUpdate_productUpdate_product_variants {

--- a/src/products/types/ProductVariantChannelListingUpdate.ts
+++ b/src/products/types/ProductVariantChannelListingUpdate.ts
@@ -130,10 +130,17 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
   currency: string;
 }
 
+export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing_channel;
   price: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing_price | null;
+  costPrice: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_channelListing_costPrice | null;
 }
 
 export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_stocks_warehouse {

--- a/src/products/types/ProductVariantChannelListingUpdate.ts
+++ b/src/products/types/ProductVariantChannelListingUpdate.ts
@@ -179,7 +179,7 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
   weight: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_weight | null;
 }
 
-export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors {
+export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_errors {
   __typename: "ProductChannelListingError";
   code: ProductErrorCode;
   field: string | null;
@@ -190,7 +190,7 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
 export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate {
   __typename: "ProductVariantChannelListingUpdate";
   variant: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant | null;
-  productChannelListingErrors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_productChannelListingErrors[];
+  errors: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_errors[];
 }
 
 export interface ProductVariantChannelListingUpdate {

--- a/src/products/types/ProductVariantCreateData.ts
+++ b/src/products/types/ProductVariantCreateData.ts
@@ -13,6 +13,18 @@ export interface ProductVariantCreateData_product_images {
   url: string;
 }
 
+export interface ProductVariantCreateData_product_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+  currencyCode: string;
+}
+
+export interface ProductVariantCreateData_product_channelListing {
+  __typename: "ProductChannelListing";
+  channel: ProductVariantCreateData_product_channelListing_channel;
+}
+
 export interface ProductVariantCreateData_product_productType_variantAttributes_values {
   __typename: "AttributeValue";
   id: string;
@@ -58,6 +70,7 @@ export interface ProductVariantCreateData_product {
   __typename: "Product";
   id: string;
   images: (ProductVariantCreateData_product_images | null)[] | null;
+  channelListing: ProductVariantCreateData_product_channelListing[] | null;
   name: string;
   productType: ProductVariantCreateData_product_productType;
   thumbnail: ProductVariantCreateData_product_thumbnail | null;

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -130,10 +130,17 @@ export interface ProductVariantDetails_productVariant_channelListing_price {
   currency: string;
 }
 
+export interface ProductVariantDetails_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductVariantDetails_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductVariantDetails_productVariant_channelListing_channel;
   price: ProductVariantDetails_productVariant_channelListing_price | null;
+  costPrice: ProductVariantDetails_productVariant_channelListing_costPrice | null;
 }
 
 export interface ProductVariantDetails_productVariant_stocks_warehouse {

--- a/src/products/types/ProductVariantReorder.ts
+++ b/src/products/types/ProductVariantReorder.ts
@@ -161,10 +161,17 @@ export interface ProductVariantReorder_productVariantReorder_product_variants_ch
   currency: string;
 }
 
+export interface ProductVariantReorder_productVariantReorder_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductVariantReorder_productVariantReorder_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductVariantReorder_productVariantReorder_product_variants_channelListing_channel;
   price: ProductVariantReorder_productVariantReorder_product_variants_channelListing_price | null;
+  costPrice: ProductVariantReorder_productVariantReorder_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductVariantReorder_productVariantReorder_product_variants {

--- a/src/products/types/ProductVariantSetDefault.ts
+++ b/src/products/types/ProductVariantSetDefault.ts
@@ -161,10 +161,17 @@ export interface ProductVariantSetDefault_productVariantSetDefault_product_varia
   currency: string;
 }
 
+export interface ProductVariantSetDefault_productVariantSetDefault_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface ProductVariantSetDefault_productVariantSetDefault_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: ProductVariantSetDefault_productVariantSetDefault_product_variants_channelListing_channel;
   price: ProductVariantSetDefault_productVariantSetDefault_product_variants_channelListing_price | null;
+  costPrice: ProductVariantSetDefault_productVariantSetDefault_product_variants_channelListing_costPrice | null;
 }
 
 export interface ProductVariantSetDefault_productVariantSetDefault_product_variants {

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -162,10 +162,17 @@ export interface SimpleProductUpdate_productUpdate_product_variants_channelListi
   currency: string;
 }
 
+export interface SimpleProductUpdate_productUpdate_product_variants_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productUpdate_product_variants_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productUpdate_product_variants_channelListing_channel;
   price: SimpleProductUpdate_productUpdate_product_variants_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productUpdate_product_variants_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productUpdate_product_variants {
@@ -349,10 +356,17 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_channel
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantUpdate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productVariantUpdate_productVariant_channelListing_channel;
   price: SimpleProductUpdate_productVariantUpdate_productVariant_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productVariantUpdate_productVariant_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_stocks_warehouse {
@@ -526,10 +540,17 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_c
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing_channel;
   price: SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_stocks_warehouse {
@@ -702,10 +723,17 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_c
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing_channel;
   price: SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_stocks_warehouse {
@@ -879,10 +907,17 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_c
   currency: string;
 }
 
+export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing_channel;
   price: SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing_price | null;
+  costPrice: SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListing_costPrice | null;
 }
 
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse {

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -137,10 +137,17 @@ export interface VariantCreate_productVariantCreate_productVariant_channelListin
   currency: string;
 }
 
+export interface VariantCreate_productVariantCreate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantCreate_productVariantCreate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantCreate_productVariantCreate_productVariant_channelListing_channel;
   price: VariantCreate_productVariantCreate_productVariant_channelListing_price | null;
+  costPrice: VariantCreate_productVariantCreate_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantCreate_productVariantCreate_productVariant_stocks_warehouse {

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -136,10 +136,17 @@ export interface VariantImageAssign_variantImageAssign_productVariant_channelLis
   currency: string;
 }
 
+export interface VariantImageAssign_variantImageAssign_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantImageAssign_variantImageAssign_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantImageAssign_variantImageAssign_productVariant_channelListing_channel;
   price: VariantImageAssign_variantImageAssign_productVariant_channelListing_price | null;
+  costPrice: VariantImageAssign_variantImageAssign_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant_stocks_warehouse {

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -136,10 +136,17 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_channe
   currency: string;
 }
 
+export interface VariantImageUnassign_variantImageUnassign_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantImageUnassign_variantImageUnassign_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantImageUnassign_variantImageUnassign_productVariant_channelListing_channel;
   price: VariantImageUnassign_variantImageUnassign_productVariant_channelListing_price | null;
+  costPrice: VariantImageUnassign_variantImageUnassign_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant_stocks_warehouse {

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -137,10 +137,17 @@ export interface VariantUpdate_productVariantUpdate_productVariant_channelListin
   currency: string;
 }
 
+export interface VariantUpdate_productVariantUpdate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantUpdate_productVariantUpdate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantUpdate_productVariantUpdate_productVariant_channelListing_channel;
   price: VariantUpdate_productVariantUpdate_productVariant_channelListing_price | null;
+  costPrice: VariantUpdate_productVariantUpdate_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant_stocks_warehouse {
@@ -314,10 +321,17 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_channel
   currency: string;
 }
 
+export interface VariantUpdate_productVariantStocksUpdate_productVariant_channelListing_costPrice {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_channelListing {
   __typename: "ProductVariantChannelListing";
   channel: VariantUpdate_productVariantStocksUpdate_productVariant_channelListing_channel;
   price: VariantUpdate_productVariantStocksUpdate_productVariant_channelListing_price | null;
+  costPrice: VariantUpdate_productVariantStocksUpdate_productVariant_channelListing_costPrice | null;
 }
 
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_stocks_warehouse {

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -1,4 +1,4 @@
-import { ChannelData } from "@saleor/channels/utils";
+import { ChannelData, ChannelPriceArgs } from "@saleor/channels/utils";
 import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocompleteSelectField";
 import { FormChange } from "@saleor/hooks/useForm";
 import { FormsetChange, FormsetData } from "@saleor/hooks/useFormset";
@@ -7,6 +7,13 @@ import { toggle } from "@saleor/utils/lists";
 
 import { ProductAttributeInputData } from "../components/ProductAttributes";
 import { getAttributeInputFromProductType, ProductType } from "./data";
+
+const setPrice = (price: string, initialPrice: number) =>
+  typeof price === "string"
+    ? price
+      ? parseInt(price, 10)
+      : null
+    : initialPrice;
 
 export function createAttributeChangeHandler(
   changeAttributeData: FormsetChange<string[]>,
@@ -23,7 +30,8 @@ export function createChannelsPriceChangeHandler(
   updateChannels: (data: ChannelData[]) => void,
   triggerChange: () => void
 ) {
-  return (id: string, price: number) => {
+  return (id: string, priceData: ChannelPriceArgs) => {
+    const { costPrice, price } = priceData;
     const channelIndex = channelListing.findIndex(channel => channel.id === id);
     const channel = channelListing[channelIndex];
 
@@ -31,7 +39,8 @@ export function createChannelsPriceChangeHandler(
       ...channelListing.slice(0, channelIndex),
       {
         ...channel,
-        price
+        costPrice: setPrice(costPrice, channel.costPrice),
+        price: setPrice(price, channel.price)
       },
       ...channelListing.slice(channelIndex + 1)
     ];
@@ -70,7 +79,8 @@ export function createVariantChannelsChangeHandler(
   setData: (data: ProductVariantPageFormData) => void,
   triggerChange: () => void
 ) {
-  return (id: string, price: number) => {
+  return (id: string, priceData: ChannelPriceArgs) => {
+    const { costPrice, price } = priceData;
     const { channelListing } = data;
     const channelIndex = channelListing.findIndex(channel => channel.id === id);
     const channel = channelListing[channelIndex];
@@ -79,7 +89,8 @@ export function createVariantChannelsChangeHandler(
       ...channelListing.slice(0, channelIndex),
       {
         ...channel,
-        price
+        costPrice: setPrice(costPrice, channel.costPrice),
+        price: setPrice(price, channel.price)
       },
       ...channelListing.slice(channelIndex + 1)
     ];
@@ -140,33 +151,6 @@ export function createProductTypeSelectHandler(
     change(event);
 
     setAttributes(getAttributeInputFromProductType(selectedProductType));
-  };
-}
-
-interface ProductAvailabilityArgs {
-  availableForPurchase: string | null;
-  isAvailableForPurchase: boolean;
-  productId: string;
-}
-
-export function getProductAvailabilityVariables({
-  isAvailableForPurchase,
-  availableForPurchase,
-  productId
-}: ProductAvailabilityArgs) {
-  const isAvailable =
-    availableForPurchase && !isAvailableForPurchase
-      ? true
-      : isAvailableForPurchase;
-
-  return {
-    isAvailable,
-    productId,
-    startDate: isAvailableForPurchase
-      ? null
-      : availableForPurchase !== ""
-      ? availableForPurchase
-      : null
   };
 }
 

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -8,13 +8,6 @@ import { toggle } from "@saleor/utils/lists";
 import { ProductAttributeInputData } from "../components/ProductAttributes";
 import { getAttributeInputFromProductType, ProductType } from "./data";
 
-const setPrice = (price: string, initialPrice: number) =>
-  typeof price === "string"
-    ? price
-      ? parseInt(price, 10)
-      : null
-    : initialPrice;
-
 export function createAttributeChangeHandler(
   changeAttributeData: FormsetChange<string[]>,
   triggerChange: () => void
@@ -39,8 +32,8 @@ export function createChannelsPriceChangeHandler(
       ...channelListing.slice(0, channelIndex),
       {
         ...channel,
-        costPrice: setPrice(costPrice, channel.costPrice),
-        price: setPrice(price, channel.price)
+        costPrice,
+        price
       },
       ...channelListing.slice(channelIndex + 1)
     ];
@@ -89,8 +82,8 @@ export function createVariantChannelsChangeHandler(
       ...channelListing.slice(0, channelIndex),
       {
         ...channel,
-        costPrice: setPrice(costPrice, channel.costPrice),
-        price: setPrice(price, channel.price)
+        costPrice,
+        price
       },
       ...channelListing.slice(channelIndex + 1)
     ];

--- a/src/products/utils/validation.ts
+++ b/src/products/utils/validation.ts
@@ -1,7 +1,5 @@
-export const validatePrice = (price: string | number) =>
-  price === "" ||
-  price === null ||
-  (typeof price === "string" ? parseInt(price, 10) : price) < 0;
+export const validatePrice = (price: string) =>
+  price === "" || parseInt(price, 10) < 0;
 
-export const validateCostPrice = (price: string | number) =>
-  (typeof price === "string" && price !== "" ? parseInt(price, 10) : price) < 0;
+export const validateCostPrice = (price: string) =>
+  price !== "" && parseInt(price, 10) < 0;

--- a/src/products/utils/validation.ts
+++ b/src/products/utils/validation.ts
@@ -2,3 +2,6 @@ export const validatePrice = (price: string | number) =>
   price === "" ||
   price === null ||
   (typeof price === "string" ? parseInt(price, 10) : price) < 0;
+
+export const validateCostPrice = (price: string | number) =>
+  (typeof price === "string" && price !== "" ? parseInt(price, 10) : price) < 0;

--- a/src/products/views/ProductCreate/ProductCreate.tsx
+++ b/src/products/views/ProductCreate/ProductCreate.tsx
@@ -8,6 +8,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import useShop from "@saleor/hooks/useShop";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
+import ProductCreatePage from "@saleor/products/components/ProductCreatePage";
 import {
   useProductChannelListingUpdate,
   useProductVariantChannelListingUpdate,
@@ -19,18 +20,17 @@ import useCategorySearch from "@saleor/searches/useCategorySearch";
 import useCollectionSearch from "@saleor/searches/useCollectionSearch";
 import useProductTypeSearch from "@saleor/searches/useProductTypeSearch";
 import { useTaxTypeList } from "@saleor/taxes/queries";
+import { getProductErrorMessage } from "@saleor/utils/errors";
 import createMetadataCreateHandler from "@saleor/utils/handlers/metadataCreateHandler";
 import {
   useMetadataUpdate,
   usePrivateMetadataUpdate
 } from "@saleor/utils/metadata/updateMetadata";
-import { getProductErrorMessage } from "@saleor/utils/errors";
 import { useWarehouseList } from "@saleor/warehouses/queries";
 import { warehouseAddPath } from "@saleor/warehouses/urls";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import ProductCreatePage from "@saleor/products/components/ProductCreatePage";
 import { createHandler } from "./handlers";
 
 export const ProductCreateView: React.FC = () => {
@@ -206,7 +206,7 @@ export const ProductCreateView: React.FC = () => {
         }
         channelsErrors={
           updateVariantChannelsOpts.data?.productVariantChannelListingUpdate
-            ?.productChannelListingErrors
+            ?.errors
         }
         errors={[
           ...(productCreateOpts.data?.productCreate.errors || []),

--- a/src/products/views/ProductCreate/handlers.ts
+++ b/src/products/views/ProductCreate/handlers.ts
@@ -35,7 +35,6 @@ const getSimpleProductVariables = (
 ) => ({
   input: {
     attributes: [],
-    costPrice: formData.basePrice,
     product: productId,
     sku: formData.sku,
     stocks: formData.stocks?.map(stock => ({
@@ -98,23 +97,16 @@ export function createHandler(
       const variantErrors = result[1].data.productVariantCreate.errors;
       const variantId = result[1].data.productVariantCreate.productVariant.id;
       if (variantErrors.length === 0 && variantId) {
-        const variantPrices = formData.channelListing
-          .map(
-            listing =>
-              listing.price !== null && {
-                channelId: listing.id,
-                price: listing.price
-              }
-          )
-          .filter(Boolean);
-        if (variantPrices.length) {
-          updateVariantChannels({
-            variables: {
-              id: variantId,
-              input: variantPrices
-            }
-          });
-        }
+        updateVariantChannels({
+          variables: {
+            id: variantId,
+            input: formData.channelListing.map(listing => ({
+              channelId: listing.id,
+              costPrice: listing.costPrice,
+              price: listing.price
+            }))
+          }
+        });
       }
     } else {
       updateChannels(getChannelsVariables(productId, formData.channelListing));

--- a/src/products/views/ProductCreate/handlers.ts
+++ b/src/products/views/ProductCreate/handlers.ts
@@ -102,7 +102,7 @@ export function createHandler(
             id: variantId,
             input: formData.channelListing.map(listing => ({
               channelId: listing.id,
-              costPrice: listing.costPrice,
+              costPrice: listing.costPrice || null,
               price: listing.price
             }))
           }

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -223,10 +223,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
 
   const [updateChannels, updateChannelsOpts] = useProductChannelListingUpdate({
     onCompleted: data => {
-      if (
-        data.productChannelListingUpdate.productChannelListingErrors.length ===
-        0
-      ) {
+      if (data.productChannelListingUpdate.errors.length === 0) {
         const updatedProductChannelsChoices: ChannelData[] = createSortedChannelsDataFromProduct(
           data.productChannelListingUpdate.product
         );
@@ -336,10 +333,9 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     null
   );
   const channelsErrors = [
-    ...(updateChannelsOpts?.data?.productChannelListingUpdate
-      ?.productChannelListingErrors || []),
+    ...(updateChannelsOpts?.data?.productChannelListingUpdate?.errors || []),
     ...(updateVariantChannelsOpts?.data?.productVariantChannelListingUpdate
-      ?.productChannelListingErrors || [])
+      ?.errors || [])
   ];
 
   return (

--- a/src/products/views/ProductUpdate/handlers.ts
+++ b/src/products/views/ProductUpdate/handlers.ts
@@ -1,5 +1,6 @@
 import { createChannelsDataFromProduct } from "@saleor/channels/utils";
 import { BulkStockErrorFragment } from "@saleor/fragments/types/BulkStockErrorFragment";
+import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { StockErrorFragment } from "@saleor/fragments/types/StockErrorFragment";
 import { weight } from "@saleor/misc";
@@ -134,7 +135,10 @@ export function createUpdateHandler(
     };
 
     let errors: Array<
-      ProductErrorFragment | StockErrorFragment | BulkStockErrorFragment
+      | ProductErrorFragment
+      | StockErrorFragment
+      | BulkStockErrorFragment
+      | ProductChannelListingErrorFragment
     >;
 
     if (product.productType.hasVariants) {

--- a/src/products/views/ProductUpdate/handlers.ts
+++ b/src/products/views/ProductUpdate/handlers.ts
@@ -90,7 +90,7 @@ const getChannelsVariables = (
 const getVariantChannelsInput = (data: ProductUpdatePageSubmitData) =>
   data.channelListing.map(listing => ({
     channelId: listing.id,
-    costPrice: listing.costPrice,
+    costPrice: listing.costPrice || null,
     price: listing.price
   }));
 

--- a/src/products/views/ProductUpdate/handlers.ts
+++ b/src/products/views/ProductUpdate/handlers.ts
@@ -51,7 +51,6 @@ const getSimpleProductVariables = (
   },
   productVariantId: productId,
   productVariantInput: {
-    costPrice: data.basePrice,
     sku: data.sku,
     trackInventory: data.trackInventory
   },
@@ -86,6 +85,13 @@ const getChannelsVariables = (
     }
   };
 };
+
+const getVariantChannelsInput = (data: ProductUpdatePageSubmitData) =>
+  data.channelListing.map(listing => ({
+    channelId: listing.id,
+    costPrice: listing.costPrice,
+    price: listing.price
+  }));
 
 export function createUpdateHandler(
   product: ProductDetails_product,
@@ -162,10 +168,7 @@ export function createUpdateHandler(
           updateVariantChannels({
             variables: {
               id: variantId,
-              input: data.channelListing.map(listing => ({
-                channelId: listing.id,
-                price: listing.price
-              }))
+              input: getVariantChannelsInput(data)
             }
           });
           updateChannels({
@@ -192,10 +195,7 @@ export function createUpdateHandler(
         updateVariantChannels({
           variables: {
             id: product.variants[0].id,
-            input: data.channelListing.map(listing => ({
-              channelId: listing.id,
-              price: listing.price
-            }))
+            input: getVariantChannelsInput(data)
           }
         });
       }

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -129,17 +129,16 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
     data: ProductVariantPageSubmitData,
     variant: ProductVariantDetails_productVariant
   ) => {
-    if (
-      data.channelListing.some(channel => {
-        const variantChannel = variant.channelListing.find(
-          variantChannel => variantChannel.channel.id === channel.id
-        );
-        return (
-          channel.price !== variantChannel?.price?.amount ||
-          channel.costPrice !== variantChannel?.costPrice?.amount
-        );
-      })
-    ) {
+    const isChannelPriceChange = data.channelListing.some(channel => {
+      const variantChannel = variant.channelListing.find(
+        variantChannel => variantChannel.channel.id === channel.id
+      );
+      return (
+        channel.price !== variantChannel?.price?.amount ||
+        channel.costPrice !== variantChannel?.costPrice?.amount
+      );
+    });
+    if (isChannelPriceChange) {
       updateChannels({
         variables: {
           id: variant.id,

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -140,6 +140,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
           id: variant.id,
           input: data.channelListing.map(listing => ({
             channelId: listing.id,
+            costPrice: listing.costPrice,
             price: listing.price
           }))
         }

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -130,10 +130,15 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
     variant: ProductVariantDetails_productVariant
   ) => {
     if (
-      data.channelListing.some(
-        (channel, index) =>
-          channel.price !== variant.channelListing[index]?.price.amount
-      )
+      data.channelListing.some(channel => {
+        const variantChannel = variant.channelListing.find(
+          variantChannel => variantChannel.channel.id === channel.id
+        );
+        return (
+          channel.price !== variantChannel?.price?.amount ||
+          channel.costPrice !== variantChannel?.costPrice?.amount
+        );
+      })
     ) {
       updateChannels({
         variables: {
@@ -237,7 +242,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
         channels={channels}
         channelErrors={
           updateChannelsOpts?.data?.productVariantChannelListingUpdate
-            ?.productChannelListingErrors || []
+            ?.errors || []
         }
         onSetDefaultVariant={onSetDefaultVariant}
         saveButtonBarState={updateVariantOpts.status}

--- a/src/products/views/ProductVariant.tsx
+++ b/src/products/views/ProductVariant.tsx
@@ -134,8 +134,8 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
         variantChannel => variantChannel.channel.id === channel.id
       );
       return (
-        channel.price !== variantChannel?.price?.amount ||
-        channel.costPrice !== variantChannel?.costPrice?.amount
+        channel.price !== variantChannel?.price?.amount.toString() ||
+        channel.costPrice !== variantChannel?.costPrice?.amount.toString()
       );
     });
     if (isChannelPriceChange) {
@@ -144,7 +144,7 @@ export const ProductVariant: React.FC<ProductUpdateProps> = ({
           id: variant.id,
           input: data.channelListing.map(listing => ({
             channelId: listing.id,
-            costPrice: listing.costPrice,
+            costPrice: listing.costPrice || null,
             price: listing.price
           }))
         }

--- a/src/products/views/ProductVariantCreate.tsx
+++ b/src/products/views/ProductVariantCreate.tsx
@@ -92,7 +92,7 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
         id: variantId,
         input: data.channelListing.map(listing => ({
           channelId: listing.id,
-          costPrice: listing.costPrice,
+          costPrice: listing.costPrice || null,
           price: listing.price
         }))
       }
@@ -169,8 +169,7 @@ export const ProductVariant: React.FC<ProductVariantCreateProps> = ({
       <ProductVariantCreatePage
         channels={channels}
         channelErrors={
-          updateChannelsOpts?.data?.productVariantChannelListingUpdate
-            ?.errors || []
+          updateChannelsOpts?.data?.productVariantChannelListingUpdate?.errors
         }
         disabled={disableForm}
         errors={variantCreateResult.data?.productVariantCreate.errors || []}

--- a/src/products/views/ProductVariantCreator/ProductVariantCreator.tsx
+++ b/src/products/views/ProductVariantCreator/ProductVariantCreator.tsx
@@ -58,7 +58,7 @@ const ProductVariantCreator: React.FC<ProductVariantCreatorProps> = ({
           currency: listing.channel.currencyCode,
           id: listing.channel.id,
           name: listing.channel.name,
-          price: null
+          price: ""
         }))}
         attributes={data?.product?.productType?.variantAttributes || []}
         onSubmit={inputs =>

--- a/src/storybook/stories/products/ProductVariantCreatePage.tsx
+++ b/src/storybook/stories/products/ProductVariantCreatePage.tsx
@@ -9,12 +9,20 @@ import { product as productFixture } from "../../../products/fixtures";
 import Decorator from "../../Decorator";
 
 const product = productFixture(placeholderImage);
+const channels = product.channelListing.map(listing => ({
+  costPrice: null,
+  currency: listing.channel.currencyCode,
+  id: listing.channel.id,
+  name: listing.channel.name,
+  price: null
+}));
 
 storiesOf("Views / Products / Create product variant", module)
   .addDecorator(Decorator)
   .add("default", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       weightUnit="kg"
       disabled={false}
       errors={[]}
@@ -31,7 +39,8 @@ storiesOf("Views / Products / Create product variant", module)
   ))
   .add("with errors", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       weightUnit="kg"
       disabled={false}
       errors={[
@@ -67,7 +76,8 @@ storiesOf("Views / Products / Create product variant", module)
   ))
   .add("when loading data", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       weightUnit="kg"
       disabled={true}
       errors={[]}
@@ -84,7 +94,8 @@ storiesOf("Views / Products / Create product variant", module)
   ))
   .add("add first variant", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       weightUnit="kg"
       disabled={false}
       errors={[]}
@@ -104,7 +115,8 @@ storiesOf("Views / Products / Create product variant", module)
   ))
   .add("no warehouses", () => (
     <ProductVariantCreatePage
-      currencySymbol="USD"
+      channels={channels}
+      channelErrors={[]}
       weightUnit="kg"
       disabled={false}
       errors={[]}


### PR DESCRIPTION
I want to merge this change because...
it adds ability to set the cost price for a variant. Cost prices are rendered next to regular selling prices in the "Pricing" box on the following pages:
- simple product page
- variant page in configurable product
- variant creator

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** feature/multichannel-multicurrency

### Screenshots
<img width="1295" alt="Screenshot 2020-10-16 at 11 14 54" src="https://user-images.githubusercontent.com/10812388/96240377-203dbb80-0fa1-11eb-8847-ca67712cf35e.png">
<img width="1279" alt="Screenshot 2020-10-16 at 11 15 14" src="https://user-images.githubusercontent.com/10812388/96240385-2469d900-0fa1-11eb-9bdc-2e3ee59fc885.png">
<img width="964" alt="Screenshot 2020-10-16 at 11 15 37" src="https://user-images.githubusercontent.com/10812388/96240399-292e8d00-0fa1-11eb-8bc1-2ef7d4b7a21a.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://feature-multichannel-multicurrency.api.saleor.rocks/graphql/
