### PR TITLE
Fix publish and available for purchase behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix style of product type attributes empty table - #744 by @orzechdev
 - Fix order draft back button redirect - #753 by @orzechdev
 - Add manage product types and attributes permission - #768 by @orzechdev
+- Fix isPublished and isAvailable behaviour for products, collections and pages - #780 by @mmarkusik
 
 ## 2.10.1
 

--- a/assets/images/close-thin.svg
+++ b/assets/images/close-thin.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.63623" y="0.000427246" width="23.1412" height="2.31412" transform="rotate(45 1.63623 0.000427246)" fill="#3D3D3D"/>
+<rect x="18" y="1.63641" width="23.1412" height="2.31412" transform="rotate(135 18 1.63641)" fill="#3D3D3D"/>
+</svg>

--- a/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
+++ b/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
@@ -83,6 +83,7 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
 
     onSubmit({
       ...data,
+      isPublished: data.isPublished || !!data.publicationDate,
       metadata,
       privateMetadata
     });

--- a/src/components/VisibilityCard/DateVisibilitySelector.tsx
+++ b/src/components/VisibilityCard/DateVisibilitySelector.tsx
@@ -69,7 +69,7 @@ const DateVisibilitySelector = ({
         <div className={classes.icon} onClick={handleCloseIconClick}>
           <img
             src={closeIcon}
-            alt=""
+            alt="close icon"
             width={CLOSE_ICON_SIZE}
             height={CLOSE_ICON_SIZE}
           />

--- a/src/components/VisibilityCard/DateVisibilitySelector.tsx
+++ b/src/components/VisibilityCard/DateVisibilitySelector.tsx
@@ -1,0 +1,83 @@
+import closeIcon from "@assets/images/close-thin.svg";
+import { Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import React, { useState } from "react";
+
+import FormSpacer from "../FormSpacer";
+
+const CLOSE_ICON_SIZE = 14;
+
+const useStyles = makeStyles(
+  theme => ({
+    buttonText: {
+      color: theme.palette.primary.main,
+      cursor: "pointer",
+      fontSize: 14,
+      marginBottom: theme.spacing(1),
+      paddingBottom: 10,
+      paddingTop: 0
+    },
+    container: {
+      alignItems: "baseline",
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "space-between"
+    },
+    icon: {
+      cursor: "pointer",
+      marginLeft: theme.spacing(2)
+    }
+  }),
+  { name: "closeableInputWrapper" }
+);
+
+interface Props {
+  buttonText: string;
+  children: React.ReactNode;
+  onInputClose: () => void;
+}
+
+const DateVisibilitySelector = ({
+  buttonText,
+  children,
+  onInputClose
+}: Props) => {
+  const classes = useStyles({});
+
+  const [showInput, setShowInput] = useState<boolean>(false);
+
+  const handleCloseIconClick = () => {
+    setShowInput(false);
+    onInputClose();
+  };
+
+  if (!showInput) {
+    return (
+      <Typography
+        className={classes.buttonText}
+        onClick={() => setShowInput(true)}
+      >
+        {buttonText}
+      </Typography>
+    );
+  }
+
+  return (
+    <>
+      <div className={classes.container}>
+        {children}
+        <div className={classes.icon} onClick={handleCloseIconClick}>
+          <img
+            src={closeIcon}
+            alt=""
+            width={CLOSE_ICON_SIZE}
+            height={CLOSE_ICON_SIZE}
+          />
+        </div>
+      </div>
+      <FormSpacer />
+    </>
+  );
+};
+
+export default DateVisibilitySelector;

--- a/src/components/VisibilityCard/DateVisibilitySelector.tsx
+++ b/src/components/VisibilityCard/DateVisibilitySelector.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(
       marginLeft: theme.spacing(2)
     }
   }),
-  { name: "closeableInputWrapper" }
+  { name: "DateVisibilitySelector" }
 );
 
 interface Props {

--- a/src/components/VisibilityCard/VisibilityCard.tsx
+++ b/src/components/VisibilityCard/VisibilityCard.tsx
@@ -12,11 +12,12 @@ import { ChangeEvent } from "@saleor/hooks/useForm";
 import { UserError } from "@saleor/types";
 import { getFieldError } from "@saleor/utils/errors";
 import classNames from "classnames";
-import React, { useState } from "react";
+import React from "react";
 import { useIntl } from "react-intl";
 
 import { DateContext } from "../Date/DateContext";
 import FormSpacer from "../FormSpacer";
+import DateVisibilitySelector from "./DateVisibilitySelector";
 
 const useStyles = makeStyles(
   theme => ({
@@ -36,7 +37,7 @@ const useStyles = makeStyles(
       "& svg": {
         fill: theme.palette.primary.main
       },
-      marginTop: theme.spacing(3)
+      marginTop: theme.spacing(1)
     },
     label: {
       lineHeight: 1.2,
@@ -48,14 +49,11 @@ const useStyles = makeStyles(
     },
     secondLabel: {
       color: theme.palette.text.hint,
-      fontSize: 12
+      fontSize: 12,
+      marginBottom: theme.spacing(2)
     },
-    setPublicationDate: {
-      color: theme.palette.primary.main,
-      cursor: "pointer",
-      fontSize: 14,
-      paddingBottom: 10,
-      paddingTop: 0
+    switchField: {
+      marginTop: theme.spacing(1)
     }
   }),
   { name: "VisibilityCard" }
@@ -107,13 +105,6 @@ export const VisibilityCard: React.FC<VisibilityCardProps> = props => {
   const dateNow = React.useContext(DateContext);
   const hasAvailableProps =
     isAvailable !== undefined && availableForPurchase !== undefined;
-
-  const [isPublicationDate, setPublicationDate] = useState(
-    publicationDate === null ? true : false
-  );
-  const [isAvailableDate, setAvailableDate] = useState(
-    availableForPurchase === null ? true : false
-  );
 
   const visibleMessage = (date: string) =>
     intl.formatMessage(
@@ -168,36 +159,33 @@ export const VisibilityCard: React.FC<VisibilityCardProps> = props => {
           onChange={onChange}
         />
         {!isPublished && (
-          <>
-            <Typography
-              className={classes.setPublicationDate}
-              onClick={() => setPublicationDate(!isPublicationDate)}
-            >
-              {intl.formatMessage({
-                defaultMessage: "Set publication date"
+          <DateVisibilitySelector
+            buttonText={intl.formatMessage({
+              defaultMessage: "Set publication date"
+            })}
+            onInputClose={() =>
+              onChange({ target: { name: "publicationDate", value: null } })
+            }
+          >
+            <TextField
+              error={!!getFieldError(errors, "publicationDate")}
+              disabled={disabled}
+              label={intl.formatMessage({
+                defaultMessage: "Publish on",
+                description: "publish on date"
               })}
-            </Typography>
-            {isPublicationDate && (
-              <TextField
-                error={!!getFieldError(errors, "publicationDate")}
-                disabled={disabled}
-                label={intl.formatMessage({
-                  defaultMessage: "Publish on",
-                  description: "publish on date"
-                })}
-                name="publicationDate"
-                type="date"
-                fullWidth={true}
-                helperText={getFieldError(errors, "publicationDate")?.message}
-                value={publicationDate ? publicationDate : ""}
-                onChange={onChange}
-                className={classes.date}
-                InputLabelProps={{
-                  shrink: true
-                }}
-              />
-            )}
-          </>
+              name="publicationDate"
+              type="date"
+              fullWidth={true}
+              helperText={getFieldError(errors, "publicationDate")?.message}
+              value={publicationDate ? publicationDate : ""}
+              onChange={onChange}
+              className={classes.date}
+              InputLabelProps={{
+                shrink: true
+              }}
+            />
+          </DateVisibilitySelector>
         )}
         {getFieldError(errors, "isPublished") && (
           <>
@@ -211,6 +199,7 @@ export const VisibilityCard: React.FC<VisibilityCardProps> = props => {
           <>
             <Hr />
             <RadioSwitchField
+              className={classes.switchField}
               disabled={disabled}
               error={!!getFieldError(errors, "isAvailableForPurchase")}
               firstOptionLabel={
@@ -251,34 +240,33 @@ export const VisibilityCard: React.FC<VisibilityCardProps> = props => {
               }}
             />
             {!isAvailable && (
-              <>
-                <Typography
-                  className={classes.setPublicationDate}
-                  onClick={() => setAvailableDate(!isAvailable)}
-                >
-                  {messages.setAvailabilityDateLabel}
-                </Typography>
-                {isAvailableDate && (
-                  <TextField
-                    error={!!getFieldError(errors, "startDate")}
-                    disabled={disabled}
-                    label={intl.formatMessage({
-                      defaultMessage: "Set available on",
-                      description: "available on date"
-                    })}
-                    name="availableForPurchase"
-                    type="date"
-                    fullWidth={true}
-                    helperText={getFieldError(errors, "startDate")?.message}
-                    value={availableForPurchase ? availableForPurchase : ""}
-                    onChange={onChange}
-                    className={classes.date}
-                    InputLabelProps={{
-                      shrink: true
-                    }}
-                  />
-                )}
-              </>
+              <DateVisibilitySelector
+                buttonText={messages.setAvailabilityDateLabel}
+                onInputClose={() =>
+                  onChange({
+                    target: { name: "availableForPurchase", value: null }
+                  })
+                }
+              >
+                <TextField
+                  error={!!getFieldError(errors, "startDate")}
+                  disabled={disabled}
+                  label={intl.formatMessage({
+                    defaultMessage: "Set available on",
+                    description: "available on date"
+                  })}
+                  name="availableForPurchase"
+                  type="date"
+                  fullWidth={true}
+                  helperText={getFieldError(errors, "startDate")?.message}
+                  value={availableForPurchase ? availableForPurchase : ""}
+                  onChange={onChange}
+                  className={classes.date}
+                  InputLabelProps={{
+                    shrink: true
+                  }}
+                />
+              </DateVisibilitySelector>
             )}
             {getFieldError(errors, "isAvailableForPurchase") && (
               <>

--- a/src/components/VisibilityCard/VisibilityCard.tsx
+++ b/src/components/VisibilityCard/VisibilityCard.tsx
@@ -69,13 +69,17 @@ interface Message {
   availableSecondLabel?: string;
   setAvailabilityDateLabel?: string;
 }
+
+export interface DateFields {
+  publicationDate: string;
+  availableForPurchase?: string;
+}
+
 export interface VisibilityCardProps {
   children?: React.ReactNode | React.ReactNodeArray;
-  data: {
-    availableForPurchase?: string;
+  data: DateFields & {
     isAvailableForPurchase?: boolean;
     isPublished: boolean;
-    publicationDate: string;
     visibleInListings?: boolean;
   };
   errors: UserError[];
@@ -117,6 +121,21 @@ export const VisibilityCard: React.FC<VisibilityCardProps> = props => {
       }
     );
 
+  const handleRadioFieldChange = (type: keyof DateFields) => (
+    e: ChangeEvent
+  ) => {
+    const { value } = e.target;
+    if (!value) {
+      onChange({
+        target: {
+          name: type,
+          value: null
+        }
+      });
+    }
+    return onChange(e);
+  };
+
   return (
     <Card>
       <CardTitle
@@ -156,7 +175,7 @@ export const VisibilityCard: React.FC<VisibilityCardProps> = props => {
             </>
           }
           value={isPublished}
-          onChange={onChange}
+          onChange={handleRadioFieldChange("publicationDate")}
         />
         {!isPublished && (
           <DateVisibilitySelector
@@ -226,18 +245,7 @@ export const VisibilityCard: React.FC<VisibilityCardProps> = props => {
                 </>
               }
               value={isAvailable}
-              onChange={e => {
-                const { value } = e.target;
-                if (!value) {
-                  onChange({
-                    target: {
-                      name: "availableForPurchase",
-                      value: null
-                    }
-                  });
-                }
-                return onChange(e);
-              }}
+              onChange={handleRadioFieldChange("availableForPurchase")}
             />
             {!isAvailable && (
               <DateVisibilitySelector

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -70,8 +70,16 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
     slug: maybe(() => page.slug, ""),
     title: maybe(() => page.title, "")
   };
+
+  const handleSubmit = (data: FormData) => onSubmit(getParsedData(data));
+
+  const getParsedData = (data: FormData) => ({
+    ...data,
+    isPublished: data.isPublished || !!data.publicationDate
+  });
+
   return (
-    <Form initial={initialForm} onSubmit={onSubmit}>
+    <Form initial={initialForm} onSubmit={handleSubmit}>
       {({ change, data, hasChanged, submit }) => (
         <Container>
           <AppHeader onBack={onBack}>

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -53,11 +53,7 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
                   input: {
                     contentJson: JSON.stringify(formData.content),
                     isPublished: formData.isPublished,
-                    publicationDate: formData.isPublished
-                      ? null
-                      : formData.publicationDate === ""
-                      ? null
-                      : formData.publicationDate,
+                    publicationDate: formData.publicationDate,
                     seo: {
                       description: formData.seoDescription,
                       title: formData.seoTitle

--- a/src/pages/views/PageDetails.tsx
+++ b/src/pages/views/PageDetails.tsx
@@ -23,11 +23,7 @@ export interface PageDetailsProps {
 const createPageInput = (data: FormData): PageInput => ({
   contentJson: JSON.stringify(data.content),
   isPublished: data.isPublished,
-  publicationDate: data.isPublished
-    ? null
-    : data.publicationDate === ""
-    ? null
-    : data.publicationDate,
+  publicationDate: data.publicationDate,
   seo: {
     description: data.seoDescription,
     title: data.seoTitle

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -189,12 +189,12 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
 
   const getAvailabilityData = ({
     availableForPurchase,
+    isAvailableForPurchase,
     isPublished,
     publicationDate
   }: ProductUpdatePageFormData) => ({
-    isAvailableForPurchase: !!availableForPurchase,
-    isPublished: isPublished || !!publicationDate,
-    startDate: availableForPurchase || null
+    isAvailableForPurchase: isAvailableForPurchase || !!availableForPurchase,
+    isPublished: isPublished || !!publicationDate
   });
 
   const getStocksData = () => {

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -187,9 +187,14 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
       value: taxType.taxCode
     })) || [];
 
-  const getAvailabilityData = (data: ProductUpdatePageFormData) => ({
-    isAvailableForPurchase: !!data.availableForPurchase,
-    isPublished: !!data.publicationDate
+  const getAvailabilityData = ({
+    availableForPurchase,
+    isPublished,
+    publicationDate
+  }: ProductUpdatePageFormData) => ({
+    isAvailableForPurchase: !!availableForPurchase,
+    isPublished: isPublished || !!publicationDate,
+    startDate: availableForPurchase || null
   });
 
   const getStocksData = () => {
@@ -211,22 +216,21 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
     };
   };
 
-  const getParsedData = (data: ProductUpdatePageFormData) => {
-    const metadata = isMetadataModified ? data.metadata : undefined;
-    const privateMetadata = isPrivateMetadataModified
+  const getMetadata = (data: ProductUpdatePageFormData) => ({
+    metadata: isMetadataModified ? data.metadata : undefined,
+    privateMetadata: isPrivateMetadataModified
       ? data.privateMetadata
-      : undefined;
+      : undefined
+  });
 
-    return {
-      ...data,
-      ...getAvailabilityData(data),
-      ...getStocksData(),
-      addStocks: [],
-      attributes,
-      metadata,
-      privateMetadata
-    };
-  };
+  const getParsedData = (data: ProductUpdatePageFormData) => ({
+    ...data,
+    ...getAvailabilityData(data),
+    ...getStocksData(),
+    ...getMetadata(data),
+    addStocks: [],
+    attributes
+  });
 
   const handleSubmit = (data: ProductUpdatePageFormData) =>
     onSubmit(getParsedData(data));

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -77,23 +77,12 @@ interface ProductAvailabilityArgs {
   productId: string;
 }
 
-export function getProductAvailabilityVariables({
+export const getProductAvailabilityVariables = ({
   isAvailableForPurchase,
   availableForPurchase,
   productId
-}: ProductAvailabilityArgs) {
-  const isAvailable =
-    availableForPurchase && !isAvailableForPurchase
-      ? true
-      : isAvailableForPurchase;
-
-  return {
-    isAvailable,
-    productId,
-    startDate: isAvailableForPurchase
-      ? null
-      : availableForPurchase !== ""
-      ? availableForPurchase
-      : null
-  };
-}
+}: ProductAvailabilityArgs) => ({
+  isAvailable: isAvailableForPurchase,
+  productId,
+  startDate: availableForPurchase
+});


### PR DESCRIPTION
I want to merge this change because it fixes sending `isPublished` and `isAvailable` data to the api when creating / updating product, category or page.

[SALEOR-1317](https://app.clickup.com/t/2549495/SALEOR-1317) 
also fixes 
[SALEOR-1344](https://app.clickup.com/t/2549495/SALEOR-1344)

- Add `DateVisibilitySelector` component to handle hide / display logic for the date input and labels

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** `use_is_visible_to_determine_if_product_is_publish_for_2_11`

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://test-deployment.api.saleor.rocks/graphql/
