### PR TITLE
Add metadata editor to page views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix order draft back button redirect - #753 by @orzechdev
 - Add manage product types and attributes permission - #768 by @orzechdev
 - Fix isPublished and isAvailable behaviour for products, collections and pages - #780 by @mmarkusik
+- Add metadata editor to page views - #782 by @dominik-zeglen
 
 ## 2.10.1
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1184,6 +1184,7 @@ enum CollectionSortField {
   NAME
   AVAILABILITY
   PRODUCT_COUNT
+  PUBLICATION_DATE
 }
 
 input CollectionSortingInput {
@@ -2306,6 +2307,7 @@ type Margin {
 type Menu implements Node {
   id: ID!
   name: String!
+  slug: String!
   items: [MenuItem]
 }
 
@@ -2334,6 +2336,7 @@ type MenuCreate {
 
 input MenuCreateInput {
   name: String!
+  slug: String
   items: [MenuItemInput]
 }
 
@@ -2363,10 +2366,12 @@ enum MenuErrorCode {
 
 input MenuFilterInput {
   search: String
+  slug: [String]
 }
 
 input MenuInput {
   name: String
+  slug: String
 }
 
 type MenuItem implements Node {
@@ -3229,7 +3234,7 @@ type OrderVoid {
   orderErrors: [OrderError!]!
 }
 
-type Page implements Node {
+type Page implements Node & ObjectWithMetadata {
   seoTitle: String
   seoDescription: String
   id: ID!
@@ -3240,6 +3245,10 @@ type Page implements Node {
   isPublished: Boolean!
   slug: String!
   created: DateTime!
+  privateMetadata: [MetadataItem]!
+  metadata: [MetadataItem]!
+  privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
+  meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
 }
 
@@ -3792,6 +3801,7 @@ input ProductFilterInput {
   price: PriceRangeInput
   minimalPrice: PriceRangeInput
   productTypes: [ID]
+  ids: [ID]
 }
 
 type ProductImage implements Node {
@@ -3878,6 +3888,7 @@ enum ProductOrderField {
   DATE
   TYPE
   PUBLISHED
+  PUBLICATION_DATE
 }
 
 type ProductPricingInfo {
@@ -4288,7 +4299,7 @@ type Query {
   draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, created: ReportingPeriod, before: String, after: String, first: Int, last: Int): OrderCountableConnection
   ordersTotal(period: ReportingPeriod): TaxedMoney
   orderByToken(token: UUID!): Order
-  menu(id: ID, name: String): Menu
+  menu(id: ID, name: String, slug: String): Menu
   menus(sortBy: MenuSortingInput, filter: MenuFilterInput, before: String, after: String, first: Int, last: Int): MenuCountableConnection
   menuItem(id: ID!): MenuItem
   menuItems(sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
@@ -4755,10 +4766,10 @@ type Shop {
   defaultMailSenderAddress: String
   description: String
   domain: Domain!
-  homepageCollection: Collection
+  homepageCollection: Collection @deprecated(reason: "Use the `collection` query with the `slug` parameter. This field will be removed in Saleor 3.0")
   languages: [LanguageDisplay]!
   name: String!
-  navigation: Navigation
+  navigation: Navigation @deprecated(reason: "Fetch menus using the `menu` query with `slug` parameter.")
   permissions: [Permission]!
   phonePrefixes: [String]!
   headerText: String

--- a/src/fragments/pages.ts
+++ b/src/fragments/pages.ts
@@ -1,5 +1,7 @@
 import gql from "graphql-tag";
 
+import { metadataFragment } from "./metadata";
+
 export const pageFragment = gql`
   fragment PageFragment on Page {
     id
@@ -11,8 +13,10 @@ export const pageFragment = gql`
 
 export const pageDetailsFragment = gql`
   ${pageFragment}
+  ${metadataFragment}
   fragment PageDetailsFragment on Page {
     ...PageFragment
+    ...MetadataFragment
     contentJson
     seoTitle
     seoDescription

--- a/src/fragments/types/MetadataFragment.ts
+++ b/src/fragments/types/MetadataFragment.ts
@@ -19,7 +19,7 @@ export interface MetadataFragment_privateMetadata {
 }
 
 export interface MetadataFragment {
-  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (MetadataFragment_metadata | null)[];
   privateMetadata: (MetadataFragment_privateMetadata | null)[];
 }

--- a/src/fragments/types/PageDetailsFragment.ts
+++ b/src/fragments/types/PageDetailsFragment.ts
@@ -6,12 +6,26 @@
 // GraphQL fragment: PageDetailsFragment
 // ====================================================
 
+export interface PageDetailsFragment_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageDetailsFragment_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageDetailsFragment {
   __typename: "Page";
   id: string;
   title: string;
   slug: string;
   isPublished: boolean;
+  metadata: (PageDetailsFragment_metadata | null)[];
+  privateMetadata: (PageDetailsFragment_privateMetadata | null)[];
   contentJson: any;
   seoTitle: string | null;
   seoDescription: string | null;

--- a/src/pages/fixtures.ts
+++ b/src/pages/fixtures.ts
@@ -37,6 +37,14 @@ export const page: PageDetails_page = {
   contentJson: JSON.stringify(content),
   id: "Kzx152sEm==",
   isPublished: false,
+  metadata: [
+    {
+      __typename: "MetadataItem",
+      key: "integration.id",
+      value: "100023123"
+    }
+  ],
+  privateMetadata: [],
   publicationDate: "",
   seoDescription: "About",
   seoTitle: "About",

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -14,12 +14,26 @@ export interface PageCreate_pageCreate_errors {
   field: string | null;
 }
 
+export interface PageCreate_pageCreate_page_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageCreate_pageCreate_page_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageCreate_pageCreate_page {
   __typename: "Page";
   id: string;
   title: string;
   slug: string;
   isPublished: boolean;
+  metadata: (PageCreate_pageCreate_page_metadata | null)[];
+  privateMetadata: (PageCreate_pageCreate_page_privateMetadata | null)[];
   contentJson: any;
   seoTitle: string | null;
   seoDescription: string | null;

--- a/src/pages/types/PageDetails.ts
+++ b/src/pages/types/PageDetails.ts
@@ -6,12 +6,26 @@
 // GraphQL query operation: PageDetails
 // ====================================================
 
+export interface PageDetails_page_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageDetails_page_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageDetails_page {
   __typename: "Page";
   id: string;
   title: string;
   slug: string;
   isPublished: boolean;
+  metadata: (PageDetails_page_metadata | null)[];
+  privateMetadata: (PageDetails_page_privateMetadata | null)[];
   contentJson: any;
   seoTitle: string | null;
   seoDescription: string | null;

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -14,12 +14,26 @@ export interface PageUpdate_pageUpdate_errors {
   field: string | null;
 }
 
+export interface PageUpdate_pageUpdate_page_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageUpdate_pageUpdate_page_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageUpdate_pageUpdate_page {
   __typename: "Page";
   id: string;
   title: string;
   slug: string;
   isPublished: boolean;
+  metadata: (PageUpdate_pageUpdate_page_metadata | null)[];
+  privateMetadata: (PageUpdate_pageUpdate_page_privateMetadata | null)[];
   contentJson: any;
   seoTitle: string | null;
   seoDescription: string | null;

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -1,10 +1,15 @@
 import { WindowTitle } from "@saleor/components/WindowTitle";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
+import createMetadataCreateHandler from "@saleor/utils/handlers/metadataCreateHandler";
+import {
+  useMetadataUpdate,
+  usePrivateMetadataUpdate
+} from "@saleor/utils/metadata/updateMetadata";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import PageDetailsPage from "../components/PageDetailsPage";
+import PageDetailsPage, { FormData } from "../components/PageDetailsPage";
 import { TypedPageCreate } from "../mutations";
 import { PageCreate as PageCreateData } from "../types/PageCreate";
 import { pageListUrl, pageUrl } from "../urls";
@@ -17,6 +22,8 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
+  const [updateMetadata] = useMetadataUpdate({});
+  const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
 
   const handlePageCreate = (data: PageCreateData) => {
     if (data.pageCreate.errors.length === 0) {
@@ -32,41 +39,52 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
 
   return (
     <TypedPageCreate onCompleted={handlePageCreate}>
-      {(pageCreate, pageCreateOpts) => (
-        <>
-          <WindowTitle
-            title={intl.formatMessage({
-              defaultMessage: "Create Page",
-              description: "header"
-            })}
-          />
-          <PageDetailsPage
-            disabled={pageCreateOpts.loading}
-            errors={pageCreateOpts.data?.pageCreate.errors || []}
-            saveButtonBarState={pageCreateOpts.status}
-            page={null}
-            onBack={() => navigate(pageListUrl())}
-            onRemove={() => undefined}
-            onSubmit={formData =>
-              pageCreate({
-                variables: {
-                  input: {
-                    contentJson: JSON.stringify(formData.content),
-                    isPublished: formData.isPublished,
-                    publicationDate: formData.publicationDate,
-                    seo: {
-                      description: formData.seoDescription,
-                      title: formData.seoTitle
-                    },
-                    slug: formData.slug === "" ? null : formData.slug,
-                    title: formData.title
-                  }
-                }
-              })
+      {(pageCreate, pageCreateOpts) => {
+        const handleCreate = async (formData: FormData) => {
+          const result = await pageCreate({
+            variables: {
+              input: {
+                contentJson: JSON.stringify(formData.content),
+                isPublished: formData.isPublished,
+                publicationDate: formData.publicationDate,
+                seo: {
+                  description: formData.seoDescription,
+                  title: formData.seoTitle
+                },
+                slug: formData.slug === "" ? null : formData.slug,
+                title: formData.title
+              }
             }
-          />
-        </>
-      )}
+          });
+
+          return result.data.pageCreate.page?.id || null;
+        };
+        const handleSubmit = createMetadataCreateHandler(
+          handleCreate,
+          updateMetadata,
+          updatePrivateMetadata
+        );
+
+        return (
+          <>
+            <WindowTitle
+              title={intl.formatMessage({
+                defaultMessage: "Create Page",
+                description: "header"
+              })}
+            />
+            <PageDetailsPage
+              disabled={pageCreateOpts.loading}
+              errors={pageCreateOpts.data?.pageCreate.errors || []}
+              saveButtonBarState={pageCreateOpts.status}
+              page={null}
+              onBack={() => navigate(pageListUrl())}
+              onRemove={() => undefined}
+              onSubmit={handleSubmit}
+            />
+          </>
+        );
+      }}
     </TypedPageCreate>
   );
 };

--- a/src/pages/views/PageDetails.tsx
+++ b/src/pages/views/PageDetails.tsx
@@ -4,6 +4,11 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import { commonMessages } from "@saleor/intl";
+import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
+import {
+  useMetadataUpdate,
+  usePrivateMetadataUpdate
+} from "@saleor/utils/metadata/updateMetadata";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -36,6 +41,8 @@ export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
+  const [updateMetadata] = useMetadataUpdate({});
+  const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
 
   const handlePageRemove = (data: PageRemove) => {
     if (data.pageDelete.errors.length === 0) {
@@ -46,68 +53,82 @@ export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
       navigate(pageListUrl());
     }
   };
+
   return (
     <TypedPageRemove variables={{ id }} onCompleted={handlePageRemove}>
       {(pageRemove, pageRemoveOpts) => (
         <TypedPageUpdate>
           {(pageUpdate, pageUpdateOpts) => (
             <TypedPageDetailsQuery variables={{ id }}>
-              {pageDetails => (
-                <>
-                  <WindowTitle
-                    title={maybe(() => pageDetails.data.page.title)}
-                  />
-                  <PageDetailsPage
-                    disabled={pageDetails.loading}
-                    errors={pageUpdateOpts.data?.pageUpdate.errors || []}
-                    saveButtonBarState={pageUpdateOpts.status}
-                    page={pageDetails.data?.page}
-                    onBack={() => navigate(pageListUrl())}
-                    onRemove={() =>
-                      navigate(
-                        pageUrl(id, {
-                          action: "remove"
-                        })
-                      )
+              {pageDetails => {
+                const handleUpdate = async (data: FormData) => {
+                  const result = await pageUpdate({
+                    variables: {
+                      id,
+                      input: createPageInput(data)
                     }
-                    onSubmit={formData =>
-                      pageUpdate({
-                        variables: {
-                          id,
-                          input: createPageInput(formData)
-                        }
-                      })
-                    }
-                  />
-                  <ActionDialog
-                    open={params.action === "remove"}
-                    confirmButtonState={pageRemoveOpts.status}
-                    title={intl.formatMessage({
-                      defaultMessage: "Delete Page",
-                      description: "dialog header"
-                    })}
-                    onClose={() => navigate(pageUrl(id))}
-                    onConfirm={pageRemove}
-                    variant="delete"
-                  >
-                    <DialogContentText>
-                      <FormattedMessage
-                        defaultMessage="Are you sure you want to delete {title}?"
-                        description="delete page"
-                        values={{
-                          title: (
-                            <strong>
-                              {getStringOrPlaceholder(
-                                pageDetails.data?.page?.title
-                              )}
-                            </strong>
-                          )
-                        }}
-                      />
-                    </DialogContentText>
-                  </ActionDialog>
-                </>
-              )}
+                  });
+
+                  return result.data.pageUpdate.errors;
+                };
+
+                const handleSubmit = createMetadataUpdateHandler(
+                  pageDetails.data?.page,
+                  handleUpdate,
+                  variables => updateMetadata({ variables }),
+                  variables => updatePrivateMetadata({ variables })
+                );
+
+                return (
+                  <>
+                    <WindowTitle
+                      title={maybe(() => pageDetails.data.page.title)}
+                    />
+                    <PageDetailsPage
+                      disabled={pageDetails.loading}
+                      errors={pageUpdateOpts.data?.pageUpdate.errors || []}
+                      saveButtonBarState={pageUpdateOpts.status}
+                      page={pageDetails.data?.page}
+                      onBack={() => navigate(pageListUrl())}
+                      onRemove={() =>
+                        navigate(
+                          pageUrl(id, {
+                            action: "remove"
+                          })
+                        )
+                      }
+                      onSubmit={handleSubmit}
+                    />
+                    <ActionDialog
+                      open={params.action === "remove"}
+                      confirmButtonState={pageRemoveOpts.status}
+                      title={intl.formatMessage({
+                        defaultMessage: "Delete Page",
+                        description: "dialog header"
+                      })}
+                      onClose={() => navigate(pageUrl(id))}
+                      onConfirm={pageRemove}
+                      variant="delete"
+                    >
+                      <DialogContentText>
+                        <FormattedMessage
+                          defaultMessage="Are you sure you want to delete {title}?"
+                          description="delete page"
+                          values={{
+                            title: (
+                              <strong>
+                                {getStringOrPlaceholder(
+                                  pageDetails.data?.page?.title
+                                )}
+                              </strong>
+                            )
+                          }}
+                        />
+                      </DialogContentText>
+                    </ActionDialog>
+                  </>
+                );
+              }}
             </TypedPageDetailsQuery>
           )}
         </TypedPageUpdate>

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -119,6 +119,7 @@ export enum CollectionSortField {
   AVAILABILITY = "AVAILABILITY",
   NAME = "NAME",
   PRODUCT_COUNT = "PRODUCT_COUNT",
+  PUBLICATION_DATE = "PUBLICATION_DATE",
 }
 
 export enum ConfigurationTypeFieldEnum {
@@ -737,6 +738,7 @@ export enum ProductOrderField {
   MINIMAL_PRICE = "MINIMAL_PRICE",
   NAME = "NAME",
   PRICE = "PRICE",
+  PUBLICATION_DATE = "PUBLICATION_DATE",
   PUBLISHED = "PUBLISHED",
   TYPE = "TYPE",
 }
@@ -1176,6 +1178,7 @@ export interface IntRangeInput {
 
 export interface MenuCreateInput {
   name: string;
+  slug?: string | null;
   items?: (MenuItemInput | null)[] | null;
 }
 
@@ -1379,6 +1382,7 @@ export interface ProductFilterInput {
   price?: PriceRangeInput | null;
   minimalPrice?: PriceRangeInput | null;
   productTypes?: (string | null)[] | null;
+  ids?: (string | null)[] | null;
 }
 
 export interface ProductInput {

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -38,7 +38,7 @@ export interface UpdateMetadata_deleteMetadata_item_privateMetadata {
 }
 
 export interface UpdateMetadata_deleteMetadata_item {
-  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdateMetadata_deleteMetadata_item_metadata | null)[];
   privateMetadata: (UpdateMetadata_deleteMetadata_item_privateMetadata | null)[];
   id: string;

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -38,7 +38,7 @@ export interface UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadat
 }
 
 export interface UpdatePrivateMetadata_deletePrivateMetadata_item {
-  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_metadata | null)[];
   privateMetadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata | null)[];
   id: string;


### PR DESCRIPTION
I want to merge this change because it adds metadata editor to page views.

**PR intended to be tested with API branch:** add/pages-metadata-1414

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
