### PR TITLE
Fix product type input

### DIFF
--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -208,6 +208,10 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
     initial?.taxCode || null
   );
 
+  const [productTypeInputValue, setProductTypeInputValue] = useStateFromProps<
+    string
+  >(initial?.productType || "");
+
   const categories = getChoices(categoryChoiceList);
   const collections = getChoices(collectionChoiceList);
   const productTypes = getChoices(productTypeChoiceList);
@@ -217,10 +221,26 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
       value: taxType.taxCode
     })) || [];
 
+  const handleFetchProductTypes = (value: string) => {
+    setProductTypeInputValue(value);
+    fetchProductTypes(value);
+  };
+
+  const getProductType = () => {
+    const selectedProductType = productTypes.find(
+      ({ label }) => label.toLowerCase() === productTypeInputValue.toLowerCase()
+    );
+
+    return !!selectedProductType
+      ? selectedProductType.value
+      : productTypeInputValue;
+  };
+
   const handleSubmit = (data: FormData) =>
     onSubmit({
       ...data,
       attributes,
+      productType: getProductType(),
       stocks
     });
 
@@ -252,7 +272,8 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
           change,
           setAttributeData,
           setProductType,
-          productTypeChoiceList
+          productTypeChoiceList,
+          setProductTypeInputValue
         );
         const handleTaxTypeSelect = createSingleAutocompleteSelectHandler(
           change,
@@ -369,7 +390,7 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
                   fetchMoreCategories={fetchMoreCategories}
                   fetchMoreCollections={fetchMoreCollections}
                   fetchMoreProductTypes={fetchMoreProductTypes}
-                  fetchProductTypes={fetchProductTypes}
+                  fetchProductTypes={handleFetchProductTypes}
                   productType={productType}
                   productTypeInputDisplayValue={productType?.name || ""}
                   productTypes={productTypes}

--- a/src/products/components/ProductOrganization/ProductOrganization.tsx
+++ b/src/products/components/ProductOrganization/ProductOrganization.tsx
@@ -112,6 +112,7 @@ const ProductOrganization: React.FC<ProductOrganizationProps> = props => {
       <CardContent>
         {canChangeType ? (
           <SingleAutocompleteSelectField
+            allowCustomValues={false}
             displayValue={productTypeInputDisplayValue}
             error={!!formErrors.productType}
             helperText={getProductErrorMessage(formErrors.productType, intl)}

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -57,14 +57,17 @@ export function createProductTypeSelectHandler(
   change: FormChange,
   setAttributes: (data: FormsetData<ProductAttributeInputData>) => void,
   setProductType: (productType: ProductType) => void,
-  productTypeChoiceList: ProductType[]
+  productTypeChoiceList: ProductType[],
+  setProductTypeInputValue: (value: string) => void
 ): FormChange {
   return (event: React.ChangeEvent<any>) => {
     const id = event.target.value;
     const selectedProductType = productTypeChoiceList.find(
       productType => productType.id === id
     );
+
     setProductType(selectedProductType);
+    setProductTypeInputValue(id);
     change(event);
 
     setAttributes(getAttributeInputFromProductType(selectedProductType));


### PR DESCRIPTION
I want to merge this change because it fixes product type input in product create and adds some validation in case value is missing or incorrect.

- Add some validation for missing / invalid value provided to product type input
- Add parsing before submission, so in case user types in product type correctly but doesn't click on select it still sends proper id
- Fix input displaying product type id instead of name when erased some part of the input and selected again

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://test-deployment.api.saleor.rocks/graphql/
