### PR TITLE
Fix single autocomplete select inputs

### DIFF
--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -125,7 +125,7 @@ const SingleAutocompleteSelectFieldComponent: React.FC<SingleAutocompleteSelectF
             );
 
             const ensureProperValues = (alwaysCheck: boolean = false) => {
-              if (allowCustomValues && !alwaysCheck) {
+              if ((allowCustomValues || isValueInLabels) && !alwaysCheck) {
                 return;
               }
 

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -131,6 +131,10 @@ const SingleAutocompleteSelectFieldComponent: React.FC<SingleAutocompleteSelectF
                   choice.label.toLowerCase() === inputValue.toLowerCase()
               );
 
+            const handleBlur = () => {
+              if(inputValue)
+            }
+
             return (
               <div
                 className={classNames(classes.container, className)}
@@ -149,7 +153,7 @@ const SingleAutocompleteSelectFieldComponent: React.FC<SingleAutocompleteSelectF
                     ),
                     error,
                     id: undefined,
-                    onBlur: closeMenu,
+                    onBlur: handleBlur,
                     onClick: toggleMenu
                   }}
                   error={error}


### PR DESCRIPTION
I want to merge this change because:
- it fixes the auto complete select input displaying id instead of label
- adds the logic where on input blur it selects / displays proper item 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://test-deployment.api.saleor.rocks/graphql/