### PR TITLE
Fix setting availability start date to null when none provided

### DIFF
--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -67,5 +67,5 @@ export const getProductAvailabilityVariables = ({
 }: ProductAvailabilityArgs) => ({
   isAvailable: isAvailableForPurchase,
   productId,
-  startDate: availableForPurchase
+  startDate: availableForPurchase || null
 });


### PR DESCRIPTION
I want to merge this change because if fixed product creation, so when no date provided, instead of "" the api will receive null.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
