### PR TITLE
Add channels to collection views/components

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1060,6 +1060,10 @@
     "context": "header",
     "string": "Products in {categoryName}"
   },
+  "src_dot_categories_dot_components_dot_CategoryProducts_dot_4183335632": {
+    "context": "categpry product channel",
+    "string": "Channel:"
+  },
   "src_dot_categories_dot_components_dot_CategoryUpdatePage_dot_2159874182": {
     "context": "number of subcategories in category",
     "string": "Subcategories"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1248,10 +1248,6 @@
     "context": "collections section name",
     "string": "Collections"
   },
-  "src_dot_collections_dot_components_dot_CollectionCreatePage_dot_2001551496": {
-    "context": "collection",
-    "string": "will be visible from {date}"
-  },
   "src_dot_collections_dot_components_dot_CollectionCreatePage_dot_643174786": {
     "context": "collection label",
     "string": "Visible"
@@ -1266,14 +1262,6 @@
   "src_dot_collections_dot_components_dot_CollectionCreatePage_dot_951411809": {
     "context": "page header",
     "string": "Add Collection"
-  },
-  "src_dot_collections_dot_components_dot_CollectionDetailsPage_dot_2001551496": {
-    "context": "collection",
-    "string": "will be visible from {date}"
-  },
-  "src_dot_collections_dot_components_dot_CollectionDetailsPage_dot_2906897537": {
-    "context": "switch button",
-    "string": "Feature on Homepage"
   },
   "src_dot_collections_dot_components_dot_CollectionDetailsPage_dot_643174786": {
     "context": "collection label",
@@ -1324,10 +1312,6 @@
   "src_dot_collections_dot_components_dot_CollectionList_dot_2137803833": {
     "string": "No collections found"
   },
-  "src_dot_collections_dot_components_dot_CollectionList_dot_2341910657": {
-    "context": "collection is not published",
-    "string": "Not published"
-  },
   "src_dot_collections_dot_components_dot_CollectionList_dot_2527742754": {
     "string": "No. of Products"
   },
@@ -1337,10 +1321,6 @@
   "src_dot_collections_dot_components_dot_CollectionList_dot_3326160357": {
     "context": "collection availability",
     "string": "Availability"
-  },
-  "src_dot_collections_dot_components_dot_CollectionList_dot_3640454975": {
-    "context": "collection is published",
-    "string": "Published"
   },
   "src_dot_collections_dot_components_dot_CollectionProducts_dot_1657559629": {
     "string": "No products found"
@@ -1379,6 +1359,9 @@
   },
   "src_dot_collections_dot_views_dot_3482612628": {
     "string": "Deleted product from collection"
+  },
+  "src_dot_collections_dot_views_dot_3576236500": {
+    "string": "Manage Collection Channel Availability"
   },
   "src_dot_collections_dot_views_dot_3791354625": {
     "context": "dialog title",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1060,10 +1060,6 @@
     "context": "header",
     "string": "Products in {categoryName}"
   },
-  "src_dot_categories_dot_components_dot_CategoryProducts_dot_4183335632": {
-    "context": "categpry product channel",
-    "string": "Channel:"
-  },
   "src_dot_categories_dot_components_dot_CategoryUpdatePage_dot_2159874182": {
     "context": "number of subcategories in category",
     "string": "Subcategories"

--- a/schema.graphql
+++ b/schema.graphql
@@ -795,6 +795,7 @@ enum CategorySortField {
 
 input CategorySortingInput {
   direction: OrderDirection!
+  channel: String
   field: CategorySortField!
 }
 
@@ -1145,22 +1146,21 @@ type Collection implements Node & ObjectWithMetadata {
   name: String!
   description: String!
   descriptionJson: JSONString!
-  publicationDate: Date
-  isPublished: Boolean!
   slug: String!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  products(channel: String, filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
+  channelListing: [CollectionChannelListing!]
 }
 
 type CollectionAddProducts {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   collection: Collection
-  productErrors: [CollectionProductError!]!
+  collectionErrors: [CollectionError!]!
 }
 
 type CollectionBulkDelete {
@@ -1169,15 +1169,41 @@ type CollectionBulkDelete {
   productErrors: [ProductError!]!
 }
 
+type CollectionChannelListing implements Node {
+  publicationDate: Date
+  isPublished: Boolean!
+  id: ID!
+  channel: Channel!
+}
+
+type CollectionChannelListingError {
+  field: String
+  message: String
+  code: ProductErrorCode!
+  attributes: [ID!]
+  channels: [ID!]
+}
+
+type CollectionChannelListingUpdate {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  collection: Collection
+  collectionChannelListingErrors: [CollectionChannelListingError!]!
+}
+
+input CollectionChannelListingUpdateInput {
+  addChannels: [PublishableChannelListingInput!]
+  removeChannels: [ID!]
+}
+
 type CollectionClearMeta {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
   collection: Collection
 }
 
 type CollectionClearPrivateMeta {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
   collection: Collection
 }
 
@@ -1194,7 +1220,7 @@ type CollectionCountableEdge {
 
 type CollectionCreate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
   collection: Collection
 }
 
@@ -1213,14 +1239,32 @@ input CollectionCreateInput {
 
 type CollectionDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
   collection: Collection
+}
+
+type CollectionError {
+  field: String
+  message: String
+  products: [ID!]
+  code: CollectionErrorCode!
+}
+
+enum CollectionErrorCode {
+  DUPLICATED_INPUT_ITEM
+  GRAPHQL_ERROR
+  INVALID
+  NOT_FOUND
+  REQUIRED
+  UNIQUE
+  CANNOT_MANAGE_PRODUCT_WITHOUT_VARIANT
 }
 
 input CollectionFilterInput {
   published: CollectionPublished
   search: String
   ids: [ID]
+  channel: String
 }
 
 input CollectionInput {
@@ -1235,14 +1279,6 @@ input CollectionInput {
   publicationDate: Date
 }
 
-type CollectionProductError {
-  field: String
-  message: String
-  code: ProductErrorCode!
-  attributes: [ID!]
-  products: [ID!]
-}
-
 enum CollectionPublished {
   PUBLISHED
   HIDDEN
@@ -1251,13 +1287,13 @@ enum CollectionPublished {
 type CollectionRemoveProducts {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   collection: Collection
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
 }
 
 type CollectionReorderProducts {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   collection: Collection
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
 }
 
 enum CollectionSortField {
@@ -1269,6 +1305,7 @@ enum CollectionSortField {
 
 input CollectionSortingInput {
   direction: OrderDirection!
+  channel: String
   field: CollectionSortField!
 }
 
@@ -1301,19 +1338,19 @@ type CollectionTranslation implements Node {
 
 type CollectionUpdate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
   collection: Collection
 }
 
 type CollectionUpdateMeta {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
   collection: Collection
 }
 
 type CollectionUpdatePrivateMeta {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  collectionErrors: [CollectionError!]!
   collection: Collection
 }
 
@@ -2210,12 +2247,6 @@ type GroupCountableEdge {
   cursor: String!
 }
 
-type HomepageCollectionUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shop: Shop
-  shopErrors: [ShopError!]!
-}
-
 type Image {
   url: String!
   alt: String
@@ -2665,7 +2696,6 @@ type Mutation {
   staffNotificationRecipientCreate(input: StaffNotificationRecipientInput!): StaffNotificationRecipientCreate
   staffNotificationRecipientUpdate(id: ID!, input: StaffNotificationRecipientInput!): StaffNotificationRecipientUpdate
   staffNotificationRecipientDelete(id: ID!): StaffNotificationRecipientDelete
-  homepageCollectionUpdate(collection: ID): HomepageCollectionUpdate
   shopDomainUpdate(input: SiteDomainInput): ShopDomainUpdate
   shopSettingsUpdate(input: ShopSettingsInput!): ShopSettingsUpdate
   shopFetchTaxRates: ShopFetchTaxRates
@@ -2719,6 +2749,7 @@ type Mutation {
   collectionClearMetadata(id: ID!, input: MetaPath!): CollectionClearMeta @deprecated(reason: "Use the `deleteMetadata` mutation instead. This field will be removed after 2020-07-31.")
   collectionUpdatePrivateMetadata(id: ID!, input: MetaInput!): CollectionUpdatePrivateMeta @deprecated(reason: "Use the `updatePrivateMetadata` mutation instead. This field will be removed after 2020-07-31.")
   collectionClearPrivateMetadata(id: ID!, input: MetaPath!): CollectionClearPrivateMeta @deprecated(reason: "Use the `deletePrivateMetadata` mutation instead. This field will be removed after 2020-07-31.")
+  collectionChannelListingUpdate(id: ID!, input: CollectionChannelListingUpdateInput!): CollectionChannelListingUpdate
   productCreate(input: ProductCreateInput!): ProductCreate
   productDelete(id: ID!): ProductDelete
   productBulkDelete(ids: [ID]!): ProductBulkDelete
@@ -4377,6 +4408,12 @@ type ProductVariantUpdatePrivateMeta {
   productVariant: ProductVariant
 }
 
+input PublishableChannelListingInput {
+  channelId: ID!
+  isPublished: Boolean
+  publicationDate: Date
+}
+
 type Query {
   webhook(id: ID!): Webhook
   webhooks(sortBy: WebhookSortingInput, filter: WebhookFilterInput, before: String, after: String, first: Int, last: Int): WebhookCountableConnection @deprecated(reason: "Use webhooks field on app(s) query instead. This field will be removed after 2020-07-31.")
@@ -4397,8 +4434,8 @@ type Query {
   attribute(id: ID!): Attribute
   categories(filter: CategoryFilterInput, sortBy: CategorySortingInput, level: Int, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   category(id: ID, slug: String): Category
-  collection(id: ID, slug: String): Collection
-  collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
+  collection(id: ID, slug: String, channel: String): Collection
+  collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, channel: String, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   product(id: ID, slug: String, channel: String): Product
   products(filter: ProductFilterInput, sortBy: ProductOrder, stockAvailability: StockAvailability, channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   productType(id: ID!): ProductType
@@ -4412,14 +4449,14 @@ type Query {
   pages(sortBy: PageSortingInput, filter: PageFilterInput, before: String, after: String, first: Int, last: Int): PageCountableConnection
   homepageEvents(before: String, after: String, first: Int, last: Int): OrderEventCountableConnection
   order(id: ID!): Order
-  orders(sortBy: OrderSortingInput, filter: OrderFilterInput, created: ReportingPeriod, status: OrderStatusFilter, before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  orders(sortBy: OrderSortingInput, filter: OrderFilterInput, created: ReportingPeriod, status: OrderStatusFilter, channel: String, before: String, after: String, first: Int, last: Int): OrderCountableConnection
   draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, created: ReportingPeriod, before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  ordersTotal(period: ReportingPeriod): TaxedMoney
+  ordersTotal(period: ReportingPeriod, channel: String): TaxedMoney
   orderByToken(token: UUID!): Order
-  menu(id: ID, name: String): Menu
-  menus(sortBy: MenuSortingInput, filter: MenuFilterInput, before: String, after: String, first: Int, last: Int): MenuCountableConnection
-  menuItem(id: ID!): MenuItem
-  menuItems(sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
+  menu(channel: String, id: ID, name: String): Menu
+  menus(channel: String, sortBy: MenuSortingInput, filter: MenuFilterInput, before: String, after: String, first: Int, last: Int): MenuCountableConnection
+  menuItem(id: ID!, channel: String): MenuItem
+  menuItems(channel: String, sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
   giftCard(id: ID!): GiftCard
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   plugin(id: ID!): Plugin
@@ -4936,7 +4973,6 @@ type Shop {
   defaultMailSenderAddress: String
   description: String
   domain: Domain!
-  homepageCollection: Collection @deprecated(reason: "Use the `collection` query with the `slug` parameter. This field will be removed in Saleor 3.0")
   languages: [LanguageDisplay]!
   name: String!
   navigation: Navigation

--- a/src/channels/utils.ts
+++ b/src/channels/utils.ts
@@ -1,4 +1,5 @@
 import { Channels_channels } from "@saleor/channels/types/Channels";
+import { CollectionDetails_collection } from "@saleor/collections/types/CollectionDetails";
 import { SaleDetails_sale } from "@saleor/discounts/types/SaleDetails";
 import { VoucherDetails_voucher } from "@saleor/discounts/types/VoucherDetails";
 import { RequireOnlyOne } from "@saleor/misc";
@@ -56,6 +57,21 @@ export interface ChannelSaleData {
   discountValue: string;
   currency: string;
 }
+
+export interface ChannelCollectionData {
+  id: string;
+  isPublished: boolean;
+  name: string;
+  publicationDate: string | null;
+}
+
+export const createCollectionChannels = (data?: Channels_channels[]) =>
+  data?.map(channel => ({
+    id: channel.id,
+    isPublished: false,
+    name: channel.name,
+    publicationDate: null
+  }));
 
 export const createVoucherChannels = (data?: Channels_channels[]) =>
   data?.map(channel => ({
@@ -177,6 +193,21 @@ export const createShippingChannelsFromRate = (
     name: channelData.channel.name,
     price: channelData.price ? channelData.price.amount.toString() : ""
   })) || [];
+
+export const createCollectionChannelsData = (
+  collectionData?: CollectionDetails_collection
+) => {
+  if (collectionData?.channelListing) {
+    const collectionDataArr = collectionData?.channelListing.map(listing => ({
+      id: listing.channel.id,
+      isPublished: listing.isPublished,
+      name: listing.channel.name,
+      publicationDate: listing.publicationDate
+    }));
+    return collectionDataArr;
+  }
+};
+
 export interface ChannelShippingData {
   currency: string;
   id: string;

--- a/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
+++ b/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
@@ -8,9 +8,7 @@ import Metadata, { MetadataFormData } from "@saleor/components/Metadata";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import SeoForm from "@saleor/components/SeoForm";
-import VisibilityCard from "@saleor/components/VisibilityCard";
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
-import useDateLocalize from "@saleor/hooks/useDateLocalize";
+import { CollectionErrorFragment } from "@saleor/fragments/types/CollectionErrorFragment";
 import { sectionNames } from "@saleor/intl";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import { ContentState, convertToRaw, RawDraftContentState } from "draft-js";
@@ -29,15 +27,13 @@ export interface CollectionCreatePageFormData extends MetadataFormData {
   description: RawDraftContentState;
   name: string;
   slug: string;
-  publicationDate: string;
-  isPublished: boolean;
   seoDescription: string;
   seoTitle: string;
 }
 
 export interface CollectionCreatePageProps {
   disabled: boolean;
-  errors: ProductErrorFragment[];
+  errors: CollectionErrorFragment[];
   saveButtonBarState: ConfirmButtonTransitionState;
   onBack: () => void;
   onSubmit: (data: CollectionCreatePageFormData) => void;
@@ -50,11 +46,9 @@ const initialForm: CollectionCreatePageFormData = {
   },
   backgroundImageAlt: "",
   description: convertToRaw(ContentState.createFromText("")),
-  isPublished: false,
   metadata: [],
   name: "",
   privateMetadata: [],
-  publicationDate: "",
   seoDescription: "",
   seoTitle: "",
   slug: ""
@@ -68,7 +62,6 @@ const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
   onSubmit
 }: CollectionCreatePageProps) => {
   const intl = useIntl();
-  const localizeDate = useDateLocalize();
   const {
     makeChangeHandler: makeMetadataChangeHandler
   } = useMetadataChangeTrigger();
@@ -151,33 +144,6 @@ const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
                 />
                 <CardSpacer />
                 <Metadata data={data} onChange={changeMetadata} />
-              </div>
-              <div>
-                <VisibilityCard
-                  data={data}
-                  errors={errors}
-                  disabled={disabled}
-                  messages={{
-                    hiddenLabel: intl.formatMessage({
-                      defaultMessage: "Hidden",
-                      description: "collection label"
-                    }),
-                    hiddenSecondLabel: intl.formatMessage(
-                      {
-                        defaultMessage: "will be visible from {date}",
-                        description: "collection"
-                      },
-                      {
-                        date: localizeDate(data.publicationDate, "L")
-                      }
-                    ),
-                    visibleLabel: intl.formatMessage({
-                      defaultMessage: "Visible",
-                      description: "collection label"
-                    })
-                  }}
-                  onChange={change}
-                />
               </div>
             </Grid>
             <SaveButtonBar

--- a/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
+++ b/src/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
@@ -1,5 +1,4 @@
 import { ChannelCollectionData } from "@saleor/channels/utils";
-import { CollectionChannelListingUpdate_collectionChannelListingUpdate_errors } from "@saleor/collections/types/CollectionChannelListingUpdate";
 import { createChannelsChangeHandler } from "@saleor/collections/utils";
 import AppHeader from "@saleor/components/AppHeader";
 import { AvailabilityCard } from "@saleor/components/AvailabilityCard";
@@ -12,6 +11,7 @@ import Metadata, { MetadataFormData } from "@saleor/components/Metadata";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import SeoForm from "@saleor/components/SeoForm";
+import { CollectionChannelListingErrorFragment } from "@saleor/fragments/types/CollectionChannelListingErrorFragment";
 import { CollectionErrorFragment } from "@saleor/fragments/types/CollectionErrorFragment";
 import { sectionNames } from "@saleor/intl";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -38,7 +38,7 @@ export interface CollectionCreatePageFormData extends MetadataFormData {
 
 export interface CollectionCreatePageProps {
   channelsCount: number;
-  channelsErrors: CollectionChannelListingUpdate_collectionChannelListingUpdate_errors[];
+  channelsErrors: CollectionChannelListingErrorFragment[];
   currentChannels: ChannelCollectionData[];
   disabled: boolean;
   errors: CollectionErrorFragment[];
@@ -51,6 +51,7 @@ export interface CollectionCreatePageProps {
 
 const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
   channelsCount,
+  channelsErrors,
   currentChannels = [],
   disabled,
   errors,
@@ -179,7 +180,7 @@ const CollectionCreatePage: React.FC<CollectionCreatePageProps> = ({
                       description: "collection label"
                     })
                   }}
-                  errors={[]}
+                  errors={channelsErrors}
                   selectedChannelsCount={data.channelListing.length}
                   allChannelsCount={channelsCount}
                   channels={currentChannels}

--- a/src/collections/components/CollectionDetails/CollectionDetails.tsx
+++ b/src/collections/components/CollectionDetails/CollectionDetails.tsx
@@ -4,7 +4,7 @@ import TextField from "@material-ui/core/TextField";
 import CardTitle from "@saleor/components/CardTitle";
 import FormSpacer from "@saleor/components/FormSpacer";
 import RichTextEditor from "@saleor/components/RichTextEditor";
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
+import { CollectionErrorFragment } from "@saleor/fragments/types/CollectionErrorFragment";
 import { commonMessages } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
@@ -21,7 +21,7 @@ export interface CollectionDetailsProps {
     name: string;
   };
   disabled: boolean;
-  errors: ProductErrorFragment[];
+  errors: CollectionErrorFragment[];
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 

--- a/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
+++ b/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
@@ -1,5 +1,4 @@
 import { ChannelCollectionData } from "@saleor/channels/utils";
-import { CollectionChannelListingUpdate_collectionChannelListingUpdate_errors } from "@saleor/collections/types/CollectionChannelListingUpdate";
 import { createChannelsChangeHandler } from "@saleor/collections/utils";
 import AppHeader from "@saleor/components/AppHeader";
 import { AvailabilityCard } from "@saleor/components/AvailabilityCard";
@@ -13,6 +12,7 @@ import { MetadataFormData } from "@saleor/components/Metadata/types";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import SeoForm from "@saleor/components/SeoForm";
+import { CollectionChannelListingErrorFragment } from "@saleor/fragments/types/CollectionChannelListingErrorFragment";
 import { CollectionErrorFragment } from "@saleor/fragments/types/CollectionErrorFragment";
 import { sectionNames } from "@saleor/intl";
 import { mapMetadataItemToInput } from "@saleor/utils/maps";
@@ -39,7 +39,7 @@ export interface CollectionDetailsPageFormData extends MetadataFormData {
 
 export interface CollectionDetailsPageProps extends PageListProps, ListActions {
   channelsCount: number;
-  channelsErrors: CollectionChannelListingUpdate_collectionChannelListingUpdate_errors[];
+  channelsErrors: CollectionChannelListingErrorFragment[];
   collection: CollectionDetails_collection;
   currentChannels: ChannelCollectionData[];
   errors: CollectionErrorFragment[];
@@ -58,6 +58,7 @@ export interface CollectionDetailsPageProps extends PageListProps, ListActions {
 
 const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
   channelsCount,
+  channelsErrors,
   collection,
   currentChannels = [],
   disabled,
@@ -90,7 +91,6 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
 
     onSubmit({
       ...data,
-      isPublished: data.isPublished || !!data.publicationDate,
       metadata,
       privateMetadata
     });
@@ -187,7 +187,7 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
                       description: "collection label"
                     })
                   }}
-                  errors={[]}
+                  errors={channelsErrors}
                   selectedChannelsCount={data.channelListing.length}
                   allChannelsCount={channelsCount}
                   channels={currentChannels}

--- a/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
+++ b/src/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
@@ -2,19 +2,14 @@ import AppHeader from "@saleor/components/AppHeader";
 import { CardSpacer } from "@saleor/components/CardSpacer";
 import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
 import { Container } from "@saleor/components/Container";
-import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import Form from "@saleor/components/Form";
-import FormSpacer from "@saleor/components/FormSpacer";
 import Grid from "@saleor/components/Grid";
-import Hr from "@saleor/components/Hr";
 import Metadata from "@saleor/components/Metadata/Metadata";
 import { MetadataFormData } from "@saleor/components/Metadata/types";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import SeoForm from "@saleor/components/SeoForm";
-import VisibilityCard from "@saleor/components/VisibilityCard";
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
-import useDateLocalize from "@saleor/hooks/useDateLocalize";
+import { CollectionErrorFragment } from "@saleor/fragments/types/CollectionErrorFragment";
 import { sectionNames } from "@saleor/intl";
 import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
@@ -22,7 +17,6 @@ import { RawDraftContentState } from "draft-js";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { maybe } from "../../../misc";
 import { ListActions, PageListProps } from "../../../types";
 import { CollectionDetails_collection } from "../../types/CollectionDetails";
 import CollectionDetails from "../CollectionDetails/CollectionDetails";
@@ -34,17 +28,15 @@ export interface CollectionDetailsPageFormData extends MetadataFormData {
   description: RawDraftContentState;
   name: string;
   slug: string;
-  publicationDate: string;
   seoDescription: string;
   seoTitle: string;
   isFeatured: boolean;
-  isPublished: boolean;
 }
 
 export interface CollectionDetailsPageProps extends PageListProps, ListActions {
   channelsCount: number;
   collection: CollectionDetails_collection;
-  errors: ProductErrorFragment[];
+  errors: CollectionErrorFragment[];
   isFeatured: boolean;
   saveButtonBarState: ConfirmButtonTransitionState;
   selectedChannel: string;
@@ -72,7 +64,7 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
   ...collectionProductsProps
 }: CollectionDetailsPageProps) => {
   const intl = useIntl();
-  const localizeDate = useDateLocalize();
+  // const localizeDate = useDateLocalize();
   const {
     isMetadataModified,
     isPrivateMetadataModified,
@@ -96,18 +88,18 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
   return (
     <Form
       initial={{
-        backgroundImageAlt: maybe(() => collection.backgroundImage.alt, ""),
-        description: maybe(() => JSON.parse(collection.descriptionJson)),
+        backgroundImageAlt: collection?.backgroundImage?.alt || "",
+        description: collection?.descriptionJson
+          ? JSON.parse(collection.descriptionJson)
+          : "",
         isFeatured,
-        isPublished: maybe(() => collection.isPublished, false),
         metadata: collection?.metadata?.map(mapMetadataItemToInput),
-        name: maybe(() => collection.name, ""),
+        name: collection?.name || "",
         privateMetadata: collection?.privateMetadata?.map(
           mapMetadataItemToInput
         ),
-        publicationDate: maybe(() => collection.publicationDate, ""),
-        seoDescription: maybe(() => collection.seoDescription, ""),
-        seoTitle: maybe(() => collection.seoTitle, ""),
+        seoDescription: collection?.seoDescription || "",
+        seoTitle: collection?.seoTitle || "",
         slug: collection?.slug || ""
       }}
       onSubmit={handleSubmit}
@@ -121,7 +113,7 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
             <AppHeader onBack={onBack}>
               {intl.formatMessage(sectionNames.collections)}
             </AppHeader>
-            <PageHeader title={maybe(() => collection.name)} />
+            <PageHeader title={collection?.name} />
             <Grid>
               <div>
                 <CollectionDetails
@@ -134,7 +126,7 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
                 <CardSpacer />
                 <CollectionImage
                   data={data}
-                  image={maybe(() => collection.backgroundImage)}
+                  image={collection?.backgroundImage}
                   onImageDelete={onImageDelete}
                   onImageUpload={onImageUpload}
                   onChange={change}
@@ -162,51 +154,11 @@ const CollectionDetailsPage: React.FC<CollectionDetailsPageProps> = ({
                   slug={data.slug}
                   slugPlaceholder={data.name}
                   title={data.seoTitle}
-                  titlePlaceholder={maybe(() => collection.name)}
+                  titlePlaceholder={collection?.name}
                   onChange={change}
                 />
               </div>
-              <div>
-                <div>
-                  <VisibilityCard
-                    data={data}
-                    errors={errors}
-                    messages={{
-                      hiddenLabel: intl.formatMessage({
-                        defaultMessage: "Hidden",
-                        description: "collection label"
-                      }),
-                      hiddenSecondLabel: intl.formatMessage(
-                        {
-                          defaultMessage: "will be visible from {date}",
-                          description: "collection"
-                        },
-                        {
-                          date: localizeDate(data.publicationDate, "L")
-                        }
-                      ),
-                      visibleLabel: intl.formatMessage({
-                        defaultMessage: "Visible",
-                        description: "collection label"
-                      })
-                    }}
-                    onChange={change}
-                  >
-                    <FormSpacer />
-                    <Hr />
-                    <ControlledCheckbox
-                      name={"isFeatured" as keyof CollectionDetailsPageFormData}
-                      label={intl.formatMessage({
-                        defaultMessage: "Feature on Homepage",
-                        description: "switch button"
-                      })}
-                      checked={data.isFeatured}
-                      onChange={change}
-                      disabled={disabled}
-                    />
-                  </VisibilityCard>
-                </div>
-              </div>
+              <div></div>
             </Grid>
             <SaveButtonBar
               state={saveButtonBarState}

--- a/src/collections/components/CollectionList/CollectionList.tsx
+++ b/src/collections/components/CollectionList/CollectionList.tsx
@@ -4,10 +4,10 @@ import TableCell from "@material-ui/core/TableCell";
 import TableFooter from "@material-ui/core/TableFooter";
 import TableRow from "@material-ui/core/TableRow";
 import { CollectionListUrlSortField } from "@saleor/collections/urls";
+import { ChannelsAvailabilityDropdown } from "@saleor/components/ChannelsAvailabilityDropdown";
 import Checkbox from "@saleor/components/Checkbox";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
-import StatusLabel from "@saleor/components/StatusLabel";
 import TableCellHeader from "@saleor/components/TableCellHeader";
 import TableHead from "@saleor/components/TableHead";
 import TablePagination from "@saleor/components/TablePagination";
@@ -15,7 +15,7 @@ import { maybe, renderCollection } from "@saleor/misc";
 import { ListActions, ListProps, SortPage } from "@saleor/types";
 import { getArrowDirection } from "@saleor/utils/sort";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 
 import { CollectionList_collections_edges_node } from "../../types/CollectionList";
 
@@ -49,12 +49,15 @@ interface CollectionListProps
     ListActions,
     SortPage<CollectionListUrlSortField> {
   collections: CollectionList_collections_edges_node[];
+  channelsCount: number;
+  selectedChannel: string;
 }
 
 const numberOfColumns = 4;
 
 const CollectionList: React.FC<CollectionListProps> = props => {
   const {
+    channelsCount,
     collections,
     disabled,
     settings,
@@ -67,13 +70,13 @@ const CollectionList: React.FC<CollectionListProps> = props => {
     pageInfo,
     isChecked,
     selected,
+    selectedChannel,
     toggle,
     toggleAll,
     toolbar
   } = props;
 
   const classes = useStyles(props);
-  const intl = useIntl();
 
   return (
     <ResponsiveTable>
@@ -143,6 +146,9 @@ const CollectionList: React.FC<CollectionListProps> = props => {
           collections,
           collection => {
             const isSelected = collection ? isChecked(collection.id) : false;
+            const channel = collection?.channelListing.find(
+              listing => listing.channel.id === selectedChannel
+            );
             return (
               <TableRow
                 className={classes.tableRow}
@@ -172,26 +178,18 @@ const CollectionList: React.FC<CollectionListProps> = props => {
                 </TableCell>
                 <TableCell
                   className={classes.colAvailability}
-                  data-test="published"
-                  data-test-published={maybe(() => collection.isPublished)}
+                  data-test="availability"
+                  data-test-availability={!!collection?.channelListing?.length}
                 >
-                  {maybe(
-                    () => (
-                      <StatusLabel
-                        status={collection.isPublished ? "success" : "error"}
-                        label={
-                          collection.isPublished
-                            ? intl.formatMessage({
-                                defaultMessage: "Published",
-                                description: "collection is published"
-                              })
-                            : intl.formatMessage({
-                                defaultMessage: "Not published",
-                                description: "collection is not published"
-                              })
-                        }
-                      />
-                    ),
+                  {collection && !collection?.channelListing?.length ? (
+                    "-"
+                  ) : collection?.channelListing !== undefined ? (
+                    <ChannelsAvailabilityDropdown
+                      allChannelsCount={channelsCount}
+                      currentChannel={channel}
+                      channels={collection?.channelListing}
+                    />
+                  ) : (
                     <Skeleton />
                   )}
                 </TableCell>

--- a/src/collections/components/CollectionListPage/CollectionListPage.tsx
+++ b/src/collections/components/CollectionListPage/CollectionListPage.tsx
@@ -32,6 +32,7 @@ export interface CollectionListPageProps
     SortPage<CollectionListUrlSortField>,
     TabPageProps {
   collections: CollectionList_collections_edges_node[];
+  channelsCount: number;
   selectedChannel: string;
   onSettingsOpen?: () => void;
 }
@@ -46,6 +47,7 @@ const useStyles = makeStyles(
 );
 
 const CollectionListPage: React.FC<CollectionListPageProps> = ({
+  channelsCount,
   currencySymbol,
   currentTab,
   disabled,
@@ -59,6 +61,7 @@ const CollectionListPage: React.FC<CollectionListPageProps> = ({
   onTabChange,
   onTabDelete,
   onTabSave,
+  selectedChannel,
   tabs,
   ...listProps
 }) => {
@@ -116,7 +119,12 @@ const CollectionListPage: React.FC<CollectionListPageProps> = ({
           onTabDelete={onTabDelete}
           onTabSave={onTabSave}
         />
-        <CollectionList disabled={disabled} {...listProps} />
+        <CollectionList
+          disabled={disabled}
+          channelsCount={channelsCount}
+          selectedChannel={selectedChannel}
+          {...listProps}
+        />
       </Card>
     </Container>
   );

--- a/src/collections/components/CollectionListPage/CollectionListPage.tsx
+++ b/src/collections/components/CollectionListPage/CollectionListPage.tsx
@@ -4,13 +4,13 @@ import makeStyles from "@material-ui/core/styles/makeStyles";
 import { CollectionListUrlSortField } from "@saleor/collections/urls";
 import CardMenu from "@saleor/components/CardMenu";
 import { Container } from "@saleor/components/Container";
-import FilterBar from "@saleor/components/FilterBar";
 import PageHeader from "@saleor/components/PageHeader";
+import SearchBar from "@saleor/components/SearchBar";
 import { sectionNames } from "@saleor/intl";
 import {
-  FilterPageProps,
   ListActions,
   PageListProps,
+  SearchPageProps,
   SortPage,
   TabPageProps
 } from "@saleor/types";
@@ -19,16 +19,11 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { CollectionList_collections_edges_node } from "../../types/CollectionList";
 import CollectionList from "../CollectionList/CollectionList";
-import {
-  CollectionFilterKeys,
-  CollectionListFilterOpts,
-  createFilterStructure
-} from "./filters";
 
 export interface CollectionListPageProps
   extends PageListProps,
     ListActions,
-    FilterPageProps<CollectionFilterKeys, CollectionListFilterOpts>,
+    SearchPageProps,
     SortPage<CollectionListUrlSortField>,
     TabPageProps {
   collections: CollectionList_collections_edges_node[];
@@ -48,14 +43,11 @@ const useStyles = makeStyles(
 
 const CollectionListPage: React.FC<CollectionListPageProps> = ({
   channelsCount,
-  currencySymbol,
   currentTab,
   disabled,
-  filterOpts,
   initialSearch,
   onAdd,
   onAll,
-  onFilterChange,
   onSearchChange,
   onSettingsOpen,
   onTabChange,
@@ -67,7 +59,6 @@ const CollectionListPage: React.FC<CollectionListPageProps> = ({
 }) => {
   const intl = useIntl();
   const classes = useStyles({});
-  const structure = createFilterStructure(intl, filterOpts);
 
   return (
     <Container>
@@ -99,21 +90,18 @@ const CollectionListPage: React.FC<CollectionListPageProps> = ({
         </Button>
       </PageHeader>
       <Card>
-        <FilterBar
+        <SearchBar
           allTabLabel={intl.formatMessage({
             defaultMessage: "All Collections",
             description: "tab name"
           })}
-          currencySymbol={currencySymbol}
           currentTab={currentTab}
-          filterStructure={structure}
           initialSearch={initialSearch}
           searchPlaceholder={intl.formatMessage({
             defaultMessage: "Search Collection"
           })}
           tabs={tabs}
           onAll={onAll}
-          onFilterChange={onFilterChange}
           onSearchChange={onSearchChange}
           onTabChange={onTabChange}
           onTabDelete={onTabDelete}

--- a/src/collections/fixtures.ts
+++ b/src/collections/fixtures.ts
@@ -5,8 +5,19 @@ import { CollectionList_collections_edges_node } from "./types/CollectionList";
 export const collections: CollectionList_collections_edges_node[] = [
   {
     __typename: "Collection",
+    channelListing: [
+      {
+        __typename: "CollectionChannelListing",
+        channel: {
+          __typename: "Channel",
+          id: "123",
+          name: "Channel"
+        },
+        isPublished: false,
+        publicationDate: null
+      }
+    ],
     id: "Q29sbGVjdGlvbjox",
-    isPublished: true,
     name: "Summer collection",
     products: {
       __typename: "ProductCountableConnection",
@@ -15,8 +26,19 @@ export const collections: CollectionList_collections_edges_node[] = [
   },
   {
     __typename: "Collection",
+    channelListing: [
+      {
+        __typename: "CollectionChannelListing",
+        channel: {
+          __typename: "Channel",
+          id: "124",
+          name: "Channel"
+        },
+        isPublished: false,
+        publicationDate: null
+      }
+    ],
     id: "Q29sbGVjdGlvbjoy",
-    isPublished: true,
     name: "Winter sale",
     products: {
       __typename: "ProductCountableConnection",
@@ -25,8 +47,19 @@ export const collections: CollectionList_collections_edges_node[] = [
   },
   {
     __typename: "Collection",
+    channelListing: [
+      {
+        __typename: "CollectionChannelListing",
+        channel: {
+          __typename: "Channel",
+          id: "125",
+          name: "Channel"
+        },
+        isPublished: false,
+        publicationDate: null
+      }
+    ],
     id: "Q29sbGVjdGlvbjoz",
-    isPublished: true,
     name: "Vintage vibes",
     products: {
       __typename: "ProductCountableConnection",
@@ -35,8 +68,19 @@ export const collections: CollectionList_collections_edges_node[] = [
   },
   {
     __typename: "Collection",
+    channelListing: [
+      {
+        __typename: "CollectionChannelListing",
+        channel: {
+          __typename: "Channel",
+          id: "126",
+          name: "Channel"
+        },
+        isPublished: false,
+        publicationDate: null
+      }
+    ],
     id: "Q29sbGVjdGlvbjoa",
-    isPublished: true,
     name: "Merry Christmas",
     products: {
       __typename: "ProductCountableConnection",
@@ -45,8 +89,19 @@ export const collections: CollectionList_collections_edges_node[] = [
   },
   {
     __typename: "Collection",
+    channelListing: [
+      {
+        __typename: "CollectionChannelListing",
+        channel: {
+          __typename: "Channel",
+          id: "127",
+          name: "Channel"
+        },
+        isPublished: false,
+        publicationDate: null
+      }
+    ],
     id: "Q29sbGVjdGlvbjob",
-    isPublished: true,
     name: "80s Miami",
     products: {
       __typename: "ProductCountableConnection",
@@ -55,8 +110,19 @@ export const collections: CollectionList_collections_edges_node[] = [
   },
   {
     __typename: "Collection",
+    channelListing: [
+      {
+        __typename: "CollectionChannelListing",
+        channel: {
+          __typename: "Channel",
+          id: "128",
+          name: "Channel"
+        },
+        isPublished: false,
+        publicationDate: null
+      }
+    ],
     id: "Q29sbGVjdGlvbjoc",
-    isPublished: true,
     name: "Yellow Submarine 2019",
     products: {
       __typename: "ProductCountableConnection",
@@ -77,9 +143,20 @@ export const collection: (
     alt: "Alt text",
     url: placeholderCollectionImage
   },
+  channelListing: [
+    {
+      __typename: "CollectionChannelListing",
+      channel: {
+        __typename: "Channel",
+        id: "223",
+        name: "Channel"
+      },
+      isPublished: false,
+      publicationDate: null
+    }
+  ],
   descriptionJson: JSON.stringify(content),
   id: "Q29sbGVjdGlvbjox",
-  isPublished: true,
   metadata: [
     {
       __typename: "MetadataItem",
@@ -317,7 +394,6 @@ export const collection: (
       startCursor: ""
     }
   },
-  publicationDate: "2018-08-25T18:45:54.125Z",
   seoDescription: "",
   seoTitle: "",
   slug: "summer-collection"

--- a/src/collections/mutations.ts
+++ b/src/collections/mutations.ts
@@ -4,8 +4,7 @@ import {
 } from "@saleor/fragments/collections";
 import {
   collectionsErrorFragment,
-  productErrorFragment,
-  shopErrorFragment
+  productErrorFragment
 } from "@saleor/fragments/errors";
 import makeMutation from "@saleor/hooks/makeMutation";
 import gql from "graphql-tag";
@@ -23,10 +22,6 @@ import {
   CollectionUpdateVariables
 } from "./types/CollectionUpdate";
 import {
-  CollectionUpdateWithHomepage,
-  CollectionUpdateWithHomepageVariables
-} from "./types/CollectionUpdateWithHomepage";
-import {
   CreateCollection,
   CreateCollectionVariables
 } from "./types/CreateCollection";
@@ -41,14 +36,14 @@ import {
 
 const collectionUpdate = gql`
   ${collectionDetailsFragment}
-  ${productErrorFragment}
+  ${collectionsErrorFragment}
   mutation CollectionUpdate($id: ID!, $input: CollectionInput!) {
     collectionUpdate(id: $id, input: $input) {
       collection {
         ...CollectionDetailsFragment
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: collectionErrors {
+        ...CollectionErrorFragment
       }
     }
   }
@@ -57,40 +52,6 @@ export const useCollectionUpdateMutation = makeMutation<
   CollectionUpdate,
   CollectionUpdateVariables
 >(collectionUpdate);
-
-const collectionUpdateWithHomepage = gql`
-  ${collectionDetailsFragment}
-  ${productErrorFragment}
-  ${shopErrorFragment}
-  mutation CollectionUpdateWithHomepage(
-    $id: ID!
-    $input: CollectionInput!
-    $homepageId: ID
-  ) {
-    homepageCollectionUpdate(collection: $homepageId) {
-      errors: shopErrors {
-        ...ShopErrorFragment
-      }
-      shop {
-        homepageCollection {
-          id
-        }
-      }
-    }
-    collectionUpdate(id: $id, input: $input) {
-      collection {
-        ...CollectionDetailsFragment
-      }
-      errors: productErrors {
-        ...ProductErrorFragment
-      }
-    }
-  }
-`;
-export const useCollectionUpdateWithHomepageMutation = makeMutation<
-  CollectionUpdateWithHomepage,
-  CollectionUpdateWithHomepageVariables
->(collectionUpdateWithHomepage);
 
 const assignCollectionProduct = gql`
   ${collectionProductFragment}
@@ -120,7 +81,7 @@ const assignCollectionProduct = gql`
           }
         }
       }
-      errors: productErrors {
+      errors: collectionErrors {
         ...CollectionErrorFragment
       }
     }
@@ -133,14 +94,14 @@ export const useCollectionAssignProductMutation = makeMutation<
 
 const createCollection = gql`
   ${collectionDetailsFragment}
-  ${productErrorFragment}
+  ${collectionsErrorFragment}
   mutation CreateCollection($input: CollectionCreateInput!) {
     collectionCreate(input: $input) {
       collection {
         ...CollectionDetailsFragment
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: collectionErrors {
+        ...CollectionErrorFragment
       }
     }
   }
@@ -151,11 +112,11 @@ export const useCollectionCreateMutation = makeMutation<
 >(createCollection);
 
 const removeCollection = gql`
-  ${productErrorFragment}
+  ${collectionsErrorFragment}
   mutation RemoveCollection($id: ID!) {
     collectionDelete(id: $id) {
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: collectionErrors {
+        ...CollectionErrorFragment
       }
     }
   }
@@ -166,7 +127,7 @@ export const useCollectionRemoveMutation = makeMutation<
 >(removeCollection);
 
 const unassignCollectionProduct = gql`
-  ${productErrorFragment}
+  ${collectionsErrorFragment}
   mutation UnassignCollectionProduct(
     $collectionId: ID!
     $productIds: [ID]!
@@ -203,8 +164,8 @@ const unassignCollectionProduct = gql`
           }
         }
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: collectionErrors {
+        ...CollectionErrorFragment
       }
     }
   }
@@ -228,3 +189,23 @@ export const useCollectionBulkDelete = makeMutation<
   CollectionBulkDelete,
   CollectionBulkDeleteVariables
 >(collectionBulkDelete);
+
+const collectionChannelListingUpdate = gql`
+  ${productErrorFragment}
+  mutation CollectionChannelListingUpdate(
+    $id: ID!
+    $input: CollectionChannelListingUpdateInput!
+  ) {
+    collectionChannelListingUpdate(ids: $ids) {
+      errors: collectionChannelListingErrors {
+        field
+        message
+        code
+        channels
+      }
+    }
+  }
+`;
+export const useCollectionChannelListingUpdate = makeMutation(
+  collectionChannelListingUpdate
+);

--- a/src/collections/mutations.ts
+++ b/src/collections/mutations.ts
@@ -1,4 +1,8 @@
 import {
+  CollectionChannelListingUpdate,
+  CollectionChannelListingUpdateVariables
+} from "@saleor/collections/types/CollectionChannelListingUpdate";
+import {
   collectionDetailsFragment,
   collectionProductFragment
 } from "@saleor/fragments/collections";
@@ -191,12 +195,11 @@ export const useCollectionBulkDelete = makeMutation<
 >(collectionBulkDelete);
 
 const collectionChannelListingUpdate = gql`
-  ${productErrorFragment}
   mutation CollectionChannelListingUpdate(
     $id: ID!
     $input: CollectionChannelListingUpdateInput!
   ) {
-    collectionChannelListingUpdate(ids: $ids) {
+    collectionChannelListingUpdate(id: $id, input: $input) {
       errors: collectionChannelListingErrors {
         field
         message
@@ -206,6 +209,7 @@ const collectionChannelListingUpdate = gql`
     }
   }
 `;
-export const useCollectionChannelListingUpdate = makeMutation(
-  collectionChannelListingUpdate
-);
+export const useCollectionChannelListingUpdate = makeMutation<
+  CollectionChannelListingUpdate,
+  CollectionChannelListingUpdateVariables
+>(collectionChannelListingUpdate);

--- a/src/collections/mutations.ts
+++ b/src/collections/mutations.ts
@@ -7,6 +7,7 @@ import {
   collectionProductFragment
 } from "@saleor/fragments/collections";
 import {
+  collectionChannelListingErrorFragment,
   collectionsErrorFragment,
   productErrorFragment
 } from "@saleor/fragments/errors";
@@ -195,16 +196,14 @@ export const useCollectionBulkDelete = makeMutation<
 >(collectionBulkDelete);
 
 const collectionChannelListingUpdate = gql`
+  ${collectionChannelListingErrorFragment}
   mutation CollectionChannelListingUpdate(
     $id: ID!
     $input: CollectionChannelListingUpdateInput!
   ) {
     collectionChannelListingUpdate(id: $id, input: $input) {
       errors: collectionChannelListingErrors {
-        field
-        message
-        code
-        channels
+        ...CollectionChannelListingErrorFragment
       }
     }
   }

--- a/src/collections/queries.ts
+++ b/src/collections/queries.ts
@@ -82,11 +82,6 @@ export const collectionDetails = gql`
         }
       }
     }
-    shop {
-      homepageCollection {
-        id
-      }
-    }
   }
 `;
 export const TypedCollectionDetailsQuery = TypedQuery<

--- a/src/collections/types/CollectionAssignProduct.ts
+++ b/src/collections/types/CollectionAssignProduct.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode } from "./../../types/globalTypes";
+import { CollectionErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CollectionAssignProduct
@@ -78,8 +78,8 @@ export interface CollectionAssignProduct_collectionAddProducts_collection {
 }
 
 export interface CollectionAssignProduct_collectionAddProducts_errors {
-  __typename: "CollectionProductError";
-  code: ProductErrorCode;
+  __typename: "CollectionError";
+  code: CollectionErrorCode;
   field: string | null;
 }
 

--- a/src/collections/types/CollectionChannelListingUpdate.ts
+++ b/src/collections/types/CollectionChannelListingUpdate.ts
@@ -10,9 +10,9 @@ import { CollectionChannelListingUpdateInput, ProductErrorCode } from "./../../t
 
 export interface CollectionChannelListingUpdate_collectionChannelListingUpdate_errors {
   __typename: "CollectionChannelListingError";
+  code: ProductErrorCode;
   field: string | null;
   message: string | null;
-  code: ProductErrorCode;
   channels: string[] | null;
 }
 

--- a/src/collections/types/CollectionChannelListingUpdate.ts
+++ b/src/collections/types/CollectionChannelListingUpdate.ts
@@ -1,0 +1,31 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { CollectionChannelListingUpdateInput, ProductErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: CollectionChannelListingUpdate
+// ====================================================
+
+export interface CollectionChannelListingUpdate_collectionChannelListingUpdate_errors {
+  __typename: "CollectionChannelListingError";
+  field: string | null;
+  message: string | null;
+  code: ProductErrorCode;
+  channels: string[] | null;
+}
+
+export interface CollectionChannelListingUpdate_collectionChannelListingUpdate {
+  __typename: "CollectionChannelListingUpdate";
+  errors: CollectionChannelListingUpdate_collectionChannelListingUpdate_errors[];
+}
+
+export interface CollectionChannelListingUpdate {
+  collectionChannelListingUpdate: CollectionChannelListingUpdate_collectionChannelListingUpdate | null;
+}
+
+export interface CollectionChannelListingUpdateVariables {
+  id: string;
+  input: CollectionChannelListingUpdateInput;
+}

--- a/src/collections/types/CollectionDetails.ts
+++ b/src/collections/types/CollectionDetails.ts
@@ -6,6 +6,19 @@
 // GraphQL query operation: CollectionDetails
 // ====================================================
 
+export interface CollectionDetails_collection_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+}
+
+export interface CollectionDetails_collection_channelListing {
+  __typename: "CollectionChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: CollectionDetails_collection_channelListing_channel;
+}
+
 export interface CollectionDetails_collection_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -90,32 +103,20 @@ export interface CollectionDetails_collection_products {
 export interface CollectionDetails_collection {
   __typename: "Collection";
   id: string;
-  isPublished: boolean;
   name: string;
+  channelListing: CollectionDetails_collection_channelListing[] | null;
   metadata: (CollectionDetails_collection_metadata | null)[];
   privateMetadata: (CollectionDetails_collection_privateMetadata | null)[];
   backgroundImage: CollectionDetails_collection_backgroundImage | null;
   slug: string;
   descriptionJson: any;
-  publicationDate: any | null;
   seoDescription: string | null;
   seoTitle: string | null;
   products: CollectionDetails_collection_products | null;
 }
 
-export interface CollectionDetails_shop_homepageCollection {
-  __typename: "Collection";
-  id: string;
-}
-
-export interface CollectionDetails_shop {
-  __typename: "Shop";
-  homepageCollection: CollectionDetails_shop_homepageCollection | null;
-}
-
 export interface CollectionDetails {
   collection: CollectionDetails_collection | null;
-  shop: CollectionDetails_shop;
 }
 
 export interface CollectionDetailsVariables {

--- a/src/collections/types/CollectionList.ts
+++ b/src/collections/types/CollectionList.ts
@@ -8,6 +8,19 @@ import { CollectionFilterInput, CollectionSortingInput } from "./../../types/glo
 // GraphQL query operation: CollectionList
 // ====================================================
 
+export interface CollectionList_collections_edges_node_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+}
+
+export interface CollectionList_collections_edges_node_channelListing {
+  __typename: "CollectionChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: CollectionList_collections_edges_node_channelListing_channel;
+}
+
 export interface CollectionList_collections_edges_node_products {
   __typename: "ProductCountableConnection";
   totalCount: number | null;
@@ -16,8 +29,8 @@ export interface CollectionList_collections_edges_node_products {
 export interface CollectionList_collections_edges_node {
   __typename: "Collection";
   id: string;
-  isPublished: boolean;
   name: string;
+  channelListing: CollectionList_collections_edges_node_channelListing[] | null;
   products: CollectionList_collections_edges_node_products | null;
 }
 

--- a/src/collections/types/CollectionUpdate.ts
+++ b/src/collections/types/CollectionUpdate.ts
@@ -2,11 +2,24 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { CollectionInput, ProductErrorCode } from "./../../types/globalTypes";
+import { CollectionInput, CollectionErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CollectionUpdate
 // ====================================================
+
+export interface CollectionUpdate_collectionUpdate_collection_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+}
+
+export interface CollectionUpdate_collectionUpdate_collection_channelListing {
+  __typename: "CollectionChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: CollectionUpdate_collectionUpdate_collection_channelListing_channel;
+}
 
 export interface CollectionUpdate_collectionUpdate_collection_metadata {
   __typename: "MetadataItem";
@@ -29,21 +42,20 @@ export interface CollectionUpdate_collectionUpdate_collection_backgroundImage {
 export interface CollectionUpdate_collectionUpdate_collection {
   __typename: "Collection";
   id: string;
-  isPublished: boolean;
   name: string;
+  channelListing: CollectionUpdate_collectionUpdate_collection_channelListing[] | null;
   metadata: (CollectionUpdate_collectionUpdate_collection_metadata | null)[];
   privateMetadata: (CollectionUpdate_collectionUpdate_collection_privateMetadata | null)[];
   backgroundImage: CollectionUpdate_collectionUpdate_collection_backgroundImage | null;
   slug: string;
   descriptionJson: any;
-  publicationDate: any | null;
   seoDescription: string | null;
   seoTitle: string | null;
 }
 
 export interface CollectionUpdate_collectionUpdate_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "CollectionError";
+  code: CollectionErrorCode;
   field: string | null;
 }
 

--- a/src/collections/types/CollectionUpdateWithHomepage.ts
+++ b/src/collections/types/CollectionUpdateWithHomepage.ts
@@ -2,32 +2,23 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { CollectionInput, ShopErrorCode, ProductErrorCode } from "./../../types/globalTypes";
+import { CollectionInput, CollectionErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CollectionUpdateWithHomepage
 // ====================================================
 
-export interface CollectionUpdateWithHomepage_homepageCollectionUpdate_errors {
-  __typename: "ShopError";
-  code: ShopErrorCode;
-  field: string | null;
-}
-
-export interface CollectionUpdateWithHomepage_homepageCollectionUpdate_shop_homepageCollection {
-  __typename: "Collection";
+export interface CollectionUpdateWithHomepage_collectionUpdate_collection_channelListing_channel {
+  __typename: "Channel";
   id: string;
+  name: string;
 }
 
-export interface CollectionUpdateWithHomepage_homepageCollectionUpdate_shop {
-  __typename: "Shop";
-  homepageCollection: CollectionUpdateWithHomepage_homepageCollectionUpdate_shop_homepageCollection | null;
-}
-
-export interface CollectionUpdateWithHomepage_homepageCollectionUpdate {
-  __typename: "HomepageCollectionUpdate";
-  errors: CollectionUpdateWithHomepage_homepageCollectionUpdate_errors[];
-  shop: CollectionUpdateWithHomepage_homepageCollectionUpdate_shop | null;
+export interface CollectionUpdateWithHomepage_collectionUpdate_collection_channelListing {
+  __typename: "CollectionChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: CollectionUpdateWithHomepage_collectionUpdate_collection_channelListing_channel;
 }
 
 export interface CollectionUpdateWithHomepage_collectionUpdate_collection_metadata {
@@ -51,21 +42,20 @@ export interface CollectionUpdateWithHomepage_collectionUpdate_collection_backgr
 export interface CollectionUpdateWithHomepage_collectionUpdate_collection {
   __typename: "Collection";
   id: string;
-  isPublished: boolean;
   name: string;
+  channelListing: CollectionUpdateWithHomepage_collectionUpdate_collection_channelListing[] | null;
   metadata: (CollectionUpdateWithHomepage_collectionUpdate_collection_metadata | null)[];
   privateMetadata: (CollectionUpdateWithHomepage_collectionUpdate_collection_privateMetadata | null)[];
   backgroundImage: CollectionUpdateWithHomepage_collectionUpdate_collection_backgroundImage | null;
   slug: string;
   descriptionJson: any;
-  publicationDate: any | null;
   seoDescription: string | null;
   seoTitle: string | null;
 }
 
 export interface CollectionUpdateWithHomepage_collectionUpdate_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "CollectionError";
+  code: CollectionErrorCode;
   field: string | null;
 }
 
@@ -76,12 +66,10 @@ export interface CollectionUpdateWithHomepage_collectionUpdate {
 }
 
 export interface CollectionUpdateWithHomepage {
-  homepageCollectionUpdate: CollectionUpdateWithHomepage_homepageCollectionUpdate | null;
   collectionUpdate: CollectionUpdateWithHomepage_collectionUpdate | null;
 }
 
 export interface CollectionUpdateWithHomepageVariables {
   id: string;
   input: CollectionInput;
-  homepageId?: string | null;
 }

--- a/src/collections/types/CreateCollection.ts
+++ b/src/collections/types/CreateCollection.ts
@@ -2,11 +2,24 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { CollectionCreateInput, ProductErrorCode } from "./../../types/globalTypes";
+import { CollectionCreateInput, CollectionErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CreateCollection
 // ====================================================
+
+export interface CreateCollection_collectionCreate_collection_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+}
+
+export interface CreateCollection_collectionCreate_collection_channelListing {
+  __typename: "CollectionChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: CreateCollection_collectionCreate_collection_channelListing_channel;
+}
 
 export interface CreateCollection_collectionCreate_collection_metadata {
   __typename: "MetadataItem";
@@ -29,21 +42,20 @@ export interface CreateCollection_collectionCreate_collection_backgroundImage {
 export interface CreateCollection_collectionCreate_collection {
   __typename: "Collection";
   id: string;
-  isPublished: boolean;
   name: string;
+  channelListing: CreateCollection_collectionCreate_collection_channelListing[] | null;
   metadata: (CreateCollection_collectionCreate_collection_metadata | null)[];
   privateMetadata: (CreateCollection_collectionCreate_collection_privateMetadata | null)[];
   backgroundImage: CreateCollection_collectionCreate_collection_backgroundImage | null;
   slug: string;
   descriptionJson: any;
-  publicationDate: any | null;
   seoDescription: string | null;
   seoTitle: string | null;
 }
 
 export interface CreateCollection_collectionCreate_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "CollectionError";
+  code: CollectionErrorCode;
   field: string | null;
 }
 

--- a/src/collections/types/RemoveCollection.ts
+++ b/src/collections/types/RemoveCollection.ts
@@ -2,15 +2,15 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode } from "./../../types/globalTypes";
+import { CollectionErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: RemoveCollection
 // ====================================================
 
 export interface RemoveCollection_collectionDelete_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "CollectionError";
+  code: CollectionErrorCode;
   field: string | null;
 }
 

--- a/src/collections/types/UnassignCollectionProduct.ts
+++ b/src/collections/types/UnassignCollectionProduct.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode } from "./../../types/globalTypes";
+import { CollectionErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UnassignCollectionProduct
@@ -53,8 +53,8 @@ export interface UnassignCollectionProduct_collectionRemoveProducts_collection {
 }
 
 export interface UnassignCollectionProduct_collectionRemoveProducts_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "CollectionError";
+  code: CollectionErrorCode;
   field: string | null;
 }
 

--- a/src/collections/utils.ts
+++ b/src/collections/utils.ts
@@ -1,0 +1,21 @@
+import { ChannelCollectionData } from "@saleor/channels/utils";
+
+export const createChannelsChangeHandler = (
+  channelListing: ChannelCollectionData[],
+  updateChannels: (data: ChannelCollectionData[]) => void,
+  triggerChange: () => void
+) => (id: string, data: Omit<ChannelCollectionData, "name" | "id">) => {
+  const channelIndex = channelListing.findIndex(channel => channel.id === id);
+  const channel = channelListing[channelIndex];
+
+  const updatedChannels = [
+    ...channelListing.slice(0, channelIndex),
+    {
+      ...channel,
+      ...data
+    },
+    ...channelListing.slice(channelIndex + 1)
+  ];
+  updateChannels(updatedChannels);
+  triggerChange();
+};

--- a/src/collections/views/CollectionCreate.tsx
+++ b/src/collections/views/CollectionCreate.tsx
@@ -1,4 +1,8 @@
+import { useChannelsList } from "@saleor/channels/queries";
+import { createCollectionChannels } from "@saleor/channels/utils";
+import ChannelsAvailabilityDialog from "@saleor/components/ChannelsAvailabilityDialog";
 import { WindowTitle } from "@saleor/components/WindowTitle";
+import useChannels from "@saleor/hooks/useChannels";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import { commonMessages } from "@saleor/intl";
@@ -14,7 +18,10 @@ import { CollectionCreateInput } from "../../types/globalTypes";
 import CollectionCreatePage, {
   CollectionCreatePageFormData
 } from "../components/CollectionCreatePage/CollectionCreatePage";
-import { useCollectionCreateMutation } from "../mutations";
+import {
+  useCollectionChannelListingUpdate,
+  useCollectionCreateMutation
+} from "../mutations";
 import { collectionListUrl, collectionUrl } from "../urls";
 
 export const CollectionCreate: React.FC = () => {
@@ -23,6 +30,31 @@ export const CollectionCreate: React.FC = () => {
   const intl = useIntl();
   const [updateMetadata] = useMetadataUpdate({});
   const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
+
+  const [
+    updateChannels,
+    updateChannelsOpts
+  ] = useCollectionChannelListingUpdate({});
+  const { data: channelsData } = useChannelsList({});
+
+  const allChannels = createCollectionChannels(
+    channelsData?.channels
+  )?.sort((channel, nextChannel) =>
+    channel.name.localeCompare(nextChannel.name)
+  );
+
+  const {
+    channelListElements,
+    channelsToggle,
+    currentChannels,
+    handleChannelsConfirm,
+    handleChannelsModalClose,
+    handleChannelsModalOpen,
+    isChannelSelected,
+    isChannelsModalOpen,
+    setCurrentChannels,
+    toggleAllChannels
+  } = useChannels(allChannels);
 
   const [createCollection, createCollectionOpts] = useCollectionCreateMutation({
     onCompleted: data => {
@@ -72,6 +104,23 @@ export const CollectionCreate: React.FC = () => {
       }
     });
 
+    const id = result.data?.collectionCreate.collection?.id || null;
+    if (id) {
+      updateChannels({
+        variables: {
+          id,
+          input: {
+            addChannels: formData.channelListing.map(channel => ({
+              channelId: channel.id,
+              isPublished: channel.isPublished,
+              publicationDate: channel.publicationDate
+            })),
+            removeChannels: []
+          }
+        }
+      });
+    }
+
     return result.data?.collectionCreate.collection?.id || null;
   };
 
@@ -89,10 +138,34 @@ export const CollectionCreate: React.FC = () => {
           description: "window title"
         })}
       />
+      {!!allChannels?.length && (
+        <ChannelsAvailabilityDialog
+          isSelected={isChannelSelected}
+          disabled={!channelListElements.length}
+          channels={allChannels}
+          onChange={channelsToggle}
+          onClose={handleChannelsModalClose}
+          open={isChannelsModalOpen}
+          title={intl.formatMessage({
+            defaultMessage: "Manage Collection Channel Availability"
+          })}
+          confirmButtonState="default"
+          selected={channelListElements.length}
+          onConfirm={handleChannelsConfirm}
+          toggleAll={toggleAllChannels}
+        />
+      )}
       <CollectionCreatePage
         errors={createCollectionOpts.data?.collectionCreate.errors || []}
+        channelsErrors={
+          updateChannelsOpts?.data?.collectionChannelListingUpdate.errors || []
+        }
+        currentChannels={currentChannels}
+        channelsCount={channelsData?.channels?.length}
+        openChannelsModal={handleChannelsModalOpen}
+        onChannelsChange={setCurrentChannels}
         onBack={() => navigate(collectionListUrl())}
-        disabled={createCollectionOpts.loading}
+        disabled={createCollectionOpts.loading || updateChannelsOpts.loading}
         onSubmit={handleSubmit}
         saveButtonBarState={createCollectionOpts.status}
       />

--- a/src/collections/views/CollectionCreate.tsx
+++ b/src/collections/views/CollectionCreate.tsx
@@ -112,7 +112,7 @@ export const CollectionCreate: React.FC = () => {
       });
     }
 
-    return result.data?.collectionCreate.collection?.id || null;
+    return id;
   };
 
   const handleSubmit = createMetadataCreateHandler(

--- a/src/collections/views/CollectionCreate.tsx
+++ b/src/collections/views/CollectionCreate.tsx
@@ -79,14 +79,6 @@ export const CollectionCreate: React.FC = () => {
     }
   });
 
-  const getPublicationData = ({
-    publicationDate,
-    isPublished
-  }: CollectionCreatePageFormData) => ({
-    isPublished: !!publicationDate || isPublished,
-    publicationDate: publicationDate || null
-  });
-
   const handleCreate = async (formData: CollectionCreatePageFormData) => {
     const result = await createCollection({
       variables: {
@@ -98,8 +90,7 @@ export const CollectionCreate: React.FC = () => {
           seo: {
             description: formData.seoDescription,
             title: formData.seoTitle
-          },
-          ...getPublicationData(formData)
+          }
         }
       }
     });

--- a/src/collections/views/CollectionDetails.tsx
+++ b/src/collections/views/CollectionDetails.tsx
@@ -34,7 +34,6 @@ import {
   useCollectionAssignProductMutation,
   useCollectionRemoveMutation,
   useCollectionUpdateMutation,
-  useCollectionUpdateWithHomepageMutation,
   useUnassignCollectionProductMutation
 } from "../mutations";
 import { TypedCollectionDetailsQuery } from "../queries";
@@ -91,17 +90,6 @@ export const CollectionDetails: React.FC<CollectionDetailsProps> = ({
   };
   const [updateCollection, updateCollectionOpts] = useCollectionUpdateMutation({
     onCompleted: handleCollectionUpdate
-  });
-
-  const [
-    updateCollectionWithHomepage,
-    updateCollectionWithHomepageOpts
-  ] = useCollectionUpdateWithHomepageMutation({
-    onCompleted: data => {
-      if (data.homepageCollectionUpdate.errors.length === 0) {
-        handleCollectionUpdate(data);
-      }
-    }
   });
 
   const [assignProduct, assignProductOpts] = useCollectionAssignProductMutation(
@@ -179,41 +167,43 @@ export const CollectionDetails: React.FC<CollectionDetailsProps> = ({
           const input: CollectionInput = {
             backgroundImageAlt: formData.backgroundImageAlt,
             descriptionJson: JSON.stringify(formData.description),
-            isPublished: formData.isPublished,
             name: formData.name,
-            publicationDate: formData.publicationDate,
             seo: {
               description: formData.seoDescription,
               title: formData.seoTitle
             },
             slug: formData.slug
           };
-          const isFeatured = data.shop.homepageCollection
-            ? data.shop.homepageCollection.id === data.collection.id
-            : false;
+          // const isFeatured = data.shop.homepageCollection
+          //   ? data.shop.homepageCollection.id === data.collection.id
+          //   : false;
 
-          if (formData.isFeatured !== isFeatured) {
-            const result = await updateCollectionWithHomepage({
-              variables: {
-                homepageId: formData.isFeatured ? id : null,
-                id,
-                input
-              }
-            });
-            return [
-              ...result.data.collectionUpdate.errors,
-              ...result.data.homepageCollectionUpdate.errors
-            ];
-          } else {
-            const result = await updateCollection({
-              variables: {
-                id,
-                input
-              }
-            });
-
-            return result.data.collectionUpdate.errors;
-          }
+          // if (formData.isFeatured !== isFeatured) {
+          //   const result = await updateCollectionWithHomepage({
+          //     variables: {
+          //       homepageId: formData.isFeatured ? id : null,
+          //       id,
+          //       input
+          //     }
+          //   });
+          //   return [
+          //     ...result.data.collectionUpdate.errors,
+          //     ...result.data.homepageCollectionUpdate.errors
+          //   ];
+          // } else {
+          //   const result = await updateCollection({
+          //     variables: {
+          //       id,
+          //       input
+          //     }
+          //   });
+          const result = await updateCollection({
+            variables: {
+              id,
+              input
+            }
+          });
+          return result.data.collectionUpdate.errors;
         };
         const handleSubmit = createMetadataUpdateHandler(
           data?.collection,
@@ -223,13 +213,9 @@ export const CollectionDetails: React.FC<CollectionDetailsProps> = ({
         );
 
         const formTransitionState = getMutationState(
-          updateCollectionOpts.called ||
-            updateCollectionWithHomepageOpts.called,
-          updateCollectionOpts.loading ||
-            updateCollectionWithHomepageOpts.loading,
-          updateCollectionOpts.data?.collectionUpdate.errors,
-          updateCollectionWithHomepageOpts.data?.collectionUpdate.errors,
-          updateCollectionWithHomepageOpts.data?.homepageCollectionUpdate.errors
+          updateCollectionOpts.called,
+          updateCollectionOpts.loading,
+          updateCollectionOpts.data?.collectionUpdate.errors
         );
 
         const { loadNextPage, loadPreviousPage, pageInfo } = paginate(
@@ -240,17 +226,14 @@ export const CollectionDetails: React.FC<CollectionDetailsProps> = ({
 
         return (
           <>
-            <WindowTitle title={maybe(() => data.collection.name)} />
+            <WindowTitle title={data?.collection?.name} />
             <CollectionDetailsPage
               onAdd={() => openModal("assign")}
               onBack={handleBack}
               disabled={loading}
               collection={data?.collection}
               errors={updateCollectionOpts?.data?.collectionUpdate.errors || []}
-              isFeatured={maybe(
-                () => data.shop.homepageCollection.id === data.collection.id,
-                false
-              )}
+              isFeatured={false}
               onCollectionRemove={() => openModal("remove")}
               onImageDelete={() => openModal("removeImage")}
               onImageUpload={file =>

--- a/src/collections/views/CollectionList/CollectionList.tsx
+++ b/src/collections/views/CollectionList/CollectionList.tsx
@@ -208,6 +208,7 @@ export const CollectionList: React.FC<CollectionListProps> = ({ params }) => {
         selected={listElements.length}
         toggle={toggle}
         toggleAll={toggleAll}
+        channelsCount={channelChoices?.length}
         selectedChannel={selectedChannel}
         onSettingsOpen={
           !!channelChoices?.length ? () => openModal("settings") : undefined

--- a/src/collections/views/CollectionList/CollectionList.tsx
+++ b/src/collections/views/CollectionList/CollectionList.tsx
@@ -15,12 +15,10 @@ import useNotifier from "@saleor/hooks/useNotifier";
 import usePaginator, {
   createPaginationState
 } from "@saleor/hooks/usePaginator";
-import useShop from "@saleor/hooks/useShop";
 import { commonMessages } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import { ListViews } from "@saleor/types";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
-import createFilterHandlers from "@saleor/utils/handlers/filterHandlers";
 import createSortHandler from "@saleor/utils/handlers/sortHandler";
 import { getSortParams } from "@saleor/utils/sort";
 import React from "react";
@@ -40,8 +38,6 @@ import {
   areFiltersApplied,
   deleteFilterTab,
   getActiveFilters,
-  getFilterOpts,
-  getFilterQueryParam,
   getFilterTabs,
   getFilterVariables,
   saveFilterTab
@@ -56,7 +52,6 @@ export const CollectionList: React.FC<CollectionListProps> = ({ params }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const paginate = usePaginator();
-  const shop = useShop();
   const { isSelected, listElements, reset, toggle, toggleAll } = useBulkActions(
     params.ids
   );
@@ -104,17 +99,15 @@ export const CollectionList: React.FC<CollectionListProps> = ({ params }) => {
         : 0
       : parseInt(params.activeTab, 0);
 
-  const [
-    changeFilters,
-    resetFilters,
-    handleSearchChange
-  ] = createFilterHandlers({
-    cleanupFn: reset,
-    createUrl: collectionListUrl,
-    getFilterQueryParam,
-    navigate,
-    params
-  });
+  const handleSearchChange = (query: string) => {
+    navigate(
+      collectionListUrl({
+        ...getActiveFilters(params),
+        activeTab: undefined,
+        query
+      })
+    );
+  };
 
   const [openModal, closeModal] = createDialogActionHandlers<
     CollectionListUrlDialog,
@@ -155,7 +148,6 @@ export const CollectionList: React.FC<CollectionListProps> = ({ params }) => {
   );
 
   const handleSort = createSortHandler(navigate, collectionListUrl, params);
-  const currencySymbol = maybe(() => shop.defaultCurrency, "USD");
 
   return (
     <>
@@ -170,14 +162,11 @@ export const CollectionList: React.FC<CollectionListProps> = ({ params }) => {
         />
       )}
       <CollectionListPage
-        currencySymbol={currencySymbol}
         currentTab={currentTab}
-        filterOpts={getFilterOpts(params)}
         initialSearch={params.query || ""}
         onSearchChange={handleSearchChange}
-        onFilterChange={changeFilters}
         onAdd={() => navigate(collectionAddUrl)}
-        onAll={resetFilters}
+        onAll={() => navigate(collectionListUrl())}
         onTabChange={handleTabChange}
         onTabDelete={() => openModal("delete-search")}
         onTabSave={() => openModal("save-search")}

--- a/src/components/ChannelsAvailability/ChannelsAvailability.tsx
+++ b/src/components/ChannelsAvailability/ChannelsAvailability.tsx
@@ -3,7 +3,7 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
-import { Channel as ChannelList, ChannelData } from "@saleor/channels/utils";
+import { Channel as ChannelList } from "@saleor/channels/utils";
 import CardTitle from "@saleor/components/CardTitle";
 import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import Hr from "@saleor/components/Hr";
@@ -19,6 +19,16 @@ import { useIntl } from "react-intl";
 
 import { DateContext } from "../Date/DateContext";
 import { useStyles } from "./styles";
+
+export interface ChannelData {
+  id: string;
+  isPublished: boolean;
+  name: string;
+  publicationDate: string | null;
+  availableForPurchase?: string;
+  isAvailableForPurchase?: boolean;
+  visibleInListings?: boolean;
+}
 
 export interface Message {
   visibleLabel: string;
@@ -79,11 +89,13 @@ const Channel: React.FC<ChannelProps> = ({
     name
   } = data;
   const formData = {
-    availableForPurchase,
-    isAvailableForPurchase: isAvailable,
+    ...(availableForPurchase !== undefined ? { availableForPurchase } : {}),
+    ...(isAvailable !== undefined
+      ? { isAvailableForPurchase: isAvailable }
+      : {}),
     isPublished,
     publicationDate,
-    visibleInListings
+    ...(visibleInListings !== undefined ? { visibleInListings } : {})
   };
   const dateNow = React.useContext(DateContext);
   const localizeDate = useDateLocalize();

--- a/src/components/ChannelsAvailability/ChannelsAvailability.tsx
+++ b/src/components/ChannelsAvailability/ChannelsAvailability.tsx
@@ -8,6 +8,7 @@ import CardTitle from "@saleor/components/CardTitle";
 import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import Hr from "@saleor/components/Hr";
 import RadioSwitchField from "@saleor/components/RadioSwitchField";
+import { CollectionChannelListingErrorFragment } from "@saleor/fragments/types/CollectionChannelListingErrorFragment";
 import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import useDateLocalize from "@saleor/hooks/useDateLocalize";
 import ArrowDropdown from "@saleor/icons/ArrowDropdown";
@@ -41,6 +42,11 @@ export interface Message {
   availableSecondLabel?: string;
   setAvailabilityDateLabel?: string;
 }
+
+type Error =
+  | ProductChannelListingErrorFragment
+  | CollectionChannelListingErrorFragment;
+
 interface Value {
   availableForPurchase?: string;
   isAvailableForPurchase?: boolean;
@@ -52,7 +58,7 @@ interface ChannelsAvailability {
   channels: ChannelData[];
   channelsList: ChannelList[];
   channelsMessages?: { [id: string]: Message };
-  errors: ProductChannelListingErrorFragment[];
+  errors: Error[];
   selectedChannelsCount: number;
   allChannelsCount: number;
   disabled?: boolean;
@@ -67,7 +73,7 @@ export type ChannelsAvailabilityProps = RequireOnlyOne<
 interface ChannelProps {
   disabled?: boolean;
   data: ChannelData;
-  errors: ProductChannelListingErrorFragment[];
+  errors: Error[];
   messages: Message;
   onChange: (id: string, data: Value) => void;
 }

--- a/src/components/ChannelsAvailabilityDialog/ChannelsAvailabilityDialog.tsx
+++ b/src/components/ChannelsAvailabilityDialog/ChannelsAvailabilityDialog.tsx
@@ -1,6 +1,7 @@
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import {
+  ChannelCollectionData,
   ChannelData,
   ChannelSaleData,
   ChannelShippingData,
@@ -20,7 +21,8 @@ type ChannelOption =
   | ChannelData
   | ChannelShippingData
   | ChannelVoucherData
-  | ChannelSaleData;
+  | ChannelSaleData
+  | ChannelCollectionData;
 
 export interface ChannelsAvailabilityDialogProps {
   isSelected: (option: ChannelOption) => boolean;

--- a/src/components/ChannelsAvailabilityDropdown/ChannelsAvailabilityDropdown.tsx
+++ b/src/components/ChannelsAvailabilityDropdown/ChannelsAvailabilityDropdown.tsx
@@ -1,6 +1,7 @@
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import Typography from "@material-ui/core/Typography";
+import { CollectionList_collections_edges_node_channelListing } from "@saleor/collections/types/CollectionList";
 import Hr from "@saleor/components/Hr";
 import StatusLabel from "@saleor/components/StatusLabel";
 import useDateLocalize from "@saleor/hooks/useDateLocalize";
@@ -10,15 +11,17 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { useStyles } from "./styles";
 
+type Channels =
+  | ProductList_products_edges_node_channelListing
+  | CollectionList_collections_edges_node_channelListing;
+
 export interface ChannelsAvailabilityDropdownProps {
   allChannelsCount: number;
-  channels: ProductList_products_edges_node_channelListing[];
-  currentChannel: ProductList_products_edges_node_channelListing;
+  channels: Channels[];
+  currentChannel: Channels;
 }
 
-const isActive = (
-  channelData: ProductList_products_edges_node_channelListing
-) => channelData.isPublished;
+const isActive = (channelData: Channels) => channelData.isPublished;
 
 export const ChannelsAvailabilityDropdown: React.FC<ChannelsAvailabilityDropdownProps> = ({
   allChannelsCount,

--- a/src/components/ChannelsAvailabilityDropdown/ChannelsAvailabilityDropdown.tsx
+++ b/src/components/ChannelsAvailabilityDropdown/ChannelsAvailabilityDropdown.tsx
@@ -21,7 +21,7 @@ export interface ChannelsAvailabilityDropdownProps {
   currentChannel: Channels;
 }
 
-const isActive = (channelData: Channels) => channelData.isPublished;
+const isActive = (channelData: Channels) => channelData?.isPublished;
 
 export const ChannelsAvailabilityDropdown: React.FC<ChannelsAvailabilityDropdownProps> = ({
   allChannelsCount,

--- a/src/components/Navigator/modes/catalog.ts
+++ b/src/components/Navigator/modes/catalog.ts
@@ -42,11 +42,11 @@ export function searchInCatalog(
   )
     .map<QuickSearchActionInput>(collection => ({
       caption: intl.formatMessage(messages.collection),
-      extraInfo: intl.formatMessage(
-        collection.isPublished
-          ? messages.collectionPublished
-          : messages.collectionUnpublished
-      ),
+      // extraInfo: intl.formatMessage(
+      //   collection.isPublished
+      //     ? messages.collectionPublished
+      //     : messages.collectionUnpublished
+      // ),
       label: collection.name,
       onClick: () => {
         navigate(collectionUrl(collection.id));

--- a/src/components/Navigator/modes/catalog.ts
+++ b/src/components/Navigator/modes/catalog.ts
@@ -42,11 +42,6 @@ export function searchInCatalog(
   )
     .map<QuickSearchActionInput>(collection => ({
       caption: intl.formatMessage(messages.collection),
-      // extraInfo: intl.formatMessage(
-      //   collection.isPublished
-      //     ? messages.collectionPublished
-      //     : messages.collectionUnpublished
-      // ),
       label: collection.name,
       onClick: () => {
         navigate(collectionUrl(collection.id));

--- a/src/components/Navigator/queries/types/SearchCatalog.ts
+++ b/src/components/Navigator/queries/types/SearchCatalog.ts
@@ -22,12 +22,24 @@ export interface SearchCatalog_categories {
   edges: SearchCatalog_categories_edges[];
 }
 
+export interface SearchCatalog_collections_edges_node_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+}
+
+export interface SearchCatalog_collections_edges_node_channelListing {
+  __typename: "CollectionChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: SearchCatalog_collections_edges_node_channelListing_channel;
+}
+
 export interface SearchCatalog_collections_edges_node {
   __typename: "Collection";
   id: string;
   name: string;
-  isPublished: boolean;
-  publicationDate: any | null;
+  channelListing: SearchCatalog_collections_edges_node_channelListing[] | null;
 }
 
 export interface SearchCatalog_collections_edges {

--- a/src/components/Navigator/queries/useCatalogSearch.ts
+++ b/src/components/Navigator/queries/useCatalogSearch.ts
@@ -21,8 +21,14 @@ const searchCatalog = gql`
         node {
           id
           name
-          isPublished
-          publicationDate
+          channelListing {
+            isPublished
+            publicationDate
+            channel {
+              id
+              name
+            }
+          }
         }
       }
     }

--- a/src/components/Navigator/queries/useCatalogSearch.ts
+++ b/src/components/Navigator/queries/useCatalogSearch.ts
@@ -1,3 +1,4 @@
+import { collectionFragment } from "@saleor/fragments/collections";
 import makeQuery, { UseQueryResult } from "@saleor/hooks/makeQuery";
 import useDebounce from "@saleor/hooks/useDebounce";
 import gql from "graphql-tag";
@@ -6,6 +7,7 @@ import { useState } from "react";
 import { SearchCatalog, SearchCatalogVariables } from "./types/SearchCatalog";
 
 const searchCatalog = gql`
+  ${collectionFragment}
   query SearchCatalog($first: Int!, $query: String!) {
     categories(first: $first, filter: { search: $query }) {
       edges {
@@ -19,16 +21,7 @@ const searchCatalog = gql`
     collections(first: $first, filter: { search: $query }) {
       edges {
         node {
-          id
-          name
-          channelListing {
-            isPublished
-            publicationDate
-            channel {
-              id
-              name
-            }
-          }
+          ...CollectionFragment
         }
       }
     }

--- a/src/components/SeoForm/SeoForm.tsx
+++ b/src/components/SeoForm/SeoForm.tsx
@@ -4,6 +4,7 @@ import CardContent from "@material-ui/core/CardContent";
 import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
+import { CollectionErrorFragment } from "@saleor/fragments/types/CollectionErrorFragment";
 import { PageErrorFragment } from "@saleor/fragments/types/PageErrorFragment";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { getFieldError, getProductErrorMessage } from "@saleor/utils/errors";
@@ -81,7 +82,9 @@ interface SeoFormProps {
   description?: string;
   descriptionPlaceholder: string;
   disabled?: boolean;
-  errors?: Array<PageErrorFragment | ProductErrorFragment>;
+  errors?: Array<
+    PageErrorFragment | ProductErrorFragment | CollectionErrorFragment
+  >;
   loading?: boolean;
   helperText?: string;
   allowEmptySlug?: boolean;

--- a/src/fragments/collections.ts
+++ b/src/fragments/collections.ts
@@ -6,8 +6,15 @@ import { metadataFragment } from "./metadata";
 export const collectionFragment = gql`
   fragment CollectionFragment on Collection {
     id
-    isPublished
     name
+    channelListing {
+      isPublished
+      publicationDate
+      channel {
+        id
+        name
+      }
+    }
   }
 `;
 
@@ -23,10 +30,8 @@ export const collectionDetailsFragment = gql`
     }
     slug
     descriptionJson
-    publicationDate
     seoDescription
     seoTitle
-    isPublished
   }
 `;
 

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -170,7 +170,7 @@ export const metadataErrorFragment = gql`
 `;
 
 export const collectionsErrorFragment = gql`
-  fragment CollectionErrorFragment on CollectionProductError {
+  fragment CollectionErrorFragment on CollectionError {
     code
     field
   }

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -24,6 +24,15 @@ export const productChannelListingErrorFragment = gql`
   }
 `;
 
+export const collectionChannelListingErrorFragment = gql`
+  fragment CollectionChannelListingErrorFragment on CollectionChannelListingError {
+    code
+    field
+    message
+    channels
+  }
+`;
+
 export const accountErrorFragment = gql`
   fragment AccountErrorFragment on AccountError {
     code

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -32,6 +32,20 @@ export const fragmentProductImage = gql`
   }
 `;
 
+export const channelListingAvailabilityFragment = gql`
+  ${fragmentMoney}
+  fragment ChannelListingAvailabilityFragment on ProductChannelListing {
+    isPublished
+    publicationDate
+    # isAvailableForPurchase
+    # availableForPurchase
+    channel {
+      id
+      name
+    }
+  }
+`;
+
 export const channelListingProductFragment = gql`
   ${fragmentMoney}
   fragment ChannelListingProductFragment on ProductChannelListing {

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -32,20 +32,6 @@ export const fragmentProductImage = gql`
   }
 `;
 
-export const channelListingAvailabilityFragment = gql`
-  ${fragmentMoney}
-  fragment ChannelListingAvailabilityFragment on ProductChannelListing {
-    isPublished
-    publicationDate
-    # isAvailableForPurchase
-    # availableForPurchase
-    channel {
-      id
-      name
-    }
-  }
-`;
-
 export const channelListingProductFragment = gql`
   ${fragmentMoney}
   fragment ChannelListingProductFragment on ProductChannelListing {

--- a/src/fragments/types/ChannelListingAvailabilityFragment.ts
+++ b/src/fragments/types/ChannelListingAvailabilityFragment.ts
@@ -1,0 +1,20 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: ChannelListingAvailabilityFragment
+// ====================================================
+
+export interface ChannelListingAvailabilityFragment_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+}
+
+export interface ChannelListingAvailabilityFragment {
+  __typename: "ProductChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: ChannelListingAvailabilityFragment_channel;
+}

--- a/src/fragments/types/CollectionChannelListingErrorFragment.ts
+++ b/src/fragments/types/CollectionChannelListingErrorFragment.ts
@@ -1,0 +1,17 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { ProductErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: CollectionChannelListingErrorFragment
+// ====================================================
+
+export interface CollectionChannelListingErrorFragment {
+  __typename: "CollectionChannelListingError";
+  code: ProductErrorCode;
+  field: string | null;
+  message: string | null;
+  channels: string[] | null;
+}

--- a/src/fragments/types/CollectionDetailsFragment.ts
+++ b/src/fragments/types/CollectionDetailsFragment.ts
@@ -6,6 +6,19 @@
 // GraphQL fragment: CollectionDetailsFragment
 // ====================================================
 
+export interface CollectionDetailsFragment_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+}
+
+export interface CollectionDetailsFragment_channelListing {
+  __typename: "CollectionChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: CollectionDetailsFragment_channelListing_channel;
+}
+
 export interface CollectionDetailsFragment_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -27,14 +40,13 @@ export interface CollectionDetailsFragment_backgroundImage {
 export interface CollectionDetailsFragment {
   __typename: "Collection";
   id: string;
-  isPublished: boolean;
   name: string;
+  channelListing: CollectionDetailsFragment_channelListing[] | null;
   metadata: (CollectionDetailsFragment_metadata | null)[];
   privateMetadata: (CollectionDetailsFragment_privateMetadata | null)[];
   backgroundImage: CollectionDetailsFragment_backgroundImage | null;
   slug: string;
   descriptionJson: any;
-  publicationDate: any | null;
   seoDescription: string | null;
   seoTitle: string | null;
 }

--- a/src/fragments/types/CollectionErrorFragment.ts
+++ b/src/fragments/types/CollectionErrorFragment.ts
@@ -2,14 +2,14 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode } from "./../../types/globalTypes";
+import { CollectionErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: CollectionErrorFragment
 // ====================================================
 
 export interface CollectionErrorFragment {
-  __typename: "CollectionProductError";
-  code: ProductErrorCode;
+  __typename: "CollectionError";
+  code: CollectionErrorCode;
   field: string | null;
 }

--- a/src/fragments/types/CollectionFragment.ts
+++ b/src/fragments/types/CollectionFragment.ts
@@ -6,9 +6,22 @@
 // GraphQL fragment: CollectionFragment
 // ====================================================
 
+export interface CollectionFragment_channelListing_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+}
+
+export interface CollectionFragment_channelListing {
+  __typename: "CollectionChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  channel: CollectionFragment_channelListing_channel;
+}
+
 export interface CollectionFragment {
   __typename: "Collection";
   id: string;
-  isPublished: boolean;
   name: string;
+  channelListing: CollectionFragment_channelListing[] | null;
 }

--- a/src/storybook/stories/collections/CollectionCreatePage.tsx
+++ b/src/storybook/stories/collections/CollectionCreatePage.tsx
@@ -1,5 +1,5 @@
 import { Omit } from "@material-ui/core";
-import { ProductErrorCode } from "@saleor/types/globalTypes";
+import { CollectionErrorCode } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -25,23 +25,15 @@ storiesOf("Views / Collections / Create collection", module)
       {...props}
       errors={[
         {
-          code: ProductErrorCode.REQUIRED,
+          code: CollectionErrorCode.REQUIRED,
           field: "name"
         },
         {
-          code: ProductErrorCode.REQUIRED,
+          code: CollectionErrorCode.REQUIRED,
           field: "descriptionJson"
-        },
-        {
-          code: ProductErrorCode.INVALID,
-          field: "publicationDate"
-        },
-        {
-          code: ProductErrorCode.INVALID,
-          field: "isPublished"
         }
       ].map(err => ({
-        __typename: "ProductError",
+        __typename: "CollectionError",
         ...err
       }))}
     />

--- a/src/storybook/stories/collections/CollectionCreatePage.tsx
+++ b/src/storybook/stories/collections/CollectionCreatePage.tsx
@@ -1,4 +1,6 @@
 import { Omit } from "@material-ui/core";
+import { channelsList } from "@saleor/channels/fixtures";
+import { createCollectionChannels } from "@saleor/channels/utils";
 import { CollectionErrorCode } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -8,11 +10,18 @@ import CollectionCreatePage, {
 } from "../../../collections/components/CollectionCreatePage";
 import Decorator from "../../Decorator";
 
+const channels = createCollectionChannels(channelsList);
+
 const props: Omit<CollectionCreatePageProps, "classes"> = {
+  channelsCount: 2,
+  channelsErrors: [],
+  currentChannels: channels,
   disabled: false,
   errors: [],
   onBack: () => undefined,
+  onChannelsChange: () => undefined,
   onSubmit: () => undefined,
+  openChannelsModal: () => undefined,
   saveButtonBarState: "default"
 };
 

--- a/src/storybook/stories/collections/CollectionDetailsPage.tsx
+++ b/src/storybook/stories/collections/CollectionDetailsPage.tsx
@@ -1,7 +1,7 @@
 import placeholderCollectionImage from "@assets/images/block1.jpg";
 import placeholderProductImage from "@assets/images/placeholder60x60.png";
 import { Omit } from "@material-ui/core";
-import { ProductErrorCode } from "@saleor/types/globalTypes";
+import { CollectionErrorCode } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -46,23 +46,15 @@ storiesOf("Views / Collections / Collection details", module)
       {...props}
       errors={[
         {
-          code: ProductErrorCode.REQUIRED,
+          code: CollectionErrorCode.REQUIRED,
           field: "name"
         },
         {
-          code: ProductErrorCode.REQUIRED,
+          code: CollectionErrorCode.REQUIRED,
           field: "descriptionJson"
-        },
-        {
-          code: ProductErrorCode.INVALID,
-          field: "publicationDate"
-        },
-        {
-          code: ProductErrorCode.INVALID,
-          field: "isPublished"
         }
       ].map(err => ({
-        __typename: "ProductError",
+        __typename: "CollectionError",
         ...err
       }))}
     />

--- a/src/storybook/stories/collections/CollectionDetailsPage.tsx
+++ b/src/storybook/stories/collections/CollectionDetailsPage.tsx
@@ -1,6 +1,7 @@
 import placeholderCollectionImage from "@assets/images/block1.jpg";
 import placeholderProductImage from "@assets/images/placeholder60x60.png";
 import { Omit } from "@material-ui/core";
+import { createCollectionChannelsData } from "@saleor/channels/utils";
 import { CollectionErrorCode } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -16,21 +17,26 @@ const collection = collectionFixture(
   placeholderCollectionImage,
   placeholderProductImage
 );
+const channels = createCollectionChannelsData(collection);
 
 const props: Omit<CollectionDetailsPageProps, "classes"> = {
   ...listActionsProps,
   ...pageListProps.default,
   channelsCount: 2,
+  channelsErrors: [],
   collection,
+  currentChannels: channels,
   disabled: false,
   errors: [],
-  isFeatured: true,
+  hasChannelChanged: false,
   onBack: () => undefined,
+  onChannelsChange: () => undefined,
   onCollectionRemove: () => undefined,
   onImageDelete: () => undefined,
   onImageUpload: () => undefined,
   onProductUnassign: () => undefined,
   onSubmit: () => undefined,
+  openChannelsModal: () => undefined,
   saveButtonBarState: "default",
   selectedChannel: "123"
 };

--- a/src/storybook/stories/collections/CollectionListPage.tsx
+++ b/src/storybook/stories/collections/CollectionListPage.tsx
@@ -23,6 +23,7 @@ const props: CollectionListPageProps = {
   ...searchPageProps,
   ...sortPageProps,
   ...filterPageProps,
+  channelsCount: 2,
   filterOpts: {
     status: {
       active: false,

--- a/src/storybook/stories/collections/CollectionListPage.tsx
+++ b/src/storybook/stories/collections/CollectionListPage.tsx
@@ -1,5 +1,4 @@
 import { CollectionListUrlSortField } from "@saleor/collections/urls";
-import { CollectionPublished } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -8,7 +7,6 @@ import CollectionListPage, {
 } from "../../../collections/components/CollectionListPage";
 import { collections } from "../../../collections/fixtures";
 import {
-  filterPageProps,
   listActionsProps,
   pageListProps,
   searchPageProps,
@@ -22,14 +20,7 @@ const props: CollectionListPageProps = {
   ...pageListProps.default,
   ...searchPageProps,
   ...sortPageProps,
-  ...filterPageProps,
   channelsCount: 2,
-  filterOpts: {
-    status: {
-      active: false,
-      value: CollectionPublished.PUBLISHED
-    }
-  },
   sort: {
     ...sortPageProps.sort,
     sort: CollectionListUrlSortField.name

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -109,11 +109,20 @@ export enum CategorySortField {
   PRODUCT_COUNT = "PRODUCT_COUNT",
   SUBCATEGORY_COUNT = "SUBCATEGORY_COUNT",
 }
-
 export enum ChannelErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
   CHANNELS_CURRENCY_MUST_BE_THE_SAME = "CHANNELS_CURRENCY_MUST_BE_THE_SAME",
   CHANNEL_TARGET_ID_MUST_BE_DIFFERENT = "CHANNEL_TARGET_ID_MUST_BE_DIFFERENT",
+  GRAPHQL_ERROR = "GRAPHQL_ERROR",
+  INVALID = "INVALID",
+  NOT_FOUND = "NOT_FOUND",
+  REQUIRED = "REQUIRED",
+  UNIQUE = "UNIQUE",
+}
+
+export enum CollectionErrorCode {
+  CANNOT_MANAGE_PRODUCT_WITHOUT_VARIANT = "CANNOT_MANAGE_PRODUCT_WITHOUT_VARIANT",
+  DUPLICATED_INPUT_ITEM = "DUPLICATED_INPUT_ITEM",
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
   INVALID = "INVALID",
   NOT_FOUND = "NOT_FOUND",
@@ -1080,6 +1089,7 @@ export interface CategoryInput {
 
 export interface CategorySortingInput {
   direction: OrderDirection;
+  channel?: string | null;
   field: CategorySortField;
 }
 
@@ -1117,6 +1127,7 @@ export interface CollectionFilterInput {
   published?: CollectionPublished | null;
   search?: string | null;
   ids?: (string | null)[] | null;
+  channel?: string | null;
 }
 
 export interface CollectionInput {
@@ -1133,6 +1144,7 @@ export interface CollectionInput {
 
 export interface CollectionSortingInput {
   direction: OrderDirection;
+  channel?: string | null;
   field: CollectionSortField;
 }
 

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -109,6 +109,7 @@ export enum CategorySortField {
   PRODUCT_COUNT = "PRODUCT_COUNT",
   SUBCATEGORY_COUNT = "SUBCATEGORY_COUNT",
 }
+
 export enum ChannelErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
   CHANNELS_CURRENCY_MUST_BE_THE_SAME = "CHANNELS_CURRENCY_MUST_BE_THE_SAME",
@@ -1110,6 +1111,11 @@ export interface ChannelUpdateInput {
   slug?: string | null;
 }
 
+export interface CollectionChannelListingUpdateInput {
+  addChannels?: PublishableChannelListingInput[] | null;
+  removeChannels?: string[] | null;
+}
+
 export interface CollectionCreateInput {
   isPublished?: boolean | null;
   name?: string | null;
@@ -1526,6 +1532,12 @@ export interface ProductVariantInput {
   sku?: string | null;
   trackInventory?: boolean | null;
   weight?: any | null;
+}
+
+export interface PublishableChannelListingInput {
+  channelId: string;
+  isPublished?: boolean | null;
+  publicationDate?: any | null;
 }
 
 export interface ReorderInput {

--- a/src/utils/errors/product.ts
+++ b/src/utils/errors/product.ts
@@ -1,4 +1,5 @@
 import { BulkProductErrorFragment } from "@saleor/fragments/types/BulkProductErrorFragment";
+import { CollectionErrorFragment } from "@saleor/fragments/types/CollectionErrorFragment";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { commonMessages } from "@saleor/intl";
 import { ProductErrorCode } from "@saleor/types/globalTypes";
@@ -50,7 +51,9 @@ const messages = defineMessages({
 });
 
 function getProductErrorMessage(
-  err: Omit<ProductErrorFragment, "__typename"> | undefined,
+  err:
+    | Omit<ProductErrorFragment | CollectionErrorFragment, "__typename">
+    | undefined,
   intl: IntlShape
 ): string {
   if (err) {


### PR DESCRIPTION
I want to merge this change because...

- it adds channels in collections views and components

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<img width="963" alt="Screenshot 2020-10-26 at 14 35 14" src="https://user-images.githubusercontent.com/10812388/97178989-94920f00-1798-11eb-80ca-57b3e0746c93.png">
<img width="950" alt="Screenshot 2020-10-26 at 14 35 25" src="https://user-images.githubusercontent.com/10812388/97178997-98be2c80-1798-11eb-953e-fc174af12bc0.png">
<img width="971" alt="Screenshot 2020-10-26 at 14 34 58" src="https://user-images.githubusercontent.com/10812388/97179045-a8d60c00-1798-11eb-9d1f-3b82dd07fc95.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
