### PR TITLE
fix adding warehouses to products

### DIFF
--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -199,7 +199,7 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
 
   const getStocksData = () => {
     if (product.productType.hasVariants) {
-      return { removeStocks: [], updateStocks: [] };
+      return { addStocks: [], removeStocks: [], updateStocks: [] };
     }
 
     const dataStocks = stocks.map(stock => stock.id);
@@ -209,6 +209,9 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
     const stockDiff = diff(variantStocks, dataStocks);
 
     return {
+      addStocks: stocks.filter(stock =>
+        stockDiff.added.some(addedStock => addedStock === stock.id)
+      ),
       removeStocks: stockDiff.removed,
       updateStocks: stocks.filter(
         stock => !stockDiff.added.some(addedStock => addedStock === stock.id)
@@ -228,7 +231,6 @@ export const ProductUpdatePage: React.FC<ProductUpdatePageProps> = ({
     ...getAvailabilityData(data),
     ...getStocksData(),
     ...getMetadata(data),
-    addStocks: [],
     attributes
   });
 


### PR DESCRIPTION
I want to merge this change because it fixes user being unable to add warehouses to products with no variants.

[SALEOR-1463](https://app.clickup.com/t/2549495/SALEOR-1463)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
