### PR TITLE
Call proper mutation on address change for draft / non draft order

### DIFF
--- a/src/orders/components/OrderAddressEditDialog/OrderAddressEditDialog.tsx
+++ b/src/orders/components/OrderAddressEditDialog/OrderAddressEditDialog.tsx
@@ -49,9 +49,9 @@ const OrderAddressEditDialog: React.FC<OrderAddressEditDialogProps> = props => {
     address,
     confirmButtonState,
     open,
-    errors,
+    errors = [],
     variant,
-    countries,
+    countries = [],
     onClose,
     onConfirm
   } = props;

--- a/src/orders/views/OrderDetails/OrderAddressFields.tsx
+++ b/src/orders/views/OrderDetails/OrderAddressFields.tsx
@@ -1,0 +1,90 @@
+import { transformAddressToForm } from "@saleor/misc";
+import OrderAddressEditDialog from "@saleor/orders/components/OrderAddressEditDialog";
+import { OrderDetails } from "@saleor/orders/types/OrderDetails";
+import {
+  OrderDraftUpdate,
+  OrderDraftUpdateVariables
+} from "@saleor/orders/types/OrderDraftUpdate";
+import {
+  OrderUpdate,
+  OrderUpdateVariables
+} from "@saleor/orders/types/OrderUpdate";
+import { PartialMutationProviderOutput } from "@saleor/types";
+import { AddressInput } from "@saleor/types/globalTypes";
+import React from "react";
+
+enum FieldType {
+  shipping = "shippingAddress",
+  billing = "billingAddress"
+}
+
+interface Props {
+  action: string;
+  id: string;
+  isDraft: boolean;
+  data: OrderDetails;
+  onClose: () => void;
+  orderUpdate: PartialMutationProviderOutput<OrderUpdate, OrderUpdateVariables>;
+  orderDraftUpdate: PartialMutationProviderOutput<
+    OrderDraftUpdate,
+    OrderDraftUpdateVariables
+  >;
+}
+
+const OrderAddressFields = ({
+  action,
+  isDraft,
+  id,
+  onClose,
+  orderUpdate,
+  orderDraftUpdate,
+  data
+}: Props) => {
+  const order = data?.order;
+
+  const handleConfirm = (type: FieldType) => (value: AddressInput) => {
+    const updateMutation = isDraft ? orderDraftUpdate : orderUpdate;
+
+    updateMutation.mutate({
+      id,
+      input: {
+        [type]: value
+      }
+    });
+  };
+
+  const addressFieldCommonProps = {
+    confirmButtonState: isDraft
+      ? orderDraftUpdate.opts.status
+      : orderUpdate.opts.status,
+    countries: data?.shop?.countries.map(country => ({
+      code: country.code,
+      label: country.country
+    })),
+    errors: isDraft
+      ? orderDraftUpdate.opts.data?.draftOrderUpdate.errors
+      : orderUpdate.opts.data?.orderUpdate.errors,
+    onClose
+  };
+
+  return (
+    <>
+      <OrderAddressEditDialog
+        {...addressFieldCommonProps}
+        address={transformAddressToForm(order?.shippingAddress)}
+        open={action === "edit-shipping-address"}
+        variant="shipping"
+        onConfirm={handleConfirm(FieldType.shipping)}
+      />
+      <OrderAddressEditDialog
+        {...addressFieldCommonProps}
+        address={transformAddressToForm(order?.billingAddress)}
+        open={action === "edit-billing-address"}
+        variant="billing"
+        onConfirm={handleConfirm(FieldType.billing)}
+      />
+    </>
+  );
+};
+
+export default OrderAddressFields;

--- a/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
+++ b/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
@@ -173,6 +173,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
         })
       });
     }
+    closeModal();
   };
   const handleShippingMethodUpdate = (data: OrderShippingMethodUpdate) => {
     const errs = data.orderUpdateShipping?.errors;

--- a/src/orders/views/OrderDetails/index.tsx
+++ b/src/orders/views/OrderDetails/index.tsx
@@ -23,19 +23,13 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { customerUrl } from "../../../customers/urls";
-import {
-  getMutationState,
-  getStringOrPlaceholder,
-  maybe,
-  transformAddressToForm
-} from "../../../misc";
+import { getMutationState, getStringOrPlaceholder, maybe } from "../../../misc";
 import { productUrl } from "../../../products/urls";
 import {
   FulfillmentStatus,
   JobStatusEnum,
   OrderStatus
 } from "../../../types/globalTypes";
-import OrderAddressEditDialog from "../../components/OrderAddressEditDialog";
 import OrderCancelDialog from "../../components/OrderCancelDialog";
 import OrderDetailsPage from "../../components/OrderDetailsPage";
 import OrderDraftCancelDialog from "../../components/OrderDraftCancelDialog/OrderDraftCancelDialog";
@@ -57,6 +51,7 @@ import {
   OrderUrlDialog,
   OrderUrlQueryParams
 } from "../../urls";
+import OrderAddressFields from "./OrderAddressFields";
 import { OrderDetailsMessages } from "./OrderDetailsMessages";
 
 interface OrderDetailsProps {
@@ -579,73 +574,14 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                         />
                       </>
                     )}
-                    <OrderAddressEditDialog
-                      confirmButtonState={
-                        order?.status === OrderStatus.DRAFT
-                          ? orderDraftUpdate.opts.status
-                          : orderUpdate.opts.status
-                      }
-                      address={transformAddressToForm(order?.shippingAddress)}
-                      countries={
-                        data?.shop?.countries.map(country => ({
-                          code: country.code,
-                          label: country.country
-                        })) || []
-                      }
-                      errors={
-                        (order?.status === OrderStatus.DRAFT
-                          ? orderDraftUpdate.opts.data?.draftOrderUpdate.errors
-                          : orderUpdate.opts.data?.orderUpdate.errors) || []
-                      }
-                      open={params.action === "edit-shipping-address"}
-                      variant="shipping"
+                    <OrderAddressFields
+                      isDraft={order?.status === OrderStatus.DRAFT}
+                      orderUpdate={orderUpdate}
+                      orderDraftUpdate={orderDraftUpdate}
+                      data={data}
+                      id={id}
                       onClose={closeModal}
-                      onConfirm={shippingAddress => {
-                        const updateMutation =
-                          order?.status === OrderStatus.DRAFT
-                            ? orderDraftUpdate
-                            : orderUpdate;
-                        updateMutation.mutate({
-                          id,
-                          input: {
-                            shippingAddress
-                          }
-                        });
-                      }}
-                    />
-                    <OrderAddressEditDialog
-                      confirmButtonState={
-                        order?.status === OrderStatus.DRAFT
-                          ? orderDraftUpdate.opts.status
-                          : orderUpdate.opts.status
-                      }
-                      address={transformAddressToForm(order?.billingAddress)}
-                      countries={
-                        data?.shop?.countries.map(country => ({
-                          code: country.code,
-                          label: country.country
-                        })) || []
-                      }
-                      errors={
-                        (order?.status === OrderStatus.DRAFT
-                          ? orderDraftUpdate.opts.data?.draftOrderUpdate.errors
-                          : orderUpdate.opts.data?.orderUpdate.errors) || []
-                      }
-                      open={params.action === "edit-billing-address"}
-                      variant="billing"
-                      onClose={closeModal}
-                      onConfirm={billingAddress => {
-                        const updateMutation =
-                          order?.status === OrderStatus.DRAFT
-                            ? orderDraftUpdate
-                            : orderUpdate;
-                        updateMutation.mutate({
-                          id,
-                          input: {
-                            billingAddress
-                          }
-                        });
-                      }}
+                      action={params.action}
                     />
                   </>
                 )}

--- a/src/orders/views/OrderDetails/index.tsx
+++ b/src/orders/views/OrderDetails/index.tsx
@@ -580,7 +580,11 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                       </>
                     )}
                     <OrderAddressEditDialog
-                      confirmButtonState={orderUpdate.opts.status}
+                      confirmButtonState={
+                        order?.status === OrderStatus.DRAFT
+                          ? orderDraftUpdate.opts.status
+                          : orderUpdate.opts.status
+                      }
                       address={transformAddressToForm(order?.shippingAddress)}
                       countries={
                         data?.shop?.countries.map(country => ({
@@ -588,21 +592,33 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                           label: country.country
                         })) || []
                       }
-                      errors={orderUpdate.opts.data?.orderUpdate.errors || []}
+                      errors={
+                        (order?.status === OrderStatus.DRAFT
+                          ? orderDraftUpdate.opts.data?.draftOrderUpdate.errors
+                          : orderUpdate.opts.data?.orderUpdate.errors) || []
+                      }
                       open={params.action === "edit-shipping-address"}
                       variant="shipping"
                       onClose={closeModal}
-                      onConfirm={shippingAddress =>
-                        orderUpdate.mutate({
+                      onConfirm={shippingAddress => {
+                        const updateMutation =
+                          order?.status === OrderStatus.DRAFT
+                            ? orderDraftUpdate
+                            : orderUpdate;
+                        updateMutation.mutate({
                           id,
                           input: {
                             shippingAddress
                           }
-                        })
-                      }
+                        });
+                      }}
                     />
                     <OrderAddressEditDialog
-                      confirmButtonState={orderUpdate.opts.status}
+                      confirmButtonState={
+                        order?.status === OrderStatus.DRAFT
+                          ? orderDraftUpdate.opts.status
+                          : orderUpdate.opts.status
+                      }
                       address={transformAddressToForm(order?.billingAddress)}
                       countries={
                         data?.shop?.countries.map(country => ({
@@ -610,18 +626,26 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                           label: country.country
                         })) || []
                       }
-                      errors={orderUpdate.opts.data?.orderUpdate.errors || []}
+                      errors={
+                        (order?.status === OrderStatus.DRAFT
+                          ? orderDraftUpdate.opts.data?.draftOrderUpdate.errors
+                          : orderUpdate.opts.data?.orderUpdate.errors) || []
+                      }
                       open={params.action === "edit-billing-address"}
                       variant="billing"
                       onClose={closeModal}
-                      onConfirm={billingAddress =>
-                        orderUpdate.mutate({
+                      onConfirm={billingAddress => {
+                        const updateMutation =
+                          order?.status === OrderStatus.DRAFT
+                            ? orderDraftUpdate
+                            : orderUpdate;
+                        updateMutation.mutate({
                           id,
                           input: {
                             billingAddress
                           }
-                        })
-                      }
+                        });
+                      }}
                     />
                   </>
                 )}


### PR DESCRIPTION
I want to merge this change because previously we used to call `orderUpdate` when updating user shipping / billing address in dashboard. It was inproper because drafts have their own mutation for that. Backend mutations have been secured not to allow draft to be updated by orderupdate and vice-versa.

Related ticket: [SALEOR-1479](https://app.clickup.com/t/2549495/SALEOR-1479)

https://github.com/mirumee/saleor/pull/6324 Should be merged **after** this is merged.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->
SALEOR-1453-fix-order-updated-on-address-change

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
