### PR TITLE
fix inputs width in variant creator

### DIFF
--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorSummary.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorSummary.tsx
@@ -107,7 +107,7 @@ const useStyles = makeStyles<
         `minmax(180px, auto) repeat(${props.data.variants[0].channelListings
           .length +
           props.data.variants[0].stocks
-            .length}, minmax(100px, auto)) 140px 64px`,
+            .length}, minmax(180px, auto)) 140px 64px`,
       overflowX: "scroll",
       rowGap: theme.spacing() + "px"
     }


### PR DESCRIPTION
I want to merge this change because...

- it fixes input price witdth in variant creator summary table

**PR intended to be tested with API branch:** feature/multichannel-multicurrency

### Screenshots

<img width="1074" alt="Screenshot 2020-10-29 at 13 13 48" src="https://user-images.githubusercontent.com/10812388/97572672-ed57e680-19e8-11eb-87b6-13e63706bf9a.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://feature-multichannel-multicurrency.api.saleor.rocks/graphql/
