### PR TITLE
Add page type configuration in page details page

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3706,8 +3706,8 @@
     "context": "page status",
     "string": "Not Published"
   },
-  "src_dot_pages_dot_components_dot_PageOrganizeContent_dot_4253279144": {
-    "string": "Page type"
+  "src_dot_pages_dot_components_dot_PageOrganizeContent_dot_2959504520": {
+    "string": "Content type"
   },
   "src_dot_pages_dot_components_dot_PageOrganizeContent_dot_590187004": {
     "context": "section header",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -212,6 +212,9 @@
     "context": "window title",
     "string": "Create Page Type"
   },
+  "pageTypeInputLabel": {
+    "string": "Select content type"
+  },
   "productExportFieldAvailability": {
     "context": "product field",
     "string": "Available for purchase"
@@ -3633,6 +3636,22 @@
     "context": "pages section name",
     "string": "Pages"
   },
+  "src_dot_pages_dot_components_dot_PageAttributes_dot_1071548120": {
+    "context": "number of page attributes",
+    "string": "{number} Attributes"
+  },
+  "src_dot_pages_dot_components_dot_PageAttributes_dot_1148029984": {
+    "context": "attribute value",
+    "string": "Value"
+  },
+  "src_dot_pages_dot_components_dot_PageAttributes_dot_1207761269": {
+    "context": "attribute values",
+    "string": "Values"
+  },
+  "src_dot_pages_dot_components_dot_PageAttributes_dot_4153345096": {
+    "context": "page attributes, section header",
+    "string": "Attributes"
+  },
   "src_dot_pages_dot_components_dot_PageDetailsPage_dot_1068617485": {
     "context": "page header",
     "string": "Create Page"
@@ -3686,6 +3705,13 @@
   "src_dot_pages_dot_components_dot_PageList_dot_3767550649": {
     "context": "page status",
     "string": "Not Published"
+  },
+  "src_dot_pages_dot_components_dot_PageOrganizeContent_dot_4253279144": {
+    "string": "Page type"
+  },
+  "src_dot_pages_dot_components_dot_PageOrganizeContent_dot_590187004": {
+    "context": "section header",
+    "string": "Organize Content"
   },
   "src_dot_pages_dot_views_dot_1068617485": {
     "context": "header",

--- a/schema.graphql
+++ b/schema.graphql
@@ -2688,7 +2688,7 @@ type Mutation {
   paymentCapture(amount: PositiveDecimal, paymentId: ID!): PaymentCapture
   paymentRefund(amount: PositiveDecimal, paymentId: ID!): PaymentRefund
   paymentVoid(paymentId: ID!): PaymentVoid
-  pageCreate(input: PageInput!): PageCreate
+  pageCreate(input: PageCreateInput!): PageCreate
   pageDelete(id: ID!): PageDelete
   pageBulkDelete(ids: [ID]!): PageBulkDelete
   pageBulkPublish(ids: [ID]!, isPublished: Boolean!): PageBulkPublish
@@ -3251,6 +3251,7 @@ type Page implements Node & ObjectWithMetadata {
   publicationDate: Date
   isPublished: Boolean!
   slug: String!
+  pageType: PageType!
   created: DateTime!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
@@ -3298,6 +3299,17 @@ type PageCreate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   pageErrors: [PageError!]!
   page: Page
+}
+
+input PageCreateInput {
+  slug: String
+  title: String
+  content: String
+  contentJson: JSONString
+  isPublished: Boolean
+  publicationDate: String
+  seo: SeoInput
+  pageType: ID!
 }
 
 type PageDelete {

--- a/schema.graphql
+++ b/schema.graphql
@@ -413,7 +413,7 @@ type Attribute implements Node & ObjectWithMetadata {
 type AttributeBulkDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
 }
 
 type AttributeClearMeta {
@@ -597,7 +597,7 @@ type AttributeValue implements Node {
 type AttributeValueBulkDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
 }
 
 type AttributeValueCreate {
@@ -3418,6 +3418,7 @@ type PageType implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   attributes: [Attribute]
   availableAttributes(filter: AttributeFilterInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
+  hasPages: Boolean
 }
 
 type PageTypeBulkDelete {
@@ -4434,7 +4435,7 @@ type Query {
   payments(before: String, after: String, first: Int, last: Int): PaymentCountableConnection
   page(id: ID, slug: String): Page
   pages(sortBy: PageSortingInput, filter: PageFilterInput, before: String, after: String, first: Int, last: Int): PageCountableConnection
-  pageType(id: ID): PageType
+  pageType(id: ID!): PageType
   pageTypes(sortBy: PageTypeSortingInput, filter: PageTypeFilterInput, before: String, after: String, first: Int, last: Int): PageTypeCountableConnection
   homepageEvents(before: String, after: String, first: Int, last: Int): OrderEventCountableConnection
   order(id: ID!): Order

--- a/schema.graphql
+++ b/schema.graphql
@@ -410,6 +410,17 @@ type Attribute implements Node & ObjectWithMetadata {
   storefrontSearchPosition: Int!
 }
 
+type AttributeAssign {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  productType: ProductType
+  productErrors: [ProductError!]!
+}
+
+input AttributeAssignInput {
+  id: ID!
+  type: ProductAttributeType!
+}
+
 type AttributeBulkDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
@@ -536,6 +547,12 @@ type AttributeTranslation implements Node {
 enum AttributeTypeEnum {
   PRODUCT_TYPE
   PAGE_TYPE
+}
+
+type AttributeUnassign {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  productType: ProductType
+  productErrors: [ProductError!]!
 }
 
 type AttributeUpdate {

--- a/schema.graphql
+++ b/schema.graphql
@@ -410,17 +410,6 @@ type Attribute implements Node & ObjectWithMetadata {
   storefrontSearchPosition: Int!
 }
 
-type AttributeAssign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productType: ProductType
-  productErrors: [ProductError!]!
-}
-
-input AttributeAssignInput {
-  id: ID!
-  type: ProductAttributeType!
-}
-
 type AttributeBulkDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
@@ -429,13 +418,13 @@ type AttributeBulkDelete {
 
 type AttributeClearMeta {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
   attribute: Attribute
 }
 
 type AttributeClearPrivateMeta {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
   attribute: Attribute
 }
 
@@ -453,7 +442,7 @@ type AttributeCountableEdge {
 type AttributeCreate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
 }
 
 input AttributeCreateInput {
@@ -473,8 +462,23 @@ input AttributeCreateInput {
 
 type AttributeDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
   attribute: Attribute
+}
+
+type AttributeError {
+  field: String
+  message: String
+  code: AttributeErrorCode!
+}
+
+enum AttributeErrorCode {
+  ALREADY_EXISTS
+  GRAPHQL_ERROR
+  INVALID
+  NOT_FOUND
+  REQUIRED
+  UNIQUE
 }
 
 input AttributeFilterInput {
@@ -505,7 +509,7 @@ enum AttributeInputTypeEnum {
 type AttributeReorderValues {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
 }
 
 enum AttributeSortField {
@@ -549,16 +553,10 @@ enum AttributeTypeEnum {
   PAGE_TYPE
 }
 
-type AttributeUnassign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productType: ProductType
-  productErrors: [ProductError!]!
-}
-
 type AttributeUpdate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
 }
 
 input AttributeUpdateInput {
@@ -577,13 +575,13 @@ input AttributeUpdateInput {
 
 type AttributeUpdateMeta {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
   attribute: Attribute
 }
 
 type AttributeUpdatePrivateMeta {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
   attribute: Attribute
 }
 
@@ -605,7 +603,7 @@ type AttributeValueBulkDelete {
 type AttributeValueCreate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
   attributeValue: AttributeValue
 }
 
@@ -616,7 +614,7 @@ input AttributeValueCreateInput {
 type AttributeValueDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
   attributeValue: AttributeValue
 }
 
@@ -654,7 +652,7 @@ enum AttributeValueType {
 type AttributeValueUpdate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
   attributeValue: AttributeValue
 }
 
@@ -2696,8 +2694,11 @@ type Mutation {
   pageTranslate(id: ID!, input: PageTranslationInput!, languageCode: LanguageCodeEnum!): PageTranslate
   pageTypeCreate(input: PageTypeCreateInput!): PageTypeCreate
   pageTypeUpdate(id: ID, input: PageTypeUpdateInput!): PageTypeUpdate
+  pageTypeDelete(id: ID!): PageTypeDelete
+  pageTypeBulkDelete(ids: [ID!]!): PageTypeBulkDelete
   pageAttributeAssign(attributeIds: [ID!]!, pageTypeId: ID!): PageAttributeAssign
   pageAttributeUnassign(attributeIds: [ID!]!, pageTypeId: ID!): PageAttributeUnassign
+  pageTypeReorderAttributes(moves: [ReorderInput!]!, pageTypeId: ID!): PageTypeReorderAttributes
   draftOrderComplete(id: ID!): DraftOrderComplete
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
@@ -3258,6 +3259,7 @@ type Page implements Node & ObjectWithMetadata {
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
+  attributes: [SelectedAttribute!]!
 }
 
 type PageAttributeAssign {
@@ -3306,6 +3308,7 @@ input PageCreateInput {
   title: String
   content: String
   contentJson: JSONString
+  attributes: [AttributeValueInput!]
   isPublished: Boolean
   publicationDate: String
   seo: SeoInput
@@ -3351,6 +3354,7 @@ input PageInput {
   title: String
   content: String
   contentJson: JSONString
+  attributes: [AttributeValueInput!]
   isPublished: Boolean
   publicationDate: String
   seo: SeoInput
@@ -3416,6 +3420,12 @@ type PageType implements Node & ObjectWithMetadata {
   availableAttributes(filter: AttributeFilterInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
 }
 
+type PageTypeBulkDelete {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  count: Int!
+  pageErrors: [PageError!]!
+}
+
 type PageTypeCountableConnection {
   pageInfo: PageInfo!
   edges: [PageTypeCountableEdge!]!
@@ -3439,8 +3449,20 @@ input PageTypeCreateInput {
   addAttributes: [ID!]
 }
 
+type PageTypeDelete {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  pageErrors: [PageError!]!
+  pageType: PageType
+}
+
 input PageTypeFilterInput {
   search: String
+}
+
+type PageTypeReorderAttributes {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  pageType: PageType
+  pageErrors: [PageError!]!
 }
 
 enum PageTypeSortField {

--- a/src/attributes/components/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/components/AttributeDetails/AttributeDetails.tsx
@@ -5,10 +5,11 @@ import CardTitle from "@saleor/components/CardTitle";
 import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import FormSpacer from "@saleor/components/FormSpacer";
 import SingleSelectField from "@saleor/components/SingleSelectField";
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
+import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import { commonMessages } from "@saleor/intl";
 import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
-import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
+import { getFormErrors } from "@saleor/utils/errors";
+import getAttributeErrorMessage from "@saleor/utils/errors/attribute";
 import React from "react";
 import { useIntl } from "react-intl";
 import slugify from "slugify";
@@ -20,7 +21,7 @@ export interface AttributeDetailsProps {
   canChangeType: boolean;
   data: AttributePageFormData;
   disabled: boolean;
-  errors: ProductErrorFragment[];
+  errors: AttributeErrorFragment[];
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
@@ -66,7 +67,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({
           })}
           name={"name" as keyof AttributePageFormData}
           fullWidth
-          helperText={getProductErrorMessage(formErrors.name, intl)}
+          helperText={getAttributeErrorMessage(formErrors.name, intl)}
           value={data.name}
           onChange={onChange}
         />
@@ -97,7 +98,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({
           choices={inputTypeChoices}
           disabled={disabled || !canChangeType}
           error={!!formErrors.inputType}
-          hint={getProductErrorMessage(formErrors.inputType, intl)}
+          hint={getAttributeErrorMessage(formErrors.inputType, intl)}
           label={intl.formatMessage({
             defaultMessage: "Catalog Input type for Store Owner",
             description: "attribute's editor component"

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -12,7 +12,7 @@ import {
   AttributeDetailsFragment,
   AttributeDetailsFragment_values
 } from "@saleor/fragments/types/AttributeDetailsFragment";
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
+import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import { sectionNames } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import { ReorderAction } from "@saleor/types";
@@ -34,7 +34,7 @@ import AttributeValues from "../AttributeValues";
 export interface AttributePageProps {
   attribute: AttributeDetailsFragment | null;
   disabled: boolean;
-  errors: ProductErrorFragment[];
+  errors: AttributeErrorFragment[];
   saveButtonBarState: ConfirmButtonTransitionState;
   values: AttributeDetailsFragment_values[];
   onBack: () => void;

--- a/src/attributes/components/AttributeProperties/AttributeProperties.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.tsx
@@ -8,10 +8,11 @@ import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import ControlledSwitch from "@saleor/components/ControlledSwitch";
 import FormSpacer from "@saleor/components/FormSpacer";
 import Hr from "@saleor/components/Hr";
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
+import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import { commonMessages } from "@saleor/intl";
 import { AttributeTypeEnum } from "@saleor/types/globalTypes";
-import { getFormErrors, getProductErrorMessage } from "@saleor/utils/errors";
+import { getFormErrors } from "@saleor/utils/errors";
+import getAttributeErrorMessage from "@saleor/utils/errors/attribute";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -20,7 +21,7 @@ import { AttributePageFormData } from "../AttributePage";
 export interface AttributePropertiesProps {
   data: AttributePageFormData;
   disabled: boolean;
-  errors: ProductErrorFragment[];
+  errors: AttributeErrorFragment[];
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
@@ -97,7 +98,7 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
               disabled={disabled}
               error={!!formErrors.storefrontSearchPosition}
               fullWidth
-              helperText={getProductErrorMessage(
+              helperText={getAttributeErrorMessage(
                 formErrors.storefrontSearchPosition,
                 intl
               )}

--- a/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
+++ b/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
@@ -9,7 +9,7 @@ import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
 import Form from "@saleor/components/Form";
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
+import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 import { buttonMessages } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
@@ -26,7 +26,7 @@ export interface AttributeValueEditDialogProps {
   attributeValue: AttributeDetails_attribute_values | null;
   confirmButtonState: ConfirmButtonTransitionState;
   disabled: boolean;
-  errors: ProductErrorFragment[];
+  errors: AttributeErrorFragment[];
   open: boolean;
   onSubmit: (data: AttributeValueEditDialogFormData) => void;
   onClose: () => void;

--- a/src/attributes/errors.ts
+++ b/src/attributes/errors.ts
@@ -1,6 +1,6 @@
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
-import { ProductErrorCode } from "@saleor/types/globalTypes";
-import { getProductErrorMessage } from "@saleor/utils/errors";
+import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
+import { AttributeErrorCode } from "@saleor/types/globalTypes";
+import getAttributeErrorMessage from "@saleor/utils/errors/attribute";
 import { defineMessages, IntlShape } from "react-intl";
 
 const messages = defineMessages({
@@ -13,25 +13,25 @@ const messages = defineMessages({
 });
 
 export function getAttributeSlugErrorMessage(
-  err: ProductErrorFragment,
+  err: AttributeErrorFragment,
   intl: IntlShape
 ): string {
   switch (err?.code) {
-    case ProductErrorCode.UNIQUE:
+    case AttributeErrorCode.UNIQUE:
       return intl.formatMessage(messages.attributeSlugUnique);
     default:
-      return getProductErrorMessage(err, intl);
+      return getAttributeErrorMessage(err, intl);
   }
 }
 
 export function getAttributeValueErrorMessage(
-  err: ProductErrorFragment,
+  err: AttributeErrorFragment,
   intl: IntlShape
 ): string {
   switch (err?.code) {
-    case ProductErrorCode.ALREADY_EXISTS:
+    case AttributeErrorCode.ALREADY_EXISTS:
       return intl.formatMessage(messages.attributeValueAlreadyExists);
     default:
-      return getProductErrorMessage(err, intl);
+      return getAttributeErrorMessage(err, intl);
   }
 }

--- a/src/attributes/mutations.ts
+++ b/src/attributes/mutations.ts
@@ -1,5 +1,8 @@
 import { attributeDetailsFragment } from "@saleor/fragments/attributes";
-import { productErrorFragment } from "@saleor/fragments/errors";
+import {
+  attributeErrorFragment,
+  productErrorFragment
+} from "@saleor/fragments/errors";
 import makeMutation from "@saleor/hooks/makeMutation";
 import gql from "graphql-tag";
 
@@ -52,11 +55,11 @@ export const useAttributeBulkDeleteMutation = makeMutation<
 >(attributeBulkDelete);
 
 const attributeDelete = gql`
-  ${productErrorFragment}
+  ${attributeErrorFragment}
   mutation AttributeDelete($id: ID!) {
     attributeDelete(id: $id) {
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: attributeErrors {
+        ...AttributeErrorFragment
       }
     }
   }
@@ -68,14 +71,14 @@ export const useAttributeDeleteMutation = makeMutation<
 
 export const attributeUpdateMutation = gql`
   ${attributeDetailsFragment}
-  ${productErrorFragment}
+  ${attributeErrorFragment}
   mutation AttributeUpdate($id: ID!, $input: AttributeUpdateInput!) {
     attributeUpdate(id: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: attributeErrors {
+        ...AttributeErrorFragment
       }
     }
   }
@@ -87,14 +90,14 @@ export const useAttributeUpdateMutation = makeMutation<
 
 const attributeValueDelete = gql`
   ${attributeDetailsFragment}
-  ${productErrorFragment}
+  ${attributeErrorFragment}
   mutation AttributeValueDelete($id: ID!) {
     attributeValueDelete(id: $id) {
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: attributeErrors {
+        ...AttributeErrorFragment
       }
     }
   }
@@ -106,14 +109,14 @@ export const useAttributeValueDeleteMutation = makeMutation<
 
 export const attributeValueUpdateMutation = gql`
   ${attributeDetailsFragment}
-  ${productErrorFragment}
+  ${attributeErrorFragment}
   mutation AttributeValueUpdate($id: ID!, $input: AttributeValueCreateInput!) {
     attributeValueUpdate(id: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: attributeErrors {
+        ...AttributeErrorFragment
       }
     }
   }
@@ -125,14 +128,14 @@ export const useAttributeValueUpdateMutation = makeMutation<
 
 export const attributeValueCreateMutation = gql`
   ${attributeDetailsFragment}
-  ${productErrorFragment}
+  ${attributeErrorFragment}
   mutation AttributeValueCreate($id: ID!, $input: AttributeValueCreateInput!) {
     attributeValueCreate(attribute: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: attributeErrors {
+        ...AttributeErrorFragment
       }
     }
   }
@@ -144,14 +147,14 @@ export const useAttributeValueCreateMutation = makeMutation<
 
 export const attributeCreateMutation = gql`
   ${attributeDetailsFragment}
-  ${productErrorFragment}
+  ${attributeErrorFragment}
   mutation AttributeCreate($input: AttributeCreateInput!) {
     attributeCreate(input: $input) {
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: attributeErrors {
+        ...AttributeErrorFragment
       }
     }
   }
@@ -162,7 +165,7 @@ export const useAttributeCreateMutation = makeMutation<
 >(attributeCreateMutation);
 
 const attributeValueReorderMutation = gql`
-  ${productErrorFragment}
+  ${attributeErrorFragment}
   mutation AttributeValueReorder($id: ID!, $move: ReorderInput!) {
     attributeReorderValues(attributeId: $id, moves: [$move]) {
       attribute {
@@ -171,8 +174,8 @@ const attributeValueReorderMutation = gql`
           id
         }
       }
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: attributeErrors {
+        ...AttributeErrorFragment
       }
     }
   }

--- a/src/attributes/mutations.ts
+++ b/src/attributes/mutations.ts
@@ -1,8 +1,5 @@
 import { attributeDetailsFragment } from "@saleor/fragments/attributes";
-import {
-  attributeErrorFragment,
-  productErrorFragment
-} from "@saleor/fragments/errors";
+import { attributeErrorFragment } from "@saleor/fragments/errors";
 import makeMutation from "@saleor/hooks/makeMutation";
 import gql from "graphql-tag";
 
@@ -40,11 +37,11 @@ import {
 } from "./types/AttributeValueUpdate";
 
 const attributeBulkDelete = gql`
-  ${productErrorFragment}
+  ${attributeErrorFragment}
   mutation AttributeBulkDelete($ids: [ID!]!) {
     attributeBulkDelete(ids: $ids) {
-      errors: productErrors {
-        ...ProductErrorFragment
+      errors: attributeErrors {
+        ...AttributeErrorFragment
       }
     }
   }

--- a/src/attributes/types/AttributeBulkDelete.ts
+++ b/src/attributes/types/AttributeBulkDelete.ts
@@ -2,15 +2,15 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode } from "./../../types/globalTypes";
+import { AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeBulkDelete
 // ====================================================
 
 export interface AttributeBulkDelete_attributeBulkDelete_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
   field: string | null;
 }
 

--- a/src/attributes/types/AttributeCreate.ts
+++ b/src/attributes/types/AttributeCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, ProductErrorCode } from "./../../types/globalTypes";
+import { AttributeCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeCreate
@@ -47,8 +47,8 @@ export interface AttributeCreate_attributeCreate_attribute {
 }
 
 export interface AttributeCreate_attributeCreate_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
   field: string | null;
 }
 

--- a/src/attributes/types/AttributeDelete.ts
+++ b/src/attributes/types/AttributeDelete.ts
@@ -2,15 +2,15 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode } from "./../../types/globalTypes";
+import { AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeDelete
 // ====================================================
 
 export interface AttributeDelete_attributeDelete_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
   field: string | null;
 }
 

--- a/src/attributes/types/AttributeUpdate.ts
+++ b/src/attributes/types/AttributeUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeUpdateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, ProductErrorCode } from "./../../types/globalTypes";
+import { AttributeUpdateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeUpdate
@@ -47,8 +47,8 @@ export interface AttributeUpdate_attributeUpdate_attribute {
 }
 
 export interface AttributeUpdate_attributeUpdate_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
   field: string | null;
 }
 

--- a/src/attributes/types/AttributeValueCreate.ts
+++ b/src/attributes/types/AttributeValueCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, ProductErrorCode } from "./../../types/globalTypes";
+import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueCreate
@@ -47,8 +47,8 @@ export interface AttributeValueCreate_attributeValueCreate_attribute {
 }
 
 export interface AttributeValueCreate_attributeValueCreate_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
   field: string | null;
 }
 

--- a/src/attributes/types/AttributeValueDelete.ts
+++ b/src/attributes/types/AttributeValueDelete.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, ProductErrorCode } from "./../../types/globalTypes";
+import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueDelete
@@ -47,8 +47,8 @@ export interface AttributeValueDelete_attributeValueDelete_attribute {
 }
 
 export interface AttributeValueDelete_attributeValueDelete_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
   field: string | null;
 }
 

--- a/src/attributes/types/AttributeValueReorder.ts
+++ b/src/attributes/types/AttributeValueReorder.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ReorderInput, ProductErrorCode } from "./../../types/globalTypes";
+import { ReorderInput, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueReorder
@@ -20,8 +20,8 @@ export interface AttributeValueReorder_attributeReorderValues_attribute {
 }
 
 export interface AttributeValueReorder_attributeReorderValues_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
   field: string | null;
 }
 

--- a/src/attributes/types/AttributeValueUpdate.ts
+++ b/src/attributes/types/AttributeValueUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, ProductErrorCode } from "./../../types/globalTypes";
+import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeValueType, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueUpdate
@@ -47,8 +47,8 @@ export interface AttributeValueUpdate_attributeValueUpdate_attribute {
 }
 
 export interface AttributeValueUpdate_attributeValueUpdate_errors {
-  __typename: "ProductError";
-  code: ProductErrorCode;
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
   field: string | null;
 }
 

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -1,9 +1,9 @@
-import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
+import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import { getStringOrPlaceholder } from "@saleor/misc";
 import { ReorderEvent } from "@saleor/types";
-import { ProductErrorCode } from "@saleor/types/globalTypes";
+import { AttributeErrorCode } from "@saleor/types/globalTypes";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataCreateHandler from "@saleor/utils/handlers/metadataCreateHandler";
 import {
@@ -41,9 +41,9 @@ interface AttributeDetailsProps {
   params: AttributeAddUrlQueryParams;
 }
 
-const attributeValueAlreadyExistsError: ProductErrorFragment = {
-  __typename: "ProductError",
-  code: ProductErrorCode.ALREADY_EXISTS,
+const attributeValueAlreadyExistsError: AttributeErrorFragment = {
+  __typename: "AttributeError",
+  code: AttributeErrorCode.ALREADY_EXISTS,
   field: "name"
 };
 
@@ -62,9 +62,9 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
   const [values, setValues] = React.useState<
     AttributeValueEditDialogFormData[]
   >([]);
-  const [valueErrors, setValueErrors] = React.useState<ProductErrorFragment[]>(
-    []
-  );
+  const [valueErrors, setValueErrors] = React.useState<
+    AttributeErrorFragment[]
+  >([]);
 
   const [attributeCreate, attributeCreateOpts] = useAttributeCreateMutation({
     onCompleted: data => {

--- a/src/attributes/views/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/views/AttributeDetails/AttributeDetails.tsx
@@ -3,7 +3,7 @@ import useNotifier from "@saleor/hooks/useNotifier";
 import { commonMessages } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import { ReorderEvent } from "@saleor/types";
-import { getProductErrorMessage } from "@saleor/utils/errors";
+import getAttributeErrorMessage from "@saleor/utils/errors/attribute";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
 import { move } from "@saleor/utils/lists";
@@ -140,7 +140,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
       if (data.attributeReorderValues.errors.length !== 0) {
         notify({
           status: "error",
-          text: getProductErrorMessage(
+          text: getAttributeErrorMessage(
             data.attributeReorderValues.errors[0],
             intl
           )

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -1,5 +1,12 @@
 import gql from "graphql-tag";
 
+export const attributeErrorFragment = gql`
+  fragment AttributeErrorFragment on AttributeError {
+    code
+    field
+  }
+`;
+
 export const productErrorFragment = gql`
   fragment ProductErrorFragment on ProductError {
     code

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -50,6 +50,14 @@ export const pageErrorFragment = gql`
   }
 `;
 
+export const pageErrorWithAttributesFragment = gql`
+  ${pageErrorFragment}
+  fragment PageErrorWithAttributesFragment on PageError {
+    ...PageErrorFragment
+    attributes
+  }
+`;
+
 export const permissionGroupErrorFragment = gql`
   fragment PermissionGroupErrorFragment on PermissionGroupError {
     code

--- a/src/fragments/pages.ts
+++ b/src/fragments/pages.ts
@@ -32,21 +32,6 @@ export const pageAttributesFragment = gql`
         slug
       }
     }
-  }
-`;
-
-export const pageDetailsFragment = gql`
-  ${pageFragment}
-  ${pageAttributesFragment}
-  ${metadataFragment}
-  fragment PageDetailsFragment on Page {
-    ...PageFragment
-    ...PageAttributesFragment
-    ...MetadataFragment
-    contentJson
-    seoTitle
-    seoDescription
-    publicationDate
     pageType {
       id
       name
@@ -62,5 +47,20 @@ export const pageDetailsFragment = gql`
         }
       }
     }
+  }
+`;
+
+export const pageDetailsFragment = gql`
+  ${pageFragment}
+  ${pageAttributesFragment}
+  ${metadataFragment}
+  fragment PageDetailsFragment on Page {
+    ...PageFragment
+    ...PageAttributesFragment
+    ...MetadataFragment
+    contentJson
+    seoTitle
+    seoDescription
+    publicationDate
   }
 `;

--- a/src/fragments/pages.ts
+++ b/src/fragments/pages.ts
@@ -11,11 +11,37 @@ export const pageFragment = gql`
   }
 `;
 
+export const pageAttributesFragment = gql`
+  fragment PageAttributesFragment on Page {
+    attributes {
+      attribute {
+        id
+        slug
+        name
+        inputType
+        valueRequired
+        values {
+          id
+          name
+          slug
+        }
+      }
+      values {
+        id
+        name
+        slug
+      }
+    }
+  }
+`;
+
 export const pageDetailsFragment = gql`
   ${pageFragment}
+  ${pageAttributesFragment}
   ${metadataFragment}
   fragment PageDetailsFragment on Page {
     ...PageFragment
+    ...PageAttributesFragment
     ...MetadataFragment
     contentJson
     seoTitle

--- a/src/fragments/pages.ts
+++ b/src/fragments/pages.ts
@@ -24,6 +24,17 @@ export const pageDetailsFragment = gql`
     pageType {
       id
       name
+      attributes {
+        id
+        name
+        inputType
+        valueRequired
+        values {
+          id
+          name
+          slug
+        }
+      }
     }
   }
 `;

--- a/src/fragments/pages.ts
+++ b/src/fragments/pages.ts
@@ -21,5 +21,9 @@ export const pageDetailsFragment = gql`
     seoTitle
     seoDescription
     publicationDate
+    pageType {
+      id
+      name
+    }
   }
 `;

--- a/src/fragments/types/AttributeErrorFragment.ts
+++ b/src/fragments/types/AttributeErrorFragment.ts
@@ -1,0 +1,15 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { AttributeErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: AttributeErrorFragment
+// ====================================================
+
+export interface AttributeErrorFragment {
+  __typename: "AttributeError";
+  code: AttributeErrorCode;
+  field: string | null;
+}

--- a/src/fragments/types/MetadataFragment.ts
+++ b/src/fragments/types/MetadataFragment.ts
@@ -19,7 +19,7 @@ export interface MetadataFragment_privateMetadata {
 }
 
 export interface MetadataFragment {
-  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice" | "PageType";
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (MetadataFragment_metadata | null)[];
   privateMetadata: (MetadataFragment_privateMetadata | null)[];
 }

--- a/src/fragments/types/PageAttributesFragment.ts
+++ b/src/fragments/types/PageAttributesFragment.ts
@@ -1,0 +1,44 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: PageAttributesFragment
+// ====================================================
+
+export interface PageAttributesFragment_attributes_attribute_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageAttributesFragment_attributes_attribute {
+  __typename: "Attribute";
+  id: string;
+  slug: string | null;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageAttributesFragment_attributes_attribute_values | null)[] | null;
+}
+
+export interface PageAttributesFragment_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageAttributesFragment_attributes {
+  __typename: "SelectedAttribute";
+  attribute: PageAttributesFragment_attributes_attribute;
+  values: (PageAttributesFragment_attributes_values | null)[];
+}
+
+export interface PageAttributesFragment {
+  __typename: "Page";
+  attributes: PageAttributesFragment_attributes[];
+}

--- a/src/fragments/types/PageAttributesFragment.ts
+++ b/src/fragments/types/PageAttributesFragment.ts
@@ -38,7 +38,31 @@ export interface PageAttributesFragment_attributes {
   values: (PageAttributesFragment_attributes_values | null)[];
 }
 
+export interface PageAttributesFragment_pageType_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageAttributesFragment_pageType_attributes {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageAttributesFragment_pageType_attributes_values | null)[] | null;
+}
+
+export interface PageAttributesFragment_pageType {
+  __typename: "PageType";
+  id: string;
+  name: string;
+  attributes: (PageAttributesFragment_pageType_attributes | null)[] | null;
+}
+
 export interface PageAttributesFragment {
   __typename: "Page";
   attributes: PageAttributesFragment_attributes[];
+  pageType: PageAttributesFragment_pageType;
 }

--- a/src/fragments/types/PageDetailsFragment.ts
+++ b/src/fragments/types/PageDetailsFragment.ts
@@ -8,6 +8,36 @@ import { AttributeInputTypeEnum } from "./../../types/globalTypes";
 // GraphQL fragment: PageDetailsFragment
 // ====================================================
 
+export interface PageDetailsFragment_attributes_attribute_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageDetailsFragment_attributes_attribute {
+  __typename: "Attribute";
+  id: string;
+  slug: string | null;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageDetailsFragment_attributes_attribute_values | null)[] | null;
+}
+
+export interface PageDetailsFragment_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageDetailsFragment_attributes {
+  __typename: "SelectedAttribute";
+  attribute: PageDetailsFragment_attributes_attribute;
+  values: (PageDetailsFragment_attributes_values | null)[];
+}
+
 export interface PageDetailsFragment_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -49,6 +79,7 @@ export interface PageDetailsFragment {
   title: string;
   slug: string;
   isPublished: boolean;
+  attributes: PageDetailsFragment_attributes[];
   metadata: (PageDetailsFragment_metadata | null)[];
   privateMetadata: (PageDetailsFragment_privateMetadata | null)[];
   contentJson: any;

--- a/src/fragments/types/PageDetailsFragment.ts
+++ b/src/fragments/types/PageDetailsFragment.ts
@@ -38,18 +38,6 @@ export interface PageDetailsFragment_attributes {
   values: (PageDetailsFragment_attributes_values | null)[];
 }
 
-export interface PageDetailsFragment_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface PageDetailsFragment_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
 export interface PageDetailsFragment_pageType_attributes_values {
   __typename: "AttributeValue";
   id: string;
@@ -73,6 +61,18 @@ export interface PageDetailsFragment_pageType {
   attributes: (PageDetailsFragment_pageType_attributes | null)[] | null;
 }
 
+export interface PageDetailsFragment_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageDetailsFragment_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageDetailsFragment {
   __typename: "Page";
   id: string;
@@ -80,11 +80,11 @@ export interface PageDetailsFragment {
   slug: string;
   isPublished: boolean;
   attributes: PageDetailsFragment_attributes[];
+  pageType: PageDetailsFragment_pageType;
   metadata: (PageDetailsFragment_metadata | null)[];
   privateMetadata: (PageDetailsFragment_privateMetadata | null)[];
   contentJson: any;
   seoTitle: string | null;
   seoDescription: string | null;
   publicationDate: any | null;
-  pageType: PageDetailsFragment_pageType;
 }

--- a/src/fragments/types/PageDetailsFragment.ts
+++ b/src/fragments/types/PageDetailsFragment.ts
@@ -18,6 +18,12 @@ export interface PageDetailsFragment_privateMetadata {
   value: string;
 }
 
+export interface PageDetailsFragment_pageType {
+  __typename: "PageType";
+  id: string;
+  name: string;
+}
+
 export interface PageDetailsFragment {
   __typename: "Page";
   id: string;
@@ -30,4 +36,5 @@ export interface PageDetailsFragment {
   seoTitle: string | null;
   seoDescription: string | null;
   publicationDate: any | null;
+  pageType: PageDetailsFragment_pageType;
 }

--- a/src/fragments/types/PageDetailsFragment.ts
+++ b/src/fragments/types/PageDetailsFragment.ts
@@ -2,6 +2,8 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
+import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+
 // ====================================================
 // GraphQL fragment: PageDetailsFragment
 // ====================================================
@@ -18,10 +20,27 @@ export interface PageDetailsFragment_privateMetadata {
   value: string;
 }
 
+export interface PageDetailsFragment_pageType_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageDetailsFragment_pageType_attributes {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageDetailsFragment_pageType_attributes_values | null)[] | null;
+}
+
 export interface PageDetailsFragment_pageType {
   __typename: "PageType";
   id: string;
   name: string;
+  attributes: (PageDetailsFragment_pageType_attributes | null)[] | null;
 }
 
 export interface PageDetailsFragment {

--- a/src/fragments/types/PageErrorWithAttributesFragment.ts
+++ b/src/fragments/types/PageErrorWithAttributesFragment.ts
@@ -1,0 +1,16 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { PageErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: PageErrorWithAttributesFragment
+// ====================================================
+
+export interface PageErrorWithAttributesFragment {
+  __typename: "PageError";
+  code: PageErrorCode;
+  field: string | null;
+  attributes: string[] | null;
+}

--- a/src/pageTypes/views/PageTypeList/fliters.ts
+++ b/src/pageTypes/views/PageTypeList/fliters.ts
@@ -1,15 +1,8 @@
-import { IFilterElement } from "@saleor/components/Filter";
-import { findValueInEnum, maybe } from "@saleor/misc";
-import {
-  PageTypeFilterKeys,
-  PageTypeListFilterOpts
-} from "@saleor/pageTypes/components/PageTypeListPage";
 import { PageTypeFilterInput } from "@saleor/types/globalTypes";
 
 import {
   createFilterTabUtils,
-  createFilterUtils,
-  getSingleValueQueryParam
+  createFilterUtils
 } from "../../../utils/filters";
 import {
   PageTypeListUrlFilters,
@@ -19,29 +12,12 @@ import {
 
 export const PAGE_TYPE_FILTERS_KEY = "pageTypeFilters";
 
-export function getFilterOpts(
-  params: PageTypeListUrlFilters
-): PageTypeListFilterOpts {
-  return {};
-}
-
 export function getFilterVariables(
   params: PageTypeListUrlFilters
 ): PageTypeFilterInput {
   return {
     search: params.query
   };
-}
-
-export function getFilterQueryParam(
-  filter: IFilterElement<PageTypeFilterKeys>
-): PageTypeListUrlFilters {
-  const { name } = filter;
-
-  switch (name) {
-    case PageTypeFilterKeys.type:
-      return getSingleValueQueryParam(filter, PageTypeListUrlFiltersEnum.type);
-  }
 }
 
 export const {

--- a/src/pageTypes/views/PageTypeList/fliters.ts
+++ b/src/pageTypes/views/PageTypeList/fliters.ts
@@ -1,0 +1,56 @@
+import { IFilterElement } from "@saleor/components/Filter";
+import { findValueInEnum, maybe } from "@saleor/misc";
+import {
+  PageTypeFilterKeys,
+  PageTypeListFilterOpts
+} from "@saleor/pageTypes/components/PageTypeListPage";
+import { PageTypeFilterInput } from "@saleor/types/globalTypes";
+
+import {
+  createFilterTabUtils,
+  createFilterUtils,
+  getSingleValueQueryParam
+} from "../../../utils/filters";
+import {
+  PageTypeListUrlFilters,
+  PageTypeListUrlFiltersEnum,
+  PageTypeListUrlQueryParams
+} from "../../urls";
+
+export const PAGE_TYPE_FILTERS_KEY = "pageTypeFilters";
+
+export function getFilterOpts(
+  params: PageTypeListUrlFilters
+): PageTypeListFilterOpts {
+  return {};
+}
+
+export function getFilterVariables(
+  params: PageTypeListUrlFilters
+): PageTypeFilterInput {
+  return {
+    search: params.query
+  };
+}
+
+export function getFilterQueryParam(
+  filter: IFilterElement<PageTypeFilterKeys>
+): PageTypeListUrlFilters {
+  const { name } = filter;
+
+  switch (name) {
+    case PageTypeFilterKeys.type:
+      return getSingleValueQueryParam(filter, PageTypeListUrlFiltersEnum.type);
+  }
+}
+
+export const {
+  deleteFilterTab,
+  getFilterTabs,
+  saveFilterTab
+} = createFilterTabUtils<PageTypeListUrlFilters>(PAGE_TYPE_FILTERS_KEY);
+
+export const { areFiltersApplied, getActiveFilters } = createFilterUtils<
+  PageTypeListUrlQueryParams,
+  PageTypeListUrlFilters
+>(PageTypeListUrlFiltersEnum);

--- a/src/pages/components/PageAttributes/PageAttributes.tsx
+++ b/src/pages/components/PageAttributes/PageAttributes.tsx
@@ -1,0 +1,247 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import IconButton from "@material-ui/core/IconButton";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import Typography from "@material-ui/core/Typography";
+import ArrowDropDownIcon from "@material-ui/icons/ArrowDropDown";
+import CardTitle from "@saleor/components/CardTitle";
+import Grid from "@saleor/components/Grid";
+import Hr from "@saleor/components/Hr";
+import MultiAutocompleteSelectField, {
+  MultiAutocompleteChoiceType
+} from "@saleor/components/MultiAutocompleteSelectField";
+import SingleAutocompleteSelectField, {
+  SingleAutocompleteChoiceType
+} from "@saleor/components/SingleAutocompleteSelectField";
+import { PageDetailsFragment_pageType_attributes_values } from "@saleor/fragments/types/PageDetailsFragment";
+import { PageErrorWithAttributesFragment } from "@saleor/fragments/types/PageErrorWithAttributesFragment";
+import { FormsetAtomicData, FormsetChange } from "@saleor/hooks/useFormset";
+import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
+import getPageErrorMessage from "@saleor/utils/errors/page";
+import classNames from "classnames";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+export interface PageAttributeInputData {
+  inputType: AttributeInputTypeEnum;
+  isRequired: boolean;
+  values: PageDetailsFragment_pageType_attributes_values[];
+}
+export type PageAttributeInput = FormsetAtomicData<
+  PageAttributeInputData,
+  string[]
+>;
+export interface PageAttributesProps {
+  attributes: PageAttributeInput[];
+  disabled: boolean;
+  errors: PageErrorWithAttributesFragment[];
+  onChange: FormsetChange;
+  onMultiChange: FormsetChange;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    attributeSection: {
+      "&:last-of-type": {
+        paddingBottom: 0
+      },
+      padding: theme.spacing(2, 0)
+    },
+    attributeSectionLabel: {
+      alignItems: "center",
+      display: "flex"
+    },
+    card: {
+      overflow: "visible"
+    },
+    cardContent: {
+      "&:last-child": {
+        paddingBottom: theme.spacing(1)
+      },
+      paddingTop: theme.spacing(1)
+    },
+    expansionBar: {
+      display: "flex"
+    },
+    expansionBarButton: {
+      marginBottom: theme.spacing(1)
+    },
+    expansionBarButtonIcon: {
+      transition: theme.transitions.duration.short + "ms"
+    },
+    expansionBarLabel: {
+      color: theme.palette.text.disabled,
+      fontSize: 14
+    },
+    expansionBarLabelContainer: {
+      alignItems: "center",
+      display: "flex",
+      flex: 1
+    },
+    rotate: {
+      transform: "rotate(180deg)"
+    }
+  }),
+  { name: "PageAttributes" }
+);
+
+function getMultiChoices(
+  values: PageDetailsFragment_pageType_attributes_values[]
+): MultiAutocompleteChoiceType[] {
+  return values.map(value => ({
+    label: value.name,
+    value: value.slug
+  }));
+}
+
+function getMultiDisplayValue(
+  attribute: PageAttributeInput
+): MultiAutocompleteChoiceType[] {
+  return attribute.value.map(attributeValue => {
+    const definedAttributeValue = attribute.data.values.find(
+      definedValue => definedValue.slug === attributeValue
+    );
+    if (!!definedAttributeValue) {
+      return {
+        label: definedAttributeValue.name,
+        value: definedAttributeValue.slug
+      };
+    }
+
+    return {
+      label: attributeValue,
+      value: attributeValue
+    };
+  });
+}
+
+function getSingleChoices(
+  values: PageDetailsFragment_pageType_attributes_values[]
+): SingleAutocompleteChoiceType[] {
+  return values.map(value => ({
+    label: value.name,
+    value: value.slug
+  }));
+}
+
+const PageAttributes: React.FC<PageAttributesProps> = ({
+  attributes,
+  disabled,
+  errors,
+  onChange,
+  onMultiChange
+}) => {
+  const intl = useIntl();
+  const classes = useStyles({});
+  const [expanded, setExpansionStatus] = React.useState(true);
+  const toggleExpansion = () => setExpansionStatus(!expanded);
+
+  return (
+    <Card className={classes.card}>
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Attributes",
+          description: "page attributes, section header"
+        })}
+      />
+      <CardContent className={classes.cardContent}>
+        <div className={classes.expansionBar}>
+          <div className={classes.expansionBarLabelContainer}>
+            <Typography className={classes.expansionBarLabel} variant="caption">
+              <FormattedMessage
+                defaultMessage="{number} Attributes"
+                description="number of page attributes"
+                values={{
+                  number: attributes.length
+                }}
+              />
+            </Typography>
+          </div>
+          <IconButton
+            className={classes.expansionBarButton}
+            onClick={toggleExpansion}
+            data-test="page-attributes-expand"
+          >
+            <ArrowDropDownIcon
+              className={classNames(classes.expansionBarButtonIcon, {
+                [classes.rotate]: expanded
+              })}
+            />
+          </IconButton>
+        </div>
+        {expanded && attributes.length > 0 && (
+          <>
+            <Hr />
+            {attributes.map((attribute, attributeIndex) => {
+              const error = errors.find(err =>
+                err.attributes?.includes(attribute.id)
+              );
+
+              return (
+                <React.Fragment key={attribute.id}>
+                  {attributeIndex > 0 && <Hr />}
+                  <Grid className={classes.attributeSection} variant="uniform">
+                    <div
+                      className={classes.attributeSectionLabel}
+                      data-test="page-attribute-label"
+                    >
+                      <Typography>{attribute.label}</Typography>
+                    </div>
+                    <div data-test="page-attribute-value">
+                      {attribute.data.inputType ===
+                      AttributeInputTypeEnum.DROPDOWN ? (
+                        <SingleAutocompleteSelectField
+                          choices={getSingleChoices(attribute.data.values)}
+                          disabled={disabled}
+                          displayValue={
+                            attribute.data.values.find(
+                              value => value.slug === attribute.value[0]
+                            )?.name ||
+                            attribute.value[0] ||
+                            ""
+                          }
+                          emptyOption={!attribute.data.isRequired}
+                          error={!!error}
+                          helperText={getPageErrorMessage(error, intl)}
+                          name={`attribute:${attribute.label}`}
+                          label={intl.formatMessage({
+                            defaultMessage: "Value",
+                            description: "attribute value"
+                          })}
+                          value={attribute.value[0]}
+                          onChange={event =>
+                            onChange(attribute.id, event.target.value)
+                          }
+                          allowCustomValues={!attribute.data.isRequired}
+                        />
+                      ) : (
+                        <MultiAutocompleteSelectField
+                          choices={getMultiChoices(attribute.data.values)}
+                          displayValues={getMultiDisplayValue(attribute)}
+                          error={!!error}
+                          helperText={getPageErrorMessage(error, intl)}
+                          label={intl.formatMessage({
+                            defaultMessage: "Values",
+                            description: "attribute values"
+                          })}
+                          name={`attribute:${attribute.label}`}
+                          value={attribute.value}
+                          onChange={event =>
+                            onMultiChange(attribute.id, event.target.value)
+                          }
+                          allowCustomValues={!attribute.data.isRequired}
+                        />
+                      )}
+                    </div>
+                  </Grid>
+                </React.Fragment>
+              );
+            })}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+PageAttributes.displayName = "PageAttributes";
+export default PageAttributes;

--- a/src/pages/components/PageAttributes/index.ts
+++ b/src/pages/components/PageAttributes/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./PageAttributes";
+export * from "./PageAttributes";

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -15,7 +15,7 @@ import useDateLocalize from "@saleor/hooks/useDateLocalize";
 import useFormset from "@saleor/hooks/useFormset";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
-import { getAttributeInputFromPageType } from "@saleor/pages/utils/data";
+import { getAttributeInputFromPage } from "@saleor/pages/utils/data";
 import {
   createAttributeChangeHandler,
   createAttributeMultiChangeHandler,
@@ -94,17 +94,16 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
 
   const pageExists = page !== null;
 
-  const initialPageType =
-    page?.pageType ||
-    pageTypes?.find(pageType => page?.pageType.id === pageType.id);
+  const attributesFromPage = React.useMemo(
+    () => getAttributeInputFromPage(page),
+    [page]
+  );
 
   const {
     change: changeAttributeData,
     data: attributes,
     set: setAttributeData
-  } = useFormset<PageAttributeInputData>(
-    page?.pageType ? getAttributeInputFromPageType(initialPageType) : []
-  );
+  } = useFormset<PageAttributeInputData>(attributesFromPage || []);
 
   const initialForm: FormData = {
     content: maybe(

--- a/src/pages/components/PageOrganizeContent/PageOrganizeContent.tsx
+++ b/src/pages/components/PageOrganizeContent/PageOrganizeContent.tsx
@@ -1,0 +1,103 @@
+import { makeStyles } from "@material-ui/core";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+import CardTitle from "@saleor/components/CardTitle";
+import SingleAutocompleteSelectField from "@saleor/components/SingleAutocompleteSelectField";
+import { PageErrorFragment } from "@saleor/fragments/types/PageErrorFragment";
+import { PageTypeFragment } from "@saleor/fragments/types/PageTypeFragment";
+import { FetchMoreProps } from "@saleor/types";
+import { getFormErrors } from "@saleor/utils/errors";
+import getPageErrorMessage from "@saleor/utils/errors/page";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { FormData } from "../PageDetailsPage";
+
+export interface PageOrganizeContentProps {
+  canChangeType: boolean;
+  data: FormData;
+  pageType?: PageTypeFragment;
+  pageTypeInputDisplayValue?: string;
+  errors: PageErrorFragment[];
+  disabled: boolean;
+  pageTypes: PageTypeFragment[];
+  onPageTypeChange?: (event: React.ChangeEvent<any>) => void;
+  fetchPageTypes?: (data: string) => void;
+  fetchMorePageTypes?: FetchMoreProps;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    label: {
+      marginBottom: theme.spacing(0.5)
+    }
+  }),
+  { name: "PageOrganizeContent" }
+);
+
+const PageOrganizeContent: React.FC<PageOrganizeContentProps> = props => {
+  const {
+    canChangeType,
+    data,
+    pageType,
+    pageTypeInputDisplayValue,
+    errors,
+    disabled,
+    pageTypes,
+    onPageTypeChange,
+    fetchPageTypes,
+    fetchMorePageTypes
+  } = props;
+
+  const classes = useStyles(props);
+  const intl = useIntl();
+
+  const formErrors = getFormErrors(["pageType"], errors);
+
+  return (
+    <Card>
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Organize Content",
+          description: "section header"
+        })}
+      />
+      <CardContent>
+        {canChangeType ? (
+          <SingleAutocompleteSelectField
+            disabled={disabled}
+            displayValue={pageTypeInputDisplayValue}
+            label={intl.formatMessage({
+              defaultMessage: "Select content type",
+              id: "pageTypeInputLabel"
+            })}
+            error={!!formErrors.pageType}
+            helperText={getPageErrorMessage(formErrors.pageType, intl)}
+            name={"pageType" as keyof FormData}
+            onChange={onPageTypeChange}
+            value={data.pageType}
+            choices={
+              pageTypes?.map(({ name, id }) => ({ label: name, value: id })) ||
+              []
+            }
+            InputProps={{
+              autoComplete: "off"
+            }}
+            fetchChoices={fetchPageTypes}
+            {...fetchMorePageTypes}
+          />
+        ) : (
+          <>
+            <Typography className={classes.label} variant="caption">
+              <FormattedMessage defaultMessage="Page type" />
+            </Typography>
+            <Typography>{pageType?.name}</Typography>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+PageOrganizeContent.displayName = "PageOrganizeContent";
+export default PageOrganizeContent;

--- a/src/pages/components/PageOrganizeContent/PageOrganizeContent.tsx
+++ b/src/pages/components/PageOrganizeContent/PageOrganizeContent.tsx
@@ -6,9 +6,11 @@ import CardTitle from "@saleor/components/CardTitle";
 import SingleAutocompleteSelectField from "@saleor/components/SingleAutocompleteSelectField";
 import { PageErrorFragment } from "@saleor/fragments/types/PageErrorFragment";
 import { PageTypeFragment } from "@saleor/fragments/types/PageTypeFragment";
+import { FormChange } from "@saleor/hooks/useForm";
 import { FetchMoreProps } from "@saleor/types";
 import { getFormErrors } from "@saleor/utils/errors";
 import getPageErrorMessage from "@saleor/utils/errors/page";
+import { mapNodeToChoice } from "@saleor/utils/maps";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -22,7 +24,7 @@ export interface PageOrganizeContentProps {
   errors: PageErrorFragment[];
   disabled: boolean;
   pageTypes: PageTypeFragment[];
-  onPageTypeChange?: (event: React.ChangeEvent<any>) => void;
+  onPageTypeChange?: FormChange;
   fetchPageTypes?: (data: string) => void;
   fetchMorePageTypes?: FetchMoreProps;
 }
@@ -77,10 +79,7 @@ const PageOrganizeContent: React.FC<PageOrganizeContentProps> = props => {
             name={"pageType" as keyof FormData}
             onChange={onPageTypeChange}
             value={data.pageType}
-            choices={
-              pageTypes?.map(({ name, id }) => ({ label: name, value: id })) ||
-              []
-            }
+            choices={pageTypes ? mapNodeToChoice(pageTypes) : []}
             InputProps={{
               autoComplete: "off"
             }}

--- a/src/pages/components/PageOrganizeContent/PageOrganizeContent.tsx
+++ b/src/pages/components/PageOrganizeContent/PageOrganizeContent.tsx
@@ -90,7 +90,7 @@ const PageOrganizeContent: React.FC<PageOrganizeContentProps> = props => {
         ) : (
           <>
             <Typography className={classes.label} variant="caption">
-              <FormattedMessage defaultMessage="Page type" />
+              <FormattedMessage defaultMessage="Content type" />
             </Typography>
             <Typography>{pageType?.name}</Typography>
           </>

--- a/src/pages/components/PageOrganizeContent/index.ts
+++ b/src/pages/components/PageOrganizeContent/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./PageOrganizeContent";
+export * from "./PageOrganizeContent";

--- a/src/pages/fixtures.ts
+++ b/src/pages/fixtures.ts
@@ -44,6 +44,11 @@ export const page: PageDetails_page = {
       value: "100023123"
     }
   ],
+  pageType: {
+    __typename: "PageType",
+    id: "UGFnZVR5cGU6MQ==",
+    name: "Blog"
+  },
   privateMetadata: [],
   publicationDate: "",
   seoDescription: "About",

--- a/src/pages/fixtures.ts
+++ b/src/pages/fixtures.ts
@@ -37,6 +37,92 @@ export const pageList: PageList_pages_edges_node[] = [
 ];
 export const page: PageDetails_page = {
   __typename: "Page",
+  attributes: [
+    {
+      attribute: {
+        id: "QXR0cmlidXRlOjI3",
+        slug: "author",
+        name: "Author",
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        valueRequired: false,
+        values: [
+          {
+            id: "QXR0cmlidXRlVmFsdWU6ODc=",
+            name: "Suzanne Ellison",
+            slug: "suzanne-ellison",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6ODg=",
+            name: "Dennis Perkins",
+            slug: "dennis-perkins",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6ODk=",
+            name: "Dylan Lamb",
+            slug: "dylan-lamb",
+            __typename: "AttributeValue"
+          }
+        ],
+        __typename: "Attribute"
+      },
+      values: [
+        {
+          id: "QXR0cmlidXRlVmFsdWU6ODk=",
+          name: "Dylan Lamb",
+          slug: "dylan-lamb",
+          __typename: "AttributeValue"
+        }
+      ],
+      __typename: "SelectedAttribute"
+    },
+    {
+      attribute: {
+        id: "QXR0cmlidXRlOjI5",
+        slug: "tag",
+        name: "Tag",
+        inputType: AttributeInputTypeEnum.MULTISELECT,
+        valueRequired: false,
+        values: [
+          {
+            id: "QXR0cmlidXRlVmFsdWU6OTA=",
+            name: "Security",
+            slug: "security",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6OTE=",
+            name: "Support",
+            slug: "support",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6OTI=",
+            name: "Medical",
+            slug: "medical",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6OTM=",
+            name: "General",
+            slug: "general",
+            __typename: "AttributeValue"
+          }
+        ],
+        __typename: "Attribute"
+      },
+      values: [
+        {
+          id: "QXR0cmlidXRlVmFsdWU6OTA=",
+          name: "Security",
+          slug: "security",
+          __typename: "AttributeValue"
+        }
+      ],
+      __typename: "SelectedAttribute"
+    }
+  ],
   contentJson: JSON.stringify(content),
   id: "Kzx152sEm==",
   isPublished: false,

--- a/src/pages/fixtures.ts
+++ b/src/pages/fixtures.ts
@@ -1,3 +1,6 @@
+/* eslint-disable sort-keys */
+import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
+
 import { content } from "../storybook/stories/components/RichTextEditor";
 import { PageDetails_page } from "./types/PageDetails";
 import { PageList_pages_edges_node } from "./types/PageList";
@@ -47,7 +50,69 @@ export const page: PageDetails_page = {
   pageType: {
     __typename: "PageType",
     id: "UGFnZVR5cGU6MQ==",
-    name: "Blog"
+    name: "Blog",
+    attributes: [
+      {
+        id: "QXR0cmlidXRlOjI3",
+        name: "Author",
+        inputType: AttributeInputTypeEnum.DROPDOWN,
+        valueRequired: false,
+        values: [
+          {
+            id: "QXR0cmlidXRlVmFsdWU6ODc=",
+            name: "Suzanne Ellison",
+            slug: "suzanne-ellison",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6ODg=",
+            name: "Dennis Perkins",
+            slug: "dennis-perkins",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6ODk=",
+            name: "Dylan Lamb",
+            slug: "dylan-lamb",
+            __typename: "AttributeValue"
+          }
+        ],
+        __typename: "Attribute"
+      },
+      {
+        id: "QXR0cmlidXRlOjI5",
+        name: "Tag",
+        inputType: AttributeInputTypeEnum.MULTISELECT,
+        valueRequired: false,
+        values: [
+          {
+            id: "QXR0cmlidXRlVmFsdWU6OTA=",
+            name: "Security",
+            slug: "security",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6OTE=",
+            name: "Support",
+            slug: "support",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6OTI=",
+            name: "Medical",
+            slug: "medical",
+            __typename: "AttributeValue"
+          },
+          {
+            id: "QXR0cmlidXRlVmFsdWU6OTM=",
+            name: "General",
+            slug: "general",
+            __typename: "AttributeValue"
+          }
+        ],
+        __typename: "Attribute"
+      }
+    ]
   },
   privateMetadata: [],
   publicationDate: "",

--- a/src/pages/mutations.ts
+++ b/src/pages/mutations.ts
@@ -18,7 +18,7 @@ import { PageUpdate, PageUpdateVariables } from "./types/PageUpdate";
 const pageCreate = gql`
   ${pageDetailsFragment}
   ${pageErrorFragment}
-  mutation PageCreate($input: PageInput!) {
+  mutation PageCreate($input: PageCreateInput!) {
     pageCreate(input: $input) {
       errors: pageErrors {
         ...PageErrorFragment

--- a/src/pages/mutations.ts
+++ b/src/pages/mutations.ts
@@ -1,4 +1,7 @@
-import { pageErrorFragment } from "@saleor/fragments/errors";
+import {
+  pageErrorFragment,
+  pageErrorWithAttributesFragment
+} from "@saleor/fragments/errors";
 import { pageDetailsFragment } from "@saleor/fragments/pages";
 import gql from "graphql-tag";
 
@@ -17,11 +20,11 @@ import { PageUpdate, PageUpdateVariables } from "./types/PageUpdate";
 
 const pageCreate = gql`
   ${pageDetailsFragment}
-  ${pageErrorFragment}
+  ${pageErrorWithAttributesFragment}
   mutation PageCreate($input: PageCreateInput!) {
     pageCreate(input: $input) {
       errors: pageErrors {
-        ...PageErrorFragment
+        ...PageErrorWithAttributesFragment
       }
       page {
         ...PageDetailsFragment
@@ -35,11 +38,11 @@ export const TypedPageCreate = TypedMutation<PageCreate, PageCreateVariables>(
 
 const pageUpdate = gql`
   ${pageDetailsFragment}
-  ${pageErrorFragment}
+  ${pageErrorWithAttributesFragment}
   mutation PageUpdate($id: ID!, $input: PageInput!) {
     pageUpdate(id: $id, input: $input) {
       errors: pageErrors {
-        ...PageErrorFragment
+        ...PageErrorWithAttributesFragment
       }
       page {
         ...PageDetailsFragment

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -15,6 +15,36 @@ export interface PageCreate_pageCreate_errors {
   attributes: string[] | null;
 }
 
+export interface PageCreate_pageCreate_page_attributes_attribute_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageCreate_pageCreate_page_attributes_attribute {
+  __typename: "Attribute";
+  id: string;
+  slug: string | null;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageCreate_pageCreate_page_attributes_attribute_values | null)[] | null;
+}
+
+export interface PageCreate_pageCreate_page_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageCreate_pageCreate_page_attributes {
+  __typename: "SelectedAttribute";
+  attribute: PageCreate_pageCreate_page_attributes_attribute;
+  values: (PageCreate_pageCreate_page_attributes_values | null)[];
+}
+
 export interface PageCreate_pageCreate_page_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -56,6 +86,7 @@ export interface PageCreate_pageCreate_page {
   title: string;
   slug: string;
   isPublished: boolean;
+  attributes: PageCreate_pageCreate_page_attributes[];
   metadata: (PageCreate_pageCreate_page_metadata | null)[];
   privateMetadata: (PageCreate_pageCreate_page_privateMetadata | null)[];
   contentJson: any;

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -15,6 +15,18 @@ export interface PageCreate_pageCreate_errors {
   attributes: string[] | null;
 }
 
+export interface PageCreate_pageCreate_page_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageCreate_pageCreate_page_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageCreate_pageCreate_page_pageType_attributes_values {
   __typename: "AttributeValue";
   id: string;
@@ -29,18 +41,6 @@ export interface PageCreate_pageCreate_page_pageType_attributes {
   inputType: AttributeInputTypeEnum | null;
   valueRequired: boolean;
   values: (PageCreate_pageCreate_page_pageType_attributes_values | null)[] | null;
-}
-
-export interface PageCreate_pageCreate_page_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface PageCreate_pageCreate_page_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
 }
 
 export interface PageCreate_pageCreate_page_pageType {

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { PageInput, PageErrorCode } from "./../../types/globalTypes";
+import { PageCreateInput, PageErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: PageCreate
@@ -26,6 +26,12 @@ export interface PageCreate_pageCreate_page_privateMetadata {
   value: string;
 }
 
+export interface PageCreate_pageCreate_page_pageType {
+  __typename: "PageType";
+  id: string;
+  name: string;
+}
+
 export interface PageCreate_pageCreate_page {
   __typename: "Page";
   id: string;
@@ -38,6 +44,7 @@ export interface PageCreate_pageCreate_page {
   seoTitle: string | null;
   seoDescription: string | null;
   publicationDate: any | null;
+  pageType: PageCreate_pageCreate_page_pageType;
 }
 
 export interface PageCreate_pageCreate {
@@ -51,5 +58,5 @@ export interface PageCreate {
 }
 
 export interface PageCreateVariables {
-  input: PageInput;
+  input: PageCreateInput;
 }

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -45,18 +45,6 @@ export interface PageCreate_pageCreate_page_attributes {
   values: (PageCreate_pageCreate_page_attributes_values | null)[];
 }
 
-export interface PageCreate_pageCreate_page_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface PageCreate_pageCreate_page_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
 export interface PageCreate_pageCreate_page_pageType_attributes_values {
   __typename: "AttributeValue";
   id: string;
@@ -80,6 +68,18 @@ export interface PageCreate_pageCreate_page_pageType {
   attributes: (PageCreate_pageCreate_page_pageType_attributes | null)[] | null;
 }
 
+export interface PageCreate_pageCreate_page_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageCreate_pageCreate_page_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageCreate_pageCreate_page {
   __typename: "Page";
   id: string;
@@ -87,13 +87,13 @@ export interface PageCreate_pageCreate_page {
   slug: string;
   isPublished: boolean;
   attributes: PageCreate_pageCreate_page_attributes[];
+  pageType: PageCreate_pageCreate_page_pageType;
   metadata: (PageCreate_pageCreate_page_metadata | null)[];
   privateMetadata: (PageCreate_pageCreate_page_privateMetadata | null)[];
   contentJson: any;
   seoTitle: string | null;
   seoDescription: string | null;
   publicationDate: any | null;
-  pageType: PageCreate_pageCreate_page_pageType;
 }
 
 export interface PageCreate_pageCreate {

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { PageCreateInput, PageErrorCode } from "./../../types/globalTypes";
+import { PageCreateInput, PageErrorCode, AttributeInputTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: PageCreate
@@ -12,6 +12,23 @@ export interface PageCreate_pageCreate_errors {
   __typename: "PageError";
   code: PageErrorCode;
   field: string | null;
+  attributes: string[] | null;
+}
+
+export interface PageCreate_pageCreate_page_pageType_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageCreate_pageCreate_page_pageType_attributes {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageCreate_pageCreate_page_pageType_attributes_values | null)[] | null;
 }
 
 export interface PageCreate_pageCreate_page_metadata {
@@ -30,6 +47,7 @@ export interface PageCreate_pageCreate_page_pageType {
   __typename: "PageType";
   id: string;
   name: string;
+  attributes: (PageCreate_pageCreate_page_pageType_attributes | null)[] | null;
 }
 
 export interface PageCreate_pageCreate_page {

--- a/src/pages/types/PageDetails.ts
+++ b/src/pages/types/PageDetails.ts
@@ -38,18 +38,6 @@ export interface PageDetails_page_attributes {
   values: (PageDetails_page_attributes_values | null)[];
 }
 
-export interface PageDetails_page_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface PageDetails_page_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
 export interface PageDetails_page_pageType_attributes_values {
   __typename: "AttributeValue";
   id: string;
@@ -73,6 +61,18 @@ export interface PageDetails_page_pageType {
   attributes: (PageDetails_page_pageType_attributes | null)[] | null;
 }
 
+export interface PageDetails_page_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageDetails_page_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageDetails_page {
   __typename: "Page";
   id: string;
@@ -80,13 +80,13 @@ export interface PageDetails_page {
   slug: string;
   isPublished: boolean;
   attributes: PageDetails_page_attributes[];
+  pageType: PageDetails_page_pageType;
   metadata: (PageDetails_page_metadata | null)[];
   privateMetadata: (PageDetails_page_privateMetadata | null)[];
   contentJson: any;
   seoTitle: string | null;
   seoDescription: string | null;
   publicationDate: any | null;
-  pageType: PageDetails_page_pageType;
 }
 
 export interface PageDetails {

--- a/src/pages/types/PageDetails.ts
+++ b/src/pages/types/PageDetails.ts
@@ -18,6 +18,12 @@ export interface PageDetails_page_privateMetadata {
   value: string;
 }
 
+export interface PageDetails_page_pageType {
+  __typename: "PageType";
+  id: string;
+  name: string;
+}
+
 export interface PageDetails_page {
   __typename: "Page";
   id: string;
@@ -30,6 +36,7 @@ export interface PageDetails_page {
   seoTitle: string | null;
   seoDescription: string | null;
   publicationDate: any | null;
+  pageType: PageDetails_page_pageType;
 }
 
 export interface PageDetails {

--- a/src/pages/types/PageDetails.ts
+++ b/src/pages/types/PageDetails.ts
@@ -8,6 +8,36 @@ import { AttributeInputTypeEnum } from "./../../types/globalTypes";
 // GraphQL query operation: PageDetails
 // ====================================================
 
+export interface PageDetails_page_attributes_attribute_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageDetails_page_attributes_attribute {
+  __typename: "Attribute";
+  id: string;
+  slug: string | null;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageDetails_page_attributes_attribute_values | null)[] | null;
+}
+
+export interface PageDetails_page_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageDetails_page_attributes {
+  __typename: "SelectedAttribute";
+  attribute: PageDetails_page_attributes_attribute;
+  values: (PageDetails_page_attributes_values | null)[];
+}
+
 export interface PageDetails_page_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -49,6 +79,7 @@ export interface PageDetails_page {
   title: string;
   slug: string;
   isPublished: boolean;
+  attributes: PageDetails_page_attributes[];
   metadata: (PageDetails_page_metadata | null)[];
   privateMetadata: (PageDetails_page_privateMetadata | null)[];
   contentJson: any;

--- a/src/pages/types/PageDetails.ts
+++ b/src/pages/types/PageDetails.ts
@@ -2,6 +2,8 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
+import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+
 // ====================================================
 // GraphQL query operation: PageDetails
 // ====================================================
@@ -18,10 +20,27 @@ export interface PageDetails_page_privateMetadata {
   value: string;
 }
 
+export interface PageDetails_page_pageType_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageDetails_page_pageType_attributes {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageDetails_page_pageType_attributes_values | null)[] | null;
+}
+
 export interface PageDetails_page_pageType {
   __typename: "PageType";
   id: string;
   name: string;
+  attributes: (PageDetails_page_pageType_attributes | null)[] | null;
 }
 
 export interface PageDetails_page {

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -15,6 +15,18 @@ export interface PageUpdate_pageUpdate_errors {
   attributes: string[] | null;
 }
 
+export interface PageUpdate_pageUpdate_page_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageUpdate_pageUpdate_page_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageUpdate_pageUpdate_page_pageType_attributes_values {
   __typename: "AttributeValue";
   id: string;
@@ -29,18 +41,6 @@ export interface PageUpdate_pageUpdate_page_pageType_attributes {
   inputType: AttributeInputTypeEnum | null;
   valueRequired: boolean;
   values: (PageUpdate_pageUpdate_page_pageType_attributes_values | null)[] | null;
-}
-
-export interface PageUpdate_pageUpdate_page_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface PageUpdate_pageUpdate_page_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
 }
 
 export interface PageUpdate_pageUpdate_page_pageType {

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -15,6 +15,36 @@ export interface PageUpdate_pageUpdate_errors {
   attributes: string[] | null;
 }
 
+export interface PageUpdate_pageUpdate_page_attributes_attribute_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageUpdate_pageUpdate_page_attributes_attribute {
+  __typename: "Attribute";
+  id: string;
+  slug: string | null;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageUpdate_pageUpdate_page_attributes_attribute_values | null)[] | null;
+}
+
+export interface PageUpdate_pageUpdate_page_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageUpdate_pageUpdate_page_attributes {
+  __typename: "SelectedAttribute";
+  attribute: PageUpdate_pageUpdate_page_attributes_attribute;
+  values: (PageUpdate_pageUpdate_page_attributes_values | null)[];
+}
+
 export interface PageUpdate_pageUpdate_page_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -56,6 +86,7 @@ export interface PageUpdate_pageUpdate_page {
   title: string;
   slug: string;
   isPublished: boolean;
+  attributes: PageUpdate_pageUpdate_page_attributes[];
   metadata: (PageUpdate_pageUpdate_page_metadata | null)[];
   privateMetadata: (PageUpdate_pageUpdate_page_privateMetadata | null)[];
   contentJson: any;

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -45,18 +45,6 @@ export interface PageUpdate_pageUpdate_page_attributes {
   values: (PageUpdate_pageUpdate_page_attributes_values | null)[];
 }
 
-export interface PageUpdate_pageUpdate_page_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface PageUpdate_pageUpdate_page_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
 export interface PageUpdate_pageUpdate_page_pageType_attributes_values {
   __typename: "AttributeValue";
   id: string;
@@ -80,6 +68,18 @@ export interface PageUpdate_pageUpdate_page_pageType {
   attributes: (PageUpdate_pageUpdate_page_pageType_attributes | null)[] | null;
 }
 
+export interface PageUpdate_pageUpdate_page_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageUpdate_pageUpdate_page_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface PageUpdate_pageUpdate_page {
   __typename: "Page";
   id: string;
@@ -87,13 +87,13 @@ export interface PageUpdate_pageUpdate_page {
   slug: string;
   isPublished: boolean;
   attributes: PageUpdate_pageUpdate_page_attributes[];
+  pageType: PageUpdate_pageUpdate_page_pageType;
   metadata: (PageUpdate_pageUpdate_page_metadata | null)[];
   privateMetadata: (PageUpdate_pageUpdate_page_privateMetadata | null)[];
   contentJson: any;
   seoTitle: string | null;
   seoDescription: string | null;
   publicationDate: any | null;
-  pageType: PageUpdate_pageUpdate_page_pageType;
 }
 
 export interface PageUpdate_pageUpdate {

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { PageInput, PageErrorCode } from "./../../types/globalTypes";
+import { PageInput, PageErrorCode, AttributeInputTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: PageUpdate
@@ -12,6 +12,23 @@ export interface PageUpdate_pageUpdate_errors {
   __typename: "PageError";
   code: PageErrorCode;
   field: string | null;
+  attributes: string[] | null;
+}
+
+export interface PageUpdate_pageUpdate_page_pageType_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface PageUpdate_pageUpdate_page_pageType_attributes {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  inputType: AttributeInputTypeEnum | null;
+  valueRequired: boolean;
+  values: (PageUpdate_pageUpdate_page_pageType_attributes_values | null)[] | null;
 }
 
 export interface PageUpdate_pageUpdate_page_metadata {
@@ -30,6 +47,7 @@ export interface PageUpdate_pageUpdate_page_pageType {
   __typename: "PageType";
   id: string;
   name: string;
+  attributes: (PageUpdate_pageUpdate_page_pageType_attributes | null)[] | null;
 }
 
 export interface PageUpdate_pageUpdate_page {

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -26,6 +26,12 @@ export interface PageUpdate_pageUpdate_page_privateMetadata {
   value: string;
 }
 
+export interface PageUpdate_pageUpdate_page_pageType {
+  __typename: "PageType";
+  id: string;
+  name: string;
+}
+
 export interface PageUpdate_pageUpdate_page {
   __typename: "Page";
   id: string;
@@ -38,6 +44,7 @@ export interface PageUpdate_pageUpdate_page {
   seoTitle: string | null;
   seoDescription: string | null;
   publicationDate: any | null;
+  pageType: PageUpdate_pageUpdate_page_pageType;
 }
 
 export interface PageUpdate_pageUpdate {

--- a/src/pages/utils/data.ts
+++ b/src/pages/utils/data.ts
@@ -1,10 +1,28 @@
 import { PageAttributeInput } from "../components/PageAttributes";
-import { PageDetails_page_pageType } from "../types/PageDetails";
+import {
+  PageDetails_page,
+  PageDetails_page_pageType
+} from "../types/PageDetails";
+
+export function getAttributeInputFromPage(
+  page: PageDetails_page
+): PageAttributeInput[] {
+  return page?.attributes.map(attribute => ({
+    data: {
+      inputType: attribute.attribute.inputType,
+      isRequired: attribute.attribute.valueRequired,
+      values: attribute.attribute.values
+    },
+    id: attribute.attribute.id,
+    label: attribute.attribute.name,
+    value: attribute.values.map(value => value.slug)
+  }));
+}
 
 export function getAttributeInputFromPageType(
   pageType: PageDetails_page_pageType
 ): PageAttributeInput[] {
-  return pageType.attributes.map(attribute => ({
+  return pageType?.attributes.map(attribute => ({
     data: {
       inputType: attribute.inputType,
       isRequired: attribute.valueRequired,

--- a/src/pages/utils/data.ts
+++ b/src/pages/utils/data.ts
@@ -1,0 +1,17 @@
+import { PageAttributeInput } from "../components/PageAttributes";
+import { PageDetails_page_pageType } from "../types/PageDetails";
+
+export function getAttributeInputFromPageType(
+  pageType: PageDetails_page_pageType
+): PageAttributeInput[] {
+  return pageType.attributes.map(attribute => ({
+    data: {
+      inputType: attribute.inputType,
+      isRequired: attribute.valueRequired,
+      values: attribute.values
+    },
+    id: attribute.id,
+    label: attribute.name,
+    value: []
+  }));
+}

--- a/src/pages/utils/handlers.test.ts
+++ b/src/pages/utils/handlers.test.ts
@@ -1,0 +1,111 @@
+import { FormsetData } from "@saleor/hooks/useFormset";
+import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
+
+import { PageAttributeInputData } from "../components/PageAttributes";
+import { createAttributeMultiChangeHandler } from "./handlers";
+
+const attributes: FormsetData<PageAttributeInputData, string[]> = [
+  {
+    data: {
+      inputType: AttributeInputTypeEnum.DROPDOWN,
+      isRequired: false,
+      values: [
+        {
+          __typename: "AttributeValue",
+          id: "attrv-1",
+          name: "Attribute 1 Value 1",
+          slug: "attr-1-v-1"
+        }
+      ]
+    },
+    id: "attr-1",
+    label: "Attribute 1",
+    value: []
+  },
+  {
+    data: {
+      inputType: AttributeInputTypeEnum.MULTISELECT,
+      isRequired: false,
+      values: [
+        {
+          __typename: "AttributeValue",
+          id: "attrv-2",
+          name: "Attribute 2 Value 1",
+          slug: "attr-2-v-1"
+        },
+        {
+          __typename: "AttributeValue",
+          id: "attrv-3",
+          name: "Attribute 2 Value 2",
+          slug: "attr-2-v-2"
+        },
+        {
+          __typename: "AttributeValue",
+          id: "attrv-4",
+          name: "Attribute 2 Value 3",
+          slug: "attr-2-v-3"
+        }
+      ]
+    },
+    id: "attr-2",
+    label: "Attribute 2",
+    value: ["attr-2-v-3"]
+  }
+];
+
+describe("Multiple select", () => {
+  it("is able to select value", () => {
+    const change = jest.fn();
+    const trigger = jest.fn();
+    const handler = createAttributeMultiChangeHandler(
+      change,
+      attributes,
+      trigger
+    );
+
+    handler("attr-2", "attr-2-v-1");
+
+    expect(change).toHaveBeenCalledTimes(1);
+    expect(change.mock.calls[0][0]).toBe("attr-2");
+    expect(change.mock.calls[0][1]).toHaveLength(2);
+    expect(change.mock.calls[0][1][0]).toBe("attr-2-v-3");
+    expect(change.mock.calls[0][1][1]).toBe("attr-2-v-1");
+    expect(trigger).toHaveBeenCalledTimes(1);
+  });
+
+  it("is able to deselect value", () => {
+    const change = jest.fn();
+    const trigger = jest.fn();
+    const handler = createAttributeMultiChangeHandler(
+      change,
+      attributes,
+      trigger
+    );
+
+    handler("attr-2", "attr-2-v-3");
+
+    expect(change).toHaveBeenCalledTimes(1);
+    expect(change.mock.calls[0][0]).toBe("attr-2");
+    expect(change.mock.calls[0][1]).toHaveLength(0);
+    expect(trigger).toHaveBeenCalledTimes(1);
+  });
+
+  it("is able to add custom value", () => {
+    const change = jest.fn();
+    const trigger = jest.fn();
+    const handler = createAttributeMultiChangeHandler(
+      change,
+      attributes,
+      trigger
+    );
+
+    handler("attr-2", "A Value");
+
+    expect(change).toHaveBeenCalledTimes(1);
+    expect(change.mock.calls[0][0]).toBe("attr-2");
+    expect(change.mock.calls[0][1]).toHaveLength(2);
+    expect(change.mock.calls[0][1][0]).toBe("attr-2-v-3");
+    expect(change.mock.calls[0][1][1]).toBe("A Value");
+    expect(trigger).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/utils/handlers.ts
+++ b/src/pages/utils/handlers.ts
@@ -1,17 +1,56 @@
-import { PageTypeFragment } from "@saleor/fragments/types/PageTypeFragment";
 import { FormChange } from "@saleor/hooks/useForm";
+import { FormsetChange, FormsetData } from "@saleor/hooks/useFormset";
+import { toggle } from "@saleor/utils/lists";
+
+import { PageAttributeInputData } from "../components/PageAttributes";
+import { PageDetails_page_pageType } from "../types/PageDetails";
+import { getAttributeInputFromPageType } from "./data";
 
 export function createPageTypeSelectHandler(
   change: FormChange,
-  setPageType: (productType: PageTypeFragment) => void,
-  pageTypeChoiceList: PageTypeFragment[]
+  setAttributes: (data: FormsetData<PageAttributeInputData>) => void,
+  setPageType: (pageType: PageDetails_page_pageType) => void,
+  pageTypeChoiceList: PageDetails_page_pageType[]
 ): FormChange {
   return (event: React.ChangeEvent<any>) => {
     const id = event.target.value;
-    const selectedProductType = pageTypeChoiceList.find(
-      productType => productType.id === id
+    const selectedPageType = pageTypeChoiceList.find(
+      pageType => pageType.id === id
     );
-    setPageType(selectedProductType);
+    setPageType(selectedPageType);
     change(event);
+
+    setAttributes(getAttributeInputFromPageType(selectedPageType));
+  };
+}
+
+export function createAttributeChangeHandler(
+  changeAttributeData: FormsetChange<string[]>,
+  triggerChange: () => void
+): FormsetChange {
+  return (attributeId: string, value: string) => {
+    triggerChange();
+    changeAttributeData(attributeId, value === "" ? [] : [value]);
+  };
+}
+
+export function createAttributeMultiChangeHandler(
+  changeAttributeData: FormsetChange<string[]>,
+  attributes: FormsetData<PageAttributeInputData, string[]>,
+  triggerChange: () => void
+): FormsetChange {
+  return (attributeId: string, value: string) => {
+    const attribute = attributes.find(
+      attribute => attribute.id === attributeId
+    );
+
+    const newAttributeValues = toggle(
+      value,
+      attribute.value,
+      (a, b) => a === b
+    );
+
+    triggerChange();
+    changeAttributeData(attributeId, newAttributeValues);
   };
 }

--- a/src/pages/utils/handlers.ts
+++ b/src/pages/utils/handlers.ts
@@ -1,0 +1,17 @@
+import { PageTypeFragment } from "@saleor/fragments/types/PageTypeFragment";
+import { FormChange } from "@saleor/hooks/useForm";
+
+export function createPageTypeSelectHandler(
+  change: FormChange,
+  setPageType: (productType: PageTypeFragment) => void,
+  pageTypeChoiceList: PageTypeFragment[]
+): FormChange {
+  return (event: React.ChangeEvent<any>) => {
+    const id = event.target.value;
+    const selectedProductType = pageTypeChoiceList.find(
+      productType => productType.id === id
+    );
+    setPageType(selectedProductType);
+    change(event);
+  };
+}

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -54,6 +54,10 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
           const result = await pageCreate({
             variables: {
               input: {
+                // attributes: formData.attributes.map(attribute => ({
+                //   id: attribute.id,
+                //   values: attribute.value
+                // })),
                 contentJson: JSON.stringify(formData.content),
                 isPublished: formData.isPublished,
                 pageType: formData.pageType,

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -1,6 +1,8 @@
 import { WindowTitle } from "@saleor/components/WindowTitle";
+import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
+import usePageTypeSearch from "@saleor/searches/usePageTypeSearch";
 import createMetadataCreateHandler from "@saleor/utils/handlers/metadataCreateHandler";
 import {
   useMetadataUpdate,
@@ -25,6 +27,14 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
   const [updateMetadata] = useMetadataUpdate({});
   const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
 
+  const {
+    loadMore: loadMorePageTypes,
+    search: searchPageTypes,
+    result: searchPageTypesOpts
+  } = usePageTypeSearch({
+    variables: DEFAULT_INITIAL_SEARCH_DATA
+  });
+
   const handlePageCreate = (data: PageCreateData) => {
     if (data.pageCreate.errors.length === 0) {
       notify({
@@ -46,6 +56,7 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
               input: {
                 contentJson: JSON.stringify(formData.content),
                 isPublished: formData.isPublished,
+                pageType: formData.pageType,
                 publicationDate: formData.publicationDate,
                 seo: {
                   description: formData.seoDescription,
@@ -78,9 +89,18 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
               errors={pageCreateOpts.data?.pageCreate.errors || []}
               saveButtonBarState={pageCreateOpts.status}
               page={null}
+              pageTypes={searchPageTypesOpts.data?.search.edges.map(
+                edge => edge.node
+              )}
               onBack={() => navigate(pageListUrl())}
               onRemove={() => undefined}
               onSubmit={handleSubmit}
+              fetchPageTypes={searchPageTypes}
+              fetchMorePageTypes={{
+                hasMore: searchPageTypesOpts.data?.search.pageInfo.hasNextPage,
+                loading: searchPageTypesOpts.loading,
+                onFetchMore: loadMorePageTypes
+              }}
             />
           </>
         );

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -11,7 +11,9 @@ import {
 import React from "react";
 import { useIntl } from "react-intl";
 
-import PageDetailsPage, { FormData } from "../components/PageDetailsPage";
+import PageDetailsPage, {
+  PageCreatePageSubmitData
+} from "../components/PageDetailsPage";
 import { TypedPageCreate } from "../mutations";
 import { PageCreate as PageCreateData } from "../types/PageCreate";
 import { pageListUrl, pageUrl } from "../urls";
@@ -50,14 +52,14 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
   return (
     <TypedPageCreate onCompleted={handlePageCreate}>
       {(pageCreate, pageCreateOpts) => {
-        const handleCreate = async (formData: FormData) => {
+        const handleCreate = async (formData: PageCreatePageSubmitData) => {
           const result = await pageCreate({
             variables: {
               input: {
-                // attributes: formData.attributes.map(attribute => ({
-                //   id: attribute.id,
-                //   values: attribute.value
-                // })),
+                attributes: formData.attributes.map(attribute => ({
+                  id: attribute.id,
+                  values: attribute.value
+                })),
                 contentJson: JSON.stringify(formData.content),
                 isPublished: formData.isPublished,
                 pageType: formData.pageType,

--- a/src/pages/views/PageDetails.tsx
+++ b/src/pages/views/PageDetails.tsx
@@ -28,10 +28,10 @@ export interface PageDetailsProps {
 }
 
 const createPageInput = (data: PageCreatePageSubmitData): PageInput => ({
-  // attributes: data.attributes.map(attribute => ({
-  //   id: attribute.id,
-  //   values: attribute.value
-  // })),
+  attributes: data.attributes.map(attribute => ({
+    id: attribute.id,
+    values: attribute.value
+  })),
   contentJson: JSON.stringify(data.content),
   isPublished: data.isPublished,
   publicationDate: data.publicationDate,

--- a/src/pages/views/PageDetails.tsx
+++ b/src/pages/views/PageDetails.tsx
@@ -14,7 +14,9 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 import { getStringOrPlaceholder, maybe } from "../../misc";
 import { PageInput } from "../../types/globalTypes";
-import PageDetailsPage, { FormData } from "../components/PageDetailsPage";
+import PageDetailsPage, {
+  PageCreatePageSubmitData
+} from "../components/PageDetailsPage";
 import { TypedPageRemove, TypedPageUpdate } from "../mutations";
 import { TypedPageDetailsQuery } from "../queries";
 import { PageRemove } from "../types/PageRemove";
@@ -25,7 +27,11 @@ export interface PageDetailsProps {
   params: PageUrlQueryParams;
 }
 
-const createPageInput = (data: FormData): PageInput => ({
+const createPageInput = (data: PageCreatePageSubmitData): PageInput => ({
+  // attributes: data.attributes.map(attribute => ({
+  //   id: attribute.id,
+  //   values: attribute.value
+  // })),
   contentJson: JSON.stringify(data.content),
   isPublished: data.isPublished,
   publicationDate: data.publicationDate,
@@ -61,7 +67,7 @@ export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
           {(pageUpdate, pageUpdateOpts) => (
             <TypedPageDetailsQuery variables={{ id }}>
               {pageDetails => {
-                const handleUpdate = async (data: FormData) => {
+                const handleUpdate = async (data: PageCreatePageSubmitData) => {
                   const result = await pageUpdate({
                     variables: {
                       id,

--- a/src/searches/types/SearchPageTypes.ts
+++ b/src/searches/types/SearchPageTypes.ts
@@ -2,14 +2,34 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
+import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+
 // ====================================================
 // GraphQL query operation: SearchPageTypes
 // ====================================================
+
+export interface SearchPageTypes_search_edges_node_attributes_values {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface SearchPageTypes_search_edges_node_attributes {
+  __typename: "Attribute";
+  id: string;
+  inputType: AttributeInputTypeEnum | null;
+  slug: string | null;
+  name: string | null;
+  valueRequired: boolean;
+  values: (SearchPageTypes_search_edges_node_attributes_values | null)[] | null;
+}
 
 export interface SearchPageTypes_search_edges_node {
   __typename: "PageType";
   id: string;
   name: string;
+  attributes: (SearchPageTypes_search_edges_node_attributes | null)[] | null;
 }
 
 export interface SearchPageTypes_search_edges {

--- a/src/searches/types/SearchPageTypes.ts
+++ b/src/searches/types/SearchPageTypes.ts
@@ -1,0 +1,42 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SearchPageTypes
+// ====================================================
+
+export interface SearchPageTypes_search_edges_node {
+  __typename: "PageType";
+  id: string;
+  name: string;
+}
+
+export interface SearchPageTypes_search_edges {
+  __typename: "PageTypeCountableEdge";
+  node: SearchPageTypes_search_edges_node;
+}
+
+export interface SearchPageTypes_search_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface SearchPageTypes_search {
+  __typename: "PageTypeCountableConnection";
+  edges: SearchPageTypes_search_edges[];
+  pageInfo: SearchPageTypes_search_pageInfo;
+}
+
+export interface SearchPageTypes {
+  search: SearchPageTypes_search | null;
+}
+
+export interface SearchPageTypesVariables {
+  after?: string | null;
+  first: number;
+  query: string;
+}

--- a/src/searches/usePageTypeSearch.ts
+++ b/src/searches/usePageTypeSearch.ts
@@ -1,0 +1,33 @@
+import { pageInfoFragment } from "@saleor/fragments/pageInfo";
+import makeTopLevelSearch from "@saleor/hooks/makeTopLevelSearch";
+import gql from "graphql-tag";
+
+import {
+  SearchPageTypes,
+  SearchPageTypesVariables
+} from "./types/SearchPageTypes";
+
+export const searchPageTypes = gql`
+  ${pageInfoFragment}
+  query SearchPageTypes($after: String, $first: Int!, $query: String!) {
+    search: pageTypes(
+      after: $after
+      first: $first
+      filter: { search: $query }
+    ) {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+      pageInfo {
+        ...PageInfoFragment
+      }
+    }
+  }
+`;
+
+export default makeTopLevelSearch<SearchPageTypes, SearchPageTypesVariables>(
+  searchPageTypes
+);

--- a/src/searches/usePageTypeSearch.ts
+++ b/src/searches/usePageTypeSearch.ts
@@ -19,6 +19,18 @@ export const searchPageTypes = gql`
         node {
           id
           name
+          attributes {
+            id
+            inputType
+            slug
+            name
+            valueRequired
+            values {
+              id
+              name
+              slug
+            }
+          }
         }
       }
       pageInfo {

--- a/src/storybook/stories/attributes/AttributePage.tsx
+++ b/src/storybook/stories/attributes/AttributePage.tsx
@@ -3,8 +3,8 @@ import AttributePage, {
 } from "@saleor/attributes/components/AttributePage";
 import { attribute } from "@saleor/attributes/fixtures";
 import {
-  AttributeInputTypeEnum,
-  ProductErrorCode
+  AttributeErrorCode,
+  AttributeInputTypeEnum
 } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -42,8 +42,8 @@ storiesOf("Views / Attributes / Attribute details", module)
     <AttributePage
       {...props}
       errors={["name", "slug", "storefrontSearchPosition"].map(field => ({
-        __typename: "ProductError",
-        code: ProductErrorCode.INVALID,
+        __typename: "AttributeError",
+        code: AttributeErrorCode.INVALID,
         field
       }))}
     />

--- a/src/storybook/stories/attributes/AttributeValueEditDialog.tsx
+++ b/src/storybook/stories/attributes/AttributeValueEditDialog.tsx
@@ -1,7 +1,7 @@
 import { attribute } from "@saleor/attributes/fixtures";
 import {
-  AttributeValueType,
-  ProductErrorCode
+  AttributeErrorCode,
+  AttributeValueType
 } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -32,8 +32,8 @@ storiesOf("Attributes / Attribute value edit", module)
       {...props}
       errors={[
         {
-          __typename: "ProductError",
-          code: ProductErrorCode.INVALID,
+          __typename: "AttributeError",
+          code: AttributeErrorCode.INVALID,
           field: "name"
         }
       ]}

--- a/src/storybook/stories/pages/PageDetailsPage.tsx
+++ b/src/storybook/stories/pages/PageDetailsPage.tsx
@@ -38,6 +38,7 @@ storiesOf("Views / Pages / Page details", module)
         "seoTitle"
       ] as Array<keyof FormData>).map(field => ({
         __typename: "PageError",
+        attributes: [],
         code: PageErrorCode.INVALID,
         field
       }))}

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1287,6 +1287,17 @@ export interface OrderUpdateShippingInput {
   shippingMethod?: string | null;
 }
 
+export interface PageCreateInput {
+  slug?: string | null;
+  title?: string | null;
+  content?: string | null;
+  contentJson?: any | null;
+  isPublished?: boolean | null;
+  publicationDate?: string | null;
+  seo?: SeoInput | null;
+  pageType: string;
+}
+
 export interface PageFilterInput {
   search?: string | null;
 }

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -70,6 +70,15 @@ export enum AppTypeEnum {
   THIRDPARTY = "THIRDPARTY",
 }
 
+export enum AttributeErrorCode {
+  ALREADY_EXISTS = "ALREADY_EXISTS",
+  GRAPHQL_ERROR = "GRAPHQL_ERROR",
+  INVALID = "INVALID",
+  NOT_FOUND = "NOT_FOUND",
+  REQUIRED = "REQUIRED",
+  UNIQUE = "UNIQUE",
+}
+
 export enum AttributeInputTypeEnum {
   DROPDOWN = "DROPDOWN",
   MULTISELECT = "MULTISELECT",
@@ -1292,6 +1301,7 @@ export interface PageCreateInput {
   title?: string | null;
   content?: string | null;
   contentJson?: any | null;
+  attributes?: AttributeValueInput[] | null;
   isPublished?: boolean | null;
   publicationDate?: string | null;
   seo?: SeoInput | null;
@@ -1307,6 +1317,7 @@ export interface PageInput {
   title?: string | null;
   content?: string | null;
   contentJson?: any | null;
+  attributes?: AttributeValueInput[] | null;
   isPublished?: boolean | null;
   publicationDate?: string | null;
   seo?: SeoInput | null;

--- a/src/utils/errors/attribute.ts
+++ b/src/utils/errors/attribute.ts
@@ -1,0 +1,46 @@
+import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
+import { commonMessages } from "@saleor/intl";
+import { AttributeErrorCode } from "@saleor/types/globalTypes";
+import { defineMessages, IntlShape } from "react-intl";
+
+import commonErrorMessages from "./common";
+
+const messages = defineMessages({
+  alreadyExists: {
+    defaultMessage: "A product with this SKU already exists"
+  },
+  nameAlreadyTaken: {
+    defaultMessage: "This name is already taken. Please provide another."
+  },
+  notFound: {
+    defaultMessage: "Attribute not found"
+  }
+});
+
+function getAttributeErrorMessage(
+  err: Omit<AttributeErrorFragment, "__typename"> | undefined,
+  intl: IntlShape
+): string {
+  if (err) {
+    switch (err.code) {
+      case AttributeErrorCode.ALREADY_EXISTS:
+        return intl.formatMessage(messages.alreadyExists);
+      case AttributeErrorCode.GRAPHQL_ERROR:
+        return intl.formatMessage(commonErrorMessages.graphqlError);
+      case AttributeErrorCode.REQUIRED:
+        return intl.formatMessage(commonMessages.requiredField);
+      case AttributeErrorCode.INVALID:
+        return intl.formatMessage(commonErrorMessages.invalid);
+      case AttributeErrorCode.UNIQUE:
+        return intl.formatMessage(messages.nameAlreadyTaken);
+      case AttributeErrorCode.NOT_FOUND:
+        return intl.formatMessage(messages.notFound);
+      default:
+        return intl.formatMessage(commonErrorMessages.unknownError);
+    }
+  }
+
+  return undefined;
+}
+
+export default getAttributeErrorMessage;

--- a/src/utils/errors/attribute.ts
+++ b/src/utils/errors/attribute.ts
@@ -7,13 +7,13 @@ import commonErrorMessages from "./common";
 
 const messages = defineMessages({
   alreadyExists: {
-    defaultMessage: "A product with this SKU already exists"
+    defaultMessage: "An attribute already exists."
   },
   nameAlreadyTaken: {
     defaultMessage: "This name is already taken. Please provide another."
   },
   notFound: {
-    defaultMessage: "Attribute not found"
+    defaultMessage: "Attribute not found."
   }
 });
 

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -38,7 +38,7 @@ export interface UpdateMetadata_deleteMetadata_item_privateMetadata {
 }
 
 export interface UpdateMetadata_deleteMetadata_item {
-  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice" | "PageType";
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdateMetadata_deleteMetadata_item_metadata | null)[];
   privateMetadata: (UpdateMetadata_deleteMetadata_item_privateMetadata | null)[];
   id: string;

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -38,7 +38,7 @@ export interface UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadat
 }
 
 export interface UpdatePrivateMetadata_deletePrivateMetadata_item {
-  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice" | "PageType";
+  __typename: "ServiceAccount" | "App" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_metadata | null)[];
   privateMetadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata | null)[];
   id: string;


### PR DESCRIPTION
I want to merge this change because... it adds:
- page type selection on page creation
- page attribute values selection based on the selected page type
- `AttributeError` as replacement of `ProductError` in some attributes mutations

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
<img width="291" alt="Zrzut ekranu 2020-10-30 o 13 32 53" src="https://user-images.githubusercontent.com/9825562/97705479-76881f80-1ab4-11eb-95a4-9d569d3949cb.png">
<img width="293" alt="Zrzut ekranu 2020-10-30 o 13 35 17" src="https://user-images.githubusercontent.com/9825562/97707840-2dd26580-1ab8-11eb-8058-67fceeaac9ad.png">
<img width="615" alt="Zrzut ekranu 2020-10-30 o 13 32 42" src="https://user-images.githubusercontent.com/9825562/97705492-7ab43d00-1ab4-11eb-8c33-4f7c56caa11e.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
