### PR TITLE
Page types attribute reorder

### DIFF
--- a/src/pageTypes/mutations.ts
+++ b/src/pageTypes/mutations.ts
@@ -8,6 +8,10 @@ import {
   AssignPageAttributeVariables
 } from "./types/AssignPageAttribute";
 import {
+  PageTypeAttributeReorder,
+  PageTypeAttributeReorderVariables
+} from "./types/PageTypeAttributeReorder";
+import {
   PageTypeBulkDelete,
   PageTypeBulkDeleteVariables
 } from "./types/PageTypeBulkDelete";
@@ -136,3 +140,22 @@ export const usePageTypeBulkDeleteMutation = makeMutation<
   PageTypeBulkDelete,
   PageTypeBulkDeleteVariables
 >(pageTypeBulkDeleteMutation);
+
+export const pageTypeAttributeReorder = gql`
+  ${pageTypeDetailsFragment}
+  ${pageErrorFragment}
+  mutation PageTypeAttributeReorder($move: ReorderInput!, $pageTypeId: ID!) {
+    pageTypeReorderAttributes(moves: [$move], pageTypeId: $pageTypeId) {
+      errors: pageErrors {
+        ...PageErrorFragment
+      }
+      pageType {
+        ...PageTypeDetailsFragment
+      }
+    }
+  }
+`;
+export const usePageTypeAttributeReorderMutation = makeMutation<
+  PageTypeAttributeReorder,
+  PageTypeAttributeReorderVariables
+>(pageTypeAttributeReorder);

--- a/src/pageTypes/types/PageTypeAttributeReorder.ts
+++ b/src/pageTypes/types/PageTypeAttributeReorder.ts
@@ -1,0 +1,62 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { ReorderInput, PageErrorCode, AttributeTypeEnum } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: PageTypeAttributeReorder
+// ====================================================
+
+export interface PageTypeAttributeReorder_pageTypeReorderAttributes_errors {
+  __typename: "PageError";
+  code: PageErrorCode;
+  field: string | null;
+}
+
+export interface PageTypeAttributeReorder_pageTypeReorderAttributes_pageType_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageTypeAttributeReorder_pageTypeReorderAttributes_pageType_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface PageTypeAttributeReorder_pageTypeReorderAttributes_pageType_attributes {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  slug: string | null;
+  type: AttributeTypeEnum | null;
+  visibleInStorefront: boolean;
+  filterableInDashboard: boolean;
+  filterableInStorefront: boolean;
+}
+
+export interface PageTypeAttributeReorder_pageTypeReorderAttributes_pageType {
+  __typename: "PageType";
+  id: string;
+  name: string;
+  metadata: (PageTypeAttributeReorder_pageTypeReorderAttributes_pageType_metadata | null)[];
+  privateMetadata: (PageTypeAttributeReorder_pageTypeReorderAttributes_pageType_privateMetadata | null)[];
+  attributes: (PageTypeAttributeReorder_pageTypeReorderAttributes_pageType_attributes | null)[] | null;
+}
+
+export interface PageTypeAttributeReorder_pageTypeReorderAttributes {
+  __typename: "PageTypeReorderAttributes";
+  errors: PageTypeAttributeReorder_pageTypeReorderAttributes_errors[];
+  pageType: PageTypeAttributeReorder_pageTypeReorderAttributes_pageType | null;
+}
+
+export interface PageTypeAttributeReorder {
+  pageTypeReorderAttributes: PageTypeAttributeReorder_pageTypeReorderAttributes | null;
+}
+
+export interface PageTypeAttributeReorderVariables {
+  move: ReorderInput;
+  pageTypeId: string;
+}

--- a/src/pageTypes/views/PageTypeDetails.tsx
+++ b/src/pageTypes/views/PageTypeDetails.tsx
@@ -14,10 +14,12 @@ import { getStringOrPlaceholder } from "@saleor/misc";
 import PageTypeDeleteDialog from "@saleor/pageTypes/components/PageTypeDeleteDialog";
 import {
   useAssignPageAttributeMutation,
+  usePageTypeAttributeReorderMutation,
   usePageTypeDeleteMutation,
   usePageTypeUpdateMutation,
   useUnassignPageAttributeMutation
 } from "@saleor/pageTypes/mutations";
+import { ReorderEvent } from "@saleor/types";
 import getPageErrorMessage from "@saleor/utils/errors/page";
 import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
 import {
@@ -102,6 +104,7 @@ export const PageTypeDetails: React.FC<PageTypeDetailsProps> = ({
       }
     }
   });
+  const [reorderAttribute] = usePageTypeAttributeReorderMutation({});
 
   const [updateMetadata] = useMetadataUpdate({});
   const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
@@ -140,6 +143,16 @@ export const PageTypeDetails: React.FC<PageTypeDetailsProps> = ({
       variables: {
         id,
         ids: params.ids
+      }
+    });
+  const handleAttributeReorder = (event: ReorderEvent) =>
+    reorderAttribute({
+      variables: {
+        move: {
+          id: data.pageType.attributes[event.oldIndex].id,
+          sortOrder: event.newIndex - event.oldIndex
+        },
+        pageTypeId: id
       }
     });
 
@@ -189,7 +202,7 @@ export const PageTypeDetails: React.FC<PageTypeDetailsProps> = ({
           )
         }
         onAttributeClick={attributeId => navigate(attributeUrl(attributeId))}
-        onAttributeReorder={() => undefined}
+        onAttributeReorder={handleAttributeReorder}
         onAttributeUnassign={attributeId =>
           navigate(
             pageTypeUrl(id, {


### PR DESCRIPTION
I want to merge this change because... it adds the possibility to reorder page types attributes.

Note: it contains changes introduced in https://github.com/mirumee/saleor-dashboard/pull/808.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** feature/page-types
https://github.com/mirumee/saleor/pull/6261

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
