### PR TITLE
Add order status component

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1245,7 +1245,6 @@ type CollectionTranslation implements Node {
 type CollectionUpdate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   collectionErrors: [CollectionError!]!
-  productErrors: [ProductError!]!
   collection: Collection
 }
 
@@ -1799,6 +1798,7 @@ input DraftOrderCreateInput {
   voucher: ID
   customerNote: String
   channel: ID
+  redirectUrl: String
   lines: [OrderLineCreateInput]
 }
 
@@ -1818,6 +1818,7 @@ input DraftOrderInput {
   voucher: ID
   customerNote: String
   channel: ID
+  redirectUrl: String
 }
 
 type DraftOrderLineDelete {
@@ -2553,6 +2554,7 @@ type Mutation {
   shopFetchTaxRates: ShopFetchTaxRates
   shopSettingsTranslate(input: ShopSettingsTranslationInput!, languageCode: LanguageCodeEnum!): ShopSettingsTranslate
   shopAddressUpdate(input: AddressInput): ShopAddressUpdate
+  orderSettingsUpdate(input: OrderSettingsUpdateInput!): OrderSettingsUpdate
   shippingMethodChannelListingUpdate(id: ID!, input: ShippingMethodChannelListingInput!): ShippingMethodChannelListingUpdate
   shippingPriceCreate(input: ShippingPriceInput!): ShippingPriceCreate
   shippingPriceDelete(id: ID!): ShippingPriceDelete
@@ -2585,7 +2587,6 @@ type Mutation {
   productUpdate(id: ID!, input: ProductInput!): ProductUpdate
   productTranslate(id: ID!, input: TranslationInput!, languageCode: LanguageCodeEnum!): ProductTranslate
   productChannelListingUpdate(id: ID!, input: ProductChannelListingUpdateInput!): ProductChannelListingUpdate
-  productSetAvailabilityForPurchase(isAvailable: Boolean!, productId: ID!, startDate: Date): ProductSetAvailabilityForPurchase
   productImageCreate(input: ProductImageCreateInput!): ProductImageCreate
   productVariantReorder(moves: [ReorderInput]!, productId: ID!): ProductVariantReorder
   productImageDelete(id: ID!): ProductImageDelete
@@ -2596,11 +2597,7 @@ type Mutation {
   productTypeDelete(id: ID!): ProductTypeDelete
   productTypeBulkDelete(ids: [ID]!): ProductTypeBulkDelete
   productTypeUpdate(id: ID!, input: ProductTypeInput!): ProductTypeUpdate
-  productTypeReorderAttributes(moves: [ReorderInput]!, productTypeId: ID!, type: AttributeTypeEnum!): ProductTypeReorderAttributes
-  productTypeUpdateMetadata(id: ID!, input: MetaInput!): ProductTypeUpdateMeta @deprecated(reason: "Use the `updateMetadata` mutation instead. This field will be removed after 2020-07-31.")
-  productTypeClearMetadata(id: ID!, input: MetaPath!): ProductTypeClearMeta @deprecated(reason: "Use the `deleteMetadata` mutation instead. This field will be removed after 2020-07-31.")
-  productTypeUpdatePrivateMetadata(id: ID!, input: MetaInput!): ProductTypeUpdatePrivateMeta @deprecated(reason: "Use the `updatePrivateMetadata` mutation instead. This field will be removed after 2020-07-31.")
-  productTypeClearPrivateMetadata(id: ID!, input: MetaPath!): ProductTypeClearPrivateMeta @deprecated(reason: "Use the `deletePrivateMetadata` mutation instead. This field will be removed after 2020-07-31.")
+  productTypeReorderAttributes(moves: [ReorderInput]!, productTypeId: ID!, type: ProductAttributeType!): ProductTypeReorderAttributes
   digitalContentCreate(input: DigitalContentUploadInput!, variantId: ID!): DigitalContentCreate
   digitalContentDelete(variantId: ID!): DigitalContentDelete
   digitalContentUpdate(input: DigitalContentInput!, variantId: ID!): DigitalContentUpdate
@@ -2647,12 +2644,7 @@ type Mutation {
   orderAddNote(order: ID!, input: OrderAddNoteInput!): OrderAddNote
   orderCancel(id: ID!): OrderCancel
   orderCapture(amount: PositiveDecimal!, id: ID!): OrderCapture
-<<<<<<< HEAD
-=======
-  orderClearPrivateMeta(id: ID!, input: MetaPath!): OrderClearPrivateMeta @deprecated(reason: "Use the `deletePrivateMetadata` mutation instead. This field will be removed after 2020-07-31.")
   orderConfirm(id: ID!): OrderConfirm
-  orderClearMeta(input: MetaPath!, token: UUID!): OrderClearMeta @deprecated(reason: "Use the `deleteMetadata` mutation instead. This field will be removed after 2020-07-31.")
->>>>>>> 39aaf958... Order confirmed webhook
   orderFulfill(input: OrderFulfillInput!, order: ID): OrderFulfill
   orderFulfillmentCancel(id: ID!, input: FulfillmentCancelInput!): FulfillmentCancel
   orderFulfillmentUpdateTracking(id: ID!, input: FulfillmentUpdateTrackingInput!): FulfillmentUpdateTracking
@@ -2781,11 +2773,6 @@ type Mutation {
   userAvatarUpdate(image: Upload!): UserAvatarUpdate
   userAvatarDelete: UserAvatarDelete
   userBulkSetActive(ids: [ID]!, isActive: Boolean!): UserBulkSetActive
-  serviceAccountCreate(input: ServiceAccountInput!): ServiceAccountCreate @deprecated(reason: "Use the `appCreate` mutation instead. This field will be removed after 2020-07-31.")
-  serviceAccountUpdate(id: ID!, input: ServiceAccountInput!): ServiceAccountUpdate @deprecated(reason: "Use the `appUpdate` mutation instead. This field will be removed after 2020-07-31.")
-  serviceAccountDelete(id: ID!): ServiceAccountDelete @deprecated(reason: "Use the `appDelete` mutation instead. This field will be removed after 2020-07-31.")
-  serviceAccountTokenCreate(input: ServiceAccountTokenInput!): ServiceAccountTokenCreate @deprecated(reason: "Use the `appTokenCreate` mutation instead. This field will be removed after 2020-07-31.")
-  serviceAccountTokenDelete(id: ID!): ServiceAccountTokenDelete @deprecated(reason: "Use the `appTokenDelete` mutation instead. This field will be removed after 2020-07-31.")
   permissionGroupCreate(input: PermissionGroupCreateInput!): PermissionGroupCreate
   permissionGroupUpdate(id: ID!, input: PermissionGroupUpdateInput!): PermissionGroupUpdate
   permissionGroupDelete(id: ID!): PermissionGroupDelete
@@ -2836,6 +2823,7 @@ type Order implements Node & ObjectWithMetadata {
   displayGrossPrices: Boolean!
   customerNote: String!
   weight: Weight
+  redirectUrl: String
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   fulfillments: [Fulfillment]!
@@ -2894,16 +2882,6 @@ type OrderCapture {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
   orderErrors: [OrderError!]!
-}
-
-type OrderClearMeta {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  order: Order
-}
-
-type OrderClearPrivateMeta {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  order: Order
 }
 
 type OrderConfirm {
@@ -3013,6 +2991,7 @@ type OrderEventOrderLineObject {
 
 enum OrderEventsEmailsEnum {
   PAYMENT_CONFIRMATION
+  CONFIRMED
   SHIPPING_CONFIRMATION
   TRACKING_UPDATED
   ORDER_CONFIRMATION
@@ -3034,6 +3013,7 @@ enum OrderEventsEnum {
   ORDER_FULLY_PAID
   UPDATED_ADDRESS
   EMAIL_SENT
+  CONFIRMED
   PAYMENT_AUTHORIZED
   PAYMENT_CAPTURED
   EXTERNAL_SERVICE_NOTIFICATION
@@ -3122,6 +3102,30 @@ type OrderRefund {
   orderErrors: [OrderError!]!
 }
 
+type OrderSettings {
+  automaticallyConfirmAllNewOrders: Boolean!
+}
+
+type OrderSettingsError {
+  field: String
+  message: String
+  code: OrderSettingsErrorCode!
+}
+
+enum OrderSettingsErrorCode {
+  INVALID
+}
+
+type OrderSettingsUpdate {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  orderSettings: OrderSettings
+  orderSettingsErrors: [OrderSettingsError!]!
+}
+
+input OrderSettingsUpdateInput {
+  automaticallyConfirmAllNewOrders: Boolean!
+}
+
 enum OrderSortField {
   NUMBER
   CREATION_DATE
@@ -3148,6 +3152,7 @@ enum OrderStatusFilter {
   READY_TO_FULFILL
   READY_TO_CAPTURE
   UNFULFILLED
+  UNCONFIRMED
   PARTIALLY_FULFILLED
   FULFILLED
   CANCELED
@@ -3777,6 +3782,7 @@ type ProductChannelListing implements Node {
   purchaseCost: MoneyRange
   margin: Margin
   isAvailableForPurchase: Boolean
+  pricing: ProductPricingInfo
 }
 
 input ProductChannelListingAddInput {
@@ -4320,6 +4326,7 @@ type Query {
   stock(id: ID!): Stock
   stocks(filter: StockFilterInput, before: String, after: String, first: Int, last: Int): StockCountableConnection
   shop: Shop!
+  orderSettings: OrderSettings
   shippingZone(id: ID!, channel: String): ShippingZone
   shippingZones(channel: String, before: String, after: String, first: Int, last: Int): ShippingZoneCountableConnection
   digitalContent(id: ID!): DigitalContent
@@ -4362,7 +4369,7 @@ type Query {
   exportFile(id: ID!): ExportFile
   exportFiles(filter: ExportFileFilterInput, sortBy: ExportFileSortingInput, before: String, after: String, first: Int, last: Int): ExportFileCountableConnection
   taxTypes: [TaxType]
-  checkout(token: UUID, channel: String): Checkout
+  checkout(token: UUID): Checkout
   checkouts(channel: String, before: String, after: String, first: Int, last: Int): CheckoutCountableConnection
   checkoutLine(id: ID): CheckoutLine
   checkoutLines(before: String, after: String, first: Int, last: Int): CheckoutLineCountableConnection
@@ -4567,92 +4574,6 @@ type SelectedAttribute {
 input SeoInput {
   title: String
   description: String
-}
-
-type ServiceAccount implements Node & ObjectWithMetadata {
-  id: ID!
-  name: String
-  created: DateTime
-  isActive: Boolean
-  permissions: [Permission]
-  tokens: [ServiceAccountToken]
-  privateMetadata: [MetadataItem]!
-  metadata: [MetadataItem]!
-}
-
-type ServiceAccountCountableConnection {
-  pageInfo: PageInfo!
-  edges: [ServiceAccountCountableEdge!]!
-  totalCount: Int
-}
-
-type ServiceAccountCountableEdge {
-  node: ServiceAccount!
-  cursor: String!
-}
-
-type ServiceAccountCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  authToken: String
-  accountErrors: [AccountError!]!
-  serviceAccount: ServiceAccount
-}
-
-type ServiceAccountDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
-  serviceAccount: ServiceAccount
-}
-
-input ServiceAccountFilterInput {
-  search: String
-  isActive: Boolean
-}
-
-input ServiceAccountInput {
-  name: String
-  isActive: Boolean
-  permissions: [PermissionEnum]
-}
-
-enum ServiceAccountSortField {
-  NAME
-  CREATION_DATE
-}
-
-input ServiceAccountSortingInput {
-  direction: OrderDirection!
-  field: ServiceAccountSortField!
-}
-
-type ServiceAccountToken implements Node {
-  name: String
-  authToken: String
-  id: ID!
-}
-
-type ServiceAccountTokenCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  authToken: String
-  accountErrors: [AccountError!]!
-  serviceAccountToken: ServiceAccountToken
-}
-
-type ServiceAccountTokenDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
-  serviceAccountToken: ServiceAccountToken
-}
-
-input ServiceAccountTokenInput {
-  name: String
-  serviceAccount: ID!
-}
-
-type ServiceAccountUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
-  serviceAccount: ServiceAccount
 }
 
 type SetPassword {
@@ -5278,7 +5199,8 @@ type User implements Node & ObjectWithMetadata {
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   addresses: [Address]
-  checkout: Checkout
+  checkout: Checkout @deprecated(reason: "Use the `checkout_tokens` field to fetch the user checkouts.")
+  checkoutTokens(channel: String): [UUID!]
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
   permissions: [Permission] @deprecated(reason: "Will be removed in Saleor 2.11.Use the `userPermissions` instead.")
@@ -5781,7 +5703,7 @@ enum WeightUnitsEnum {
 
 scalar _Any
 
-union _Entity = Address | User | Group | ServiceAccount | App | ProductVariant | Product | ProductType | Collection | Category | ProductImage | PageType
+union _Entity = Address | User | Group | App | ProductVariant | Product | ProductType | Collection | Category | ProductImage | PageType
 
 type _Service {
   sdl: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -2556,7 +2556,6 @@ type Mutation {
   shopAddressUpdate(input: AddressInput): ShopAddressUpdate
   orderSettingsUpdate(input: OrderSettingsUpdateInput!): OrderSettingsUpdate
   shippingMethodChannelListingUpdate(id: ID!, input: ShippingMethodChannelListingInput!): ShippingMethodChannelListingUpdate
-  orderSettingsUpdate(input: OrderSettingsUpdateInput!): OrderSettingsUpdate
   shippingPriceCreate(input: ShippingPriceInput!): ShippingPriceCreate
   shippingPriceDelete(id: ID!): ShippingPriceDelete
   shippingPriceBulkDelete(ids: [ID]!): ShippingPriceBulkDelete
@@ -2645,9 +2644,7 @@ type Mutation {
   orderAddNote(order: ID!, input: OrderAddNoteInput!): OrderAddNote
   orderCancel(id: ID!): OrderCancel
   orderCapture(amount: PositiveDecimal!, id: ID!): OrderCapture
-  orderClearPrivateMeta(id: ID!, input: MetaPath!): OrderClearPrivateMeta @deprecated(reason: "Use the `deletePrivateMetadata` mutation instead. This field will be removed after 2020-07-31.")
   orderConfirm(id: ID!): OrderConfirm
-  orderClearMeta(input: MetaPath!, token: UUID!): OrderClearMeta @deprecated(reason: "Use the `deleteMetadata` mutation instead. This field will be removed after 2020-07-31.")
   orderFulfill(input: OrderFulfillInput!, order: ID): OrderFulfill
   orderFulfillmentCancel(id: ID!, input: FulfillmentCancelInput!): FulfillmentCancel
   orderFulfillmentUpdateTracking(id: ID!, input: FulfillmentUpdateTrackingInput!): FulfillmentUpdateTracking
@@ -2851,30 +2848,6 @@ type Order implements Node & ObjectWithMetadata {
   isShippingRequired: Boolean!
 }
 
-type OrderSettings {
-  automaticallyConfirmAllNewOrders: Boolean!
-}
-
-type OrderSettingsError {
-  field: String
-  message: String
-  code: OrderSettingsErrorCode!
-}
-
-enum OrderSettingsErrorCode {
-  INVALID
-}
-
-type OrderSettingsUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  orderSettings: OrderSettings
-  orderSettingsErrors: [OrderSettingsError!]!
-}
-
-input OrderSettingsUpdateInput {
-  automaticallyConfirmAllNewOrders: Boolean!
-}
-
 enum OrderAction {
   CAPTURE
   MARK_AS_PAID
@@ -2909,16 +2882,6 @@ type OrderCapture {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
   orderErrors: [OrderError!]!
-}
-
-type OrderClearMeta {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  order: Order
-}
-
-type OrderClearPrivateMeta {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  order: Order
 }
 
 type OrderConfirm {
@@ -4388,7 +4351,6 @@ type Query {
   homepageEvents(before: String, after: String, first: Int, last: Int): OrderEventCountableConnection
   order(id: ID!): Order
   orders(sortBy: OrderSortingInput, filter: OrderFilterInput, created: ReportingPeriod, status: OrderStatusFilter, channel: String, before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  orderSettings: OrderSettings
   draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, created: ReportingPeriod, before: String, after: String, first: Int, last: Int): OrderCountableConnection
   ordersTotal(period: ReportingPeriod, channel: String): TaxedMoney
   orderByToken(token: UUID!): Order

--- a/src/components/StatusChip/StatusChip.stories.tsx
+++ b/src/components/StatusChip/StatusChip.stories.tsx
@@ -1,0 +1,19 @@
+import Decorator from "@saleor/storybook/Decorator";
+import { OrderStatusType } from "@saleor/types/globalTypes";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import StatusChip from "./StatusChip";
+
+storiesOf("Generics / Status Chip", module)
+  .addDecorator(Decorator)
+  .add("neutral", () => (
+    <StatusChip label="label" type={OrderStatusType.neutral} />
+  ))
+  .add("error", () => <StatusChip label="label" type={OrderStatusType.error} />)
+  .add("success", () => (
+    <StatusChip label="label" type={OrderStatusType.success} />
+  ))
+  .add("alert", () => (
+    <StatusChip label="label" type={OrderStatusType.alert} />
+  ));

--- a/src/components/StatusChip/StatusChip.stories.tsx
+++ b/src/components/StatusChip/StatusChip.stories.tsx
@@ -1,19 +1,13 @@
 import Decorator from "@saleor/storybook/Decorator";
-import { OrderStatusType } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import StatusChip from "./StatusChip";
+import { StatusType } from "./types";
 
 storiesOf("Generics / Status Chip", module)
   .addDecorator(Decorator)
-  .add("neutral", () => (
-    <StatusChip label="label" type={OrderStatusType.neutral} />
-  ))
-  .add("error", () => <StatusChip label="label" type={OrderStatusType.error} />)
-  .add("success", () => (
-    <StatusChip label="label" type={OrderStatusType.success} />
-  ))
-  .add("alert", () => (
-    <StatusChip label="label" type={OrderStatusType.alert} />
-  ));
+  .add("neutral", () => <StatusChip label="label" type={StatusType.NEUTRAL} />)
+  .add("error", () => <StatusChip label="label" type={StatusType.ERROR} />)
+  .add("success", () => <StatusChip label="label" type={StatusType.SUCCESS} />)
+  .add("alert", () => <StatusChip label="label" type={StatusType.ALERT} />);

--- a/src/components/StatusChip/StatusChip.tsx
+++ b/src/components/StatusChip/StatusChip.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles(
     },
     root: {
       borderRadius: 22,
-      display: "flex",
+      display: "inline-block",
       padding: "8px 24px"
     },
     ...StatusChipStyles

--- a/src/components/StatusChip/StatusChip.tsx
+++ b/src/components/StatusChip/StatusChip.tsx
@@ -1,0 +1,75 @@
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import { OrderStatusType } from "@saleor/types/globalTypes";
+import classNames from "classnames";
+import React from "react";
+
+export interface StatusChipProps {
+  type?: OrderStatusType;
+  label?: string;
+}
+
+const StatusChipStyles = {
+  alert: {
+    background: "#FFF4E4"
+  },
+  alertLabel: {
+    color: "#FFB84E"
+  },
+  error: {
+    backgroundColor: "rgba(254, 110, 118, 0.15)"
+  },
+  errorLabel: {
+    color: "#FE6E76"
+  },
+  neutral: {
+    background: "rgba(40, 35, 74, 0.1)"
+  },
+  neutralLabel: {
+    color: "#28234A"
+  },
+  success: {
+    background: "rgba(93, 194, 146, 0.3)"
+  },
+  successLabel: {
+    color: "#5DC292"
+  }
+};
+
+const useStyles = makeStyles(
+  theme => ({
+    label: {
+      fontSize: "1rem",
+      fontWeight: theme.typography.fontWeightBold,
+      textTransform: "uppercase"
+    },
+    root: {
+      borderRadius: 22,
+      display: "flex",
+      padding: "8px 24px"
+    },
+    ...StatusChipStyles
+  }),
+  { name: "StatusChip" }
+);
+
+const StatusChip: React.FC<StatusChipProps> = props => {
+  const { type = OrderStatusType.neutral, label } = props;
+  const classes = useStyles(props);
+
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <div className={classNames(classes.root, classes[type])}>
+      <Typography
+        className={classNames(classes.label, classes[`${type}Label`])}
+      >
+        {label}
+      </Typography>
+    </div>
+  );
+};
+
+export default StatusChip;

--- a/src/components/StatusChip/StatusChip.tsx
+++ b/src/components/StatusChip/StatusChip.tsx
@@ -1,11 +1,12 @@
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
-import { OrderStatusType } from "@saleor/types/globalTypes";
 import classNames from "classnames";
 import React from "react";
 
+import { StatusType } from "./types";
+
 export interface StatusChipProps {
-  type?: OrderStatusType;
+  type?: StatusType;
   label?: string;
 }
 
@@ -54,7 +55,7 @@ const useStyles = makeStyles(
 );
 
 const StatusChip: React.FC<StatusChipProps> = props => {
-  const { type = OrderStatusType.neutral, label } = props;
+  const { type = StatusType.NEUTRAL, label } = props;
   const classes = useStyles(props);
 
   if (!label) {

--- a/src/components/StatusChip/index.ts
+++ b/src/components/StatusChip/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StatusChip";

--- a/src/components/StatusChip/types.ts
+++ b/src/components/StatusChip/types.ts
@@ -1,0 +1,6 @@
+export enum StatusType {
+  NEUTRAL = "neutral",
+  ERROR = "error",
+  ALERT = "alert",
+  SUCCESS = "success"
+}

--- a/src/fragments/types/MetadataFragment.ts
+++ b/src/fragments/types/MetadataFragment.ts
@@ -19,7 +19,7 @@ export interface MetadataFragment_privateMetadata {
 }
 
 export interface MetadataFragment {
-  __typename: "ServiceAccount" | "App" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (MetadataFragment_metadata | null)[];
   privateMetadata: (MetadataFragment_privateMetadata | null)[];
 }

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -4,6 +4,7 @@ import { defineMessages, IntlShape } from "react-intl";
 import urlJoin from "url-join";
 
 import { ConfirmButtonTransitionState } from "./components/ConfirmButton/ConfirmButton";
+import { StatusType } from "./components/StatusChip/types";
 import { APP_MOUNT_URI } from "./config";
 import { AddressType, AddressTypeInput } from "./customers/types";
 import {
@@ -16,7 +17,6 @@ import {
   AuthorizationKeyType,
   CountryCode,
   OrderStatus,
-  OrderStatusType,
   PaymentChargeStatusEnum
 } from "./types/globalTypes";
 
@@ -158,42 +158,42 @@ export const orderStatusMessages = defineMessages({
 export const transformOrderStatus = (
   status: string,
   intl: IntlShape
-): { localized: string; status: OrderStatusType } => {
+): { localized: string; status: StatusType } => {
   switch (status) {
     case OrderStatus.FULFILLED:
       return {
         localized: intl.formatMessage(orderStatusMessages.fulfilled),
-        status: OrderStatusType.success
+        status: StatusType.SUCCESS
       };
     case OrderStatus.PARTIALLY_FULFILLED:
       return {
         localized: intl.formatMessage(orderStatusMessages.partiallyFulfilled),
-        status: OrderStatusType.neutral
+        status: StatusType.NEUTRAL
       };
     case OrderStatus.UNFULFILLED:
       return {
         localized: intl.formatMessage(orderStatusMessages.unfulfilled),
-        status: OrderStatusType.error
+        status: StatusType.ERROR
       };
     case OrderStatus.CANCELED:
       return {
         localized: intl.formatMessage(orderStatusMessages.cancelled),
-        status: OrderStatusType.error
+        status: StatusType.ERROR
       };
     case OrderStatus.DRAFT:
       return {
         localized: intl.formatMessage(orderStatusMessages.draft),
-        status: OrderStatusType.error
+        status: StatusType.ERROR
       };
     case OrderStatus.UNCONFIRMED:
       return {
         localized: intl.formatMessage(orderStatusMessages.unconfirmed),
-        status: OrderStatusType.neutral
+        status: StatusType.NEUTRAL
       };
   }
   return {
     localized: status,
-    status: OrderStatusType.error
+    status: StatusType.ERROR
   };
 };
 

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -16,6 +16,7 @@ import {
   AuthorizationKeyType,
   CountryCode,
   OrderStatus,
+  OrderStatusType,
   PaymentChargeStatusEnum
 } from "./types/globalTypes";
 
@@ -144,43 +145,55 @@ export const orderStatusMessages = defineMessages({
     defaultMessage: "Ready to fulfill",
     description: "order status"
   },
+  unconfirmed: {
+    defaultMessage: "Unconfirmed",
+    description: "order status"
+  },
   unfulfilled: {
     defaultMessage: "Unfulfilled",
     description: "order status"
   }
 });
 
-export const transformOrderStatus = (status: string, intl: IntlShape) => {
+export const transformOrderStatus = (
+  status: string,
+  intl: IntlShape
+): { localized: string; status: OrderStatusType } => {
   switch (status) {
     case OrderStatus.FULFILLED:
       return {
         localized: intl.formatMessage(orderStatusMessages.fulfilled),
-        status: "success"
+        status: OrderStatusType.success
       };
     case OrderStatus.PARTIALLY_FULFILLED:
       return {
         localized: intl.formatMessage(orderStatusMessages.partiallyFulfilled),
-        status: "neutral"
+        status: OrderStatusType.neutral
       };
     case OrderStatus.UNFULFILLED:
       return {
         localized: intl.formatMessage(orderStatusMessages.unfulfilled),
-        status: "error"
+        status: OrderStatusType.error
       };
     case OrderStatus.CANCELED:
       return {
         localized: intl.formatMessage(orderStatusMessages.cancelled),
-        status: "error"
+        status: OrderStatusType.error
       };
     case OrderStatus.DRAFT:
       return {
         localized: intl.formatMessage(orderStatusMessages.draft),
-        status: "error"
+        status: OrderStatusType.error
+      };
+    case OrderStatus.UNCONFIRMED:
+      return {
+        localized: intl.formatMessage(orderStatusMessages.unconfirmed),
+        status: OrderStatusType.neutral
       };
   }
   return {
     localized: status,
-    status: "error"
+    status: OrderStatusType.error
   };
 };
 

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -31,6 +31,7 @@ import OrderHistory, { FormData as HistoryFormData } from "../OrderHistory";
 import OrderInvoiceList from "../OrderInvoiceList";
 import OrderPayment from "../OrderPayment/OrderPayment";
 import OrderUnfulfilledItems from "../OrderUnfulfilledItems/OrderUnfulfilledItems";
+import Title from "./Title";
 
 const useStyles = makeStyles(
   theme => ({
@@ -39,6 +40,7 @@ const useStyles = makeStyles(
     },
     header: {
       display: "flex",
+      justifyContent: "space-between",
       marginBottom: 0
     }
   }),
@@ -149,7 +151,7 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
             <PageHeader
               className={classes.header}
               inline
-              title={maybe(() => order.number) ? "#" + order.number : undefined}
+              title={<Title order={order} />}
             >
               {canCancel && (
                 <CardMenu

--- a/src/orders/components/OrderDetailsPage/Title.tsx
+++ b/src/orders/components/OrderDetailsPage/Title.tsx
@@ -1,0 +1,46 @@
+import { makeStyles } from "@material-ui/core/styles";
+import StatusChip from "@saleor/components/StatusChip";
+import { transformOrderStatus } from "@saleor/misc";
+import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
+import React from "react";
+import { useIntl } from "react-intl";
+
+export interface TitleProps {
+  order?: OrderDetails_order;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    container: {
+      alignItems: "center",
+      display: "flex"
+    },
+    statusContainer: {
+      marginLeft: theme.spacing(2)
+    }
+  }),
+  { name: "OrderDetailsTitle" }
+);
+
+const Title: React.FC<TitleProps> = props => {
+  const intl = useIntl();
+  const classes = useStyles(props);
+  const { order } = props;
+
+  if (!order) {
+    return null;
+  }
+
+  const { localized, status } = transformOrderStatus(order.status, intl);
+
+  return (
+    <div className={classes.container}>
+      {`#${order.number}`}
+      <div className={classes.statusContainer}>
+        <StatusChip label={localized} type={status} />
+      </div>
+    </div>
+  );
+};
+
+export default Title;

--- a/src/orders/views/OrderDetails/index.tsx
+++ b/src/orders/views/OrderDetails/index.tsx
@@ -70,6 +70,7 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
   } = useCustomerSearch({
     variables: DEFAULT_INITIAL_SEARCH_DATA
   });
+
   const {
     loadMore,
     search: variantSearch,

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -67,7 +67,6 @@ export interface PageCreate_pageCreate_page_pageType {
   id: string;
   name: string;
   attributes: (PageCreate_pageCreate_page_pageType_attributes | null)[] | null;
-  message: string | null;
 }
 
 export interface PageCreate_pageCreate_page_metadata {

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -592,6 +592,7 @@ export enum OrderErrorCode {
 }
 
 export enum OrderEventsEmailsEnum {
+  CONFIRMED = "CONFIRMED",
   DIGITAL_LINKS = "DIGITAL_LINKS",
   FULFILLMENT_CONFIRMATION = "FULFILLMENT_CONFIRMATION",
   ORDER_CANCEL = "ORDER_CANCEL",
@@ -604,6 +605,7 @@ export enum OrderEventsEmailsEnum {
 
 export enum OrderEventsEnum {
   CANCELED = "CANCELED",
+  CONFIRMED = "CONFIRMED",
   DRAFT_ADDED_PRODUCTS = "DRAFT_ADDED_PRODUCTS",
   DRAFT_CREATED = "DRAFT_CREATED",
   DRAFT_REMOVED_PRODUCTS = "DRAFT_REMOVED_PRODUCTS",
@@ -649,19 +651,13 @@ export enum OrderStatus {
   UNFULFILLED = "UNFULFILLED",
 }
 
-export enum OrderStatusType {
-  error = "error",
-  neutral = "neutral",
-  alert = "alert",
-  success = "success"
-}
-
 export enum OrderStatusFilter {
   CANCELED = "CANCELED",
   FULFILLED = "FULFILLED",
   PARTIALLY_FULFILLED = "PARTIALLY_FULFILLED",
   READY_TO_CAPTURE = "READY_TO_CAPTURE",
   READY_TO_FULFILL = "READY_TO_FULFILL",
+  UNCONFIRMED = "UNCONFIRMED",
   UNFULFILLED = "UNFULFILLED",
 }
 
@@ -1219,6 +1215,7 @@ export interface DraftOrderCreateInput {
   voucher?: string | null;
   customerNote?: string | null;
   channel?: string | null;
+  redirectUrl?: string | null;
   lines?: (OrderLineCreateInput | null)[] | null;
 }
 
@@ -1232,6 +1229,7 @@ export interface DraftOrderInput {
   voucher?: string | null;
   customerNote?: string | null;
   channel?: string | null;
+  redirectUrl?: string | null;
 }
 
 export interface ExportInfoInput {
@@ -1376,10 +1374,6 @@ export interface PageCreateInput {
   pageType: string;
 }
 
-export interface PageFilterInput {
-  search?: string | null;
-}
-
 export interface PageInput {
   slug?: string | null;
   title?: string | null;
@@ -1469,6 +1463,11 @@ export interface PriceRangeInput {
   lte?: number | null;
 }
 
+export interface ProductAttributeAssignInput {
+  id: string;
+  type: ProductAttributeType;
+}
+
 export interface ProductChannelListingAddInput {
   channelId: string;
   isPublished?: boolean | null;
@@ -1481,11 +1480,6 @@ export interface ProductChannelListingAddInput {
 export interface ProductChannelListingUpdateInput {
   addChannels?: ProductChannelListingAddInput[] | null;
   removeChannels?: string[] | null;
-}
-
-export interface ProductAttributeAssignInput {
-  id: string;
-  type: ProductAttributeType;
 }
 
 export interface ProductCreateInput {

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -649,6 +649,13 @@ export enum OrderStatus {
   UNFULFILLED = "UNFULFILLED",
 }
 
+export enum OrderStatusType {
+  error = "error",
+  neutral = "neutral",
+  alert = "alert",
+  success = "success"
+}
+
 export enum OrderStatusFilter {
   CANCELED = "CANCELED",
   FULFILLED = "FULFILLED",

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -632,7 +632,6 @@ export enum OrderEventsEnum {
   PLACED_FROM_DRAFT = "PLACED_FROM_DRAFT",
   TRACKING_UPDATED = "TRACKING_UPDATED",
   UPDATED_ADDRESS = "UPDATED_ADDRESS",
-  CONFIRMED = 'CONFIRMED'
 }
 
 export enum OrderSettingsErrorCode {

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -38,7 +38,7 @@ export interface UpdateMetadata_deleteMetadata_item_privateMetadata {
 }
 
 export interface UpdateMetadata_deleteMetadata_item {
-  __typename: "ServiceAccount" | "App" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdateMetadata_deleteMetadata_item_metadata | null)[];
   privateMetadata: (UpdateMetadata_deleteMetadata_item_privateMetadata | null)[];
   id: string;

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -38,7 +38,7 @@ export interface UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadat
 }
 
 export interface UpdatePrivateMetadata_deletePrivateMetadata_item {
-  __typename: "ServiceAccount" | "App" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_metadata | null)[];
   privateMetadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata | null)[];
   id: string;


### PR DESCRIPTION
I want to merge this change because it adds order status to order details page. Also added the new statusChip component, according to [this figma file](https://www.figma.com/file/ZSAaKFWi05Weyuyy7GsAR4/WIP-BRANDING-SALEOR?node-id=754%3A2887).

https://app.clickup.com/t/2549495/SALEOR-1393

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** feature/order-confirmation
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
