### PR TITLE
Use proper loading and null value logic in voucher list

### DIFF
--- a/src/components/Percent/Percent.tsx
+++ b/src/components/Percent/Percent.tsx
@@ -9,10 +9,12 @@ interface PercentProps {
 const Percent: React.FC<PercentProps> = ({ amount }) => (
   <LocaleConsumer>
     {({ locale }) =>
-      (amount / 100).toLocaleString(locale, {
-        maximumFractionDigits: 2,
-        style: "percent"
-      })
+      amount
+        ? (amount / 100).toLocaleString(locale, {
+            maximumFractionDigits: 2,
+            style: "percent"
+          })
+        : "-"
     }
   </LocaleConsumer>
 );

--- a/src/discounts/components/VoucherList/VoucherList.tsx
+++ b/src/discounts/components/VoucherList/VoucherList.tsx
@@ -221,6 +221,8 @@ const VoucherList: React.FC<VoucherListProps> = props => {
             const channel = voucher?.channelListings?.find(
               listing => listing.channel.id === selectedChannel
             );
+            const hasChannelsLoaded = voucher?.channelListings?.length;
+
             return (
               <TableRow
                 className={!!voucher ? classes.tableRow : undefined}
@@ -241,10 +243,8 @@ const VoucherList: React.FC<VoucherListProps> = props => {
                   {maybe<React.ReactNode>(() => voucher.code, <Skeleton />)}
                 </TableCell>
                 <TableCell className={classes.colMinSpent}>
-                  {channel?.minSpent ? (
-                    <Money money={channel.minSpent} />
-                  ) : channel && channel.minSpent === null ? (
-                    "-"
+                  {hasChannelsLoaded ? (
+                    <Money money={channel?.minSpent} />
                   ) : (
                     <Skeleton />
                   )}
@@ -269,21 +269,19 @@ const VoucherList: React.FC<VoucherListProps> = props => {
                   className={classes.colValue}
                   onClick={voucher ? onRowClick(voucher.id) : undefined}
                 >
-                  {voucher &&
-                  voucher.discountValueType &&
-                  channel?.discountValue ? (
+                  {hasChannelsLoaded ? (
                     voucher.discountValueType ===
                     DiscountValueTypeEnum.FIXED ? (
                       <Money
-                        money={{
-                          amount: channel.discountValue,
-                          currency: channel.currency
-                        }}
+                        money={
+                          channel?.discountValue && {
+                            amount: channel?.discountValue,
+                            currency: channel?.currency
+                          }
+                        }
                       />
-                    ) : channel?.discountValue ? (
-                      <Percent amount={channel.discountValue} />
                     ) : (
-                      "-"
+                      <Percent amount={channel?.discountValue} />
                     )
                   ) : (
                     <Skeleton />


### PR DESCRIPTION
I want to merge this change because it fixes bug causing voucher list to display skeleton if discount has no defined value in chosen channel.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
