### PR TITLE
Create channel picker for draft order creation

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1209,17 +1209,13 @@
     "context": "channel currency",
     "string": "Currency"
   },
-  "src_dot_channels_dot_components_dot_ChannelSettingsDialog_dot_1391686013": {
+  "src_dot_channels_dot_components_dot_ChannelPickerDialog_dot_2423186459": {
     "context": "dialog header",
-    "string": "Settings"
+    "string": "Select a channel"
   },
-  "src_dot_channels_dot_components_dot_ChannelSettingsDialog_dot_2721512922": {
-    "context": "channel settings",
-    "string": "Configure the way information are presented in catalog section of Dashboard."
-  },
-  "src_dot_channels_dot_components_dot_ChannelSettingsDialog_dot_645871430": {
+  "src_dot_channels_dot_components_dot_ChannelPickerDialog_dot_507892781": {
     "context": "select label",
-    "string": "Show prices for"
+    "string": "Channel name"
   },
   "src_dot_channels_dot_components_dot_ChannelStatus_dot_1004218338": {
     "context": "inactive",

--- a/src/channels/components/ChannelPickerDialog/ChannelPickerDialog.stories.tsx
+++ b/src/channels/components/ChannelPickerDialog/ChannelPickerDialog.stories.tsx
@@ -3,16 +3,16 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import { channelsList } from "../../fixtures";
-import ChannelSettingsDialog, {
-  ChannelSettingsDialogProps
-} from "./ChannelSettingsDialog";
+import ChannelPickerDialog, {
+  ChannelPickerDialogProps
+} from "./ChannelPickerDialog";
 
 const channelsChoices = channelsList.map(channel => ({
   label: channel.name,
   value: channel.id
 }));
 
-const props: ChannelSettingsDialogProps = {
+const props: ChannelPickerDialogProps = {
   channelsChoices,
   confirmButtonState: "default",
   defaultChoice: channelsChoices[0]?.value,
@@ -23,4 +23,4 @@ const props: ChannelSettingsDialogProps = {
 
 storiesOf("Views / Channels / Settings dialog", module)
   .addDecorator(Decorator)
-  .add("default", () => <ChannelSettingsDialog {...props} />);
+  .add("default", () => <ChannelPickerDialog {...props} />);

--- a/src/channels/components/ChannelPickerDialog/ChannelPickerDialog.tsx
+++ b/src/channels/components/ChannelPickerDialog/ChannelPickerDialog.tsx
@@ -1,4 +1,3 @@
-import Typography from "@material-ui/core/Typography";
 import ActionDialog from "@saleor/components/ActionDialog";
 import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
 import {
@@ -6,11 +5,11 @@ import {
   SingleSelectField
 } from "@saleor/components/SingleSelectField";
 import React, { useState } from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import { useStyles } from "../styles";
 
-export interface ChannelSettingsDialogProps {
+export interface ChannelPickerDialogProps {
   channelsChoices: Choices;
   confirmButtonState: ConfirmButtonTransitionState;
   defaultChoice: string;
@@ -19,7 +18,7 @@ export interface ChannelSettingsDialogProps {
   onConfirm: (choice: string) => void;
 }
 
-const ChannelSettingsDialog: React.FC<ChannelSettingsDialogProps> = ({
+const ChannelPickerDialog: React.FC<ChannelPickerDialogProps> = ({
   channelsChoices = [],
   confirmButtonState,
   defaultChoice,
@@ -40,23 +39,17 @@ const ChannelSettingsDialog: React.FC<ChannelSettingsDialogProps> = ({
       onClose={onClose}
       onConfirm={() => onConfirm(choice)}
       title={intl.formatMessage({
-        defaultMessage: "Settings",
+        defaultMessage: "Select a channel",
         description: "dialog header"
       })}
     >
       <div>
-        <Typography>
-          <FormattedMessage
-            defaultMessage="Configure the way information are presented in catalog section of Dashboard."
-            description="channel settings"
-          />
-        </Typography>
         <div className={classes.select}>
           <SingleSelectField
             choices={channelsChoices}
             name="channels"
             label={intl.formatMessage({
-              defaultMessage: "Show prices for",
+              defaultMessage: "Channel name",
               description: "select label"
             })}
             value={choice}
@@ -67,5 +60,5 @@ const ChannelSettingsDialog: React.FC<ChannelSettingsDialogProps> = ({
     </ActionDialog>
   );
 };
-ChannelSettingsDialog.displayName = "ChannelSettingsDialog";
-export default ChannelSettingsDialog;
+ChannelPickerDialog.displayName = "ChannelPickerDialog";
+export default ChannelPickerDialog;

--- a/src/channels/components/ChannelPickerDialog/index.ts
+++ b/src/channels/components/ChannelPickerDialog/index.ts
@@ -1,0 +1,2 @@
+export * from "./ChannelPickerDialog";
+export { default } from "./ChannelPickerDialog";

--- a/src/channels/components/ChannelSettingsDialog/index.ts
+++ b/src/channels/components/ChannelSettingsDialog/index.ts
@@ -1,2 +1,0 @@
-export * from "./ChannelSettingsDialog";
-export { default } from "./ChannelSettingsDialog";

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -15,6 +15,8 @@ import {
 
 const orderSectionUrl = "/orders";
 
+type CreateOrderDialog = "create-order";
+
 export const orderListPath = orderSectionUrl;
 export enum OrderListUrlFiltersEnum {
   createdFrom = "createdFrom",
@@ -28,7 +30,7 @@ export enum OrderListUrlFiltersWithMultipleValuesEnum {
 }
 export type OrderListUrlFilters = Filters<OrderListUrlFiltersEnum> &
   FiltersWithMultipleValues<OrderListUrlFiltersWithMultipleValuesEnum>;
-export type OrderListUrlDialog = "cancel" | TabActionDialog;
+export type OrderListUrlDialog = "cancel" | CreateOrderDialog | TabActionDialog;
 export enum OrderListUrlSortField {
   number = "number",
   customer = "customer",
@@ -61,7 +63,10 @@ export enum OrderDraftListUrlFiltersEnum {
   query = "query"
 }
 export type OrderDraftListUrlFilters = Filters<OrderDraftListUrlFiltersEnum>;
-export type OrderDraftListUrlDialog = "remove" | TabActionDialog;
+export type OrderDraftListUrlDialog =
+  | "remove"
+  | CreateOrderDialog
+  | TabActionDialog;
 export enum OrderDraftListUrlSortField {
   number = "number",
   customer = "customer",

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -1,6 +1,7 @@
 import DialogContentText from "@material-ui/core/DialogContentText";
 import IconButton from "@material-ui/core/IconButton";
 import DeleteIcon from "@material-ui/icons/Delete";
+import ChannelPickerDialog from "@saleor/channels/components/ChannelPickerDialog";
 import ActionDialog from "@saleor/components/ActionDialog";
 import useAppChannel from "@saleor/components/AppLayout/AppChannelContext";
 import DeleteFilterTabDialog from "@saleor/components/DeleteFilterTabDialog";
@@ -79,7 +80,10 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
     onCompleted: handleCreateOrderCreateSuccess
   });
 
-  const { channel } = useAppChannel();
+  const { channel, availableChannels } = useAppChannel();
+  const [channelPickerDialogOpen, setChannelPickerDialogOpen] = React.useState(
+    false
+  );
 
   const tabs = getFilterTabs();
 
@@ -196,13 +200,7 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
                   data.draftOrders.edges.map(edge => edge.node)
                 )}
                 pageInfo={pageInfo}
-                onAdd={() =>
-                  createOrder({
-                    variables: {
-                      input: { channel: channel.id }
-                    }
-                  })
-                }
+                onAdd={() => setChannelPickerDialogOpen(true)}
                 onNextPage={loadNextPage}
                 onPreviousPage={loadPreviousPage}
                 onRowClick={id => () => navigate(orderUrl(id))}
@@ -262,6 +260,23 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
                 onClose={closeModal}
                 onSubmit={handleTabDelete}
                 tabName={maybe(() => tabs[currentTab - 1].name, "...")}
+              />
+              <ChannelPickerDialog
+                channelsChoices={availableChannels.map(channel => ({
+                  label: channel.name,
+                  value: channel.id
+                }))}
+                confirmButtonState="success"
+                defaultChoice={channel.id}
+                open={channelPickerDialogOpen}
+                onClose={() => setChannelPickerDialogOpen(false)}
+                onConfirm={channel =>
+                  createOrder({
+                    variables: {
+                      input: { channel }
+                    }
+                  })
+                }
               />
             </>
           );

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -81,9 +81,6 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
   });
 
   const { channel, availableChannels } = useAppChannel();
-  const [channelPickerDialogOpen, setChannelPickerDialogOpen] = React.useState(
-    false
-  );
 
   const tabs = getFilterTabs();
 
@@ -200,7 +197,7 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
                   data.draftOrders.edges.map(edge => edge.node)
                 )}
                 pageInfo={pageInfo}
-                onAdd={() => setChannelPickerDialogOpen(true)}
+                onAdd={() => openModal("create-order")}
                 onNextPage={loadNextPage}
                 onPreviousPage={loadPreviousPage}
                 onRowClick={id => () => navigate(orderUrl(id))}
@@ -268,8 +265,8 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
                 }))}
                 confirmButtonState="success"
                 defaultChoice={channel.id}
-                open={channelPickerDialogOpen}
-                onClose={() => setChannelPickerDialogOpen(false)}
+                open={params.action === "create-order"}
+                onClose={closeModal}
                 onConfirm={channel =>
                   createOrder({
                     variables: {

--- a/src/orders/views/OrderList/OrderList.tsx
+++ b/src/orders/views/OrderList/OrderList.tsx
@@ -1,3 +1,4 @@
+import ChannelPickerDialog from "@saleor/channels/components/ChannelPickerDialog";
 import useAppChannel from "@saleor/components/AppLayout/AppChannelContext";
 import DeleteFilterTabDialog from "@saleor/components/DeleteFilterTabDialog";
 import SaveFilterTabDialog, {
@@ -67,7 +68,10 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
     onCompleted: handleCreateOrderCreateSuccess
   });
 
-  const { channel } = useAppChannel();
+  const { channel, availableChannels } = useAppChannel();
+  const [channelPickerDialogOpen, setChannelPickerDialogOpen] = React.useState(
+    false
+  );
 
   const tabs = getFilterTabs();
 
@@ -145,13 +149,7 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
         orders={maybe(() => data.orders.edges.map(edge => edge.node))}
         pageInfo={pageInfo}
         sort={getSortParams(params)}
-        onAdd={() =>
-          createOrder({
-            variables: {
-              input: { channel: channel.id }
-            }
-          })
-        }
+        onAdd={() => setChannelPickerDialogOpen(true)}
         onNextPage={loadNextPage}
         onPreviousPage={loadPreviousPage}
         onUpdateListSettings={updateListSettings}
@@ -178,6 +176,23 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
         onClose={closeModal}
         onSubmit={handleFilterTabDelete}
         tabName={getStringOrPlaceholder(tabs[currentTab - 1]?.name)}
+      />
+      <ChannelPickerDialog
+        channelsChoices={availableChannels.map(channel => ({
+          label: channel.name,
+          value: channel.id
+        }))}
+        confirmButtonState="success"
+        defaultChoice={channel.id}
+        open={channelPickerDialogOpen}
+        onClose={() => setChannelPickerDialogOpen(false)}
+        onConfirm={channel =>
+          createOrder({
+            variables: {
+              input: { channel }
+            }
+          })
+        }
       />
     </>
   );

--- a/src/orders/views/OrderList/OrderList.tsx
+++ b/src/orders/views/OrderList/OrderList.tsx
@@ -69,9 +69,6 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
   });
 
   const { channel, availableChannels } = useAppChannel();
-  const [channelPickerDialogOpen, setChannelPickerDialogOpen] = React.useState(
-    false
-  );
 
   const tabs = getFilterTabs();
 
@@ -149,7 +146,7 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
         orders={maybe(() => data.orders.edges.map(edge => edge.node))}
         pageInfo={pageInfo}
         sort={getSortParams(params)}
-        onAdd={() => setChannelPickerDialogOpen(true)}
+        onAdd={() => openModal("create-order")}
         onNextPage={loadNextPage}
         onPreviousPage={loadPreviousPage}
         onUpdateListSettings={updateListSettings}
@@ -184,8 +181,8 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
         }))}
         confirmButtonState="success"
         defaultChoice={channel.id}
-        open={channelPickerDialogOpen}
-        onClose={() => setChannelPickerDialogOpen(false)}
+        open={params.action === "create-order"}
+        onClose={closeModal}
         onConfirm={channel =>
           createOrder({
             variables: {


### PR DESCRIPTION
To create a draft order we need to know its channel beforehand. This picker allows user to specify the channel explicitly while also defaulting to the currently selected global channel.
<!-- Please mention all relevant issue numbers. -->
https://app.clickup.com/t/2549495/SALEOR-1611
**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
![image](https://user-images.githubusercontent.com/28310983/99822666-cc9c3000-2b53-11eb-8b14-298d13de74da.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
