### PR TITLE
Saleor 1670 visual improvements for dashboard homepage

### DIFF
--- a/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -18,6 +18,9 @@ const useStyles = makeStyles(
     arrowIcon: {
       width: theme.spacing(4)
     },
+    tableCard: {
+      overflow: "hidden"
+    },
     tableRow: {
       cursor: "pointer"
     }
@@ -48,7 +51,7 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
   const classes = useStyles(props);
 
   return (
-    <Card>
+    <Card className={classes.tableCard}>
       <ResponsiveTable>
         <TableBody className={classes.tableRow}>
           <RequirePermissions

--- a/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -14,9 +14,10 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 
 const useStyles = makeStyles(
-  theme => ({
+  () => ({
     arrowIcon: {
-      width: theme.spacing(4)
+      textAlign: "right",
+      width: "auto"
     },
     tableCard: {
       overflow: "hidden"


### PR DESCRIPTION
I want to merge this change because it fixes hover overflow on dashboard homepage and adds padding on arrow icons.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

before:
<img width="559" alt="image" src="https://user-images.githubusercontent.com/29279389/99826698-028fe300-2b59-11eb-9d39-28a4ccd1430c.png">

after:
<img width="697" alt="image" src="https://user-images.githubusercontent.com/29279389/99826610-e3915100-2b58-11eb-81a2-fc827c00f937.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
