### PR TITLE
Fix wrong placeholder text

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -5201,8 +5201,8 @@
   "src_dot_shipping_dot_components_dot_ShippingZoneDetailsPage_dot_4270729636": {
     "string": "This is default shipping zone, which means that it covers all of the countries which are not assigned to other shipping zones"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneInfo_dot_1109610983": {
-    "string": "Shipping Zone Name"
+  "src_dot_shipping_dot_components_dot_ShippingZoneInfo_dot_579967655": {
+    "string": "Shipping rate name"
   },
   "src_dot_shipping_dot_components_dot_ShippingZoneRatesPage_dot_1161979494": {
     "context": "page title",

--- a/src/shipping/components/ShippingZoneInfo/ShippingZoneInfo.tsx
+++ b/src/shipping/components/ShippingZoneInfo/ShippingZoneInfo.tsx
@@ -38,7 +38,7 @@ const ShippingZoneInfo: React.FC<ShippingZoneInfoProps> = ({
           fullWidth
           helperText={getShippingErrorMessage(formErrors.name, intl)}
           label={intl.formatMessage({
-            defaultMessage: "Shipping Zone Name"
+            defaultMessage: "Shipping rate name"
           })}
           name="name"
           value={data.name}


### PR DESCRIPTION
I want to merge this change because it fixes wrong placeholder text.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<img width="495" alt="image" src="https://user-images.githubusercontent.com/29279389/100082923-1da86e80-2e49-11eb-9b16-2ceba0261337.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
