### PR TITLE
1721 - add refunds miscellaneous view

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3534,10 +3534,6 @@
     "context": "dialog header",
     "string": "Capture Payment"
   },
-  "src_dot_orders_dot_components_dot_OrderPaymentDialog_dot_250371749": {
-    "context": "dialog header",
-    "string": "Refund Payment"
-  },
   "src_dot_orders_dot_components_dot_OrderPaymentDialog_dot_75546233": {
     "context": "amount of refunded money",
     "string": "Amount"
@@ -3620,6 +3616,64 @@
   },
   "src_dot_orders_dot_components_dot_OrderProductAddDialog_dot_353369701": {
     "string": "No products matching given query"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_120912052": {
+    "context": "order refund amount",
+    "string": "Refunded items can’t be fulfilled"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_159210811": {
+    "string": "Amount must be bigger than 0"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_1705174606": {
+    "context": "order refund amount",
+    "string": "Max Refund"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_2045860028": {
+    "context": "order refund amount",
+    "string": "Authorized Amount"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_2256869831": {
+    "context": "section header",
+    "string": "Refunded Amount"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_2845258362": {
+    "context": "order refund amount, input button",
+    "string": "Refund"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_2854815744": {
+    "context": "order refund amount",
+    "string": "Previously refunded"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_4033685232": {
+    "string": "Amount cannot be bigger than max refund"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_40513382": {
+    "context": "order refund amount, input button",
+    "string": "Refund {currency} {amount}"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundAmount_dot_75546233": {
+    "context": "order refund amount, input label",
+    "string": "Amount"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundPage_dot_194531545": {
+    "context": "page header",
+    "string": "Order no. {orderNumber} - Refund"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundPage_dot_3620521256": {
+    "context": "page header",
+    "string": "Order"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundPage_dot_580490159": {
+    "context": "page header with order number",
+    "string": "Order #{orderNumber}"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefund_dot_1275363773": {
+    "context": "section header",
+    "string": "Refund Order"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefund_dot_refundMiscellaneous": {
+    "context": "refund type",
+    "string": "Miscellaneous Refund"
   },
   "src_dot_orders_dot_components_dot_OrderShippingMethodEditDialog_dot_3369240294": {
     "context": "dialog header",
@@ -3740,6 +3794,10 @@
   },
   "src_dot_orders_dot_views_dot_OrderList_dot_1738939038": {
     "string": "Order draft successfully created"
+  },
+  "src_dot_orders_dot_views_dot_OrderRefund_dot_1366101924": {
+    "context": "order refunded success message",
+    "string": "Refunded Items"
   },
   "src_dot_pageTypes": {
     "context": "page types section name",

--- a/src/components/PriceField/PriceField.tsx
+++ b/src/components/PriceField/PriceField.tsx
@@ -39,6 +39,7 @@ interface PriceFieldProps {
   name?: string;
   value?: string | number;
   InputProps?: InputProps;
+  inputProps?: InputProps["inputProps"];
   required?: boolean;
   onChange(event: any);
 }
@@ -55,7 +56,8 @@ export const PriceField: React.FC<PriceFieldProps> = props => {
     onChange,
     required,
     value,
-    InputProps
+    InputProps,
+    inputProps
   } = props;
 
   const classes = useStyles(props);
@@ -93,7 +95,8 @@ export const PriceField: React.FC<PriceFieldProps> = props => {
       }}
       inputProps={{
         min: minValue,
-        type: "number"
+        type: "number",
+        ...inputProps
       }}
       name={name}
       disabled={disabled}

--- a/src/components/RadioGroupField/RadioGroupField.tsx
+++ b/src/components/RadioGroupField/RadioGroupField.tsx
@@ -15,8 +15,14 @@ const useStyles = makeStyles(
     formLabel: {
       marginBottom: theme.spacing(1)
     },
+    radioGroupInline: {
+      flexDirection: "row"
+    },
     radioLabel: {
       marginBottom: -theme.spacing(0.5)
+    },
+    radioLabelInline: {
+      marginRight: theme.spacing(4)
     },
     root: {
       "& $radioLabel": {
@@ -53,6 +59,7 @@ interface RadioGroupFieldProps {
   label?: React.ReactNode;
   name?: string;
   value: string | number;
+  variant?: "block" | "inline";
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
@@ -66,7 +73,8 @@ export const RadioGroupField: React.FC<RadioGroupFieldProps> = props => {
     value,
     onChange,
     name,
-    hint
+    hint,
+    variant = "block"
   } = props;
   const classes = useStyles(props);
 
@@ -86,13 +94,19 @@ export const RadioGroupField: React.FC<RadioGroupFieldProps> = props => {
         name={name}
         value={value}
         onChange={onChange}
+        className={classNames({
+          [classes.radioGroupInline]: variant === "inline"
+        })}
       >
         {choices.length > 0 ? (
           choices.map(choice => (
             <FormControlLabel
               disabled={choice.disabled}
               value={choice.value}
-              className={classes.radioLabel}
+              className={classNames({
+                [classes.radioLabel]: variant !== "inline",
+                [classes.radioLabelInline]: variant === "inline"
+              })}
               control={<Radio color="primary" />}
               label={choice.label}
               key={choice.value}

--- a/src/orders/components/OrderPaymentDialog/OrderPaymentDialog.tsx
+++ b/src/orders/components/OrderPaymentDialog/OrderPaymentDialog.tsx
@@ -26,7 +26,6 @@ export interface OrderPaymentDialogProps {
   errors: OrderErrorFragment[];
   open: boolean;
   initial: number;
-  variant: "capture" | "refund";
   onClose: () => void;
   onSubmit: (data: FormData) => void;
 }
@@ -36,7 +35,6 @@ const OrderPaymentDialog: React.FC<OrderPaymentDialogProps> = ({
   errors,
   open,
   initial,
-  variant,
   onClose,
   onSubmit
 }) => {
@@ -56,15 +54,10 @@ const OrderPaymentDialog: React.FC<OrderPaymentDialogProps> = ({
         {({ data, change, submit }) => (
           <>
             <DialogTitle>
-              {variant === "capture"
-                ? intl.formatMessage({
-                    defaultMessage: "Capture Payment",
-                    description: "dialog header"
-                  })
-                : intl.formatMessage({
-                    defaultMessage: "Refund Payment",
-                    description: "dialog header"
-                  })}
+              {intl.formatMessage({
+                defaultMessage: "Capture Payment",
+                description: "dialog header"
+              })}
             </DialogTitle>
             <DialogContent>
               <TextField

--- a/src/orders/components/OrderRefund/OrderRefund.tsx
+++ b/src/orders/components/OrderRefund/OrderRefund.tsx
@@ -1,0 +1,62 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import CardTitle from "@saleor/components/CardTitle";
+import RadioGroupField from "@saleor/components/RadioGroupField";
+import React from "react";
+import { defineMessages, useIntl } from "react-intl";
+
+import { OrderRefundData, OrderRefundType } from "../OrderRefundPage/form";
+
+interface OrderRefundProps {
+  data: OrderRefundData;
+  disabled: boolean;
+  onChange: (event: React.ChangeEvent<any>) => void;
+}
+
+const messages = defineMessages({
+  refundMiscellaneous: {
+    defaultMessage: "Miscellaneous Refund",
+    description: "refund type"
+  },
+  refundProducts: {
+    defaultMessage: "Refund Products",
+    description: "refund type"
+  }
+});
+
+const OrderRefund: React.FC<OrderRefundProps> = props => {
+  const { data, disabled, onChange } = props;
+  const intl = useIntl();
+
+  return (
+    <Card>
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Refund Order",
+          description: "section header"
+        })}
+      />
+      <CardContent>
+        <RadioGroupField
+          choices={[
+            {
+              label: intl.formatMessage(messages.refundProducts),
+              value: OrderRefundType.PRODUCTS
+            },
+            {
+              label: intl.formatMessage(messages.refundMiscellaneous),
+              value: OrderRefundType.MISCELLANEOUS
+            }
+          ]}
+          disabled={disabled}
+          name={"type" as keyof FormData}
+          value={data.type}
+          onChange={onChange}
+          variant="inline"
+        />
+      </CardContent>
+    </Card>
+  );
+};
+OrderRefund.displayName = "OrderRefund";
+export default OrderRefund;

--- a/src/orders/components/OrderRefund/OrderRefund.tsx
+++ b/src/orders/components/OrderRefund/OrderRefund.tsx
@@ -17,10 +17,6 @@ const messages = defineMessages({
   refundMiscellaneous: {
     defaultMessage: "Miscellaneous Refund",
     description: "refund type"
-  },
-  refundProducts: {
-    defaultMessage: "Refund Products",
-    description: "refund type"
   }
 });
 
@@ -39,10 +35,6 @@ const OrderRefund: React.FC<OrderRefundProps> = props => {
       <CardContent>
         <RadioGroupField
           choices={[
-            {
-              label: intl.formatMessage(messages.refundProducts),
-              value: OrderRefundType.PRODUCTS
-            },
             {
               label: intl.formatMessage(messages.refundMiscellaneous),
               value: OrderRefundType.MISCELLANEOUS

--- a/src/orders/components/OrderRefund/index.ts
+++ b/src/orders/components/OrderRefund/index.ts
@@ -1,0 +1,2 @@
+export * from "./OrderRefund";
+export { default } from "./OrderRefund";

--- a/src/orders/components/OrderRefundAmount/OrderRefundAmount.tsx
+++ b/src/orders/components/OrderRefundAmount/OrderRefundAmount.tsx
@@ -145,7 +145,10 @@ const OrderRefundAmount: React.FC<OrderRefundAmountProps> = props => {
           })}
           className={classes.priceField}
           InputProps={{ inputProps: { max: maxRefund?.amount } }}
-          inputProps={{ max: maxRefund?.amount }}
+          inputProps={{
+            "data-test": "amountInput",
+            max: maxRefund?.amount
+          }}
           error={!!formErrors.amount || isAmountTooSmall || isAmountTooBig}
           hint={
             getOrderErrorMessage(formErrors.amount, intl) ||
@@ -168,6 +171,7 @@ const OrderRefundAmount: React.FC<OrderRefundAmountProps> = props => {
           onClick={onRefund}
           className={classes.refundButton}
           disabled={disabled || disableRefundButton}
+          data-test="submit"
         >
           {!disableRefundButton ? (
             <FormattedMessage

--- a/src/orders/components/OrderRefundAmount/OrderRefundAmount.tsx
+++ b/src/orders/components/OrderRefundAmount/OrderRefundAmount.tsx
@@ -1,0 +1,198 @@
+import { makeStyles } from "@material-ui/core";
+import Button from "@material-ui/core/Button";
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+import CardTitle from "@saleor/components/CardTitle";
+import Money from "@saleor/components/Money";
+import PriceField from "@saleor/components/PriceField";
+import Skeleton from "@saleor/components/Skeleton";
+import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
+import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
+import { getFormErrors } from "@saleor/utils/errors";
+import getOrderErrorMessage from "@saleor/utils/errors/order";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { OrderRefundData } from "../OrderRefundPage/form";
+
+const useStyles = makeStyles(
+  theme => ({
+    maxRefundRow: {
+      fontWeight: 600
+    },
+    priceField: {
+      marginTop: theme.spacing(2)
+    },
+    refundButton: {
+      marginTop: theme.spacing(2)
+    },
+    refundCaution: {
+      marginTop: theme.spacing(1)
+    },
+    root: {
+      ...theme.typography.body1,
+      lineHeight: 1.9,
+      width: "100%"
+    },
+    textRight: {
+      textAlign: "right"
+    }
+  }),
+  { name: "OrderRefundAmount" }
+);
+
+interface OrderRefundAmountProps {
+  data: OrderRefundData;
+  order: OrderDetails_order;
+  disabled: boolean;
+  errors: OrderErrorFragment[];
+  onChange: (event: React.ChangeEvent<any>) => void;
+  onRefund: () => void;
+}
+
+const OrderRefundAmount: React.FC<OrderRefundAmountProps> = props => {
+  const { data, order, disabled, errors, onChange, onRefund } = props;
+  const classes = useStyles(props);
+  const intl = useIntl();
+
+  // TODO: change below values...
+  const authorizedAmount = order?.totalAuthorized;
+  const previouslyRefunded = order?.totalAuthorized;
+  const maxRefund = order?.totalAuthorized;
+  const amountCurrency = order?.totalAuthorized.currency;
+  // ...end of values requiring change
+
+  const formErrors = getFormErrors(["amount"], errors);
+
+  const isAmountTooSmall = data.amount && data.amount <= 0;
+  const isAmountTooBig = data.amount > maxRefund.amount;
+
+  const disableRefundButton =
+    !data.amount || isAmountTooSmall || isAmountTooBig;
+
+  return (
+    <Card>
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Refunded Amount",
+          description: "section header"
+        })}
+      />
+      <CardContent>
+        <table className={classes.root}>
+          <tbody>
+            <tr>
+              <td>
+                <FormattedMessage
+                  defaultMessage="Authorized Amount"
+                  description="order refund amount"
+                />
+              </td>
+              <td className={classes.textRight}>
+                {authorizedAmount.amount ? (
+                  <Money money={authorizedAmount} />
+                ) : (
+                  <Skeleton />
+                )}
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <FormattedMessage
+                  defaultMessage="Previously refunded"
+                  description="order refund amount"
+                />
+              </td>
+              <td className={classes.textRight}>
+                {previouslyRefunded.amount ? (
+                  <>
+                    {"- "}
+                    <Money money={previouslyRefunded} />
+                  </>
+                ) : (
+                  <Skeleton />
+                )}
+              </td>
+            </tr>
+            <tr className={classes.maxRefundRow}>
+              <td>
+                <FormattedMessage
+                  defaultMessage="Max Refund"
+                  description="order refund amount"
+                />
+              </td>
+              <td className={classes.textRight}>
+                {maxRefund.amount ? <Money money={maxRefund} /> : <Skeleton />}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <PriceField
+          disabled={disabled}
+          onChange={onChange}
+          currencySymbol={amountCurrency}
+          name={"amount" as keyof FormData}
+          value={data.amount}
+          label={intl.formatMessage({
+            defaultMessage: "Amount",
+            description: "order refund amount, input label"
+          })}
+          className={classes.priceField}
+          InputProps={{ inputProps: { max: maxRefund.amount } }}
+          inputProps={{ max: maxRefund.amount }}
+          error={!!formErrors.amount || isAmountTooSmall || isAmountTooBig}
+          hint={
+            getOrderErrorMessage(formErrors.amount, intl) ||
+            (isAmountTooSmall &&
+              intl.formatMessage({
+                defaultMessage: "Amount must be bigger than 0"
+              })) ||
+            (isAmountTooBig &&
+              intl.formatMessage({
+                defaultMessage: "Amount cannot be bigger than max refund"
+              }))
+          }
+        />
+        <Button
+          type="submit"
+          color="primary"
+          variant="contained"
+          fullWidth
+          size="large"
+          onClick={onRefund}
+          className={classes.refundButton}
+          disabled={disabled || disableRefundButton}
+        >
+          {!disableRefundButton ? (
+            <FormattedMessage
+              defaultMessage="Refund {currency} {amount}"
+              description="order refund amount, input button"
+              values={{
+                amount: data.amount,
+                currency: amountCurrency
+              }}
+            />
+          ) : (
+            <FormattedMessage
+              defaultMessage="Refund"
+              description="order refund amount, input button"
+            />
+          )}
+        </Button>
+        <Typography
+          variant="caption"
+          color="textSecondary"
+          className={classes.refundCaution}
+        >
+          <FormattedMessage
+            defaultMessage="Refunded items can’t be fulfilled"
+            description="order refund amount"
+          />
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+};
+OrderRefundAmount.displayName = "OrderRefundAmount";
+export default OrderRefundAmount;

--- a/src/orders/components/OrderRefundAmount/index.ts
+++ b/src/orders/components/OrderRefundAmount/index.ts
@@ -1,0 +1,2 @@
+export * from "./OrderRefundAmount";
+export { default } from "./OrderRefundAmount";

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.stories.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.stories.tsx
@@ -1,0 +1,18 @@
+import Decorator from "@saleor/storybook/Decorator";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { orderToRefund } from "./fixtures";
+import OrderRefundPage, { OrderRefundPageProps } from "./OrderRefundPage";
+
+const props: OrderRefundPageProps = {
+  disabled: false,
+  errors: [],
+  onBack: () => undefined,
+  onSubmit: () => undefined,
+  order: orderToRefund
+};
+
+storiesOf("Views / Orders / Refund order", module)
+  .addDecorator(Decorator)
+  .add("default", () => <OrderRefundPage {...props} />);

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
@@ -1,0 +1,80 @@
+import AppHeader from "@saleor/components/AppHeader";
+import Container from "@saleor/components/Container";
+import Grid from "@saleor/components/Grid";
+import PageHeader from "@saleor/components/PageHeader";
+import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
+import { SubmitPromise } from "@saleor/hooks/useForm";
+import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
+import React from "react";
+import { useIntl } from "react-intl";
+
+import OrderRefund from "../OrderRefund";
+import OrderRefundAmount from "../OrderRefundAmount";
+import OrderRefundForm, { OrderRefundSubmitData } from "./form";
+
+export interface OrderRefundPageProps {
+  order: OrderDetails_order;
+  disabled: boolean;
+  errors: OrderErrorFragment[];
+  onBack: () => void;
+  onSubmit: (data: OrderRefundSubmitData) => SubmitPromise;
+}
+
+const OrderRefundPage: React.FC<OrderRefundPageProps> = props => {
+  const { order, disabled, errors, onBack, onSubmit } = props;
+
+  const intl = useIntl();
+
+  return (
+    <OrderRefundForm order={order} onSubmit={onSubmit}>
+      {({ data, change, submit }) => (
+        <Container>
+          <AppHeader onBack={onBack}>
+            {order?.number
+              ? intl.formatMessage(
+                  {
+                    defaultMessage: "Order #{orderNumber}",
+                    description: "page header with order number"
+                  },
+                  {
+                    orderNumber: order.number
+                  }
+                )
+              : intl.formatMessage({
+                  defaultMessage: "Order",
+                  description: "page header"
+                })}
+          </AppHeader>
+          <PageHeader
+            title={intl.formatMessage(
+              {
+                defaultMessage: "Order no. {orderNumber} - Refund",
+                description: "page header"
+              },
+              {
+                orderNumber: order?.number
+              }
+            )}
+          />
+          <Grid>
+            <div>
+              <OrderRefund data={data} disabled={disabled} onChange={change} />
+            </div>
+            <div>
+              <OrderRefundAmount
+                data={data}
+                order={order}
+                disabled={disabled}
+                errors={errors}
+                onChange={change}
+                onRefund={submit}
+              />
+            </div>
+          </Grid>
+        </Container>
+      )}
+    </OrderRefundForm>
+  );
+};
+OrderRefundPage.displayName = "OrderRefundPage";
+export default OrderRefundPage;

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
@@ -4,7 +4,7 @@ import Grid from "@saleor/components/Grid";
 import PageHeader from "@saleor/components/PageHeader";
 import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
 import { SubmitPromise } from "@saleor/hooks/useForm";
-import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
+import { OrderRefundData_order } from "@saleor/orders/types/OrderRefundData";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -13,7 +13,7 @@ import OrderRefundAmount from "../OrderRefundAmount";
 import OrderRefundForm, { OrderRefundSubmitData } from "./form";
 
 export interface OrderRefundPageProps {
-  order: OrderDetails_order;
+  order: OrderRefundData_order;
   disabled: boolean;
   errors: OrderErrorFragment[];
   onBack: () => void;
@@ -21,7 +21,7 @@ export interface OrderRefundPageProps {
 }
 
 const OrderRefundPage: React.FC<OrderRefundPageProps> = props => {
-  const { order, disabled, errors, onBack, onSubmit } = props;
+  const { order, disabled, errors = [], onBack, onSubmit } = props;
 
   const intl = useIntl();
 

--- a/src/orders/components/OrderRefundPage/fixtures.ts
+++ b/src/orders/components/OrderRefundPage/fixtures.ts
@@ -1,5 +1,22 @@
 /* eslint-disable sort-keys */
 
-import { order } from "@saleor/orders/fixtures";
+import { OrderRefundData_order } from "@saleor/orders/types/OrderRefundData";
 
-export const orderToRefund = order("urlPlaceholder");
+export const orderToRefund: OrderRefundData_order = {
+  __typename: "Order",
+  id: "ifgdfuhdfdf",
+  number: "22",
+  total: {
+    __typename: "TaxedMoney",
+    gross: {
+      __typename: "Money",
+      amount: 260.2,
+      currency: "USD"
+    }
+  },
+  totalCaptured: {
+    __typename: "Money",
+    amount: 160.2,
+    currency: "USD"
+  }
+};

--- a/src/orders/components/OrderRefundPage/fixtures.ts
+++ b/src/orders/components/OrderRefundPage/fixtures.ts
@@ -1,0 +1,5 @@
+/* eslint-disable sort-keys */
+
+import { order } from "@saleor/orders/fixtures";
+
+export const orderToRefund = order("urlPlaceholder");

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -1,16 +1,15 @@
 import useForm, { FormChange, SubmitPromise } from "@saleor/hooks/useForm";
-import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
+import { OrderRefundData_order } from "@saleor/orders/types/OrderRefundData";
 import handleFormSubmit from "@saleor/utils/handlers/handleFormSubmit";
 import React from "react";
 
-// TODO: This type need to be replaced with generated GraphQL type before merge to master!
+// TODO: This type probably need to be replaced with generated GraphQL type!
 export enum OrderRefundType {
-  PRODUCTS,
   MISCELLANEOUS
 }
 
 export interface OrderRefundData {
-  amount?: number | string;
+  amount: number | string;
   type: OrderRefundType;
 }
 
@@ -31,7 +30,7 @@ export interface UseOrderRefundFormResult {
 
 interface OrderRefundFormProps {
   children: (props: UseOrderRefundFormResult) => React.ReactNode;
-  order: OrderDetails_order;
+  order: OrderRefundData_order;
   onSubmit: (data: OrderRefundSubmitData) => SubmitPromise;
 }
 
@@ -43,7 +42,7 @@ function getOrderRefundPageFormData() {
 }
 
 function useOrderRefundForm(
-  order: OrderDetails_order,
+  order: OrderRefundData_order,
   onSubmit: (data: OrderRefundSubmitData) => SubmitPromise
 ): UseOrderRefundFormResult {
   const [changed, setChanged] = React.useState(false);

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -1,0 +1,90 @@
+import useForm, { FormChange, SubmitPromise } from "@saleor/hooks/useForm";
+import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
+import handleFormSubmit from "@saleor/utils/handlers/handleFormSubmit";
+import React from "react";
+
+// TODO: This type need to be replaced with generated GraphQL type before merge to master!
+export enum OrderRefundType {
+  PRODUCTS,
+  MISCELLANEOUS
+}
+
+export interface OrderRefundData {
+  amount?: number | string;
+  type: OrderRefundType;
+}
+
+export interface OrderRefundHandlers {
+  changeOrderRefundType: FormChange;
+}
+
+export type OrderRefundSubmitData = OrderRefundData;
+
+export interface UseOrderRefundFormResult {
+  change: FormChange;
+  data: OrderRefundData;
+  disabled: boolean;
+  handlers: OrderRefundHandlers;
+  hasChanged: boolean;
+  submit: () => Promise<boolean>;
+}
+
+interface OrderRefundFormProps {
+  children: (props: UseOrderRefundFormResult) => React.ReactNode;
+  order: OrderDetails_order;
+  onSubmit: (data: OrderRefundSubmitData) => SubmitPromise;
+}
+
+function getOrderRefundPageFormData() {
+  return {
+    amount: undefined,
+    type: OrderRefundType.MISCELLANEOUS
+  };
+}
+
+function useOrderRefundForm(
+  order: OrderDetails_order,
+  onSubmit: (data: OrderRefundSubmitData) => SubmitPromise
+): UseOrderRefundFormResult {
+  const [changed, setChanged] = React.useState(false);
+  const triggerChange = () => setChanged(true);
+
+  const form = useForm(getOrderRefundPageFormData());
+
+  const handleChange: FormChange = (event, cb) => {
+    form.change(event, cb);
+    triggerChange();
+  };
+
+  const handleOrderRefundTypeChange: FormChange = () => undefined; // TODO: handle change!!!
+
+  const data: OrderRefundData = {
+    ...form.data
+  };
+
+  const submit = () => handleFormSubmit(data, onSubmit, setChanged);
+
+  const disabled = !order;
+
+  return {
+    change: handleChange,
+    data,
+    disabled,
+    handlers: { changeOrderRefundType: handleOrderRefundTypeChange },
+    hasChanged: changed,
+    submit
+  };
+}
+
+const OrderRefundForm: React.FC<OrderRefundFormProps> = ({
+  children,
+  order,
+  onSubmit
+}) => {
+  const props = useOrderRefundForm(order, onSubmit);
+
+  return <form onSubmit={props.submit}>{children(props)}</form>;
+};
+
+OrderRefundForm.displayName = "OrderRefundForm";
+export default OrderRefundForm;

--- a/src/orders/components/OrderRefundPage/index.ts
+++ b/src/orders/components/OrderRefundPage/index.ts
@@ -1,0 +1,2 @@
+export * from "./OrderRefundPage";
+export { default } from "./OrderRefundPage";

--- a/src/orders/containers/OrderOperations.tsx
+++ b/src/orders/containers/OrderOperations.tsx
@@ -17,7 +17,6 @@ import {
   TypedOrderLinesAddMutation,
   TypedOrderLineUpdateMutation,
   TypedOrderMarkAsPaidMutation,
-  TypedOrderRefundMutation,
   TypedOrderShippingMethodUpdateMutation,
   TypedOrderUpdateMutation,
   TypedOrderVoidMutation
@@ -66,7 +65,6 @@ import {
   OrderMarkAsPaid,
   OrderMarkAsPaidVariables
 } from "../types/OrderMarkAsPaid";
-import { OrderRefund, OrderRefundVariables } from "../types/OrderRefund";
 import {
   OrderShippingMethodUpdate,
   OrderShippingMethodUpdateVariables
@@ -96,10 +94,6 @@ interface OrderOperationsProps {
     orderPaymentCapture: PartialMutationProviderOutput<
       OrderCapture,
       OrderCaptureVariables
-    >;
-    orderPaymentRefund: PartialMutationProviderOutput<
-      OrderRefund,
-      OrderRefundVariables
     >;
     orderPaymentMarkAsPaid: PartialMutationProviderOutput<
       OrderMarkAsPaid,
@@ -154,7 +148,6 @@ interface OrderOperationsProps {
   onOrderMarkAsPaid: (data: OrderMarkAsPaid) => void;
   onNoteAdd: (data: OrderAddNote) => void;
   onPaymentCapture: (data: OrderCapture) => void;
-  onPaymentRefund: (data: OrderRefund) => void;
   onUpdate: (data: OrderUpdate) => void;
   onDraftCancel: (data: OrderDraftCancel) => void;
   onDraftFinalize: (data: OrderDraftFinalize) => void;
@@ -177,7 +170,6 @@ const OrderOperations: React.FC<OrderOperationsProps> = ({
   onOrderLineUpdate,
   onOrderVoid,
   onPaymentCapture,
-  onPaymentRefund,
   onShippingMethodUpdate,
   onUpdate,
   onDraftCancel,
@@ -194,172 +186,159 @@ const OrderOperations: React.FC<OrderOperationsProps> = ({
         {(...orderCancel) => (
           <TypedOrderCaptureMutation onCompleted={onPaymentCapture}>
             {(...paymentCapture) => (
-              <TypedOrderRefundMutation onCompleted={onPaymentRefund}>
-                {(...paymentRefund) => (
-                  <TypedOrderAddNoteMutation onCompleted={onNoteAdd}>
-                    {(...addNote) => (
-                      <TypedOrderUpdateMutation onCompleted={onUpdate}>
-                        {(...update) => (
-                          <TypedOrderDraftUpdateMutation
-                            onCompleted={onDraftUpdate}
+              <TypedOrderAddNoteMutation onCompleted={onNoteAdd}>
+                {(...addNote) => (
+                  <TypedOrderUpdateMutation onCompleted={onUpdate}>
+                    {(...update) => (
+                      <TypedOrderDraftUpdateMutation
+                        onCompleted={onDraftUpdate}
+                      >
+                        {(...updateDraft) => (
+                          <TypedOrderShippingMethodUpdateMutation
+                            onCompleted={onShippingMethodUpdate}
                           >
-                            {(...updateDraft) => (
-                              <TypedOrderShippingMethodUpdateMutation
-                                onCompleted={onShippingMethodUpdate}
+                            {(...updateShippingMethod) => (
+                              <TypedOrderLineDeleteMutation
+                                onCompleted={onOrderLineDelete}
                               >
-                                {(...updateShippingMethod) => (
-                                  <TypedOrderLineDeleteMutation
-                                    onCompleted={onOrderLineDelete}
+                                {(...deleteOrderLine) => (
+                                  <TypedOrderLinesAddMutation
+                                    onCompleted={onOrderLinesAdd}
                                   >
-                                    {(...deleteOrderLine) => (
-                                      <TypedOrderLinesAddMutation
-                                        onCompleted={onOrderLinesAdd}
+                                    {(...addOrderLine) => (
+                                      <TypedOrderLineUpdateMutation
+                                        onCompleted={onOrderLineUpdate}
                                       >
-                                        {(...addOrderLine) => (
-                                          <TypedOrderLineUpdateMutation
-                                            onCompleted={onOrderLineUpdate}
+                                        {(...updateOrderLine) => (
+                                          <TypedOrderFulfillmentCancelMutation
+                                            onCompleted={
+                                              onOrderFulfillmentCancel
+                                            }
                                           >
-                                            {(...updateOrderLine) => (
-                                              <TypedOrderFulfillmentCancelMutation
+                                            {(...cancelFulfillment) => (
+                                              <TypedOrderFulfillmentUpdateTrackingMutation
                                                 onCompleted={
-                                                  onOrderFulfillmentCancel
+                                                  onOrderFulfillmentUpdate
                                                 }
                                               >
-                                                {(...cancelFulfillment) => (
-                                                  <TypedOrderFulfillmentUpdateTrackingMutation
+                                                {(...updateTrackingNumber) => (
+                                                  <TypedOrderDraftFinalizeMutation
                                                     onCompleted={
-                                                      onOrderFulfillmentUpdate
+                                                      onDraftFinalize
                                                     }
                                                   >
-                                                    {(
-                                                      ...updateTrackingNumber
-                                                    ) => (
-                                                      <TypedOrderDraftFinalizeMutation
+                                                    {(...finalizeDraft) => (
+                                                      <TypedOrderDraftCancelMutation
                                                         onCompleted={
-                                                          onDraftFinalize
+                                                          onDraftCancel
                                                         }
                                                       >
-                                                        {(...finalizeDraft) => (
-                                                          <TypedOrderDraftCancelMutation
+                                                        {(...cancelDraft) => (
+                                                          <TypedOrderMarkAsPaidMutation
                                                             onCompleted={
-                                                              onDraftCancel
+                                                              onOrderMarkAsPaid
                                                             }
                                                           >
                                                             {(
-                                                              ...cancelDraft
+                                                              ...markAsPaid
                                                             ) => (
-                                                              <TypedOrderMarkAsPaidMutation
+                                                              <TypedInvoiceRequestMutation
                                                                 onCompleted={
-                                                                  onOrderMarkAsPaid
+                                                                  onInvoiceRequest
                                                                 }
                                                               >
                                                                 {(
-                                                                  ...markAsPaid
+                                                                  ...invoiceRequest
                                                                 ) => (
-                                                                  <TypedInvoiceRequestMutation
+                                                                  <TypedInvoiceEmailSendMutation
                                                                     onCompleted={
-                                                                      onInvoiceRequest
+                                                                      onInvoiceSend
                                                                     }
                                                                   >
                                                                     {(
-                                                                      ...invoiceRequest
-                                                                    ) => (
-                                                                      <TypedInvoiceEmailSendMutation
-                                                                        onCompleted={
-                                                                          onInvoiceSend
-                                                                        }
-                                                                      >
-                                                                        {(
+                                                                      ...invoiceEmailSend
+                                                                    ) =>
+                                                                      children({
+                                                                        orderAddNote: getMutationProviderData(
+                                                                          ...addNote
+                                                                        ),
+                                                                        orderCancel: getMutationProviderData(
+                                                                          ...orderCancel
+                                                                        ),
+                                                                        orderDraftCancel: getMutationProviderData(
+                                                                          ...cancelDraft
+                                                                        ),
+                                                                        orderDraftFinalize: getMutationProviderData(
+                                                                          ...finalizeDraft
+                                                                        ),
+                                                                        orderDraftUpdate: getMutationProviderData(
+                                                                          ...updateDraft
+                                                                        ),
+                                                                        orderFulfillmentCancel: getMutationProviderData(
+                                                                          ...cancelFulfillment
+                                                                        ),
+                                                                        orderFulfillmentUpdateTracking: getMutationProviderData(
+                                                                          ...updateTrackingNumber
+                                                                        ),
+                                                                        orderInvoiceRequest: getMutationProviderData(
+                                                                          ...invoiceRequest
+                                                                        ),
+                                                                        orderInvoiceSend: getMutationProviderData(
                                                                           ...invoiceEmailSend
-                                                                        ) =>
-                                                                          children(
-                                                                            {
-                                                                              orderAddNote: getMutationProviderData(
-                                                                                ...addNote
-                                                                              ),
-                                                                              orderCancel: getMutationProviderData(
-                                                                                ...orderCancel
-                                                                              ),
-                                                                              orderDraftCancel: getMutationProviderData(
-                                                                                ...cancelDraft
-                                                                              ),
-                                                                              orderDraftFinalize: getMutationProviderData(
-                                                                                ...finalizeDraft
-                                                                              ),
-                                                                              orderDraftUpdate: getMutationProviderData(
-                                                                                ...updateDraft
-                                                                              ),
-                                                                              orderFulfillmentCancel: getMutationProviderData(
-                                                                                ...cancelFulfillment
-                                                                              ),
-                                                                              orderFulfillmentUpdateTracking: getMutationProviderData(
-                                                                                ...updateTrackingNumber
-                                                                              ),
-                                                                              orderInvoiceRequest: getMutationProviderData(
-                                                                                ...invoiceRequest
-                                                                              ),
-                                                                              orderInvoiceSend: getMutationProviderData(
-                                                                                ...invoiceEmailSend
-                                                                              ),
-                                                                              orderLineDelete: getMutationProviderData(
-                                                                                ...deleteOrderLine
-                                                                              ),
-                                                                              orderLineUpdate: getMutationProviderData(
-                                                                                ...updateOrderLine
-                                                                              ),
-                                                                              orderLinesAdd: getMutationProviderData(
-                                                                                ...addOrderLine
-                                                                              ),
-                                                                              orderPaymentCapture: getMutationProviderData(
-                                                                                ...paymentCapture
-                                                                              ),
-                                                                              orderPaymentMarkAsPaid: getMutationProviderData(
-                                                                                ...markAsPaid
-                                                                              ),
-                                                                              orderPaymentRefund: getMutationProviderData(
-                                                                                ...paymentRefund
-                                                                              ),
-                                                                              orderShippingMethodUpdate: getMutationProviderData(
-                                                                                ...updateShippingMethod
-                                                                              ),
-                                                                              orderUpdate: getMutationProviderData(
-                                                                                ...update
-                                                                              ),
-                                                                              orderVoid: getMutationProviderData(
-                                                                                ...orderVoid
-                                                                              )
-                                                                            }
-                                                                          )
-                                                                        }
-                                                                      </TypedInvoiceEmailSendMutation>
-                                                                    )}
-                                                                  </TypedInvoiceRequestMutation>
+                                                                        ),
+                                                                        orderLineDelete: getMutationProviderData(
+                                                                          ...deleteOrderLine
+                                                                        ),
+                                                                        orderLineUpdate: getMutationProviderData(
+                                                                          ...updateOrderLine
+                                                                        ),
+                                                                        orderLinesAdd: getMutationProviderData(
+                                                                          ...addOrderLine
+                                                                        ),
+                                                                        orderPaymentCapture: getMutationProviderData(
+                                                                          ...paymentCapture
+                                                                        ),
+                                                                        orderPaymentMarkAsPaid: getMutationProviderData(
+                                                                          ...markAsPaid
+                                                                        ),
+                                                                        orderShippingMethodUpdate: getMutationProviderData(
+                                                                          ...updateShippingMethod
+                                                                        ),
+                                                                        orderUpdate: getMutationProviderData(
+                                                                          ...update
+                                                                        ),
+                                                                        orderVoid: getMutationProviderData(
+                                                                          ...orderVoid
+                                                                        )
+                                                                      })
+                                                                    }
+                                                                  </TypedInvoiceEmailSendMutation>
                                                                 )}
-                                                              </TypedOrderMarkAsPaidMutation>
+                                                              </TypedInvoiceRequestMutation>
                                                             )}
-                                                          </TypedOrderDraftCancelMutation>
+                                                          </TypedOrderMarkAsPaidMutation>
                                                         )}
-                                                      </TypedOrderDraftFinalizeMutation>
+                                                      </TypedOrderDraftCancelMutation>
                                                     )}
-                                                  </TypedOrderFulfillmentUpdateTrackingMutation>
+                                                  </TypedOrderDraftFinalizeMutation>
                                                 )}
-                                              </TypedOrderFulfillmentCancelMutation>
+                                              </TypedOrderFulfillmentUpdateTrackingMutation>
                                             )}
-                                          </TypedOrderLineUpdateMutation>
+                                          </TypedOrderFulfillmentCancelMutation>
                                         )}
-                                      </TypedOrderLinesAddMutation>
+                                      </TypedOrderLineUpdateMutation>
                                     )}
-                                  </TypedOrderLineDeleteMutation>
+                                  </TypedOrderLinesAddMutation>
                                 )}
-                              </TypedOrderShippingMethodUpdateMutation>
+                              </TypedOrderLineDeleteMutation>
                             )}
-                          </TypedOrderDraftUpdateMutation>
+                          </TypedOrderShippingMethodUpdateMutation>
                         )}
-                      </TypedOrderUpdateMutation>
+                      </TypedOrderDraftUpdateMutation>
                     )}
-                  </TypedOrderAddNoteMutation>
+                  </TypedOrderUpdateMutation>
                 )}
-              </TypedOrderRefundMutation>
+              </TypedOrderAddNoteMutation>
             )}
           </TypedOrderCaptureMutation>
         )}

--- a/src/orders/index.tsx
+++ b/src/orders/index.tsx
@@ -15,12 +15,14 @@ import {
   OrderListUrlQueryParams,
   OrderListUrlSortField,
   orderPath,
+  orderRefundPath,
   OrderUrlQueryParams
 } from "./urls";
 import OrderDetailsComponent from "./views/OrderDetails";
 import OrderDraftListComponent from "./views/OrderDraftList";
 import OrderFulfillComponent from "./views/OrderFulfill";
 import OrderListComponent from "./views/OrderList";
+import OrderRefundComponent from "./views/OrderRefund";
 
 const OrderList: React.FC<RouteComponentProps<any>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
@@ -63,6 +65,10 @@ const OrderFulfill: React.FC<RouteComponentProps<any>> = ({ match }) => (
   <OrderFulfillComponent orderId={decodeURIComponent(match.params.id)} />
 );
 
+const OrderRefund: React.FC<RouteComponentProps<any>> = ({ match }) => (
+  <OrderRefundComponent orderId={decodeURIComponent(match.params.id)} />
+);
+
 const Component = () => {
   const intl = useIntl();
 
@@ -73,6 +79,7 @@ const Component = () => {
         <Route exact path={orderDraftListPath} component={OrderDraftList} />
         <Route exact path={orderListPath} component={OrderList} />
         <Route path={orderFulfillPath(":id")} component={OrderFulfill} />
+        <Route path={orderRefundPath(":id")} component={OrderRefund} />
         <Route path={orderPath(":id")} component={OrderDetails} />
       </Switch>
     </>

--- a/src/orders/mutations.ts
+++ b/src/orders/mutations.ts
@@ -158,7 +158,7 @@ const orderRefundMutation = gql`
     }
   }
 `;
-export const TypedOrderRefundMutation = TypedMutation<
+export const useOrderRefundMutation = makeMutation<
   OrderRefund,
   OrderRefundVariables
 >(orderRefundMutation);

--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -16,6 +16,10 @@ import {
 } from "./types/OrderFulfillData";
 import { OrderList, OrderListVariables } from "./types/OrderList";
 import {
+  OrderRefundData,
+  OrderRefundDataVariables
+} from "./types/OrderRefundData";
+import {
   SearchOrderVariant as SearchOrderVariantType,
   SearchOrderVariantVariables
 } from "./types/SearchOrderVariant";
@@ -238,3 +242,26 @@ export const useOrderFulfillData = makeQuery<
   OrderFulfillData,
   OrderFulfillDataVariables
 >(orderFulfillData);
+
+const orderRefundData = gql`
+  query OrderRefundData($orderId: ID!) {
+    order(id: $orderId) {
+      id
+      number
+      total {
+        gross {
+          amount
+          currency
+        }
+      }
+      totalCaptured {
+        amount
+        currency
+      }
+    }
+  }
+`;
+export const useOrderRefundData = makeQuery<
+  OrderRefundData,
+  OrderRefundDataVariables
+>(orderRefundData);

--- a/src/orders/types/OrderRefundData.ts
+++ b/src/orders/types/OrderRefundData.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: OrderRefundData
+// ====================================================
+
+export interface OrderRefundData_order_total_gross {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderRefundData_order_total {
+  __typename: "TaxedMoney";
+  gross: OrderRefundData_order_total_gross;
+}
+
+export interface OrderRefundData_order_totalCaptured {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface OrderRefundData_order {
+  __typename: "Order";
+  id: string;
+  number: string | null;
+  total: OrderRefundData_order_total | null;
+  totalCaptured: OrderRefundData_order_totalCaptured | null;
+}
+
+export interface OrderRefundData {
+  order: OrderRefundData_order | null;
+}
+
+export interface OrderRefundDataVariables {
+  orderId: string;
+}

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -103,7 +103,6 @@ export type OrderUrlDialog =
   | "edit-shipping-address"
   | "finalize"
   | "mark-paid"
-  | "refund"
   | "void"
   | "invoice-send";
 export type OrderUrlQueryParams = Dialog<OrderUrlDialog> & SingleAction;
@@ -114,3 +113,7 @@ export const orderFulfillPath = (id: string) =>
   urlJoin(orderPath(id), "fulfill");
 export const orderFulfillUrl = (id: string) =>
   orderFulfillPath(encodeURIComponent(id));
+
+export const orderRefundPath = (id: string) => urlJoin(orderPath(id), "refund");
+export const orderRefundUrl = (id: string) =>
+  orderRefundPath(encodeURIComponent(id));

--- a/src/orders/views/OrderDetails/index.tsx
+++ b/src/orders/views/OrderDetails/index.tsx
@@ -47,6 +47,7 @@ import {
   orderDraftListUrl,
   orderFulfillUrl,
   orderListUrl,
+  orderRefundUrl,
   orderUrl,
   OrderUrlDialog,
   OrderUrlQueryParams
@@ -136,7 +137,6 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                 onOrderCancel={orderMessages.handleOrderCancel}
                 onOrderVoid={orderMessages.handleOrderVoid}
                 onPaymentCapture={orderMessages.handlePaymentCapture}
-                onPaymentRefund={orderMessages.handlePaymentRefund}
                 onUpdate={orderMessages.handleUpdate}
                 onDraftUpdate={orderMessages.handleDraftUpdate}
                 onShippingMethodUpdate={
@@ -179,7 +179,6 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                   orderLineDelete,
                   orderLineUpdate,
                   orderPaymentCapture,
-                  orderPaymentRefund,
                   orderVoid,
                   orderShippingMethodUpdate,
                   orderUpdate,
@@ -261,7 +260,7 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                           }
                           onPaymentCapture={() => openModal("capture")}
                           onPaymentVoid={() => openModal("void")}
-                          onPaymentRefund={() => openModal("refund")}
+                          onPaymentRefund={() => navigate(orderRefundUrl(id))}
                           onProductClick={id => () => navigate(productUrl(id))}
                           onBillingAddressEdit={() =>
                             openModal("edit-billing-address")
@@ -351,27 +350,9 @@ export const OrderDetails: React.FC<OrderDetailsProps> = ({ id, params }) => {
                           }
                           initial={order?.total.gross.amount}
                           open={params.action === "capture"}
-                          variant="capture"
                           onClose={closeModal}
                           onSubmit={variables =>
                             orderPaymentCapture.mutate({
-                              ...variables,
-                              id
-                            })
-                          }
-                        />
-                        <OrderPaymentDialog
-                          confirmButtonState={orderPaymentRefund.opts.status}
-                          errors={
-                            orderPaymentRefund.opts.data?.orderRefund.errors ||
-                            []
-                          }
-                          initial={order?.total.gross.amount}
-                          open={params.action === "refund"}
-                          variant="refund"
-                          onClose={closeModal}
-                          onSubmit={variables =>
-                            orderPaymentRefund.mutate({
                               ...variables,
                               id
                             })

--- a/src/orders/views/OrderRefund/OrderRefund.tsx
+++ b/src/orders/views/OrderRefund/OrderRefund.tsx
@@ -1,0 +1,63 @@
+import useNavigator from "@saleor/hooks/useNavigator";
+import useNotifier from "@saleor/hooks/useNotifier";
+import OrderRefundPage from "@saleor/orders/components/OrderRefundPage";
+import { OrderRefundData } from "@saleor/orders/components/OrderRefundPage/form";
+import { useOrderRefundMutation } from "@saleor/orders/mutations";
+import { useOrderRefundData } from "@saleor/orders/queries";
+import { orderUrl } from "@saleor/orders/urls";
+import React from "react";
+import { useIntl } from "react-intl";
+
+interface OrderRefundProps {
+  orderId: string;
+}
+
+const OrderRefund: React.FC<OrderRefundProps> = ({ orderId }) => {
+  const navigate = useNavigator();
+  const notify = useNotifier();
+  const intl = useIntl();
+
+  const { data, loading } = useOrderRefundData({
+    displayLoader: true,
+    variables: {
+      orderId
+    }
+  });
+  const [refundOrder, refundOrderOpts] = useOrderRefundMutation({
+    onCompleted: data => {
+      if (data.orderRefund.errors.length === 0) {
+        navigate(orderUrl(orderId), true);
+        notify({
+          status: "success",
+          text: intl.formatMessage({
+            defaultMessage: "Refunded Items",
+            description: "order refunded success message"
+          })
+        });
+      }
+    }
+  });
+
+  const handleSubmit = async (formData: OrderRefundData) => {
+    const response = await refundOrder({
+      variables: {
+        amount: formData.amount,
+        id: orderId
+      }
+    });
+
+    return response.errors || [];
+  };
+
+  return (
+    <OrderRefundPage
+      order={data?.order}
+      disabled={loading || refundOrderOpts.loading}
+      errors={refundOrderOpts.data?.orderRefund.errors}
+      onSubmit={handleSubmit}
+      onBack={() => navigate(orderUrl(orderId))}
+    />
+  );
+};
+OrderRefund.displayName = "OrderRefund";
+export default OrderRefund;

--- a/src/orders/views/OrderRefund/index.ts
+++ b/src/orders/views/OrderRefund/index.ts
@@ -1,0 +1,2 @@
+export * from "./OrderRefund";
+export { default } from "./OrderRefund";

--- a/src/storybook/stories/orders/OrderPaymentDialog.tsx
+++ b/src/storybook/stories/orders/OrderPaymentDialog.tsx
@@ -13,23 +13,19 @@ const props: OrderPaymentDialogProps = {
   initial: 0,
   onClose: () => undefined,
   onSubmit: () => undefined,
-  open: true,
-  variant: "capture"
+  open: true
 };
 
 storiesOf("Orders / OrderPaymentDialog", module)
   .addDecorator(Decorator)
   .add("capture payment", () => <OrderPaymentDialog {...props} />)
-  .add("refund payment", () => (
-    <OrderPaymentDialog {...props} variant="refund" />
-  ))
   .add("errors", () => (
     <OrderPaymentDialog
       {...props}
       errors={[
         {
           __typename: "OrderError",
-          code: OrderErrorCode.CANNOT_REFUND,
+          code: OrderErrorCode.CAPTURE_INACTIVE_PAYMENT,
           field: null
         },
         {
@@ -38,6 +34,5 @@ storiesOf("Orders / OrderPaymentDialog", module)
           field: "payment"
         }
       ]}
-      variant="refund"
     />
   ));


### PR DESCRIPTION
I want to merge this change because... it replaces the payment refund dialog with a dedicated order refund page.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> master

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
![Zrzut ekranu 2020-11-25 o 14 44 24](https://user-images.githubusercontent.com/9825562/100238098-19a34c00-2f30-11eb-83aa-914044ea5420.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
