### PR TITLE
Update Attributes to sort by slug on initial load

### DIFF
--- a/src/attributes/index.tsx
+++ b/src/attributes/index.tsx
@@ -22,7 +22,10 @@ import AttributeListComponent from "./views/AttributeList";
 const AttributeList: React.FC<RouteComponentProps<{}>> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));
   const params: AttributeListUrlQueryParams = asSortParams(
-    qs,
+    {
+      sort: "slug",
+      ...qs
+    },
     AttributeListUrlSortField
   );
 


### PR DESCRIPTION
I want to merge this change because...

When initially loading the attributes page the default sort key is "name" which is the Default Label column. A user has to click on the first column to sort items by code.

It would be nice if the attributes were initially sorted by Attribute Code. This allows for the easy grouping of attributes with the use of code prefixes.

This change sets the initial sort key to the "slug" field.

PS: This is my first PR, not too sure how it will work. Let me know if there is anything I messed up :)

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ X] All visible strings are translated with proper context.
1. [ X] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ X] Translated strings are extracted.
1. [ X] Number of API calls is optimized.
1. [ X] The changes are tested.
1. [ X] Data-test are added for new elements.
1. [ X] Type definitions are up to date.
1. [X ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
