### PR TITLE
Add zip code deletion

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -5144,6 +5144,13 @@
     "context": "column title",
     "string": "Channel name"
   },
+  "src_dot_shipping_dot_components_dot_ShippingRateZipCodeRangeRemoveDialog_dot_1083561409": {
+    "string": "Are you sure you want to remove this ZIP-code rule?"
+  },
+  "src_dot_shipping_dot_components_dot_ShippingRateZipCodeRangeRemoveDialog_dot_2944856644": {
+    "context": "header",
+    "string": "Remove ZIP-codes from Shipping Rate"
+  },
   "src_dot_shipping_dot_components_dot_ShippingWeightUnitForm_dot_2863708228": {
     "string": "This unit will be used as default shipping weight"
   },
@@ -5271,6 +5278,25 @@
   "src_dot_shipping_dot_components_dot_ShippingZoneWarehouses_dot_46197273": {
     "context": "input placeholder",
     "string": "Select Warehouse"
+  },
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_1938537617": {
+    "string": "Please provide range of ZIP codes you want to add to the include/exclude list."
+  },
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_3099331554": {
+    "context": "add zip code range, button",
+    "string": "Add"
+  },
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_3529644799": {
+    "context": "range input label",
+    "string": "Zip Codes (Start)"
+  },
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_4196919717": {
+    "context": "dialog header",
+    "string": "Add ZIP-Codes"
+  },
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_551327109": {
+    "context": "range input label",
+    "string": "Zip Codes (End)"
   },
   "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_1462092303": {
     "string": "Added ZIP-codes will be excluded from using this delivery methods. If none are added all ZIP-Codes will be able to use that shipping rate"

--- a/src/shipping/components/ShippingRateZipCodeRangeRemoveDialog/ShippingRateZipCodeRangeRemoveDialog.tsx
+++ b/src/shipping/components/ShippingRateZipCodeRangeRemoveDialog/ShippingRateZipCodeRangeRemoveDialog.tsx
@@ -1,0 +1,42 @@
+import DialogContentText from "@material-ui/core/DialogContentText";
+import ActionDialog from "@saleor/components/ActionDialog";
+import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
+import { DialogProps } from "@saleor/types";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+export interface ShippingRateZipCodeRangeRemoveDialogProps extends DialogProps {
+  confirmButtonState: ConfirmButtonTransitionState;
+  onConfirm: () => void;
+}
+
+const ShippingRateZipCodeRangeRemoveDialog: React.FC<ShippingRateZipCodeRangeRemoveDialogProps> = ({
+  confirmButtonState,
+  open,
+  onClose,
+  onConfirm
+}) => {
+  const intl = useIntl();
+
+  return (
+    <ActionDialog
+      confirmButtonState={confirmButtonState}
+      open={open}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title={intl.formatMessage({
+        defaultMessage: "Remove ZIP-codes from Shipping Rate",
+        description: "header"
+      })}
+      variant="delete"
+    >
+      <DialogContentText>
+        <FormattedMessage defaultMessage="Are you sure you want to remove this ZIP-code rule?" />
+      </DialogContentText>
+    </ActionDialog>
+  );
+};
+
+ShippingRateZipCodeRangeRemoveDialog.displayName =
+  "ShippingRateZipCodeRangeRemoveDialog";
+export default ShippingRateZipCodeRangeRemoveDialog;

--- a/src/shipping/components/ShippingRateZipCodeRangeRemoveDialog/index.ts
+++ b/src/shipping/components/ShippingRateZipCodeRangeRemoveDialog/index.ts
@@ -1,0 +1,2 @@
+export * from "./ShippingRateZipCodeRangeRemoveDialog";
+export { default } from "./ShippingRateZipCodeRangeRemoveDialog";

--- a/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.stories.tsx
+++ b/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.stories.tsx
@@ -47,11 +47,27 @@ const props: ShippingZoneRatesPageProps = {
   onChannelsChange: () => undefined,
   onDelete: () => undefined,
   onSubmit: () => undefined,
+  onZipCodeAssign: () => undefined,
+  onZipCodeUnassign: () => undefined,
   openChannelsModal: () => undefined,
   rate: null,
   saveButtonBarState: "default",
   shippingChannels: defaultChannels,
-  variant: ShippingMethodTypeEnum.PRICE
+  variant: ShippingMethodTypeEnum.PRICE,
+  zipCodes: [
+    {
+      __typename: "ShippingMethodZipCode",
+      end: "51-200",
+      id: "1",
+      start: "51-220"
+    },
+    {
+      __typename: "ShippingMethodZipCode",
+      end: "31-101",
+      id: "1",
+      start: "44-205"
+    }
+  ]
 };
 
 storiesOf("Views / Shipping / Shipping rate", module)
@@ -82,4 +98,7 @@ storiesOf("Views / Shipping / Shipping rate", module)
       rate={shippingZone.shippingMethods[0]}
       variant={ShippingMethodTypeEnum.WEIGHT}
     />
+  ))
+  .add("no zip codes", () => (
+    <ShippingZoneRatesPage {...props} zipCodes={[]} />
   ));

--- a/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
+++ b/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
@@ -10,7 +10,10 @@ import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import { ShippingChannelsErrorFragment } from "@saleor/fragments/types/ShippingChannelsErrorFragment";
 import { ShippingErrorFragment } from "@saleor/fragments/types/ShippingErrorFragment";
-import { ShippingMethodFragment } from "@saleor/fragments/types/ShippingMethodFragment";
+import {
+  ShippingMethodFragment,
+  ShippingMethodFragment_zipCodes
+} from "@saleor/fragments/types/ShippingMethodFragment";
 import { validatePrice } from "@saleor/products/utils/validation";
 import OrderValue from "@saleor/shipping/components/OrderValue";
 import OrderWeight from "@saleor/shipping/components/OrderWeight";
@@ -41,12 +44,15 @@ export interface ShippingZoneRatesPageProps {
   disabled: boolean;
   hasChannelChanged?: boolean;
   rate: ShippingMethodFragment | null;
+  zipCodes?: ShippingMethodFragment_zipCodes[];
   channelErrors: ShippingChannelsErrorFragment[];
   errors: ShippingErrorFragment[];
   saveButtonBarState: ConfirmButtonTransitionState;
   onBack: () => void;
   onDelete?: () => void;
   onSubmit: (data: FormData) => void;
+  onZipCodeAssign: () => void;
+  onZipCodeUnassign: (id: string) => void;
   onChannelsChange: (data: ChannelShippingData[]) => void;
   openChannelsModal: () => void;
   variant: ShippingMethodTypeEnum;
@@ -63,10 +69,13 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
   onDelete,
   onSubmit,
   onChannelsChange,
+  onZipCodeAssign,
+  onZipCodeUnassign,
   openChannelsModal,
   rate,
   saveButtonBarState,
-  variant
+  variant,
+  zipCodes
 }) => {
   const intl = useIntl();
   const isPriceVariant = variant === ShippingMethodTypeEnum.PRICE;
@@ -152,10 +161,10 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
                 <ShippingZoneZipCodes
                   data={data}
                   disabled={disabled}
-                  onZipCodeDelete={() => undefined}
+                  onZipCodeDelete={onZipCodeUnassign}
                   onZipCodeInclusionChange={() => undefined}
-                  onZipCodeRangeAdd={() => undefined}
-                  zipCodes={rateExists ? rate?.zipCodes : []}
+                  onZipCodeRangeAdd={onZipCodeAssign}
+                  zipCodes={rateExists ? rate?.zipCodes : zipCodes}
                 />
               </div>
               <div>

--- a/src/shipping/components/ShippingZoneZipCodeRangeDialog/ShippingZoneZipCodeRangeDialog.stories.tsx
+++ b/src/shipping/components/ShippingZoneZipCodeRangeDialog/ShippingZoneZipCodeRangeDialog.stories.tsx
@@ -1,0 +1,16 @@
+import Decorator from "@saleor/storybook/Decorator";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import ShippingZoneZipCodeRangeDialog from "./ShippingZoneZipCodeRangeDialog";
+
+storiesOf("Shipping / Add zip code range", module)
+  .addDecorator(Decorator)
+  .add("default", () => (
+    <ShippingZoneZipCodeRangeDialog
+      confirmButtonState="default"
+      open={true}
+      onClose={() => undefined}
+      onSubmit={() => undefined}
+    />
+  ));

--- a/src/shipping/components/ShippingZoneZipCodeRangeDialog/ShippingZoneZipCodeRangeDialog.tsx
+++ b/src/shipping/components/ShippingZoneZipCodeRangeDialog/ShippingZoneZipCodeRangeDialog.tsx
@@ -1,0 +1,108 @@
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import TextField from "@material-ui/core/TextField";
+import Typography from "@material-ui/core/Typography";
+import ConfirmButton, {
+  ConfirmButtonTransitionState
+} from "@saleor/components/ConfirmButton";
+import Form from "@saleor/components/Form";
+import Grid from "@saleor/components/Grid";
+import { buttonMessages } from "@saleor/intl";
+import { DialogProps, MinMax } from "@saleor/types";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+export interface ShippingZoneZipCodeRangeDialogProps extends DialogProps {
+  confirmButtonState: ConfirmButtonTransitionState;
+  onSubmit: (range: MinMax) => void;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    info: {
+      marginBottom: theme.spacing(2)
+    }
+  }),
+  {
+    name: "ShippingZoneZipCodeRangeDialog"
+  }
+);
+
+const ShippingZoneZipCodeRangeDialog: React.FC<ShippingZoneZipCodeRangeDialogProps> = ({
+  confirmButtonState,
+  open,
+  onClose,
+  onSubmit
+}) => {
+  const classes = useStyles({});
+  const intl = useIntl();
+
+  const initial: MinMax = {
+    max: "",
+    min: ""
+  };
+
+  return (
+    <Dialog open={open}>
+      <DialogTitle>
+        <FormattedMessage
+          defaultMessage="Add ZIP-Codes"
+          description="dialog header"
+        />
+      </DialogTitle>
+      <Form initial={initial} onSubmit={onSubmit}>
+        {({ change, data, hasChanged }) => (
+          <>
+            <DialogContent>
+              <Typography className={classes.info}>
+                <FormattedMessage defaultMessage="Please provide range of ZIP codes you want to add to the include/exclude list." />
+              </Typography>
+              <Grid variant="uniform">
+                <TextField
+                  label={intl.formatMessage({
+                    defaultMessage: "Zip Codes (Start)",
+                    description: "range input label"
+                  })}
+                  name="min"
+                  value={data.min}
+                  onChange={change}
+                />
+                <TextField
+                  label={intl.formatMessage({
+                    defaultMessage: "Zip Codes (End)",
+                    description: "range input label"
+                  })}
+                  name="max"
+                  value={data.max}
+                  onChange={change}
+                />
+              </Grid>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={onClose}>
+                <FormattedMessage {...buttonMessages.back} />
+              </Button>
+              <ConfirmButton
+                disabled={!hasChanged}
+                transitionState={confirmButtonState}
+                type="submit"
+              >
+                <FormattedMessage
+                  defaultMessage="Add"
+                  description="add zip code range, button"
+                />
+              </ConfirmButton>
+            </DialogActions>
+          </>
+        )}
+      </Form>
+    </Dialog>
+  );
+};
+
+ShippingZoneZipCodeRangeDialog.displayName = "ShippingZoneZipCodeRangeDialog";
+export default ShippingZoneZipCodeRangeDialog;

--- a/src/shipping/components/ShippingZoneZipCodeRangeDialog/index.ts
+++ b/src/shipping/components/ShippingZoneZipCodeRangeDialog/index.ts
@@ -1,0 +1,2 @@
+export * from "./ShippingZoneZipCodeRangeDialog";
+export { default } from "./ShippingZoneZipCodeRangeDialog";

--- a/src/shipping/index.tsx
+++ b/src/shipping/index.tsx
@@ -8,6 +8,7 @@ import { WindowTitle } from "../components/WindowTitle";
 import {
   shippingPriceRatesEditPath,
   shippingPriceRatesPath,
+  ShippingRateUrlQueryParams,
   shippingWeightRatesEditPath,
   shippingWeightRatesPath,
   shippingZoneAddPath,
@@ -57,22 +58,34 @@ const WeightRatesCreate: React.FC<RouteComponentProps<{ id: string }>> = ({
 const WeightRatesUpdate: React.FC<RouteComponentProps<{
   id: string;
   rateId: string;
-}>> = ({ match }) => (
-  <WeightRatesUpdateComponent
-    id={decodeURIComponent(match.params.id)}
-    rateId={decodeURIComponent(match.params.rateId)}
-  />
-);
+}>> = ({ match }) => {
+  const qs = parseQs(location.search.substr(1));
+  const params: ShippingRateUrlQueryParams = qs;
+
+  return (
+    <WeightRatesUpdateComponent
+      id={decodeURIComponent(match.params.id)}
+      rateId={decodeURIComponent(match.params.rateId)}
+      params={params}
+    />
+  );
+};
 
 const PriceRatesUpdate: React.FC<RouteComponentProps<{
   id: string;
   rateId: string;
-}>> = ({ match }) => (
-  <PriceRatesUpdateComponent
-    id={decodeURIComponent(match.params.id)}
-    rateId={decodeURIComponent(match.params.rateId)}
-  />
-);
+}>> = ({ match }) => {
+  const qs = parseQs(location.search.substr(1));
+  const params: ShippingRateUrlQueryParams = qs;
+
+  return (
+    <PriceRatesUpdateComponent
+      id={decodeURIComponent(match.params.id)}
+      rateId={decodeURIComponent(match.params.rateId)}
+      params={params}
+    />
+  );
+};
 
 export const ShippingRouter: React.FC = () => {
   const intl = useIntl();

--- a/src/shipping/index.tsx
+++ b/src/shipping/index.tsx
@@ -6,10 +6,10 @@ import { Route, RouteComponentProps, Switch } from "react-router-dom";
 
 import { WindowTitle } from "../components/WindowTitle";
 import {
-  shippingPriceRatesEditUrl,
-  shippingPriceRatesUrl,
-  shippingWeightRatesEditUrl,
-  shippingWeightRatesUrl,
+  shippingPriceRatesEditPath,
+  shippingPriceRatesPath,
+  shippingWeightRatesEditPath,
+  shippingWeightRatesPath,
   shippingZoneAddPath,
   shippingZonePath,
   shippingZonesListPath,
@@ -97,19 +97,19 @@ export const ShippingRouter: React.FC = () => {
           component={ShippingZoneDetails}
         />
         <Route
-          path={shippingPriceRatesUrl(":id")}
+          path={shippingPriceRatesPath(":id")}
           component={PriceRatesCreate}
         />
         <Route
-          path={shippingWeightRatesUrl(":id")}
+          path={shippingWeightRatesPath(":id")}
           component={WeightRatesCreate}
         />
         <Route
-          path={shippingWeightRatesEditUrl(":id", ":rateId")}
+          path={shippingWeightRatesEditPath(":id", ":rateId")}
           component={WeightRatesUpdate}
         />
         <Route
-          path={shippingPriceRatesEditUrl(":id", ":rateId")}
+          path={shippingPriceRatesEditPath(":id", ":rateId")}
           component={PriceRatesUpdate}
         />
       </Switch>

--- a/src/shipping/index.tsx
+++ b/src/shipping/index.tsx
@@ -8,6 +8,7 @@ import { WindowTitle } from "../components/WindowTitle";
 import {
   shippingPriceRatesEditPath,
   shippingPriceRatesPath,
+  ShippingRateCreateUrlQueryParams,
   ShippingRateUrlQueryParams,
   shippingWeightRatesEditPath,
   shippingWeightRatesPath,
@@ -49,11 +50,31 @@ const ShippingZoneDetails: React.FC<RouteComponentProps<
 
 const PriceRatesCreate: React.FC<RouteComponentProps<{ id: string }>> = ({
   match
-}) => <PriceRatesCreateComponent id={decodeURIComponent(match.params.id)} />;
+}) => {
+  const qs = parseQs(location.search.substr(1));
+  const params: ShippingRateCreateUrlQueryParams = qs;
+
+  return (
+    <PriceRatesCreateComponent
+      id={decodeURIComponent(match.params.id)}
+      params={params}
+    />
+  );
+};
 
 const WeightRatesCreate: React.FC<RouteComponentProps<{ id: string }>> = ({
   match
-}) => <WeightRatesCreateComponent id={decodeURIComponent(match.params.id)} />;
+}) => {
+  const qs = parseQs(location.search.substr(1));
+  const params: ShippingRateCreateUrlQueryParams = qs;
+
+  return (
+    <WeightRatesCreateComponent
+      id={decodeURIComponent(match.params.id)}
+      params={params}
+    />
+  );
+};
 
 const WeightRatesUpdate: React.FC<RouteComponentProps<{
   id: string;

--- a/src/shipping/mutations.ts
+++ b/src/shipping/mutations.ts
@@ -39,6 +39,10 @@ import {
   ShippingMethodChannelListingUpdateVariables
 } from "./types/ShippingMethodChannelListingUpdate";
 import {
+  ShippingMethodZipCodeRangeAssign,
+  ShippingMethodZipCodeRangeAssignVariables
+} from "./types/ShippingMethodZipCodeRangeAssign";
+import {
   UpdateDefaultWeightUnit,
   UpdateDefaultWeightUnitVariables
 } from "./types/UpdateDefaultWeightUnit";
@@ -245,3 +249,21 @@ export const useShippingMethodChannelListingUpdate = makeMutation<
   ShippingMethodChannelListingUpdate,
   ShippingMethodChannelListingUpdateVariables
 >(shippingMethodChannelListingUpdate);
+
+export const shippingMethodZipCodeRangeAssign = gql`
+  ${shippingChannelsErrorFragment}
+  mutation ShippingMethodZipCodeRangeAssign(
+    $input: ShippingZipCodeCreateInput!
+  ) {
+    shippingMethodZipCodeCreate(input: $input) {
+      errors: shippingErrors {
+        ...ShippingChannelsErrorFragment
+      }
+    }
+  }
+`;
+
+export const useShippingMethodZipCodeRangeAssign = makeMutation<
+  ShippingMethodZipCodeRangeAssign,
+  ShippingMethodZipCodeRangeAssignVariables
+>(shippingMethodZipCodeRangeAssign);

--- a/src/shipping/mutations.ts
+++ b/src/shipping/mutations.ts
@@ -43,6 +43,10 @@ import {
   ShippingMethodZipCodeRangeAssignVariables
 } from "./types/ShippingMethodZipCodeRangeAssign";
 import {
+  ShippingMethodZipCodeRangeUnassign,
+  ShippingMethodZipCodeRangeUnassignVariables
+} from "./types/ShippingMethodZipCodeRangeUnassign";
+import {
   UpdateDefaultWeightUnit,
   UpdateDefaultWeightUnitVariables
 } from "./types/UpdateDefaultWeightUnit";
@@ -267,3 +271,19 @@ export const useShippingMethodZipCodeRangeAssign = makeMutation<
   ShippingMethodZipCodeRangeAssign,
   ShippingMethodZipCodeRangeAssignVariables
 >(shippingMethodZipCodeRangeAssign);
+
+export const shippingMethodZipCodeDelete = gql`
+  ${shippingChannelsErrorFragment}
+  mutation ShippingMethodZipCodeRangeUnassign($id: ID!) {
+    shippingMethodZipCodeDelete(id: $id) {
+      errors: shippingErrors {
+        ...ShippingChannelsErrorFragment
+      }
+    }
+  }
+`;
+
+export const useShippingMethodZipCodeRangeUnassign = makeMutation<
+  ShippingMethodZipCodeRangeUnassign,
+  ShippingMethodZipCodeRangeUnassignVariables
+>(shippingMethodZipCodeDelete);

--- a/src/shipping/types/ShippingMethodZipCodeRangeAssign.ts
+++ b/src/shipping/types/ShippingMethodZipCodeRangeAssign.ts
@@ -1,0 +1,29 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { ShippingZipCodeCreateInput, ShippingErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: ShippingMethodZipCodeRangeAssign
+// ====================================================
+
+export interface ShippingMethodZipCodeRangeAssign_shippingMethodZipCodeCreate_errors {
+  __typename: "ShippingError";
+  code: ShippingErrorCode;
+  field: string | null;
+  channels: string[] | null;
+}
+
+export interface ShippingMethodZipCodeRangeAssign_shippingMethodZipCodeCreate {
+  __typename: "ShippingZipCodeCreate";
+  errors: ShippingMethodZipCodeRangeAssign_shippingMethodZipCodeCreate_errors[];
+}
+
+export interface ShippingMethodZipCodeRangeAssign {
+  shippingMethodZipCodeCreate: ShippingMethodZipCodeRangeAssign_shippingMethodZipCodeCreate | null;
+}
+
+export interface ShippingMethodZipCodeRangeAssignVariables {
+  input: ShippingZipCodeCreateInput;
+}

--- a/src/shipping/types/ShippingMethodZipCodeRangeUnassign.ts
+++ b/src/shipping/types/ShippingMethodZipCodeRangeUnassign.ts
@@ -1,0 +1,29 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { ShippingErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: ShippingMethodZipCodeRangeUnassign
+// ====================================================
+
+export interface ShippingMethodZipCodeRangeUnassign_shippingMethodZipCodeDelete_errors {
+  __typename: "ShippingError";
+  code: ShippingErrorCode;
+  field: string | null;
+  channels: string[] | null;
+}
+
+export interface ShippingMethodZipCodeRangeUnassign_shippingMethodZipCodeDelete {
+  __typename: "ShippingZipCodeDelete";
+  errors: ShippingMethodZipCodeRangeUnassign_shippingMethodZipCodeDelete_errors[];
+}
+
+export interface ShippingMethodZipCodeRangeUnassign {
+  shippingMethodZipCodeDelete: ShippingMethodZipCodeRangeUnassign_shippingMethodZipCodeDelete | null;
+}
+
+export interface ShippingMethodZipCodeRangeUnassignVariables {
+  id: string;
+}

--- a/src/shipping/urls.ts
+++ b/src/shipping/urls.ts
@@ -55,7 +55,7 @@ export const shippingPriceRatesEditPath = (id: string, rateId: string) =>
 export const shippingPriceRatesEditUrl = (
   id: string,
   rateId: string,
-  params: ShippingRateUrlQueryParams
+  params?: ShippingRateUrlQueryParams
 ) =>
   shippingPriceRatesEditPath(
     encodeURIComponent(id),
@@ -69,7 +69,7 @@ export const shippingWeightRatesEditPath = (id: string, rateId: string) =>
 export const shippingWeightRatesEditUrl = (
   id: string,
   rateId: string,
-  params: ShippingRateUrlQueryParams
+  params?: ShippingRateUrlQueryParams
 ) =>
   shippingWeightRatesEditPath(
     encodeURIComponent(id),

--- a/src/shipping/urls.ts
+++ b/src/shipping/urls.ts
@@ -36,17 +36,47 @@ export const shippingZoneUrl = (
   params?: ShippingZoneUrlQueryParams
 ) => shippingZonePath(encodeURIComponent(id)) + "?" + stringifyQs(params);
 
-export const shippingPriceRatesUrl = (id: string) =>
+export type ShippingRateUrlDialog = "add-range" | "remove" | "remove-range";
+export type ShippingRateUrlQueryParams = Dialog<ShippingRateUrlDialog> &
+  SingleAction;
+
+export const shippingPriceRatesPath = (id: string) =>
   urlJoin(shippingZonePath(id), "price", "add");
+export const shippingPriceRatesUrl = (id: string) =>
+  shippingPriceRatesPath(encodeURIComponent(id));
 
-export const shippingWeightRatesUrl = (id: string) =>
+export const shippingWeightRatesPath = (id: string) =>
   urlJoin(shippingZonePath(id), "weight", "add");
+export const shippingWeightRatesUrl = (id: string) =>
+  shippingWeightRatesPath(encodeURIComponent(id));
 
-export const shippingWeightRatesEditUrl = (id: string, rateId: string) =>
-  urlJoin(shippingZonePath(id), "weight", rateId);
-
-export const shippingPriceRatesEditUrl = (id: string, rateId: string) =>
+export const shippingPriceRatesEditPath = (id: string, rateId: string) =>
   urlJoin(shippingZonePath(id), "price", rateId);
+export const shippingPriceRatesEditUrl = (
+  id: string,
+  rateId: string,
+  params: ShippingRateUrlQueryParams
+) =>
+  shippingPriceRatesEditPath(
+    encodeURIComponent(id),
+    encodeURIComponent(rateId)
+  ) +
+  "?" +
+  stringifyQs(params);
+
+export const shippingWeightRatesEditPath = (id: string, rateId: string) =>
+  urlJoin(shippingZonePath(id), "weight", rateId);
+export const shippingWeightRatesEditUrl = (
+  id: string,
+  rateId: string,
+  params: ShippingRateUrlQueryParams
+) =>
+  shippingWeightRatesEditPath(
+    encodeURIComponent(id),
+    encodeURIComponent(rateId)
+  ) +
+  "?" +
+  stringifyQs(params);
 
 export const shippingZoneAddPath = urlJoin(shippingZonesListPath, "add");
 export const shippingZoneAddUrl = shippingZoneAddPath;

--- a/src/shipping/urls.ts
+++ b/src/shipping/urls.ts
@@ -36,19 +36,30 @@ export const shippingZoneUrl = (
   params?: ShippingZoneUrlQueryParams
 ) => shippingZonePath(encodeURIComponent(id)) + "?" + stringifyQs(params);
 
-export type ShippingRateUrlDialog = "add-range" | "remove" | "remove-range";
+type ZipCodeRangeActions = "add-range" | "remove-range";
+export type ShippingRateUrlDialog = ZipCodeRangeActions | "remove";
 export type ShippingRateUrlQueryParams = Dialog<ShippingRateUrlDialog> &
+  SingleAction;
+export type ShippingRateCreateUrlDialog = ZipCodeRangeActions;
+export type ShippingRateCreateUrlQueryParams = Dialog<
+  ShippingRateCreateUrlDialog
+> &
   SingleAction;
 
 export const shippingPriceRatesPath = (id: string) =>
   urlJoin(shippingZonePath(id), "price", "add");
-export const shippingPriceRatesUrl = (id: string) =>
-  shippingPriceRatesPath(encodeURIComponent(id));
+export const shippingPriceRatesUrl = (
+  id: string,
+  params?: ShippingRateCreateUrlQueryParams
+) => shippingPriceRatesPath(encodeURIComponent(id)) + "?" + stringifyQs(params);
 
 export const shippingWeightRatesPath = (id: string) =>
   urlJoin(shippingZonePath(id), "weight", "add");
-export const shippingWeightRatesUrl = (id: string) =>
-  shippingWeightRatesPath(encodeURIComponent(id));
+export const shippingWeightRatesUrl = (
+  id: string,
+  params?: ShippingRateCreateUrlQueryParams
+) =>
+  shippingWeightRatesPath(encodeURIComponent(id)) + "?" + stringifyQs(params);
 
 export const shippingPriceRatesEditPath = (id: string, rateId: string) =>
   urlJoin(shippingZonePath(id), "price", rateId);
@@ -79,9 +90,4 @@ export const shippingWeightRatesEditUrl = (
   stringifyQs(params);
 
 export const shippingZoneAddPath = urlJoin(shippingZonesListPath, "add");
-export const shippingZoneAddUrl = shippingZoneAddPath;
-export const shippingPriceRatesAddPath = urlJoin(
-  shippingZonesListPath,
-  "price",
-  "add"
-);
+export const shippingZoneAddUrl = shippingZoneAddPath + "?";

--- a/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
+++ b/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
@@ -130,6 +130,7 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({ id }) => {
         rate={null}
         openChannelsModal={handleChannelsModalOpen}
         onChannelsChange={setCurrentChannels}
+        rate={null}
         variant={ShippingMethodTypeEnum.PRICE}
       />
     </>

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -14,11 +14,15 @@ import DeleteShippingRateDialog from "@saleor/shipping/components/DeleteShipping
 import ShippingZoneRatesPage, {
   FormData
 } from "@saleor/shipping/components/ShippingZoneRatesPage";
+import ShippingZoneZipCodeRangeDialog from "@saleor/shipping/components/ShippingZoneZipCodeRangeDialog";
 import {
   getShippingMethodChannelVariables,
   getUpdateShippingPriceRateVariables
 } from "@saleor/shipping/handlers";
-import { useShippingMethodChannelListingUpdate } from "@saleor/shipping/mutations";
+import {
+  useShippingMethodChannelListingUpdate,
+  useShippingMethodZipCodeRangeAssign
+} from "@saleor/shipping/mutations";
 import {
   useShippingRateDelete,
   useShippingRateUpdate
@@ -69,6 +73,21 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
     updateShippingMethodChannelListing,
     updateShippingMethodChannelListingOpts
   ] = useShippingMethodChannelListingUpdate({});
+
+  const [
+    assignZipCodeRange,
+    assignZipCodeRangeOpts
+  ] = useShippingMethodZipCodeRangeAssign({
+    onCompleted: data => {
+      if (data.shippingMethodZipCodeCreate.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        closeModal();
+      }
+    }
+  });
 
   const shippingChannels = createShippingChannelsFromRate(
     rate?.channelListings
@@ -183,7 +202,22 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
         onChannelsChange={setCurrentChannels}
         variant={ShippingMethodTypeEnum.PRICE}
       />
-      {}
+      <ShippingZoneZipCodeRangeDialog
+        confirmButtonState={assignZipCodeRangeOpts.status}
+        onClose={closeModal}
+        onSubmit={data =>
+          assignZipCodeRange({
+            variables: {
+              input: {
+                end: data.max,
+                shippingMethod: rateId,
+                start: data.min
+              }
+            }
+          })
+        }
+        open={params.action === "add-range"}
+      />
     </>
   );
 };

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -14,11 +14,13 @@ import DeleteShippingRateDialog from "@saleor/shipping/components/DeleteShipping
 import ShippingZoneRatesPage, {
   FormData
 } from "@saleor/shipping/components/ShippingZoneRatesPage";
+import ShippingZoneZipCodeRangeDialog from "@saleor/shipping/components/ShippingZoneZipCodeRangeDialog";
 import {
   getShippingMethodChannelVariables,
   getUpdateShippingWeightRateVariables
 } from "@saleor/shipping/handlers";
 import {
+  useShippingMethodZipCodeRangeAssign,
   useShippingRateDelete,
   useShippingRateUpdate
 } from "@saleor/shipping/mutations";
@@ -107,6 +109,21 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     }
   });
 
+  const [
+    assignZipCodeRange,
+    assignZipCodeRangeOpts
+  ] = useShippingMethodZipCodeRangeAssign({
+    onCompleted: data => {
+      if (data.shippingMethodZipCodeCreate.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        closeModal();
+      }
+    }
+  });
+
   const handleSubmit = async (data: FormData) => {
     const response = await updateShippingRate({
       variables: getUpdateShippingWeightRateVariables(data, id, rateId)
@@ -182,6 +199,22 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
         openChannelsModal={handleChannelsModalOpen}
         onChannelsChange={setCurrentChannels}
         variant={ShippingMethodTypeEnum.WEIGHT}
+      />
+      <ShippingZoneZipCodeRangeDialog
+        confirmButtonState={assignZipCodeRangeOpts.status}
+        onClose={closeModal}
+        onSubmit={data =>
+          assignZipCodeRange({
+            variables: {
+              input: {
+                end: data.max,
+                shippingMethod: rateId,
+                start: data.min
+              }
+            }
+          })
+        }
+        open={params.action === "add-range"}
       />
     </>
   );

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -11,6 +11,7 @@ import useNotifier from "@saleor/hooks/useNotifier";
 import { sectionNames } from "@saleor/intl";
 import { commonMessages } from "@saleor/intl";
 import DeleteShippingRateDialog from "@saleor/shipping/components/DeleteShippingRateDialog";
+import ShippingRateZipCodeRangeRemoveDialog from "@saleor/shipping/components/ShippingRateZipCodeRangeRemoveDialog";
 import ShippingZoneRatesPage, {
   FormData
 } from "@saleor/shipping/components/ShippingZoneRatesPage";
@@ -21,6 +22,7 @@ import {
 } from "@saleor/shipping/handlers";
 import {
   useShippingMethodZipCodeRangeAssign,
+  useShippingMethodZipCodeRangeUnassign,
   useShippingRateDelete,
   useShippingRateUpdate
 } from "@saleor/shipping/mutations";
@@ -123,6 +125,20 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
       }
     }
   });
+  const [
+    unassignZipCodeRange,
+    unassignZipCodeRangeOpts
+  ] = useShippingMethodZipCodeRangeUnassign({
+    onCompleted: data => {
+      if (data.shippingMethodZipCodeDelete.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        closeModal();
+      }
+    }
+  });
 
   const handleSubmit = async (data: FormData) => {
     const response = await updateShippingRate({
@@ -199,6 +215,12 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
         openChannelsModal={handleChannelsModalOpen}
         onChannelsChange={setCurrentChannels}
         variant={ShippingMethodTypeEnum.WEIGHT}
+        onZipCodeAssign={() => openModal("add-range")}
+        onZipCodeUnassign={id =>
+          openModal("remove-range", {
+            id
+          })
+        }
       />
       <ShippingZoneZipCodeRangeDialog
         confirmButtonState={assignZipCodeRangeOpts.status}
@@ -215,6 +237,18 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
           })
         }
         open={params.action === "add-range"}
+      />
+      <ShippingRateZipCodeRangeRemoveDialog
+        confirmButtonState={unassignZipCodeRangeOpts.status}
+        onClose={closeModal}
+        onConfirm={() =>
+          unassignZipCodeRange({
+            variables: {
+              id: params.id
+            }
+          })
+        }
+        open={params.action === "remove-range"}
       />
     </>
   );

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1663,6 +1663,12 @@ export interface ShippingPriceInput {
   shippingZone?: string | null;
 }
 
+export interface ShippingZipCodeCreateInput {
+  shippingMethod: string;
+  start: string;
+  end: string;
+}
+
 export interface ShippingZoneCreateInput {
   name?: string | null;
   countries?: (string | null)[] | null;


### PR DESCRIPTION
I want to merge this change because it adds ability to delete zip code ranges.
Note: build on top of #862 

**PR intended to be tested with API branch:** SALEOR-1627-create-zip-code-mutation

### Screenshots
<img width="467" alt="Screenshot 2020-11-27 at 16 10 30" src="https://user-images.githubusercontent.com/6833443/100462807-16909300-30cb-11eb-95a4-f9195f8bf101.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
