### PR TITLE
Saleor 1662 sort just added channel availability

### DIFF
--- a/src/hooks/useChannels.ts
+++ b/src/hooks/useChannels.ts
@@ -23,7 +23,10 @@ function useChannels<T extends Channel>(channels: T[]) {
   const handleChannelsModalOpen = () => setChannelsModalOpen(true);
 
   const handleChannelsConfirm = () => {
-    setCurrentChannels(channelListElements);
+    const sortedChannelListElements = channelListElements.sort(
+      (channel, nextChannel) => channel.name.localeCompare(nextChannel.name)
+    );
+    setCurrentChannels(sortedChannelListElements);
     setChannelsModalOpen(false);
   };
 

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -215,10 +215,6 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     toggleAllChannels
   } = useChannels(productChannelsChoices);
 
-  const sortedCurrentChannels: ChannelData[] = currentChannels.sort(
-    (channel, nextChannel) => channel.name.localeCompare(nextChannel.name)
-  );
-
   const [updateChannels, updateChannelsOpts] = useProductChannelListingUpdate({
     onCompleted: data => {
       if (data.productChannelListingUpdate.errors.length === 0) {
@@ -352,7 +348,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
         }
         categories={categories}
         collections={collections}
-        currentChannels={sortedCurrentChannels}
+        currentChannels={currentChannels}
         defaultWeightUnit={shop?.defaultWeightUnit}
         channelChoices={channelChoices}
         disabled={disableFormSave}

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -215,6 +215,10 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     toggleAllChannels
   } = useChannels(productChannelsChoices);
 
+  const sortedCurrentChannels: ChannelData[] = currentChannels.sort((channel, nextChannel) =>
+    channel.name.localeCompare(nextChannel.name)
+  );
+
   const [updateChannels, updateChannelsOpts] = useProductChannelListingUpdate({
     onCompleted: data => {
       if (data.productChannelListingUpdate.errors.length === 0) {
@@ -348,7 +352,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
         }
         categories={categories}
         collections={collections}
-        currentChannels={currentChannels}
+        currentChannels={sortedCurrentChannels}
         defaultWeightUnit={shop?.defaultWeightUnit}
         channelChoices={channelChoices}
         disabled={disableFormSave}

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -215,8 +215,8 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     toggleAllChannels
   } = useChannels(productChannelsChoices);
 
-  const sortedCurrentChannels: ChannelData[] = currentChannels.sort((channel, nextChannel) =>
-    channel.name.localeCompare(nextChannel.name)
+  const sortedCurrentChannels: ChannelData[] = currentChannels.sort(
+    (channel, nextChannel) => channel.name.localeCompare(nextChannel.name)
   );
 
   const [updateChannels, updateChannelsOpts] = useProductChannelListingUpdate({


### PR DESCRIPTION
I want to merge this change because it adds sorting on local changes of channels on product update page.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<img width="407" alt="image" src="https://user-images.githubusercontent.com/29279389/100622987-d4ad5a00-3321-11eb-9967-b3f570c1113d.png">


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
