### PR TITLE
Fix react-intl missing translation error

### DIFF
--- a/src/components/Locale/Locale.tsx
+++ b/src/components/Locale/Locale.tsx
@@ -1,10 +1,6 @@
 import useLocalStorage from "@saleor/hooks/useLocalStorage";
 import React from "react";
-import {
-  IntlProvider,
-  MissingTranslationError,
-  ReactIntlErrorCode
-} from "react-intl";
+import { IntlProvider, ReactIntlErrorCode } from "react-intl";
 
 export enum Locale {
   AR = "ar",

--- a/src/components/Locale/Locale.tsx
+++ b/src/components/Locale/Locale.tsx
@@ -1,6 +1,10 @@
 import useLocalStorage from "@saleor/hooks/useLocalStorage";
 import React from "react";
-import { IntlProvider, MissingTranslationError } from "react-intl";
+import {
+  IntlProvider,
+  MissingTranslationError,
+  ReactIntlErrorCode
+} from "react-intl";
 
 export enum Locale {
   AR = "ar",
@@ -165,7 +169,7 @@ const LocaleProvider: React.FC = ({ children }) => {
       locale={locale}
       messages={getKeyValueJson(messages)}
       onError={err => {
-        if (!(err instanceof MissingTranslationError)) {
+        if (!(err.code === ReactIntlErrorCode.MISSING_TRANSLATION)) {
           console.error(err);
         }
       }}


### PR DESCRIPTION
I want to merge this change because it stops throwing errors like this:
<img width="1678" alt="Screenshot 2020-12-01 at 16 28 06" src="https://user-images.githubusercontent.com/6833443/100760598-36d59000-33f2-11eb-8651-f7d3e2cecc85.png">


**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
