### PR TITLE
Fix Chrome 87 fieldset rendering bug

### DIFF
--- a/src/components/SingleSelectField/SingleSelectField.tsx
+++ b/src/components/SingleSelectField/SingleSelectField.tsx
@@ -18,6 +18,9 @@ const useStyles = makeStyles(
       },
       width: "100%"
     },
+    label: {
+      zIndex: 3
+    },
     noLabel: {
       padding: theme.spacing(2, 1.5)
     }
@@ -77,7 +80,9 @@ export const SingleSelectField: React.FC<SingleSelectFieldProps> = props => {
       error={error}
       disabled={disabled}
     >
-      <InputLabel shrink={!!value}>{label}</InputLabel>
+      <InputLabel className={classes.label} shrink={!!value}>
+        {label}
+      </InputLabel>
       <Select
         variant="outlined"
         fullWidth

--- a/src/components/Timeline/Timeline.tsx
+++ b/src/components/Timeline/Timeline.tsx
@@ -28,9 +28,6 @@ const useStyles = makeStyles(
       "& > div": {
         padding: "0 14px"
       },
-      "& fieldset": {
-        background: theme.palette.background.paper
-      },
       "& textarea": {
         "&::placeholder": {
           opacity: [[1], "!important"] as any

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -22,7 +22,7 @@ export const ICONBUTTON_SIZE = 48;
 
 const fontFamily = '"Inter", "roboto", "sans-serif"';
 
-export default (colors: IThemeColors): Theme =>
+const createTheme = (colors: IThemeColors): Theme =>
   createMuiTheme({
     overrides: {
       MuiButton: {
@@ -72,8 +72,7 @@ export default (colors: IThemeColors): Theme =>
           borderColor: colors.paperBorder,
           borderRadius: 8,
           borderStyle: "solid",
-          borderWidth: 1,
-          overflow: "visible"
+          borderWidth: 1
         }
       },
       MuiCardActions: {
@@ -572,3 +571,5 @@ Checkbox.defaultProps = {
   icon: createElement(CheckboxIcon),
   indeterminateIcon: createElement(CheckboxIndeterminateIcon)
 };
+
+export default createTheme;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -229,7 +229,7 @@ const createTheme = (colors: IThemeColors): Theme =>
           borderRadius: 8,
           borderStyle: "solid",
           borderWidth: 1,
-          overflow: "hidden"
+          overflow: "visible"
         }
       },
       MuiCardActions: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,6 +2,7 @@ import Card from "@material-ui/core/Card";
 import Checkbox from "@material-ui/core/Checkbox";
 import { createMuiTheme, Theme } from "@material-ui/core/styles";
 import { darken, fade } from "@material-ui/core/styles/colorManipulator";
+import { Overrides } from "@material-ui/core/styles/overrides";
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import { createElement } from "react";
@@ -22,9 +23,163 @@ export const ICONBUTTON_SIZE = 48;
 
 const fontFamily = '"Inter", "roboto", "sans-serif"';
 
+const inputOverrides = (colors: IThemeColors): Overrides => ({
+  MuiInput: {
+    input: {
+      "&:-webkit-autofill": {
+        WebkitTextFillColor: colors.font.default,
+        boxShadow: `inset 0 0 0px 9999px ${colors.autofill}`
+      },
+      "&::placeholder": {
+        opacity: "1 !important" as any
+      },
+      color: colors.font.default
+    },
+    underline: {
+      "&:after": {
+        borderBottomColor: colors.primary
+      }
+    }
+  },
+  MuiInputBase: {
+    input: {
+      "&$disabled": {
+        color: colors.input.disabledText
+      },
+      "&::placeholder": {
+        color: colors.font.gray,
+        opacity: "1 !important" as any
+      },
+      zIndex: 2
+    }
+  },
+  MuiInputLabel: {
+    filled: {
+      zIndex: 2
+    },
+    formControl: {
+      transform: "translate(0, 1.5px) scale(0.75)",
+      transformOrigin: "top left" as "top left",
+      width: "100%"
+    },
+    outlined: {
+      "&$shrink": {
+        transform: "translate(12px, 9px) scale(0.75)"
+      },
+      transform: "translate(14px, 18px) scale(1)",
+      zIndex: 9
+    },
+    root: {
+      "&$disabled": {
+        color: `${fade(colors.primary, 0.4)} !important` as any
+      },
+      "&$error": {
+        "&$focused": {
+          color: colors.error
+        },
+        color: colors.error
+      },
+      "&&$focused": {
+        "&:not($error)": {
+          color: colors.primary
+        }
+      },
+      color: fade(colors.input.text, 0.6)
+    },
+    shrink: {
+      // Negates x0.75 scale
+      width: "133%"
+    }
+  },
+  MuiOutlinedInput: {
+    input: {
+      "&:-webkit-autofill": {
+        borderRadius: 4,
+        boxShadow: `0 0 0px 1000px rgba(19, 190, 187, 0.1) inset`,
+        zIndex: 0
+      },
+      color: colors.input.text,
+      padding: "23px 12px 10px 12px"
+    },
+    inputMultiline: {
+      left: -2,
+      padding: "10px 0",
+      position: "relative"
+    },
+    root: {
+      "& fieldset": {
+        "&&:not($error)": {
+          borderColor: colors.input.border
+        },
+        top: 0,
+        zIndex: 1
+      },
+      "& legend": {
+        display: "none"
+      },
+      "&$disabled": {
+        "& fieldset": {
+          borderColor: [[colors.input.disabled], "!important"] as any
+        },
+        "& input": {
+          color: colors.input.disabledText,
+          zIndex: 2
+        }
+      },
+      "&$error": {
+        "&$focused": {
+          "& fieldset": {
+            borderColor: colors.error
+          },
+          "& input": {
+            color: colors.error,
+            zIndex: 2
+          }
+        },
+        "&:hover": {
+          "& fieldset": {
+            borderColor: colors.error
+          },
+          "& input": {
+            color: colors.error,
+            zIndex: 2
+          }
+        }
+      },
+      "&$focused": {
+        "& input": {
+          "& fieldset": {
+            borderColor: colors.primary
+          },
+          "&::placeholder": {
+            opacity: [[1], "!important"] as any
+          },
+          color: colors.font.default
+        }
+      },
+      "&:hover": {
+        "& input": {
+          color: colors.font.default
+        },
+        "&&&": {
+          "& fieldset": {
+            borderColor: colors.primary
+          },
+          "&$error fieldset": {
+            borderColor: colors.input.error
+          }
+        }
+      },
+      backgroundColor: colors.background.paper,
+      borderColor: colors.input.border,
+      top: 0
+    }
+  }
+});
 const createTheme = (colors: IThemeColors): Theme =>
   createMuiTheme({
     overrides: {
+      ...inputOverrides(colors),
       MuiButton: {
         contained: {
           "&$disabled": {
@@ -72,7 +227,8 @@ const createTheme = (colors: IThemeColors): Theme =>
           borderColor: colors.paperBorder,
           borderRadius: 8,
           borderStyle: "solid",
-          borderWidth: 1
+          borderWidth: 1,
+          overflow: "hidden"
         }
       },
       MuiCardActions: {
@@ -144,73 +300,6 @@ const createTheme = (colors: IThemeColors): Theme =>
           }
         }
       },
-      MuiInput: {
-        input: {
-          "&:-webkit-autofill": {
-            WebkitTextFillColor: colors.font.default,
-            boxShadow: `inset 0 0 0px 9999px ${colors.autofill}`
-          },
-          "&::placeholder": {
-            opacity: "1 !important" as any
-          },
-          color: colors.font.default
-        },
-        underline: {
-          "&:after": {
-            borderBottomColor: colors.primary
-          }
-        }
-      },
-      MuiInputBase: {
-        input: {
-          "&$disabled": {
-            color: colors.input.disabledText
-          },
-          "&::placeholder": {
-            color: colors.font.gray,
-            opacity: "1 !important" as any
-          },
-          zIndex: 2
-        }
-      },
-      MuiInputLabel: {
-        filled: {
-          zIndex: 2
-        },
-        formControl: {
-          transform: "translate(0, 1.5px) scale(0.75)",
-          transformOrigin: "top left" as "top left",
-          width: "100%"
-        },
-        outlined: {
-          "&$shrink": {
-            transform: "translate(12px, 9px) scale(0.75)"
-          },
-          transform: "translate(14px, 18px) scale(1)",
-          zIndex: 9
-        },
-        root: {
-          "&$disabled": {
-            color: `${fade(colors.primary, 0.4)} !important` as any
-          },
-          "&$error": {
-            "&$focused": {
-              color: colors.error
-            },
-            color: colors.error
-          },
-          "&&$focused": {
-            "&:not($error)": {
-              color: colors.primary
-            }
-          },
-          color: fade(colors.input.text, 0.6)
-        },
-        shrink: {
-          // Negates x0.75 scale
-          width: "133%"
-        }
-      },
       MuiList: {
         root: {
           display: "grid",
@@ -251,91 +340,6 @@ const createTheme = (colors: IThemeColors): Theme =>
             fontWeight: 400
           },
           borderRadius: 4
-        }
-      },
-      MuiOutlinedInput: {
-        input: {
-          "&:-webkit-autofill": {
-            borderRadius: 4,
-            boxShadow: `0 0 0px 1000px rgba(19, 190, 187, 0.1) inset`,
-            zIndex: 0
-          },
-          color: colors.input.text,
-          padding: "23px 12px 10px 12px"
-        },
-        inputMultiline: {
-          left: -2,
-          padding: "10px 0",
-          position: "relative"
-        },
-        root: {
-          "& fieldset": {
-            "&&:not($error)": {
-              borderColor: colors.input.border
-            },
-            top: 0,
-            zIndex: 1
-          },
-          "& legend": {
-            display: "none"
-          },
-          "&$disabled": {
-            "& fieldset": {
-              backgroundColor: colors.input.disabledBackground,
-              borderColor: [[colors.input.disabled], "!important"] as any
-            },
-            "& input": {
-              color: colors.input.disabledText,
-              zIndex: 2
-            }
-          },
-          "&$error": {
-            "&$focused": {
-              "& fieldset": {
-                borderColor: colors.error
-              },
-              "& input": {
-                color: colors.error,
-                zIndex: 2
-              }
-            },
-            "&:hover": {
-              "& fieldset": {
-                borderColor: colors.error
-              },
-              "& input": {
-                color: colors.error,
-                zIndex: 2
-              }
-            }
-          },
-          "&$focused": {
-            "& input": {
-              "& fieldset": {
-                borderColor: colors.primary
-              },
-              "&::placeholder": {
-                opacity: [[1], "!important"] as any
-              },
-              color: colors.font.default
-            }
-          },
-          "&:hover": {
-            "& input": {
-              color: colors.font.default
-            },
-            "&&&": {
-              "& fieldset": {
-                borderColor: colors.primary
-              },
-              "&$error fieldset": {
-                borderColor: colors.input.error
-              }
-            }
-          },
-          backgroundColor: colors.background.paper,
-          borderColor: colors.input.border,
-          top: 0
         }
       },
       MuiSnackbarContent: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -122,6 +122,7 @@ const inputOverrides = (colors: IThemeColors): Overrides => ({
           borderColor: [[colors.input.disabled], "!important"] as any
         },
         "& input": {
+          backgroundColor: colors.input.disabledBackground,
           color: colors.input.disabledText,
           zIndex: 2
         }
@@ -340,6 +341,13 @@ const createTheme = (colors: IThemeColors): Theme =>
             fontWeight: 400
           },
           borderRadius: 4
+        }
+      },
+      MuiSelect: {
+        root: {
+          "&$disabled": {
+            backgroundColor: colors.input.disabledBackground
+          }
         }
       },
       MuiSnackbarContent: {


### PR DESCRIPTION
I want to merge this change because it happened:
<img width="1680" alt="Screenshot 2020-11-30 at 12 57 58" src="https://user-images.githubusercontent.com/6833443/100769291-1f030980-33fc-11eb-8af3-fe21006f58ff.png">
<img width="1680" alt="Screenshot 2020-11-26 at 15 47 06" src="https://user-images.githubusercontent.com/6833443/100769323-29bd9e80-33fc-11eb-8a43-d185ac70491b.png">
<img width="1680" alt="Screenshot 2020-11-25 at 11 59 41" src="https://user-images.githubusercontent.com/6833443/100769345-3215d980-33fc-11eb-9cc6-c8b6d969dfc0.png">

... and now it doesn't.

Ref https://www.drupal.org/project/drupal/issues/3183425

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
