### PR TITLE
SALEOR-1658 Add fulfill finalize button display logic

### DIFF
--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.stories.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.stories.tsx
@@ -8,8 +8,8 @@ import { orderToFulfill } from "./fixtures";
 import OrderFulfillPage, { OrderFulfillPageProps } from "./OrderFulfillPage";
 
 const props: OrderFulfillPageProps = {
-  disabled: false,
   errors: [],
+  loading: false,
   onBack: () => undefined,
   onSubmit: () => undefined,
   order: orderToFulfill,
@@ -23,7 +23,7 @@ storiesOf("Views / Orders / Fulfill order", module)
   .add("loading", () => (
     <OrderFulfillPage
       {...props}
-      disabled={true}
+      loading={true}
       order={undefined}
       warehouses={undefined}
     />

--- a/src/orders/views/OrderFulfill/OrderFulfill.tsx
+++ b/src/orders/views/OrderFulfill/OrderFulfill.tsx
@@ -23,12 +23,14 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
       orderId
     }
   });
+
   const { data: warehouseData, loading: warehousesLoading } = useWarehouseList({
     displayLoader: true,
     variables: {
       first: 20
     }
   });
+
   const [fulfillOrder, fulfillOrderOpts] = useOrderFulfill({
     onCompleted: data => {
       if (data.orderFulfill.errors.length === 0) {
@@ -65,7 +67,7 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
         }
       />
       <OrderFulfillPage
-        disabled={loading || warehousesLoading || fulfillOrderOpts.loading}
+        loading={loading || warehousesLoading || fulfillOrderOpts.loading}
         errors={fulfillOrderOpts.data?.orderFulfill.errors}
         onBack={() => navigate(orderUrl(orderId))}
         onSubmit={formData =>


### PR DESCRIPTION
I want to merge this change because it adds disabled / enabled state logic for fulfillment "finalize" button. It now should be disabled if there are no items set to at least 1, and also when too many items are selected. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
