### PR TITLE
Saleor 1606 send invoice button not visible

### DIFF
--- a/src/orders/components/OrderInvoiceList/OrderInvoiceList.tsx
+++ b/src/orders/components/OrderInvoiceList/OrderInvoiceList.tsx
@@ -23,10 +23,22 @@ const useStyles = makeStyles(
       },
       padding: 0
     },
-    colAction: { paddingRight: "0.5rem", width: "auto" },
+    colAction: {
+      padding: "0 0.5rem",
+      width: "auto",
+      button: {
+        padding: "0"
+      }
+    },
     colNumber: { width: "100%" },
     colNumberClickable: {
       cursor: "pointer",
+      width: "100%"
+    },
+    invoicesTable: {
+      display: "flex"
+    },
+    invoicesTableBody: {
       width: "100%"
     }
   }),
@@ -79,8 +91,8 @@ const OrderInvoiceList: React.FC<OrderInvoiceListProps> = props => {
             <FormattedMessage defaultMessage="No invoices to be shown" />
           </Typography>
         ) : (
-          <ResponsiveTable>
-            <TableBody>
+          <ResponsiveTable className={classes.invoicesTable}>
+            <TableBody className={classes.invoicesTableBody}>
               {generatedInvoices.map(invoice => (
                 <TableRow key={invoice.id} hover={!!invoice}>
                   <TableCell

--- a/src/orders/components/OrderInvoiceList/OrderInvoiceList.tsx
+++ b/src/orders/components/OrderInvoiceList/OrderInvoiceList.tsx
@@ -17,6 +17,9 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 const useStyles = makeStyles(
   () => ({
+    card: {
+      overflow: "hidden"
+    },
     cardContentTable: {
       "&:last-child": {
         padding: 0
@@ -64,7 +67,7 @@ const OrderInvoiceList: React.FC<OrderInvoiceListProps> = props => {
   );
 
   return (
-    <Card>
+    <Card className={classes.card}>
       <CardTitle
         title={intl.formatMessage({
           defaultMessage: "Invoices",


### PR DESCRIPTION
I want to merge this change because... it fixes styles of button for sending invoice and fixes highlight on hover

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/29279389/101165542-1f3b1900-3637-11eb-97e5-eb0d8f97f5b5.png">

After:
<img width="372" alt="image" src="https://user-images.githubusercontent.com/29279389/101165581-2eba6200-3637-11eb-8144-a2eb7edff4f3.png">


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
