### PR TITLE
Fix null voucher name handle

### DIFF
--- a/src/discounts/components/VoucherList/VoucherList.tsx
+++ b/src/discounts/components/VoucherList/VoucherList.tsx
@@ -246,7 +246,7 @@ const VoucherList: React.FC<VoucherListProps> = props => {
                   {hasChannelsLoaded ? (
                     <Money money={channel?.minSpent} />
                   ) : (
-                    <Skeleton />
+                    "-"
                   )}
                 </TableCell>
                 <TableCell className={classes.colStart}>
@@ -284,7 +284,7 @@ const VoucherList: React.FC<VoucherListProps> = props => {
                       <Percent amount={channel?.discountValue} />
                     )
                   ) : (
-                    <Skeleton />
+                    "-"
                   )}
                 </TableCell>
                 <TableCell className={classes.colUses}>

--- a/src/discounts/components/VoucherList/VoucherList.tsx
+++ b/src/discounts/components/VoucherList/VoucherList.tsx
@@ -243,10 +243,14 @@ const VoucherList: React.FC<VoucherListProps> = props => {
                   {maybe<React.ReactNode>(() => voucher.code, <Skeleton />)}
                 </TableCell>
                 <TableCell className={classes.colMinSpent}>
-                  {hasChannelsLoaded ? (
-                    <Money money={channel?.minSpent} />
+                  {voucher?.code ? (
+                    hasChannelsLoaded ? (
+                      <Money money={channel?.minSpent} />
+                    ) : (
+                      "-"
+                    )
                   ) : (
-                    "-"
+                    <Skeleton />
                   )}
                 </TableCell>
                 <TableCell className={classes.colStart}>
@@ -269,22 +273,26 @@ const VoucherList: React.FC<VoucherListProps> = props => {
                   className={classes.colValue}
                   onClick={voucher ? onRowClick(voucher.id) : undefined}
                 >
-                  {hasChannelsLoaded ? (
-                    voucher.discountValueType ===
-                    DiscountValueTypeEnum.FIXED ? (
-                      <Money
-                        money={
-                          channel?.discountValue && {
-                            amount: channel?.discountValue,
-                            currency: channel?.currency
+                  {voucher?.code ? (
+                    hasChannelsLoaded ? (
+                      voucher.discountValueType ===
+                      DiscountValueTypeEnum.FIXED ? (
+                        <Money
+                          money={
+                            channel?.discountValue && {
+                              amount: channel?.discountValue,
+                              currency: channel?.currency
+                            }
                           }
-                        }
-                      />
+                        />
+                      ) : (
+                        <Percent amount={channel?.discountValue} />
+                      )
                     ) : (
-                      <Percent amount={channel?.discountValue} />
+                      "-"
                     )
                   ) : (
-                    "-"
+                    <Skeleton />
                   )}
                 </TableCell>
                 <TableCell className={classes.colUses}>

--- a/src/translations/views/TranslationsEntities.tsx
+++ b/src/translations/views/TranslationsEntities.tsx
@@ -346,10 +346,9 @@ const TranslationsEntities: React.FC<TranslationsEntitiesProps> = ({
                           max: 1
                         },
                         id: node.voucher?.id,
-                        name: node.voucher?.name
+                        name: node.voucher?.name || "-"
                       }
-                  )
-                  .filter(node => node.name)}
+                  )}
                 onRowClick={id =>
                   navigate(
                     languageEntityUrl(

--- a/src/translations/views/TranslationsEntities.tsx
+++ b/src/translations/views/TranslationsEntities.tsx
@@ -348,7 +348,8 @@ const TranslationsEntities: React.FC<TranslationsEntitiesProps> = ({
                         id: node.voucher?.id,
                         name: node.voucher?.name
                       }
-                  )}
+                  )
+                  .filter(node => node.name)}
                 onRowClick={id =>
                   navigate(
                     languageEntityUrl(


### PR DESCRIPTION
I want to merge this change because... it fixes handling null voucher name in Translations

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

before:
![image](https://user-images.githubusercontent.com/29279389/101347053-c1ead600-3889-11eb-8efb-be78c156fcd4.png)

after:
![image](https://user-images.githubusercontent.com/29279389/101347067-c7e0b700-3889-11eb-8e56-7d8c76d9d94f.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
