### PR TITLE
Replacing typed queries with hooks in Site settings and Staff modules

### DIFF
--- a/src/components/ActionDialog/ActionDialog.tsx
+++ b/src/components/ActionDialog/ActionDialog.tsx
@@ -35,7 +35,7 @@ interface ActionDialogProps extends DialogProps {
   maxWidth?: "xs" | "sm" | "md" | "lg" | "xl" | false;
   title: string;
   variant?: "default" | "delete" | "info";
-  onConfirm();
+  onConfirm: () => void;
 }
 
 const ActionDialog: React.FC<ActionDialogProps> = props => {

--- a/src/components/Shop/index.tsx
+++ b/src/components/Shop/index.tsx
@@ -5,29 +5,31 @@ import safariPinnedTab from "@assets/favicons/safari-pinned-tab.svg";
 import React from "react";
 import Helmet from "react-helmet";
 
-import { TypedShopInfoQuery } from "./query";
+import { useShopInfoQuery } from "./query";
 import { ShopInfo_shop } from "./types/ShopInfo";
 
 type ShopContext = ShopInfo_shop;
 
 export const ShopContext = React.createContext<ShopContext>(undefined);
 
-export const ShopProvider: React.FC = ({ children }) => (
-  <TypedShopInfoQuery>
-    {({ data }) => (
-      <>
-        <Helmet>
-          <link rel="apple-touch-icon" sizes="180x180" href={appleTouchIcon} />
-          <link rel="icon" type="image/png" sizes="32x32" href={favicon32} />
-          <link rel="icon" type="image/png" sizes="16x16" href={favicon16} />
-          <link rel="mask-icon" href={safariPinnedTab} />
-        </Helmet>
-        <ShopContext.Provider value={data ? data.shop : undefined}>
-          {children}
-        </ShopContext.Provider>
-      </>
-    )}
-  </TypedShopInfoQuery>
-);
+export const ShopProvider: React.FC = ({ children }) => {
+  const { data: shopInfoQueryData } = useShopInfoQuery({
+    displayLoader: true,
+    variables: {}
+  });
+  return (
+    <>
+      <Helmet>
+        <link rel="apple-touch-icon" sizes="180x180" href={appleTouchIcon} />
+        <link rel="icon" type="image/png" sizes="32x32" href={favicon32} />
+        <link rel="icon" type="image/png" sizes="16x16" href={favicon16} />
+        <link rel="mask-icon" href={safariPinnedTab} />
+      </Helmet>
+      <ShopContext.Provider value={shopInfoQueryData?.shop}>
+        {children}
+      </ShopContext.Provider>
+    </>
+  );
+};
 export const Shop = ShopContext.Consumer;
 export default Shop;

--- a/src/components/Shop/query.ts
+++ b/src/components/Shop/query.ts
@@ -1,6 +1,6 @@
+import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
 
-import { TypedQuery } from "../../queries";
 import { ShopInfo } from "./types/ShopInfo";
 
 const shopInfo = gql`
@@ -34,4 +34,4 @@ const shopInfo = gql`
     }
   }
 `;
-export const TypedShopInfoQuery = TypedQuery<ShopInfo, {}>(shopInfo);
+export const useShopInfoQuery = makeQuery<ShopInfo, {}>(shopInfo);

--- a/src/discounts/views/SaleCreate/SaleCreate.tsx
+++ b/src/discounts/views/SaleCreate/SaleCreate.tsx
@@ -20,7 +20,7 @@ import { createHandler } from "./handlers";
 
 export const SaleDetails: React.FC = () => {
   const navigate = useNavigator();
-  const pushMessage = useNotifier();
+  const notify = useNotifier();
   const intl = useIntl();
 
   const { data: channelsData } = useChannelsList({});
@@ -45,7 +45,7 @@ export const SaleDetails: React.FC = () => {
 
   const handleSaleCreate = (data: SaleCreate) => {
     if (data.saleCreate.errors.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Successfully created sale"

--- a/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
+++ b/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
@@ -57,7 +57,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   params
 }) => {
   const navigate = useNavigator();
-  const pushMessage = useNotifier();
+  const notify = useNotifier();
   const intl = useIntl();
 
   const [, closeModal] = createDialogActionHandlers(
@@ -69,7 +69,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handlePaymentCapture = (data: OrderCapture) => {
     const errs = data.orderCapture?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Payment successfully captured"
@@ -81,7 +81,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleOrderMarkAsPaid = (data: OrderMarkAsPaid) => {
     const errs = data.orderMarkAsPaid?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order marked as paid"
@@ -93,7 +93,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleOrderCancel = (data: OrderCancel) => {
     const errs = data.orderCancel?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order successfully cancelled"
@@ -105,7 +105,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleDraftCancel = (data: OrderDraftCancel) => {
     const errs = data.draftOrderDelete?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order successfully cancelled"
@@ -117,7 +117,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleOrderVoid = (data: OrderVoid) => {
     const errs = data.orderVoid?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order payment successfully voided"
@@ -129,7 +129,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleNoteAdd = (data: OrderAddNote) => {
     const errs = data.orderAddNote?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Note successfully added"
@@ -140,7 +140,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleUpdate = (data: OrderUpdate) => {
     const errs = data.orderUpdate?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order successfully updated"
@@ -152,7 +152,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleDraftUpdate = (data: OrderDraftUpdate) => {
     const errs = data.draftOrderUpdate?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order successfully updated"
@@ -164,7 +164,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleShippingMethodUpdate = (data: OrderShippingMethodUpdate) => {
     const errs = data.orderUpdateShipping?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Shipping method successfully updated"
@@ -176,7 +176,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleOrderLineDelete = (data: OrderLineDelete) => {
     const errs = data.draftOrderLineDelete?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order line deleted"
@@ -187,7 +187,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleOrderLinesAdd = (data: OrderLinesAdd) => {
     const errs = data.draftOrderLinesCreate?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order line added"
@@ -199,7 +199,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleOrderLineUpdate = (data: OrderLineUpdate) => {
     const errs = data.draftOrderLineUpdate?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Order line updated"
@@ -210,7 +210,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleOrderFulfillmentCancel = (data: OrderFulfillmentCancel) => {
     const errs = data.orderFulfillmentCancel?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Fulfillment successfully cancelled"
@@ -224,7 +224,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   ) => {
     const errs = data.orderFulfillmentUpdateTracking?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Fulfillment successfully updated"
@@ -236,7 +236,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleDraftFinalize = (data: OrderDraftFinalize) => {
     const errs = data.draftOrderComplete?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage({
           defaultMessage: "Draft order successfully finalized"
@@ -247,7 +247,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleInvoiceGeneratePending = (data: InvoiceRequest) => {
     const errs = data.invoiceRequest?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         text: intl.formatMessage({
           defaultMessage:
             "We’re generating the invoice you requested. Please wait a couple of moments"
@@ -262,7 +262,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleInvoiceGenerateFinished = (data: InvoiceRequest) => {
     const errs = data.invoiceRequest?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         status: "success",
         text: intl.formatMessage(messages.invoiceGenerateFinishedText),
         title: intl.formatMessage(messages.invoiceGenerateFinishedTitle)
@@ -273,7 +273,7 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
   const handleInvoiceSend = (data: InvoiceEmailSend) => {
     const errs = data.invoiceSendEmail?.errors;
     if (errs.length === 0) {
-      pushMessage({
+      notify({
         text: intl.formatMessage({
           defaultMessage: "Invoice email sent"
         })

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -11,7 +11,6 @@ import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import { ShopErrorFragment } from "@saleor/fragments/types/ShopErrorFragment";
 import useAddressValidation from "@saleor/hooks/useAddressValidation";
-import { SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { commonMessages, sectionNames } from "@saleor/intl";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
@@ -55,7 +54,7 @@ export interface SiteSettingsPageProps {
   onBack: () => void;
   onKeyAdd: () => void;
   onKeyRemove: (keyType: AuthorizationKeyType) => void;
-  onSubmit: (data: SiteSettingsPageFormData) => SubmitPromise;
+  onSubmit: (data: SiteSettingsPageFormData) => void;
 }
 
 export function areAddressInputFieldsModified(

--- a/src/siteSettings/mutations.ts
+++ b/src/siteSettings/mutations.ts
@@ -1,9 +1,9 @@
 import { fragmentAddress } from "@saleor/fragments/address";
 import { shopErrorFragment } from "@saleor/fragments/errors";
 import { shopFragment } from "@saleor/fragments/shop";
+import makeMutation from "@saleor/hooks/makeMutation";
 import gql from "graphql-tag";
 
-import { TypedMutation } from "../mutations";
 import {
   AuthorizationKeyAdd,
   AuthorizationKeyAddVariables
@@ -34,7 +34,7 @@ const authorizationKeyAdd = gql`
     }
   }
 `;
-export const TypedAuthorizationKeyAdd = TypedMutation<
+export const useAuthorizationKeyAdd = makeMutation<
   AuthorizationKeyAdd,
   AuthorizationKeyAddVariables
 >(authorizationKeyAdd);
@@ -53,7 +53,7 @@ const authorizationKeyDelete = gql`
     }
   }
 `;
-export const TypedAuthorizationKeyDelete = TypedMutation<
+export const useAuthorizationKeyDelete = makeMutation<
   AuthorizationKeyDelete,
   AuthorizationKeyDeleteVariables
 >(authorizationKeyDelete);
@@ -98,7 +98,7 @@ const shopSettingsUpdate = gql`
     }
   }
 `;
-export const TypedShopSettingsUpdate = TypedMutation<
+export const useShopSettingsUpdate = makeMutation<
   ShopSettingsUpdate,
   ShopSettingsUpdateVariables
 >(shopSettingsUpdate);

--- a/src/siteSettings/queries.ts
+++ b/src/siteSettings/queries.ts
@@ -1,7 +1,7 @@
 import { shopFragment } from "@saleor/fragments/shop";
+import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
 
-import { TypedQuery } from "../queries";
 import { SiteSettings } from "./types/SiteSettings";
 
 const siteSettings = gql`
@@ -12,6 +12,4 @@ const siteSettings = gql`
     }
   }
 `;
-export const TypedSiteSettingsQuery = TypedQuery<SiteSettings, {}>(
-  siteSettings
-);
+export const useSiteSettingsQuery = makeQuery<SiteSettings, {}>(siteSettings);

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -117,7 +117,7 @@ export const SiteSettings: React.FC<SiteSettingsProps> = ({ params }) => {
       : {
           companyName: data.companyName
         };
-    shopSettingsUpdate({
+    const result = await shopSettingsUpdate({
       variables: {
         addressInput,
         shopDomainInput: {
@@ -132,6 +132,11 @@ export const SiteSettings: React.FC<SiteSettingsProps> = ({ params }) => {
         }
       }
     });
+    return [
+      ...result.data.shopAddressUpdate.errors,
+      ...result.data.shopDomainUpdate.errors,
+      ...result.data.shopSettingsUpdate.errors
+    ];
   };
 
   const errors = [

--- a/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/src/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -12,7 +12,6 @@ import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocomplet
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import { StaffErrorFragment } from "@saleor/fragments/types/StaffErrorFragment";
-import { SubmitPromise } from "@saleor/hooks/useForm";
 import useLocale from "@saleor/hooks/useLocale";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { sectionNames } from "@saleor/intl";
@@ -51,7 +50,7 @@ export interface StaffDetailsPageProps extends SearchPageProps {
   onChangePassword: () => void;
   onDelete: () => void;
   onImageDelete: () => void;
-  onSubmit: (data: StaffDetailsFormData) => SubmitPromise;
+  onSubmit: (data: StaffDetailsFormData) => void;
   onImageUpload(file: File);
 }
 

--- a/src/staff/mutations.ts
+++ b/src/staff/mutations.ts
@@ -43,7 +43,7 @@ const staffMemberAddMutation = gql`
     }
   }
 `;
-export const TypedStaffMemberAddMutation = TypedMutation<
+export const useStaffMemberAddMutation = makeMutation<
   StaffMemberAdd,
   StaffMemberAddVariables
 >(staffMemberAddMutation);

--- a/src/staff/mutations.ts
+++ b/src/staff/mutations.ts
@@ -6,7 +6,6 @@ import { staffMemberDetailsFragment } from "@saleor/fragments/staff";
 import makeMutation from "@saleor/hooks/makeMutation";
 import gql from "graphql-tag";
 
-import { TypedMutation } from "../mutations";
 import {
   ChangeStaffPassword,
   ChangeStaffPasswordVariables
@@ -62,7 +61,8 @@ const staffMemberUpdateMutation = gql`
     }
   }
 `;
-export const TypedStaffMemberUpdateMutation = TypedMutation<
+
+export const useStaffMemberUpdateMutation = makeMutation<
   StaffMemberUpdate,
   StaffMemberUpdateVariables
 >(staffMemberUpdateMutation);
@@ -77,7 +77,7 @@ const staffMemberDeleteMutation = gql`
     }
   }
 `;
-export const TypedStaffMemberDeleteMutation = TypedMutation<
+export const useStaffMemberDeleteMutation = makeMutation<
   StaffMemberDelete,
   StaffMemberDeleteVariables
 >(staffMemberDeleteMutation);
@@ -98,7 +98,7 @@ const staffAvatarUpdateMutation = gql`
     }
   }
 `;
-export const TypedStaffAvatarUpdateMutation = TypedMutation<
+export const useStaffAvatarUpdateMutation = makeMutation<
   StaffAvatarUpdate,
   StaffAvatarUpdateVariables
 >(staffAvatarUpdateMutation);
@@ -119,7 +119,7 @@ const staffAvatarDeleteMutation = gql`
     }
   }
 `;
-export const TypedStaffAvatarDeleteMutation = TypedMutation<
+export const useStaffAvatarDeleteMutation = makeMutation<
   StaffAvatarDelete,
   StaffMemberDeleteVariables
 >(staffAvatarDeleteMutation);

--- a/src/staff/queries.ts
+++ b/src/staff/queries.ts
@@ -5,7 +5,6 @@ import {
 import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
 
-import { TypedQuery } from "../queries";
 import { StaffList, StaffListVariables } from "./types/StaffList";
 import {
   StaffMemberDetails,
@@ -60,7 +59,7 @@ export const staffMemberDetails = gql`
     }
   }
 `;
-export const TypedStaffMemberDetailsQuery = TypedQuery<
+export const useStaffMemberDetailsQuery = makeQuery<
   StaffMemberDetails,
   StaffMemberDetailsVariables
 >(staffMemberDetails);

--- a/src/staff/views/StaffDetails.tsx
+++ b/src/staff/views/StaffDetails.tsx
@@ -7,7 +7,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import useUser from "@saleor/hooks/useUser";
 import { commonMessages } from "@saleor/intl";
-import { getStringOrPlaceholder, maybe } from "@saleor/misc";
+import { getStringOrPlaceholder } from "@saleor/misc";
 import usePermissionGroupSearch from "@saleor/searches/usePermissionGroupSearch";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -17,18 +17,13 @@ import StaffDetailsPage, {
 } from "../components/StaffDetailsPage/StaffDetailsPage";
 import StaffPasswordResetDialog from "../components/StaffPasswordResetDialog";
 import {
-  TypedStaffAvatarDeleteMutation,
-  TypedStaffAvatarUpdateMutation,
-  TypedStaffMemberDeleteMutation,
-  TypedStaffMemberUpdateMutation,
-  useChangeStaffPassword
+  useChangeStaffPassword,
+  useStaffAvatarDeleteMutation,
+  useStaffAvatarUpdateMutation,
+  useStaffMemberDeleteMutation,
+  useStaffMemberUpdateMutation
 } from "../mutations";
-import { TypedStaffMemberDetailsQuery } from "../queries";
-import { ChangeStaffPassword } from "../types/ChangeStaffPassword";
-import { StaffAvatarDelete } from "../types/StaffAvatarDelete";
-import { StaffAvatarUpdate } from "../types/StaffAvatarUpdate";
-import { StaffMemberDelete } from "../types/StaffMemberDelete";
-import { StaffMemberUpdate } from "../types/StaffMemberUpdate";
+import { useStaffMemberDetailsQuery } from "../queries";
 import {
   staffListUrl,
   staffMemberDetailsUrl,
@@ -46,6 +41,20 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
   const notify = useNotifier();
   const user = useUser();
   const intl = useIntl();
+  const handleBack = () => navigate(staffListUrl());
+
+  const { data: staffDetailsQueryData, loading } = useStaffMemberDetailsQuery({
+    displayLoader: true,
+    variables: { id }
+  });
+
+  const staffMember = staffDetailsQueryData?.user;
+
+  if (staffMember === null) {
+    return <NotFoundPage onBack={handleBack} />;
+  }
+
+  const isUserSameAsViewer = user.user?.id === staffDetailsQueryData.user?.id;
 
   const closeModal = () =>
     navigate(
@@ -55,20 +64,17 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
       })
     );
 
-  const handleChangePassword = (data: ChangeStaffPassword) => {
-    if (data.passwordChange.errors.length === 0) {
-      notify({
-        status: "success",
-        text: intl.formatMessage(commonMessages.savedChanges)
-      });
-      closeModal();
-    }
-  };
   const [changePassword, changePasswordOpts] = useChangeStaffPassword({
-    onCompleted: handleChangePassword
+    onCompleted: data => {
+      if (data.passwordChange.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        closeModal();
+      }
+    }
   });
-
-  const handleBack = () => navigate(staffListUrl());
 
   const {
     loadMore: loadMorePermissionGroups,
@@ -78,225 +84,201 @@ export const StaffDetails: React.FC<OrderListProps> = ({ id, params }) => {
     variables: DEFAULT_INITIAL_SEARCH_DATA
   });
 
-  return (
-    <TypedStaffMemberDetailsQuery displayLoader variables={{ id }}>
-      {({ data, loading }) => {
-        const staffMember = data?.user;
+  const [
+    staffMemberUpdate,
+    staffMemberUpdateOpts
+  ] = useStaffMemberUpdateMutation({
+    onCompleted: data => {
+      if (data.staffUpdate.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        navigate(staffMemberDetailsUrl(data.staffUpdate.user.id));
+      }
+    }
+  });
 
-        if (staffMember === null) {
-          return <NotFoundPage onBack={handleBack} />;
+  const [
+    staffMemberDelete,
+    staffMemberDeleteOpts
+  ] = useStaffMemberDeleteMutation({
+    onCompleted: data => {
+      if (data.staffDelete.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        navigate(staffListUrl());
+      }
+    }
+  });
+
+  const [staffAvatarUpdate] = useStaffAvatarUpdateMutation({
+    onCompleted: data => {
+      if (data.userAvatarUpdate.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        navigate(staffMemberDetailsUrl(id));
+      }
+    }
+  });
+
+  const [
+    staffAvatarDelete,
+    staffAvatarDeleteOpts
+  ] = useStaffAvatarDeleteMutation({
+    onCompleted: data => {
+      if (data.userAvatarDelete.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        navigate(staffMemberDetailsUrl(id));
+      }
+    }
+  });
+
+  const handleStaffMemberUpdate = async (formData: StaffDetailsFormData) => {
+    staffMemberUpdate({
+      variables: {
+        id,
+        input: {
+          email: formData.email,
+          firstName: formData.firstName,
+          isActive: formData.isActive,
+          lastName: formData.lastName,
+          ...groupsDiff(staffDetailsQueryData?.user, formData)
         }
+      }
+    });
+  };
 
-        const handleStaffMemberUpdate = (data: StaffMemberUpdate) => {
-          if (!maybe(() => data.staffUpdate.errors.length !== 0)) {
-            notify({
-              status: "success",
-              text: intl.formatMessage(commonMessages.savedChanges)
-            });
-          }
-        };
-        const handleStaffMemberDelete = (data: StaffMemberDelete) => {
-          if (!maybe(() => data.staffDelete.errors.length !== 0)) {
-            notify({
-              status: "success",
-              text: intl.formatMessage(commonMessages.savedChanges)
-            });
-            navigate(staffListUrl());
-          }
-        };
-        const handleStaffMemberAvatarUpdate = (data: StaffAvatarUpdate) => {
-          if (!maybe(() => data.userAvatarUpdate.errors.length !== 0)) {
-            notify({
-              status: "success",
-              text: intl.formatMessage(commonMessages.savedChanges)
-            });
-          }
-        };
-        const handleStaffMemberAvatarDelete = (data: StaffAvatarDelete) => {
-          if (!maybe(() => data.userAvatarDelete.errors.length !== 0)) {
-            notify({
-              status: "success",
-              text: intl.formatMessage(commonMessages.savedChanges)
-            });
-            navigate(staffMemberDetailsUrl(id));
-          }
-        };
+  const handleStaffMemberDelete = async () => {
+    staffMemberDelete({
+      variables: { id }
+    });
+  };
 
-        return (
-          <TypedStaffMemberUpdateMutation onCompleted={handleStaffMemberUpdate}>
-            {(updateStaffMember, updateResult) => {
-              const handleSubmit = async (formData: StaffDetailsFormData) => {
-                const result = await updateStaffMember({
-                  variables: {
-                    id,
-                    input: {
-                      email: formData.email,
-                      firstName: formData.firstName,
-                      isActive: formData.isActive,
-                      lastName: formData.lastName,
-                      ...groupsDiff(data?.user, formData)
-                    }
-                  }
-                });
+  const handleStaffAvatarDelete = async () => {
+    staffAvatarDelete({
+      variables: { id }
+    });
+  };
 
-                return result.data.staffUpdate.errors;
-              };
+  const handleStaffAvatarUpdate = async (file: File) => {
+    staffAvatarUpdate({
+      variables: {
+        image: file
+      }
+    });
+  };
 
-              return (
-                <TypedStaffMemberDeleteMutation
-                  variables={{ id }}
-                  onCompleted={handleStaffMemberDelete}
-                >
-                  {(deleteStaffMember, deleteResult) => (
-                    <TypedStaffAvatarUpdateMutation
-                      onCompleted={handleStaffMemberAvatarUpdate}
-                    >
-                      {updateStaffAvatar => (
-                        <TypedStaffAvatarDeleteMutation
-                          onCompleted={handleStaffMemberAvatarDelete}
-                        >
-                          {(deleteStaffAvatar, deleteAvatarResult) => {
-                            const isUserSameAsViewer =
-                              user.user?.id === data?.user?.id;
-
-                            return (
-                              <>
-                                <WindowTitle
-                                  title={getStringOrPlaceholder(
-                                    staffMember?.email
-                                  )}
-                                />
-                                <StaffDetailsPage
-                                  errors={
-                                    updateResult?.data?.staffUpdate?.errors ||
-                                    []
-                                  }
-                                  canEditAvatar={isUserSameAsViewer}
-                                  canEditPreferences={isUserSameAsViewer}
-                                  canEditStatus={!isUserSameAsViewer}
-                                  canRemove={!isUserSameAsViewer}
-                                  disabled={loading}
-                                  onBack={handleBack}
-                                  initialSearch=""
-                                  onChangePassword={() =>
-                                    navigate(
-                                      staffMemberDetailsUrl(id, {
-                                        action: "change-password"
-                                      })
-                                    )
-                                  }
-                                  onDelete={() =>
-                                    navigate(
-                                      staffMemberDetailsUrl(id, {
-                                        action: "remove"
-                                      })
-                                    )
-                                  }
-                                  onSubmit={handleSubmit}
-                                  onImageUpload={file =>
-                                    updateStaffAvatar({
-                                      variables: {
-                                        image: file
-                                      }
-                                    })
-                                  }
-                                  onImageDelete={() =>
-                                    navigate(
-                                      staffMemberDetailsUrl(id, {
-                                        action: "remove-avatar"
-                                      })
-                                    )
-                                  }
-                                  availablePermissionGroups={searchPermissionGroupsOpts.data?.search.edges.map(
-                                    edge => edge.node
-                                  )}
-                                  staffMember={staffMember}
-                                  saveButtonBarState={updateResult.status}
-                                  fetchMorePermissionGroups={{
-                                    hasMore:
-                                      searchPermissionGroupsOpts.data?.search
-                                        .pageInfo.hasNextPage,
-                                    loading: searchPermissionGroupsOpts.loading,
-                                    onFetchMore: loadMorePermissionGroups
-                                  }}
-                                  onSearchChange={searchPermissionGroups}
-                                />
-                                <ActionDialog
-                                  open={params.action === "remove"}
-                                  title={intl.formatMessage({
-                                    defaultMessage: "delete Staff User",
-                                    description: "dialog header"
-                                  })}
-                                  confirmButtonState={deleteResult.status}
-                                  variant="delete"
-                                  onClose={closeModal}
-                                  onConfirm={deleteStaffMember}
-                                >
-                                  <DialogContentText>
-                                    <FormattedMessage
-                                      defaultMessage="Are you sure you want to delete {email} from staff members?"
-                                      values={{
-                                        email: getStringOrPlaceholder(
-                                          data?.user?.email
-                                        )
-                                      }}
-                                    />
-                                  </DialogContentText>
-                                </ActionDialog>
-                                <ActionDialog
-                                  open={params.action === "remove-avatar"}
-                                  title={intl.formatMessage({
-                                    defaultMessage: "Delete Staff User Avatar",
-                                    description: "dialog header"
-                                  })}
-                                  confirmButtonState={deleteAvatarResult.status}
-                                  variant="delete"
-                                  onClose={closeModal}
-                                  onConfirm={deleteStaffAvatar}
-                                >
-                                  <DialogContentText>
-                                    <FormattedMessage
-                                      defaultMessage="Are you sure you want to remove {email} avatar?"
-                                      values={{
-                                        email: (
-                                          <strong>
-                                            {getStringOrPlaceholder(
-                                              data?.user?.email
-                                            )}
-                                          </strong>
-                                        )
-                                      }}
-                                    />
-                                  </DialogContentText>
-                                </ActionDialog>
-                                <StaffPasswordResetDialog
-                                  confirmButtonState={changePasswordOpts.status}
-                                  errors={
-                                    changePasswordOpts?.data?.passwordChange
-                                      ?.errors || []
-                                  }
-                                  open={params.action === "change-password"}
-                                  onClose={closeModal}
-                                  onSubmit={data =>
-                                    changePassword({
-                                      variables: data
-                                    })
-                                  }
-                                />
-                              </>
-                            );
-                          }}
-                        </TypedStaffAvatarDeleteMutation>
-                      )}
-                    </TypedStaffAvatarUpdateMutation>
-                  )}
-                </TypedStaffMemberDeleteMutation>
-              );
+  return (
+    <>
+      <WindowTitle title={getStringOrPlaceholder(staffMember?.email)} />
+      <StaffDetailsPage
+        errors={staffMemberUpdateOpts?.data?.staffUpdate?.errors || []}
+        canEditAvatar={isUserSameAsViewer}
+        canEditPreferences={isUserSameAsViewer}
+        canEditStatus={!isUserSameAsViewer}
+        canRemove={!isUserSameAsViewer}
+        disabled={loading}
+        onBack={handleBack}
+        initialSearch=""
+        onChangePassword={() =>
+          navigate(
+            staffMemberDetailsUrl(id, {
+              action: "change-password"
+            })
+          )
+        }
+        onDelete={() =>
+          navigate(
+            staffMemberDetailsUrl(id, {
+              action: "remove"
+            })
+          )
+        }
+        onSubmit={handleStaffMemberUpdate}
+        onImageUpload={handleStaffAvatarUpdate}
+        onImageDelete={() =>
+          navigate(
+            staffMemberDetailsUrl(id, {
+              action: "remove-avatar"
+            })
+          )
+        }
+        availablePermissionGroups={searchPermissionGroupsOpts.data?.search.edges.map(
+          edge => edge.node
+        )}
+        staffMember={staffMember}
+        saveButtonBarState={staffMemberUpdateOpts.status}
+        fetchMorePermissionGroups={{
+          hasMore: searchPermissionGroupsOpts.data?.search.pageInfo.hasNextPage,
+          loading: searchPermissionGroupsOpts.loading,
+          onFetchMore: loadMorePermissionGroups
+        }}
+        onSearchChange={searchPermissionGroups}
+      />
+      <ActionDialog
+        open={params.action === "remove"}
+        title={intl.formatMessage({
+          defaultMessage: "delete Staff User",
+          description: "dialog header"
+        })}
+        confirmButtonState={staffMemberDeleteOpts.status}
+        variant="delete"
+        onClose={closeModal}
+        onConfirm={handleStaffMemberDelete}
+      >
+        <DialogContentText>
+          <FormattedMessage
+            defaultMessage="Are you sure you want to delete {email} from staff members?"
+            values={{
+              email: getStringOrPlaceholder(staffDetailsQueryData.user?.email)
             }}
-          </TypedStaffMemberUpdateMutation>
-        );
-      }}
-    </TypedStaffMemberDetailsQuery>
+          />
+        </DialogContentText>
+      </ActionDialog>
+      <ActionDialog
+        open={params.action === "remove-avatar"}
+        title={intl.formatMessage({
+          defaultMessage: "Delete Staff User Avatar",
+          description: "dialog header"
+        })}
+        confirmButtonState={staffAvatarDeleteOpts.status}
+        variant="delete"
+        onClose={closeModal}
+        onConfirm={handleStaffAvatarDelete}
+      >
+        <DialogContentText>
+          <FormattedMessage
+            defaultMessage="Are you sure you want to remove {email} avatar?"
+            values={{
+              email: (
+                <strong>
+                  {getStringOrPlaceholder(staffDetailsQueryData.user?.email)}
+                </strong>
+              )
+            }}
+          />
+        </DialogContentText>
+      </ActionDialog>
+      <StaffPasswordResetDialog
+        confirmButtonState={changePasswordOpts.status}
+        errors={changePasswordOpts?.data?.passwordChange?.errors || []}
+        open={params.action === "change-password"}
+        onClose={closeModal}
+        onSubmit={data =>
+          changePassword({
+            variables: data
+          })
+        }
+      />
+    </>
   );
 };
 

--- a/src/staff/views/StaffList/StaffList.tsx
+++ b/src/staff/views/StaffList/StaffList.tsx
@@ -27,9 +27,8 @@ import StaffAddMemberDialog, {
   AddMemberFormData
 } from "../../components/StaffAddMemberDialog";
 import StaffListPage from "../../components/StaffListPage";
-import { TypedStaffMemberAddMutation } from "../../mutations";
+import { useStaffMemberAddMutation } from "../../mutations";
 import { useStaffListQuery } from "../../queries";
-import { StaffMemberAdd } from "../../types/StaffMemberAdd";
 import {
   staffListUrl,
   StaffListUrlDialog,
@@ -127,16 +126,6 @@ export const StaffList: React.FC<StaffListProps> = ({ params }) => {
     handleTabChange(tabs.length + 1);
   };
 
-  const handleStaffMemberAddSuccess = (data: StaffMemberAdd) => {
-    if (data.staffCreate.errors.length === 0) {
-      notify({
-        status: "success",
-        text: intl.formatMessage(commonMessages.savedChanges)
-      });
-      navigate(staffMemberDetailsUrl(data.staffCreate.user.id));
-    }
-  };
-
   const {
     loadMore: loadMorePermissionGroups,
     search: searchPermissionGroups,
@@ -145,90 +134,94 @@ export const StaffList: React.FC<StaffListProps> = ({ params }) => {
     variables: DEFAULT_INITIAL_SEARCH_DATA
   });
 
-  return (
-    <TypedStaffMemberAddMutation onCompleted={handleStaffMemberAddSuccess}>
-      {(addStaffMember, addStaffMemberData) => {
-        const handleStaffMemberAdd = (variables: AddMemberFormData) =>
-          addStaffMember({
-            variables: {
-              input: {
-                addGroups: variables.permissionGroups,
-                email: variables.email,
-                firstName: variables.firstName,
-                lastName: variables.lastName,
-                redirectUrl: urlJoin(
-                  window.location.origin,
-                  APP_MOUNT_URI === "/" ? "" : APP_MOUNT_URI,
-                  newPasswordUrl().replace(/\?/, "")
-                )
-              }
-            }
-          });
+  const [staffMemberAdd, staffMemberAddOpts] = useStaffMemberAddMutation({
+    onCompleted: data => {
+      if (data.staffCreate.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        navigate(staffMemberDetailsUrl(data.staffCreate.user.id));
+      }
+    }
+  });
 
-        return (
-          <>
-            <StaffListPage
-              currentTab={currentTab}
-              filterOpts={getFilterOpts(params)}
-              initialSearch={params.query || ""}
-              onSearchChange={handleSearchChange}
-              onFilterChange={changeFilters}
-              onAll={resetFilters}
-              onTabChange={handleTabChange}
-              onTabDelete={() => openModal("delete-search")}
-              onTabSave={() => openModal("save-search")}
-              tabs={tabs.map(tab => tab.name)}
-              disabled={loading || addStaffMemberData.loading}
-              settings={settings}
-              pageInfo={pageInfo}
-              sort={getSortParams(params)}
-              staffMembers={staffQueryData?.staffUsers.edges.map(
-                edge => edge.node
-              )}
-              onAdd={() => openModal("add")}
-              onBack={() => navigate(configurationMenuUrl)}
-              onNextPage={loadNextPage}
-              onPreviousPage={loadPreviousPage}
-              onUpdateListSettings={updateListSettings}
-              onRowClick={id => () => navigate(staffMemberDetailsUrl(id))}
-              onSort={handleSort}
-            />
-            <StaffAddMemberDialog
-              availablePermissionGroups={searchPermissionGroupsOpts.data?.search.edges.map(
-                edge => edge.node
-              )}
-              confirmButtonState={addStaffMemberData.status}
-              initialSearch=""
-              disabled={loading}
-              errors={addStaffMemberData.data?.staffCreate.errors || []}
-              open={params.action === "add"}
-              onClose={closeModal}
-              onConfirm={handleStaffMemberAdd}
-              fetchMorePermissionGroups={{
-                hasMore:
-                  searchPermissionGroupsOpts.data?.search.pageInfo.hasNextPage,
-                loading: searchPermissionGroupsOpts.loading,
-                onFetchMore: loadMorePermissionGroups
-              }}
-              onSearchChange={searchPermissionGroups}
-            />
-            <SaveFilterTabDialog
-              open={params.action === "save-search"}
-              confirmButtonState="default"
-              onClose={closeModal}
-              onSubmit={handleTabSave}
-            />
-            <DeleteFilterTabDialog
-              open={params.action === "delete-search"}
-              confirmButtonState="default"
-              onClose={closeModal}
-              onSubmit={handleTabDelete}
-              tabName={getStringOrPlaceholder(tabs[currentTab - 1]?.name)}
-            />
-          </>
-        );
-      }}
-    </TypedStaffMemberAddMutation>
+  const handleStaffMemberAdd = async (formData: AddMemberFormData) => {
+    staffMemberAdd({
+      variables: {
+        input: {
+          addGroups: formData.permissionGroups,
+          email: formData.email,
+          firstName: formData.firstName,
+          lastName: formData.lastName,
+          redirectUrl: urlJoin(
+            window.location.origin,
+            APP_MOUNT_URI === "/" ? "" : APP_MOUNT_URI,
+            newPasswordUrl().replace(/\?/, "")
+          )
+        }
+      }
+    });
+  };
+
+  return (
+    <>
+      <StaffListPage
+        currentTab={currentTab}
+        filterOpts={getFilterOpts(params)}
+        initialSearch={params.query || ""}
+        onSearchChange={handleSearchChange}
+        onFilterChange={changeFilters}
+        onAll={resetFilters}
+        onTabChange={handleTabChange}
+        onTabDelete={() => openModal("delete-search")}
+        onTabSave={() => openModal("save-search")}
+        tabs={tabs.map(tab => tab.name)}
+        disabled={loading || staffMemberAddOpts.loading}
+        settings={settings}
+        pageInfo={pageInfo}
+        sort={getSortParams(params)}
+        staffMembers={staffQueryData?.staffUsers.edges.map(edge => edge.node)}
+        onAdd={() => openModal("add")}
+        onBack={() => navigate(configurationMenuUrl)}
+        onNextPage={loadNextPage}
+        onPreviousPage={loadPreviousPage}
+        onUpdateListSettings={updateListSettings}
+        onRowClick={id => () => navigate(staffMemberDetailsUrl(id))}
+        onSort={handleSort}
+      />
+      <StaffAddMemberDialog
+        availablePermissionGroups={searchPermissionGroupsOpts.data?.search.edges.map(
+          edge => edge.node
+        )}
+        confirmButtonState={staffMemberAddOpts.status}
+        initialSearch=""
+        disabled={loading}
+        errors={staffMemberAddOpts.data?.staffCreate.errors || []}
+        open={params.action === "add"}
+        onClose={closeModal}
+        onConfirm={handleStaffMemberAdd}
+        fetchMorePermissionGroups={{
+          hasMore: searchPermissionGroupsOpts.data?.search.pageInfo.hasNextPage,
+          loading: searchPermissionGroupsOpts.loading,
+          onFetchMore: loadMorePermissionGroups
+        }}
+        onSearchChange={searchPermissionGroups}
+      />
+      <SaveFilterTabDialog
+        open={params.action === "save-search"}
+        confirmButtonState="default"
+        onClose={closeModal}
+        onSubmit={handleTabSave}
+      />
+      <DeleteFilterTabDialog
+        open={params.action === "delete-search"}
+        confirmButtonState="default"
+        onClose={closeModal}
+        onSubmit={handleTabDelete}
+        tabName={getStringOrPlaceholder(tabs[currentTab - 1]?.name)}
+      />
+    </>
   );
 };
 

--- a/src/storybook/stories/components/messages.tsx
+++ b/src/storybook/stories/components/messages.tsx
@@ -19,14 +19,14 @@ const Story: React.FC<IMessage> = ({
   title,
   text
 }) => {
-  const pushMessage = useNotifier();
+  const notify = useNotifier();
 
   return (
     <Button
       color="primary"
       variant="contained"
       onClick={() =>
-        pushMessage({
+        notify({
           actionBtn,
           expandText,
           onUndo: onUndo ? () => undefined : undefined,


### PR DESCRIPTION
I want to merge this change because typed queries are outdated and are blocking us from migrating to the new apollo.

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
