### PR TITLE
Add file attribute upload to page attributes

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4659,6 +4659,8 @@ type ShippingMethod implements Node & ObjectWithMetadata {
   name: String!
   minimumOrderWeight: Weight
   maximumOrderWeight: Weight
+  maximumDeliveryDays: Int
+  minimumDeliveryDays: Int
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   type: ShippingMethodTypeEnum
@@ -4755,6 +4757,8 @@ input ShippingPriceInput {
   name: String
   minimumOrderWeight: WeightScalar
   maximumOrderWeight: WeightScalar
+  maximumDeliveryDays: Int
+  minimumDeliveryDays: Int
   type: ShippingMethodTypeEnum
   shippingZone: ID
 }

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -3,7 +3,10 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import { getStringOrPlaceholder } from "@saleor/misc";
 import { ReorderEvent } from "@saleor/types";
-import { AttributeErrorCode } from "@saleor/types/globalTypes";
+import {
+  AttributeErrorCode,
+  AttributeInputTypeEnum
+} from "@saleor/types/globalTypes";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataCreateHandler from "@saleor/utils/handlers/metadataCreateHandler";
 import {
@@ -52,6 +55,39 @@ function areValuesEqual(
   b: AttributeValueEditDialogFormData
 ) {
   return a.name === b.name;
+}
+
+function getSimpleAttributeData(
+  data: AttributePageFormData,
+  values: AttributeValueEditDialogFormData[]
+) {
+  return {
+    ...data,
+    metadata: undefined,
+    privateMetadata: undefined,
+    storefrontSearchPosition: parseInt(data.storefrontSearchPosition, 0),
+    values: values.map(value => ({
+      name: value.name
+    }))
+  };
+}
+
+function getFileAttributeData(
+  data: AttributePageFormData,
+  values: AttributeValueEditDialogFormData[]
+) {
+  return {
+    ...data,
+    availableInGrid: undefined,
+    filterableInDashboard: undefined,
+    filterableInStorefront: undefined,
+    metadata: undefined,
+    privateMetadata: undefined,
+    storefrontSearchPosition: parseInt(data.storefrontSearchPosition, 0),
+    values: values.map(value => ({
+      name: value.name
+    }))
+  };
 }
 
 const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
@@ -115,15 +151,10 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
     setValues(move(values[oldIndex], values, areValuesEqual, newIndex));
 
   const handleCreate = async (data: AttributePageFormData) => {
-    const input = {
-      ...data,
-      metadata: undefined,
-      privateMetadata: undefined,
-      storefrontSearchPosition: parseInt(data.storefrontSearchPosition, 0),
-      values: values.map(value => ({
-        name: value.name
-      }))
-    };
+    const input =
+      data.inputType === AttributeInputTypeEnum.FILE
+        ? getFileAttributeData(data, values)
+        : getSimpleAttributeData(data, values);
 
     const result = await attributeCreate({
       variables: {

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -77,16 +77,10 @@ function getFileAttributeData(
   values: AttributeValueEditDialogFormData[]
 ) {
   return {
-    ...data,
+    ...getSimpleAttributeData(data, values),
     availableInGrid: undefined,
     filterableInDashboard: undefined,
-    filterableInStorefront: undefined,
-    metadata: undefined,
-    privateMetadata: undefined,
-    storefrontSearchPosition: parseInt(data.storefrontSearchPosition, 0),
-    values: values.map(value => ({
-      name: value.name
-    }))
+    filterableInStorefront: undefined
   };
 }
 

--- a/src/files/mutations.ts
+++ b/src/files/mutations.ts
@@ -1,0 +1,25 @@
+import { uploadErrorFragment } from "@saleor/fragments/errors";
+import { fileFragment } from "@saleor/fragments/file";
+import makeMutation from "@saleor/hooks/makeMutation";
+import gql from "graphql-tag";
+
+import { FileUpload, FileUploadVariables } from "./types/FileUpload";
+
+const fileUploadMutation = gql`
+  ${fileFragment}
+  ${uploadErrorFragment}
+  mutation FileUpload($file: Upload!) {
+    fileUpload(file: $file) {
+      uploadedFile {
+        ...FileFragment
+      }
+      uploadErrors {
+        ...UploadErrorFragment
+      }
+    }
+  }
+`;
+export const useFileUploadMutation = makeMutation<
+  FileUpload,
+  FileUploadVariables
+>(fileUploadMutation);

--- a/src/files/types/FileUpload.ts
+++ b/src/files/types/FileUpload.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { UploadErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: FileUpload
+// ====================================================
+
+export interface FileUpload_fileUpload_uploadedFile {
+  __typename: "File";
+  url: string;
+  contentType: string | null;
+}
+
+export interface FileUpload_fileUpload_uploadErrors {
+  __typename: "UploadError";
+  code: UploadErrorCode;
+  field: string | null;
+}
+
+export interface FileUpload_fileUpload {
+  __typename: "FileUpload";
+  uploadedFile: FileUpload_fileUpload_uploadedFile | null;
+  uploadErrors: FileUpload_fileUpload_uploadErrors[];
+}
+
+export interface FileUpload {
+  fileUpload: FileUpload_fileUpload | null;
+}
+
+export interface FileUploadVariables {
+  file: any;
+}

--- a/src/fragments/attributes.ts
+++ b/src/fragments/attributes.ts
@@ -1,15 +1,16 @@
 import gql from "graphql-tag";
 
+import { fileFragment } from "./file";
 import { metadataFragment } from "./metadata";
 
 export const attributeValueFragment = gql`
+  ${fileFragment}
   fragment AttributeValueFragment on AttributeValue {
     id
     name
     slug
     file {
-      url
-      contentType
+      ...FileFragment
     }
   }
 `;

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -206,3 +206,10 @@ export const collectionsErrorFragment = gql`
     field
   }
 `;
+
+export const uploadErrorFragment = gql`
+  fragment UploadErrorFragment on UploadError {
+    code
+    field
+  }
+`;

--- a/src/fragments/file.ts
+++ b/src/fragments/file.ts
@@ -1,0 +1,8 @@
+import gql from "graphql-tag";
+
+export const fileFragment = gql`
+  fragment FileFragment on File {
+    url
+    contentType
+  }
+`;

--- a/src/fragments/types/FileFragment.ts
+++ b/src/fragments/types/FileFragment.ts
@@ -1,0 +1,13 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: FileFragment
+// ====================================================
+
+export interface FileFragment {
+  __typename: "File";
+  url: string;
+  contentType: string | null;
+}

--- a/src/fragments/types/UploadErrorFragment.ts
+++ b/src/fragments/types/UploadErrorFragment.ts
@@ -1,0 +1,15 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { UploadErrorCode } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: UploadErrorFragment
+// ====================================================
+
+export interface UploadErrorFragment {
+  __typename: "UploadError";
+  code: UploadErrorCode;
+  field: string | null;
+}

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -103,8 +103,9 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
                   attributes={data.attributes}
                   disabled={disabled}
                   errors={errors}
-                  onChange={handlers.changeAttribute}
-                  onMultiChange={handlers.changeAttributeMulti}
+                  onChange={handlers.selectAttribute}
+                  onMultiChange={handlers.selectAttributeMulti}
+                  onFileChange={handlers.selectAttributeFile}
                 />
               )}
               <CardSpacer />

--- a/src/pages/mutations.ts
+++ b/src/pages/mutations.ts
@@ -3,6 +3,7 @@ import {
   pageErrorWithAttributesFragment
 } from "@saleor/fragments/errors";
 import { pageDetailsFragment } from "@saleor/fragments/pages";
+import makeMutation from "@saleor/hooks/makeMutation";
 import gql from "graphql-tag";
 
 import { TypedMutation } from "../mutations";
@@ -51,9 +52,10 @@ const pageUpdate = gql`
     }
   }
 `;
-export const TypedPageUpdate = TypedMutation<PageUpdate, PageUpdateVariables>(
-  pageUpdate
-);
+export const usePageUpdateMutation = makeMutation<
+  PageUpdate,
+  PageUpdateVariables
+>(pageUpdate);
 
 const pageRemove = gql`
   ${pageErrorFragment}
@@ -65,9 +67,10 @@ const pageRemove = gql`
     }
   }
 `;
-export const TypedPageRemove = TypedMutation<PageRemove, PageRemoveVariables>(
-  pageRemove
-);
+export const usePageRemoveMutation = makeMutation<
+  PageRemove,
+  PageRemoveVariables
+>(pageRemove);
 
 const pageBulkPublish = gql`
   mutation PageBulkPublish($ids: [ID]!, $isPublished: Boolean!) {

--- a/src/pages/queries.ts
+++ b/src/pages/queries.ts
@@ -2,7 +2,6 @@ import { pageDetailsFragment, pageFragment } from "@saleor/fragments/pages";
 import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
 
-import { TypedQuery } from "../queries";
 import { PageDetails, PageDetailsVariables } from "./types/PageDetails";
 import { PageList, PageListVariables } from "./types/PageList";
 
@@ -48,7 +47,6 @@ const pageDetails = gql`
     }
   }
 `;
-export const TypedPageDetailsQuery = TypedQuery<
-  PageDetails,
-  PageDetailsVariables
->(pageDetails);
+export const usePageDetailsQuery = makeQuery<PageDetails, PageDetailsVariables>(
+  pageDetails
+);

--- a/src/pages/utils/data.ts
+++ b/src/pages/utils/data.ts
@@ -1,4 +1,5 @@
 import { AttributeInput } from "@saleor/components/Attributes";
+import { FormsetData } from "@saleor/hooks/useFormset";
 
 import {
   PageDetails_page,
@@ -34,3 +35,21 @@ export function getAttributeInputFromPageType(
     value: []
   }));
 }
+
+export const getAttributesDisplayData = (
+  attributes: AttributeInput[],
+  attributesWithNewFileValue: FormsetData<null, File>
+) =>
+  attributes.map(attribute => {
+    const attributeWithNewFileValue = attributesWithNewFileValue.find(
+      attributeWithNewFile => attribute.id === attributeWithNewFile.id
+    );
+
+    if (attributeWithNewFileValue) {
+      return {
+        ...attribute,
+        value: [attributeWithNewFileValue.value.name]
+      };
+    }
+    return attribute;
+  });

--- a/src/pages/utils/data.ts
+++ b/src/pages/utils/data.ts
@@ -1,8 +1,17 @@
 import { AttributeInput } from "@saleor/components/Attributes";
+import { FileUpload } from "@saleor/files/types/FileUpload";
+import { UploadErrorFragment } from "@saleor/fragments/types/UploadErrorFragment";
 import { FormsetData } from "@saleor/hooks/useFormset";
+import {
+  AttributeInputTypeEnum,
+  AttributeValueInput
+} from "@saleor/types/globalTypes";
+import { MutationFetchResult } from "react-apollo";
 
+import { PageSubmitData } from "../components/PageDetailsPage/form";
 import {
   PageDetails_page,
+  PageDetails_page_attributes,
   PageDetails_page_pageType
 } from "../types/PageDetails";
 
@@ -53,3 +62,44 @@ export const getAttributesDisplayData = (
     }
     return attribute;
   });
+
+export const isFileValueUnused = (
+  data: PageSubmitData,
+  existingAttribute: PageDetails_page_attributes
+) => {
+  if (existingAttribute.attribute.inputType !== AttributeInputTypeEnum.FILE) {
+    return false;
+  }
+  if (existingAttribute.values.length === 0) {
+    return false;
+  }
+
+  const modifiedAttribute = data.attributes.find(
+    dataAttribute => dataAttribute.id === existingAttribute.attribute.id
+  );
+  return modifiedAttribute.value.length === 0;
+};
+
+export const mergeFileUploadErrors = (
+  uploadFilesResult: Array<MutationFetchResult<FileUpload>>
+): UploadErrorFragment[] =>
+  uploadFilesResult.reduce((errors, uploadFileResult) => {
+    const uploadErrors = uploadFileResult.data.fileUpload.uploadErrors;
+    if (uploadErrors) {
+      return [...errors, ...uploadErrors];
+    }
+  }, []);
+
+export const mergeAttributesWithFileUploadResult = (
+  attributesWithNewFileValue: FormsetData<null, File>,
+  uploadFilesResult: Array<MutationFetchResult<FileUpload>>
+): AttributeValueInput[] =>
+  uploadFilesResult.map((uploadFileResult, index) => {
+    const attribute = attributesWithNewFileValue[index];
+
+    return {
+      file: uploadFileResult.data.fileUpload.uploadedFile.url,
+      id: attribute.id,
+      values: []
+    };
+  }, []);

--- a/src/pages/utils/handlers.test.ts
+++ b/src/pages/utils/handlers.test.ts
@@ -54,6 +54,28 @@ const attributes: FormsetData<AttributeInputData, string[]> = [
     id: "attr-2",
     label: "Attribute 2",
     value: ["attr-2-v-3"]
+  },
+  {
+    data: {
+      inputType: AttributeInputTypeEnum.FILE,
+      isRequired: false,
+      values: [
+        {
+          __typename: "AttributeValue",
+          file: {
+            __typename: "File",
+            contentType: "image/png",
+            url: "some-non-existing-url"
+          },
+          id: "gdghdgdhkkdae",
+          name: "File First Value",
+          slug: "file-first-value"
+        }
+      ]
+    },
+    id: "ifudbgidfsb",
+    label: "File Attribute",
+    value: []
   }
 ];
 

--- a/src/pages/utils/handlers.ts
+++ b/src/pages/utils/handlers.ts
@@ -1,6 +1,13 @@
-import { AttributeInputData } from "@saleor/components/Attributes";
+import {
+  AttributeInput,
+  AttributeInputData
+} from "@saleor/components/Attributes";
 import { FormChange } from "@saleor/hooks/useForm";
 import { FormsetChange, FormsetData } from "@saleor/hooks/useFormset";
+import {
+  AttributeInputTypeEnum,
+  AttributeValueInput
+} from "@saleor/types/globalTypes";
 import { toggle } from "@saleor/utils/lists";
 
 import { PageDetails_page_pageType } from "../types/PageDetails";
@@ -54,3 +61,33 @@ export function createAttributeMultiChangeHandler(
     changeAttributeData(attributeId, newAttributeValues);
   };
 }
+
+interface PageAttributesArgs {
+  attributes: AttributeInput[];
+  attributesWithAddedNewFiles: AttributeValueInput[];
+}
+
+export const getAttributesVariables = ({
+  attributes,
+  attributesWithAddedNewFiles
+}: PageAttributesArgs): AttributeValueInput[] =>
+  attributes.map(attribute => {
+    if (attribute.data.inputType === AttributeInputTypeEnum.FILE) {
+      const attributeWithNewFile = attributesWithAddedNewFiles.find(
+        attributeWithNewFile => attribute.id === attributeWithNewFile.id
+      );
+      if (attributeWithNewFile) {
+        return attributeWithNewFile;
+      }
+      return {
+        file: attribute.value[0],
+        id: attribute.id,
+        values: []
+      };
+    }
+    return {
+      file: undefined,
+      id: attribute.id,
+      values: attribute.value[0] === "" ? [] : attribute.value
+    };
+  });

--- a/src/pages/utils/handlers.ts
+++ b/src/pages/utils/handlers.ts
@@ -67,7 +67,7 @@ interface PageAttributesArgs {
   attributesWithAddedNewFiles: AttributeValueInput[];
 }
 
-export const getAttributesVariables = ({
+export const prepareAttributesInput = ({
   attributes,
   attributesWithAddedNewFiles
 }: PageAttributesArgs): AttributeValueInput[] =>

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -4,7 +4,6 @@ import { useFileUploadMutation } from "@saleor/files/mutations";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import usePageTypeSearch from "@saleor/searches/usePageTypeSearch";
-import { AttributeValueInput } from "@saleor/types/globalTypes";
 import createMetadataCreateHandler from "@saleor/utils/handlers/metadataCreateHandler";
 import {
   useMetadataUpdate,
@@ -18,7 +17,8 @@ import { PageSubmitData } from "../components/PageDetailsPage/form";
 import { TypedPageCreate } from "../mutations";
 import { PageCreate as PageCreateData } from "../types/PageCreate";
 import { pageListUrl, pageUrl } from "../urls";
-import { getAttributesVariables } from "../utils/handlers";
+import { mergeAttributesWithFileUploadResult } from "../utils/data";
+import { prepareAttributesInput } from "../utils/handlers";
 
 export interface PageCreateProps {
   id: string;
@@ -67,26 +67,15 @@ export const PageCreate: React.FC<PageCreateProps> = () => {
             )
           );
 
-          const attributesWithAddedNewFiles: AttributeValueInput[] = uploadFilesResult.reduce(
-            (attributesWithAddedFiles, uploadFileResult, index) => {
-              const attribute = formData.attributesWithNewFileValue[index];
-
-              return [
-                ...attributesWithAddedFiles,
-                {
-                  file: uploadFileResult.data.fileUpload.uploadedFile.url,
-                  id: attribute.id,
-                  values: []
-                }
-              ];
-            },
-            []
+          const attributesWithAddedNewFiles = mergeAttributesWithFileUploadResult(
+            formData.attributesWithNewFileValue,
+            uploadFilesResult
           );
 
           const result = await pageCreate({
             variables: {
               input: {
-                attributes: getAttributesVariables({
+                attributes: prepareAttributesInput({
                   attributes: formData.attributes,
                   attributesWithAddedNewFiles
                 }),

--- a/src/pages/views/PageDetails.tsx
+++ b/src/pages/views/PageDetails.tsx
@@ -18,18 +18,19 @@ import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { getStringOrPlaceholder, maybe } from "../../misc";
-import {
-  AttributeInputTypeEnum,
-  AttributeValueInput,
-  PageInput
-} from "../../types/globalTypes";
+import { AttributeValueInput, PageInput } from "../../types/globalTypes";
 import PageDetailsPage from "../components/PageDetailsPage";
 import { PageData, PageSubmitData } from "../components/PageDetailsPage/form";
-import { TypedPageRemove, TypedPageUpdate } from "../mutations";
-import { TypedPageDetailsQuery } from "../queries";
+import { usePageRemoveMutation, usePageUpdateMutation } from "../mutations";
+import { usePageDetailsQuery } from "../queries";
 import { PageRemove } from "../types/PageRemove";
 import { pageListUrl, pageUrl, PageUrlQueryParams } from "../urls";
-import { getAttributesVariables } from "../utils/handlers";
+import {
+  isFileValueUnused,
+  mergeAttributesWithFileUploadResult,
+  mergeFileUploadErrors
+} from "../utils/data";
+import { prepareAttributesInput } from "../utils/handlers";
 
 export interface PageDetailsProps {
   id: string;
@@ -40,7 +41,7 @@ const createPageInput = (
   data: PageData,
   attributesWithAddedNewFiles: AttributeValueInput[]
 ): PageInput => ({
-  attributes: getAttributesVariables({
+  attributes: prepareAttributesInput({
     attributes: data.attributes,
     attributesWithAddedNewFiles
   }),
@@ -62,179 +63,145 @@ export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
   const [updateMetadata] = useMetadataUpdate({});
   const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
 
+  const pageDetails = usePageDetailsQuery({
+    variables: {
+      id
+    }
+  });
+
   const [uploadFile, uploadFileOpts] = useFileUploadMutation({});
 
-  const handlePageRemove = (data: PageRemove) => {
-    if (data.pageDelete.errors.length === 0) {
-      notify({
-        status: "success",
-        text: intl.formatMessage(commonMessages.savedChanges)
-      });
-      navigate(pageListUrl());
-    }
-  };
+  const [pageUpdate, pageUpdateOpts] = usePageUpdateMutation({});
 
   const [
     deleteAttributeValue,
     deleteAttributeValueOpts
   ] = useAttributeValueDeleteMutation({});
 
+  const [pageRemove, pageRemoveOpts] = usePageRemoveMutation({
+    onCompleted: (data: PageRemove) => {
+      if (data.pageDelete.errors.length === 0) {
+        notify({
+          status: "success",
+          text: intl.formatMessage(commonMessages.savedChanges)
+        });
+        navigate(pageListUrl());
+      }
+    }
+  });
+
+  const handleUpdate = async (data: PageSubmitData) => {
+    let errors: Array<
+      AttributeErrorFragment | UploadErrorFragment | PageErrorFragment
+    > = [];
+
+    const uploadFilesResult = await Promise.all(
+      data.attributesWithNewFileValue.map(fileAttribute =>
+        uploadFile({
+          variables: {
+            file: fileAttribute.value
+          }
+        })
+      )
+    );
+
+    errors = [...errors, ...mergeFileUploadErrors(uploadFilesResult)];
+
+    const attributesWithAddedNewFiles = mergeAttributesWithFileUploadResult(
+      data.attributesWithNewFileValue,
+      uploadFilesResult
+    );
+
+    const result = await pageUpdate({
+      variables: {
+        id,
+        input: createPageInput(data, attributesWithAddedNewFiles)
+      }
+    });
+
+    errors = [...errors, ...result.data.pageUpdate.errors];
+
+    if (errors.length === 0) {
+      const deleteAttributeValuesResult = await Promise.all(
+        pageDetails?.data?.page?.attributes.map(existingAttribute => {
+          const fileValueUnused = isFileValueUnused(data, existingAttribute);
+
+          if (fileValueUnused) {
+            return deleteAttributeValue({
+              variables: {
+                id: existingAttribute.values[0].id
+              }
+            });
+          }
+        })
+      );
+
+      deleteAttributeValuesResult.forEach(deleteValueResult => {
+        errors = [
+          ...errors,
+          ...deleteValueResult.data.attributeValueDelete.errors
+        ];
+      });
+    }
+
+    return errors;
+  };
+
+  const handleSubmit = createMetadataUpdateHandler(
+    pageDetails.data?.page,
+    handleUpdate,
+    variables => updateMetadata({ variables }),
+    variables => updatePrivateMetadata({ variables })
+  );
+
   return (
-    <TypedPageRemove variables={{ id }} onCompleted={handlePageRemove}>
-      {(pageRemove, pageRemoveOpts) => (
-        <TypedPageUpdate>
-          {(pageUpdate, pageUpdateOpts) => (
-            <TypedPageDetailsQuery variables={{ id }}>
-              {pageDetails => {
-                const handleUpdate = async (data: PageSubmitData) => {
-                  let errors: Array<
-                    | AttributeErrorFragment
-                    | UploadErrorFragment
-                    | PageErrorFragment
-                  > = [];
-
-                  const uploadFilesResult = await Promise.all(
-                    data.attributesWithNewFileValue.map(fileAttribute =>
-                      uploadFile({
-                        variables: {
-                          file: fileAttribute.value
-                        }
-                      })
-                    )
-                  );
-
-                  const attributesWithAddedNewFiles: AttributeValueInput[] = uploadFilesResult.reduce(
-                    (attributesWithAddedFiles, uploadFileResult, index) => {
-                      const attribute = data.attributesWithNewFileValue[index];
-
-                      errors = [
-                        ...errors,
-                        ...uploadFileResult.data.fileUpload.uploadErrors
-                      ];
-                      return [
-                        ...attributesWithAddedFiles,
-                        {
-                          file:
-                            uploadFileResult.data.fileUpload.uploadedFile.url,
-                          id: attribute.id,
-                          values: []
-                        }
-                      ];
-                    },
-                    []
-                  );
-
-                  const result = await pageUpdate({
-                    variables: {
-                      id,
-                      input: createPageInput(data, attributesWithAddedNewFiles)
-                    }
-                  });
-
-                  errors = [...errors, ...result.data.pageUpdate.errors];
-
-                  if (errors.length === 0) {
-                    const deleteAttributeValuesResult = await Promise.all(
-                      pageDetails?.data?.page?.attributes.map(
-                        existingAttribute => {
-                          const fileValueUnused =
-                            existingAttribute.attribute.inputType ===
-                              AttributeInputTypeEnum.FILE &&
-                            existingAttribute.values.length > 0 &&
-                            data.attributes.find(
-                              dataAttribute =>
-                                dataAttribute.id ===
-                                existingAttribute.attribute.id
-                            ).value.length === 0;
-
-                          if (fileValueUnused) {
-                            return deleteAttributeValue({
-                              variables: {
-                                id: existingAttribute.values[0].id
-                              }
-                            });
-                          }
-                        }
-                      )
-                    );
-
-                    deleteAttributeValuesResult.forEach(deleteValueResult => {
-                      errors = [
-                        ...errors,
-                        ...deleteValueResult.data.attributeValueDelete.errors
-                      ];
-                    });
-                  }
-
-                  return errors;
-                };
-
-                const handleSubmit = createMetadataUpdateHandler(
-                  pageDetails.data?.page,
-                  handleUpdate,
-                  variables => updateMetadata({ variables }),
-                  variables => updatePrivateMetadata({ variables })
-                );
-
-                return (
-                  <>
-                    <WindowTitle
-                      title={maybe(() => pageDetails.data.page.title)}
-                    />
-                    <PageDetailsPage
-                      disabled={
-                        pageDetails.loading ||
-                        uploadFileOpts.loading ||
-                        deleteAttributeValueOpts.loading
-                      }
-                      errors={pageUpdateOpts.data?.pageUpdate.errors || []}
-                      saveButtonBarState={pageUpdateOpts.status}
-                      page={pageDetails.data?.page}
-                      onBack={() => navigate(pageListUrl())}
-                      onRemove={() =>
-                        navigate(
-                          pageUrl(id, {
-                            action: "remove"
-                          })
-                        )
-                      }
-                      onSubmit={handleSubmit}
-                    />
-                    <ActionDialog
-                      open={params.action === "remove"}
-                      confirmButtonState={pageRemoveOpts.status}
-                      title={intl.formatMessage({
-                        defaultMessage: "Delete Page",
-                        description: "dialog header"
-                      })}
-                      onClose={() => navigate(pageUrl(id))}
-                      onConfirm={pageRemove}
-                      variant="delete"
-                    >
-                      <DialogContentText>
-                        <FormattedMessage
-                          defaultMessage="Are you sure you want to delete {title}?"
-                          description="delete page"
-                          values={{
-                            title: (
-                              <strong>
-                                {getStringOrPlaceholder(
-                                  pageDetails.data?.page?.title
-                                )}
-                              </strong>
-                            )
-                          }}
-                        />
-                      </DialogContentText>
-                    </ActionDialog>
-                  </>
-                );
-              }}
-            </TypedPageDetailsQuery>
-          )}
-        </TypedPageUpdate>
-      )}
-    </TypedPageRemove>
+    <>
+      <WindowTitle title={maybe(() => pageDetails.data.page.title)} />
+      <PageDetailsPage
+        disabled={
+          pageDetails.loading ||
+          uploadFileOpts.loading ||
+          deleteAttributeValueOpts.loading
+        }
+        errors={pageUpdateOpts.data?.pageUpdate.errors || []}
+        saveButtonBarState={pageUpdateOpts.status}
+        page={pageDetails.data?.page}
+        onBack={() => navigate(pageListUrl())}
+        onRemove={() =>
+          navigate(
+            pageUrl(id, {
+              action: "remove"
+            })
+          )
+        }
+        onSubmit={handleSubmit}
+      />
+      <ActionDialog
+        open={params.action === "remove"}
+        confirmButtonState={pageRemoveOpts.status}
+        title={intl.formatMessage({
+          defaultMessage: "Delete Page",
+          description: "dialog header"
+        })}
+        onClose={() => navigate(pageUrl(id))}
+        onConfirm={() => pageRemove({ variables: { id } })}
+        variant="delete"
+      >
+        <DialogContentText>
+          <FormattedMessage
+            defaultMessage="Are you sure you want to delete {title}?"
+            description="delete page"
+            values={{
+              title: (
+                <strong>
+                  {getStringOrPlaceholder(pageDetails.data?.page?.title)}
+                </strong>
+              )
+            }}
+          />
+        </DialogContentText>
+      </ActionDialog>
+    </>
   );
 };
 PageDetails.displayName = "PageDetails";

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -270,16 +270,14 @@ export const product: (
             file: null,
             id: "ptvav47282",
             name: "Black",
-            slug: "black",
-            sortOrder: 0
+            slug: "black"
           },
           {
             __typename: "AttributeValue",
             file: null,
             id: "ptvav17253",
             name: "White",
-            slug: "white",
-            sortOrder: 1
+            slug: "white"
           }
         ]
       }

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -133,6 +133,7 @@ export function createAttributeFileChangeHandler(
 ): FormsetChange<File> {
   return (attributeId: string, value: File) => {
     triggerChange();
+
     if (value) {
       addAttributeNewFileValue({
         data: null,
@@ -140,15 +141,16 @@ export function createAttributeFileChangeHandler(
         label: null,
         value
       });
+      return;
+    }
+
+    const removingNewFileValue = attributesWithNewFileValue.find(
+      attribute => attribute.id === attributeId
+    );
+    if (removingNewFileValue) {
+      removeAttributeNewFileValue(attributeId);
     } else {
-      const removeingNewFileValue = attributesWithNewFileValue.find(
-        attribute => attribute.id === attributeId
-      );
-      if (removeingNewFileValue) {
-        removeAttributeNewFileValue(attributeId);
-      } else {
-        changeAttributeData(attributeId, []);
-      }
+      changeAttributeData(attributeId, []);
     }
   };
 }

--- a/src/products/utils/handlers.ts
+++ b/src/products/utils/handlers.ts
@@ -5,7 +5,11 @@ import {
 } from "@saleor/channels/utils";
 import { AttributeInputData } from "@saleor/components/Attributes";
 import { FormChange } from "@saleor/hooks/useForm";
-import { FormsetChange, FormsetData } from "@saleor/hooks/useFormset";
+import {
+  FormsetAtomicData,
+  FormsetChange,
+  FormsetData
+} from "@saleor/hooks/useFormset";
 import { toggle } from "@saleor/utils/lists";
 
 import { getAttributeInputFromProductType, ProductType } from "./data";
@@ -117,6 +121,35 @@ export function createAttributeMultiChangeHandler(
 
     triggerChange();
     changeAttributeData(attributeId, newAttributeValues);
+  };
+}
+
+export function createAttributeFileChangeHandler(
+  changeAttributeData: FormsetChange<string[]>,
+  attributesWithNewFileValue: FormsetData<FormsetData<null, File>>,
+  addAttributeNewFileValue: (data: FormsetAtomicData<null, File>) => void,
+  removeAttributeNewFileValue: (id: string) => void,
+  triggerChange: () => void
+): FormsetChange<File> {
+  return (attributeId: string, value: File) => {
+    triggerChange();
+    if (value) {
+      addAttributeNewFileValue({
+        data: null,
+        id: attributeId,
+        label: null,
+        value
+      });
+    } else {
+      const removeingNewFileValue = attributesWithNewFileValue.find(
+        attribute => attribute.id === attributeId
+      );
+      if (removeingNewFileValue) {
+        removeAttributeNewFileValue(attributeId);
+      } else {
+        changeAttributeData(attributeId, []);
+      }
+    }
   };
 }
 

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -900,6 +900,10 @@ export enum TaxRateType {
   WINE = "WINE",
 }
 
+export enum UploadErrorCode {
+  GRAPHQL_ERROR = "GRAPHQL_ERROR",
+}
+
 export enum UserSortField {
   EMAIL = "EMAIL",
   FIRST_NAME = "FIRST_NAME",
@@ -1698,6 +1702,8 @@ export interface ShippingPriceInput {
   name?: string | null;
   minimumOrderWeight?: any | null;
   maximumOrderWeight?: any | null;
+  maximumDeliveryDays?: number | null;
+  minimumDeliveryDays?: number | null;
   type?: ShippingMethodTypeEnum | null;
   shippingZone?: string | null;
 }


### PR DESCRIPTION
I want to merge this change because... it adds file attribute upload to page attributes.

Feature branch: https://github.com/mirumee/saleor-dashboard/pull/884

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> feature/file-uploads
https://github.com/mirumee/saleor/pull/6568

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="670" alt="Zrzut ekranu 2020-12-8 o 00 12 36" src="https://user-images.githubusercontent.com/9825562/101417561-322a4380-38ec-11eb-83dc-326b6d5a5b4a.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://feature-file-uploads.api.saleor.rocks/graphql/
