### PR TITLE
Saleor 1531 add metadata UI for shipping zones and methods

### DIFF
--- a/src/fragments/shipping.ts
+++ b/src/fragments/shipping.ts
@@ -1,26 +1,18 @@
 import { fragmentMoney } from "@saleor/fragments/products";
 import gql from "graphql-tag";
 
+import { metadataFragment } from "./metadata";
+
 export const shippingZoneFragment = gql`
+  ${metadataFragment}
   fragment ShippingZoneFragment on ShippingZone {
+    ...MetadataFragment
     id
     countries {
       code
       country
     }
     name
-    metadata {
-      key
-      value
-    }
-    metadata {
-      key
-      value
-    }
-    privateMetadata {
-      key
-      value
-    }
   }
 `;
 

--- a/src/fragments/shipping.ts
+++ b/src/fragments/shipping.ts
@@ -27,10 +27,12 @@ export const shippingMethodWithZipCodesFragment = gql`
   }
 `;
 export const shippingMethodFragment = gql`
+  ${metadataFragment}
   ${fragmentMoney}
   ${shippingMethodWithZipCodesFragment}
   fragment ShippingMethodFragment on ShippingMethod {
     ...ShippingMethodWithZipCodesFragment
+    ...MetadataFragment
     minimumOrderWeight {
       unit
       value

--- a/src/fragments/shipping.ts
+++ b/src/fragments/shipping.ts
@@ -9,6 +9,18 @@ export const shippingZoneFragment = gql`
       country
     }
     name
+    metadata {
+      key
+      value
+    }
+    metadata {
+      key
+      value
+    }
+    privateMetadata {
+      key
+      value
+    }
   }
 `;
 

--- a/src/fragments/types/ShippingMethodFragment.ts
+++ b/src/fragments/types/ShippingMethodFragment.ts
@@ -15,6 +15,18 @@ export interface ShippingMethodFragment_zipCodeRules {
   end: string | null;
 }
 
+export interface ShippingMethodFragment_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingMethodFragment_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingMethodFragment_minimumOrderWeight {
   __typename: "Weight";
   unit: WeightUnitsEnum;
@@ -65,6 +77,8 @@ export interface ShippingMethodFragment {
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (ShippingMethodFragment_zipCodeRules | null)[] | null;
+  metadata: (ShippingMethodFragment_metadata | null)[];
+  privateMetadata: (ShippingMethodFragment_privateMetadata | null)[];
   minimumOrderWeight: ShippingMethodFragment_minimumOrderWeight | null;
   maximumOrderWeight: ShippingMethodFragment_maximumOrderWeight | null;
   name: string;

--- a/src/fragments/types/ShippingMethodWithExcludedProductsFragment.ts
+++ b/src/fragments/types/ShippingMethodWithExcludedProductsFragment.ts
@@ -15,6 +15,18 @@ export interface ShippingMethodWithExcludedProductsFragment_zipCodeRules {
   end: string | null;
 }
 
+export interface ShippingMethodWithExcludedProductsFragment_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingMethodWithExcludedProductsFragment_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingMethodWithExcludedProductsFragment_minimumOrderWeight {
   __typename: "Weight";
   unit: WeightUnitsEnum;
@@ -96,6 +108,8 @@ export interface ShippingMethodWithExcludedProductsFragment {
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (ShippingMethodWithExcludedProductsFragment_zipCodeRules | null)[] | null;
+  metadata: (ShippingMethodWithExcludedProductsFragment_metadata | null)[];
+  privateMetadata: (ShippingMethodWithExcludedProductsFragment_privateMetadata | null)[];
   minimumOrderWeight: ShippingMethodWithExcludedProductsFragment_minimumOrderWeight | null;
   maximumOrderWeight: ShippingMethodWithExcludedProductsFragment_maximumOrderWeight | null;
   name: string;

--- a/src/fragments/types/ShippingZoneDetailsFragment.ts
+++ b/src/fragments/types/ShippingZoneDetailsFragment.ts
@@ -14,6 +14,18 @@ export interface ShippingZoneDetailsFragment_countries {
   country: string;
 }
 
+export interface ShippingZoneDetailsFragment_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingZoneDetailsFragment_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingZoneDetailsFragment_shippingMethods_zipCodeRules {
   __typename: "ShippingMethodZipCodeRule";
   id: string;
@@ -89,6 +101,8 @@ export interface ShippingZoneDetailsFragment {
   id: string;
   countries: (ShippingZoneDetailsFragment_countries | null)[] | null;
   name: string;
+  metadata: (ShippingZoneDetailsFragment_metadata | null)[];
+  privateMetadata: (ShippingZoneDetailsFragment_privateMetadata | null)[];
   default: boolean;
   shippingMethods: (ShippingZoneDetailsFragment_shippingMethods | null)[] | null;
   warehouses: (ShippingZoneDetailsFragment_warehouses | null)[] | null;

--- a/src/fragments/types/ShippingZoneDetailsFragment.ts
+++ b/src/fragments/types/ShippingZoneDetailsFragment.ts
@@ -8,12 +8,6 @@ import { WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTyp
 // GraphQL fragment: ShippingZoneDetailsFragment
 // ====================================================
 
-export interface ShippingZoneDetailsFragment_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
 export interface ShippingZoneDetailsFragment_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -24,6 +18,12 @@ export interface ShippingZoneDetailsFragment_privateMetadata {
   __typename: "MetadataItem";
   key: string;
   value: string;
+}
+
+export interface ShippingZoneDetailsFragment_countries {
+  __typename: "CountryDisplay";
+  code: string;
+  country: string;
 }
 
 export interface ShippingZoneDetailsFragment_shippingMethods_zipCodeRules {
@@ -98,11 +98,11 @@ export interface ShippingZoneDetailsFragment_warehouses {
 
 export interface ShippingZoneDetailsFragment {
   __typename: "ShippingZone";
+  metadata: (ShippingZoneDetailsFragment_metadata | null)[];
+  privateMetadata: (ShippingZoneDetailsFragment_privateMetadata | null)[];
   id: string;
   countries: (ShippingZoneDetailsFragment_countries | null)[] | null;
   name: string;
-  metadata: (ShippingZoneDetailsFragment_metadata | null)[];
-  privateMetadata: (ShippingZoneDetailsFragment_privateMetadata | null)[];
   default: boolean;
   shippingMethods: (ShippingZoneDetailsFragment_shippingMethods | null)[] | null;
   warehouses: (ShippingZoneDetailsFragment_warehouses | null)[] | null;

--- a/src/fragments/types/ShippingZoneDetailsFragment.ts
+++ b/src/fragments/types/ShippingZoneDetailsFragment.ts
@@ -33,6 +33,18 @@ export interface ShippingZoneDetailsFragment_shippingMethods_zipCodeRules {
   end: string | null;
 }
 
+export interface ShippingZoneDetailsFragment_shippingMethods_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingZoneDetailsFragment_shippingMethods_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingZoneDetailsFragment_shippingMethods_minimumOrderWeight {
   __typename: "Weight";
   unit: WeightUnitsEnum;
@@ -83,6 +95,8 @@ export interface ShippingZoneDetailsFragment_shippingMethods {
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (ShippingZoneDetailsFragment_shippingMethods_zipCodeRules | null)[] | null;
+  metadata: (ShippingZoneDetailsFragment_shippingMethods_metadata | null)[];
+  privateMetadata: (ShippingZoneDetailsFragment_shippingMethods_privateMetadata | null)[];
   minimumOrderWeight: ShippingZoneDetailsFragment_shippingMethods_minimumOrderWeight | null;
   maximumOrderWeight: ShippingZoneDetailsFragment_shippingMethods_maximumOrderWeight | null;
   name: string;

--- a/src/fragments/types/ShippingZoneFragment.ts
+++ b/src/fragments/types/ShippingZoneFragment.ts
@@ -6,12 +6,6 @@
 // GraphQL fragment: ShippingZoneFragment
 // ====================================================
 
-export interface ShippingZoneFragment_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
 export interface ShippingZoneFragment_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -24,11 +18,17 @@ export interface ShippingZoneFragment_privateMetadata {
   value: string;
 }
 
+export interface ShippingZoneFragment_countries {
+  __typename: "CountryDisplay";
+  code: string;
+  country: string;
+}
+
 export interface ShippingZoneFragment {
   __typename: "ShippingZone";
+  metadata: (ShippingZoneFragment_metadata | null)[];
+  privateMetadata: (ShippingZoneFragment_privateMetadata | null)[];
   id: string;
   countries: (ShippingZoneFragment_countries | null)[] | null;
   name: string;
-  metadata: (ShippingZoneFragment_metadata | null)[];
-  privateMetadata: (ShippingZoneFragment_privateMetadata | null)[];
 }

--- a/src/fragments/types/ShippingZoneFragment.ts
+++ b/src/fragments/types/ShippingZoneFragment.ts
@@ -12,9 +12,23 @@ export interface ShippingZoneFragment_countries {
   country: string;
 }
 
+export interface ShippingZoneFragment_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingZoneFragment_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingZoneFragment {
   __typename: "ShippingZone";
   id: string;
   countries: (ShippingZoneFragment_countries | null)[] | null;
   name: string;
+  metadata: (ShippingZoneFragment_metadata | null)[];
+  privateMetadata: (ShippingZoneFragment_privateMetadata | null)[];
 }

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -254,6 +254,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     deleteProductImage({ variables: { id } });
   const handleImageEdit = (imageId: string) => () =>
     navigate(productImageUrl(id, imageId));
+
   const handleSubmit = createMetadataUpdateHandler(
     product,
     createUpdateHandler(

--- a/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
@@ -19,6 +19,7 @@ import {
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import createMultiAutocompleteSelectHandler from "@saleor/utils/handlers/multiAutocompleteSelectChangeHandler";
+import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -94,8 +95,8 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
   const initialForm: FormData = {
     name: shippingZone?.name || "",
     warehouses: shippingZone?.warehouses?.map(warehouse => warehouse.id) || [],
-    metadata: shippingZone?.metadata || [],
-    privateMetadata: shippingZone?.privateMetadata || []
+    metadata: shippingZone?.metadata.map(mapMetadataItemToInput),
+    privateMetadata: shippingZone?.privateMetadata.map(mapMetadataItemToInput)
   };
   const [warehouseDisplayValues, setWarehouseDisplayValues] = useStateFromProps<
     MultiAutocompleteChoiceType[]

--- a/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
@@ -5,6 +5,8 @@ import Container from "@saleor/components/Container";
 import CountryList from "@saleor/components/CountryList";
 import Form from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
+import Metadata from "@saleor/components/Metadata/Metadata";
+import { MetadataFormData } from "@saleor/components/Metadata/types";
 import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocompleteSelectField";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
@@ -17,6 +19,7 @@ import {
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import createMultiAutocompleteSelectHandler from "@saleor/utils/handlers/multiAutocompleteSelectChangeHandler";
+import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -27,7 +30,7 @@ import ShippingZoneInfo from "../ShippingZoneInfo";
 import ShippingZoneRates from "../ShippingZoneRates";
 import ShippingZoneWarehouses from "../ShippingZoneWarehouses";
 
-export interface FormData {
+export interface FormData extends MetadataFormData {
   name: string;
   warehouses: string[];
 }
@@ -90,7 +93,9 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
 
   const initialForm: FormData = {
     name: shippingZone?.name || "",
-    warehouses: shippingZone?.warehouses?.map(warehouse => warehouse.id) || []
+    warehouses: shippingZone?.warehouses?.map(warehouse => warehouse.id) || [],
+    metadata: [],
+    privateMetadata: []
   };
   const [warehouseDisplayValues, setWarehouseDisplayValues] = useStateFromProps<
     MultiAutocompleteChoiceType[]
@@ -103,6 +108,10 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
 
   const warehouseChoices = warehouses.map(warehouseToChoice);
 
+  const {
+    makeChangeHandler: makeMetadataChangeHandler
+  } = useMetadataChangeTrigger();
+
   return (
     <Form initial={initialForm} onSubmit={onSubmit}>
       {({ change, data, hasChanged, submit, toggleValue }) => {
@@ -112,6 +121,8 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
           warehouseDisplayValues,
           warehouseChoices
         );
+
+        const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
           <Container>
@@ -174,6 +185,8 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
                   variant="weight"
                   selectedChannelId={selectedChannelId}
                 />
+                <CardSpacer />
+                <Metadata data={data} onChange={changeMetadata} />
               </div>
               <div>
                 <ShippingZoneWarehouses

--- a/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
+++ b/src/shipping/components/ShippingZoneDetailsPage/ShippingZoneDetailsPage.tsx
@@ -94,8 +94,8 @@ const ShippingZoneDetailsPage: React.FC<ShippingZoneDetailsPageProps> = ({
   const initialForm: FormData = {
     name: shippingZone?.name || "",
     warehouses: shippingZone?.warehouses?.map(warehouse => warehouse.id) || [],
-    metadata: [],
-    privateMetadata: []
+    metadata: shippingZone?.metadata || [],
+    privateMetadata: shippingZone?.privateMetadata || []
   };
   const [warehouseDisplayValues, setWarehouseDisplayValues] = useStateFromProps<
     MultiAutocompleteChoiceType[]

--- a/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
+++ b/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
@@ -22,6 +22,7 @@ import { createChannelsChangeHandler } from "@saleor/shipping/handlers";
 import { ShippingZone_shippingZone_shippingMethods } from "@saleor/shipping/types/ShippingZone";
 import { ListActions, ListProps } from "@saleor/types";
 import { ShippingMethodTypeEnum } from "@saleor/types/globalTypes";
+import { mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
 import { FormattedMessage } from "react-intl";
@@ -93,8 +94,8 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
     name: rate?.name || "",
     noLimits: false,
     type: rate?.type || null,
-    metadata: rate?.metadata || [],
-    privateMetadata: rate?.privateMetadata || []
+    metadata: rate?.metadata.map(mapMetadataItemToInput),
+    privateMetadata: rate?.privateMetadata.map(mapMetadataItemToInput)
   };
 
   const {

--- a/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
+++ b/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
@@ -6,6 +6,8 @@ import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
 import Container from "@saleor/components/Container";
 import Form from "@saleor/components/Form";
 import Grid from "@saleor/components/Grid";
+import Metadata from "@saleor/components/Metadata/Metadata";
+import { MetadataFormData } from "@saleor/components/Metadata/types";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import { ShippingChannelsErrorFragment } from "@saleor/fragments/types/ShippingChannelsErrorFragment";
@@ -20,6 +22,7 @@ import { createChannelsChangeHandler } from "@saleor/shipping/handlers";
 import { ShippingZone_shippingZone_shippingMethods } from "@saleor/shipping/types/ShippingZone";
 import { ListActions, ListProps } from "@saleor/types";
 import { ShippingMethodTypeEnum } from "@saleor/types/globalTypes";
+import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -27,7 +30,7 @@ import ShippingZoneZipCodes, {
   ZipCodeInclusion
 } from "../ShippingZoneZipCodes";
 
-export interface FormData {
+export interface FormData extends MetadataFormData {
   channelListings: ChannelShippingData[];
   includeZipCodes: ZipCodeInclusion;
   name: string;
@@ -89,8 +92,14 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
     minValue: rate?.minimumOrderWeight?.value.toString() || "",
     name: rate?.name || "",
     noLimits: false,
-    type: rate?.type || null
+    type: rate?.type || null,
+    metadata: rate?.metadata || [],
+    privateMetadata: rate?.privateMetadata || []
   };
+
+  const {
+    makeChangeHandler: makeMetadataChangeHandler
+  } = useMetadataChangeTrigger();
 
   return (
     <Form initial={initialForm} onSubmit={onSubmit}>
@@ -103,6 +112,8 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
         const formDisabled = data.channelListings?.some(channel =>
           validatePrice(channel.price)
         );
+
+        const changeMetadata = makeMetadataChangeHandler(change);
 
         return (
           <Container>
@@ -164,6 +175,8 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
                   disabled={disabled}
                   {...listProps}
                 />
+                <CardSpacer />
+                <Metadata data={data} onChange={changeMetadata} />
               </div>
               <div>
                 <ChannelsAvailability

--- a/src/shipping/fixtures.ts
+++ b/src/shipping/fixtures.ts
@@ -265,7 +265,9 @@ export const shippingZones: ShippingZoneFragment[] = [
       }
     ],
     id: "U2hpcHBpbmdab25lOjE=",
-    name: "Europe"
+    name: "Europe",
+    metadata: [],
+    privateMetadata: []
   },
   {
     __typename: "ShippingZone",
@@ -417,7 +419,9 @@ export const shippingZones: ShippingZoneFragment[] = [
       }
     ],
     id: "U2hpcHBpbmdab25lOjI=",
-    name: "Oceania"
+    name: "Oceania",
+    metadata: [],
+    privateMetadata: []
   },
   {
     __typename: "ShippingZone",
@@ -680,7 +684,9 @@ export const shippingZones: ShippingZoneFragment[] = [
       }
     ],
     id: "U2hpcHBpbmdab25lOjM=",
-    name: "Asia"
+    name: "Asia",
+    metadata: [],
+    privateMetadata: []
   },
   {
     __typename: "ShippingZone",
@@ -973,7 +979,9 @@ export const shippingZones: ShippingZoneFragment[] = [
       }
     ],
     id: "U2hpcHBpbmdab25lOjQ=",
-    name: "Americas"
+    name: "Americas",
+    metadata: [],
+    privateMetadata: []
   },
   {
     __typename: "ShippingZone",
@@ -1282,12 +1290,16 @@ export const shippingZones: ShippingZoneFragment[] = [
       }
     ],
     id: "U2hpcHBpbmdab25lOjU=",
-    name: "Africa"
+    name: "Africa",
+    metadata: [],
+    privateMetadata: []
   }
 ];
 
 export const shippingZone: ShippingZone_shippingZone = {
   __typename: "ShippingZone",
+  metadata: [],
+  privateMetadata: [],
   countries: [
     {
       __typename: "CountryDisplay",
@@ -1551,6 +1563,8 @@ export const shippingZone: ShippingZone_shippingZone = {
   shippingMethods: [
     {
       __typename: "ShippingMethod",
+      metadata: [],
+      privateMetadata: [],
       channelListings: [
         {
           __typename: "ShippingMethodChannelListing",
@@ -1638,6 +1652,8 @@ export const shippingZone: ShippingZone_shippingZone = {
     },
     {
       __typename: "ShippingMethod",
+      metadata: [],
+      privateMetadata: [],
       channelListings: [],
       excludedProducts: {
         __typename: "ProductCountableConnection",
@@ -1695,6 +1711,8 @@ export const shippingZone: ShippingZone_shippingZone = {
     },
     {
       __typename: "ShippingMethod",
+      metadata: [],
+      privateMetadata: [],
       channelListings: [],
       excludedProducts: {
         __typename: "ProductCountableConnection",
@@ -1773,6 +1791,8 @@ export const shippingZone: ShippingZone_shippingZone = {
       },
       name: "DHL",
       type: ShippingMethodTypeEnum.PRICE,
+      metadata: [],
+      privateMetadata: [],
       zipCodeRules: [
         {
           __typename: "ShippingMethodZipCodeRule",

--- a/src/shipping/types/CreateShippingRate.ts
+++ b/src/shipping/types/CreateShippingRate.ts
@@ -14,12 +14,6 @@ export interface CreateShippingRate_shippingPriceCreate_errors {
   field: string | null;
 }
 
-export interface CreateShippingRate_shippingPriceCreate_shippingZone_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
 export interface CreateShippingRate_shippingPriceCreate_shippingZone_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -30,6 +24,12 @@ export interface CreateShippingRate_shippingPriceCreate_shippingZone_privateMeta
   __typename: "MetadataItem";
   key: string;
   value: string;
+}
+
+export interface CreateShippingRate_shippingPriceCreate_shippingZone_countries {
+  __typename: "CountryDisplay";
+  code: string;
+  country: string;
 }
 
 export interface CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_zipCodeRules {
@@ -104,11 +104,11 @@ export interface CreateShippingRate_shippingPriceCreate_shippingZone_warehouses 
 
 export interface CreateShippingRate_shippingPriceCreate_shippingZone {
   __typename: "ShippingZone";
+  metadata: (CreateShippingRate_shippingPriceCreate_shippingZone_metadata | null)[];
+  privateMetadata: (CreateShippingRate_shippingPriceCreate_shippingZone_privateMetadata | null)[];
   id: string;
   countries: (CreateShippingRate_shippingPriceCreate_shippingZone_countries | null)[] | null;
   name: string;
-  metadata: (CreateShippingRate_shippingPriceCreate_shippingZone_metadata | null)[];
-  privateMetadata: (CreateShippingRate_shippingPriceCreate_shippingZone_privateMetadata | null)[];
   default: boolean;
   shippingMethods: (CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods | null)[] | null;
   warehouses: (CreateShippingRate_shippingPriceCreate_shippingZone_warehouses | null)[] | null;

--- a/src/shipping/types/CreateShippingRate.ts
+++ b/src/shipping/types/CreateShippingRate.ts
@@ -20,6 +20,18 @@ export interface CreateShippingRate_shippingPriceCreate_shippingZone_countries {
   country: string;
 }
 
+export interface CreateShippingRate_shippingPriceCreate_shippingZone_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface CreateShippingRate_shippingPriceCreate_shippingZone_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_zipCodeRules {
   __typename: "ShippingMethodZipCodeRule";
   id: string;
@@ -95,6 +107,8 @@ export interface CreateShippingRate_shippingPriceCreate_shippingZone {
   id: string;
   countries: (CreateShippingRate_shippingPriceCreate_shippingZone_countries | null)[] | null;
   name: string;
+  metadata: (CreateShippingRate_shippingPriceCreate_shippingZone_metadata | null)[];
+  privateMetadata: (CreateShippingRate_shippingPriceCreate_shippingZone_privateMetadata | null)[];
   default: boolean;
   shippingMethods: (CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods | null)[] | null;
   warehouses: (CreateShippingRate_shippingPriceCreate_shippingZone_warehouses | null)[] | null;

--- a/src/shipping/types/CreateShippingRate.ts
+++ b/src/shipping/types/CreateShippingRate.ts
@@ -39,6 +39,18 @@ export interface CreateShippingRate_shippingPriceCreate_shippingZone_shippingMet
   end: string | null;
 }
 
+export interface CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_minimumOrderWeight {
   __typename: "Weight";
   unit: WeightUnitsEnum;
@@ -89,6 +101,8 @@ export interface CreateShippingRate_shippingPriceCreate_shippingZone_shippingMet
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_zipCodeRules | null)[] | null;
+  metadata: (CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_metadata | null)[];
+  privateMetadata: (CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_privateMetadata | null)[];
   minimumOrderWeight: CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_minimumOrderWeight | null;
   maximumOrderWeight: CreateShippingRate_shippingPriceCreate_shippingZone_shippingMethods_maximumOrderWeight | null;
   name: string;
@@ -119,6 +133,18 @@ export interface CreateShippingRate_shippingPriceCreate_shippingMethod_zipCodeRu
   id: string;
   start: string | null;
   end: string | null;
+}
+
+export interface CreateShippingRate_shippingPriceCreate_shippingMethod_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface CreateShippingRate_shippingPriceCreate_shippingMethod_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
 }
 
 export interface CreateShippingRate_shippingPriceCreate_shippingMethod_minimumOrderWeight {
@@ -171,6 +197,8 @@ export interface CreateShippingRate_shippingPriceCreate_shippingMethod {
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (CreateShippingRate_shippingPriceCreate_shippingMethod_zipCodeRules | null)[] | null;
+  metadata: (CreateShippingRate_shippingPriceCreate_shippingMethod_metadata | null)[];
+  privateMetadata: (CreateShippingRate_shippingPriceCreate_shippingMethod_privateMetadata | null)[];
   minimumOrderWeight: CreateShippingRate_shippingPriceCreate_shippingMethod_minimumOrderWeight | null;
   maximumOrderWeight: CreateShippingRate_shippingPriceCreate_shippingMethod_maximumOrderWeight | null;
   name: string;

--- a/src/shipping/types/DeleteShippingRate.ts
+++ b/src/shipping/types/DeleteShippingRate.ts
@@ -39,6 +39,18 @@ export interface DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMet
   end: string | null;
 }
 
+export interface DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_minimumOrderWeight {
   __typename: "Weight";
   unit: WeightUnitsEnum;
@@ -89,6 +101,8 @@ export interface DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMet
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_zipCodeRules | null)[] | null;
+  metadata: (DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_metadata | null)[];
+  privateMetadata: (DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_privateMetadata | null)[];
   minimumOrderWeight: DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_minimumOrderWeight | null;
   maximumOrderWeight: DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_maximumOrderWeight | null;
   name: string;

--- a/src/shipping/types/DeleteShippingRate.ts
+++ b/src/shipping/types/DeleteShippingRate.ts
@@ -14,12 +14,6 @@ export interface DeleteShippingRate_shippingPriceDelete_errors {
   field: string | null;
 }
 
-export interface DeleteShippingRate_shippingPriceDelete_shippingZone_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
 export interface DeleteShippingRate_shippingPriceDelete_shippingZone_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -30,6 +24,12 @@ export interface DeleteShippingRate_shippingPriceDelete_shippingZone_privateMeta
   __typename: "MetadataItem";
   key: string;
   value: string;
+}
+
+export interface DeleteShippingRate_shippingPriceDelete_shippingZone_countries {
+  __typename: "CountryDisplay";
+  code: string;
+  country: string;
 }
 
 export interface DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_zipCodeRules {
@@ -104,11 +104,11 @@ export interface DeleteShippingRate_shippingPriceDelete_shippingZone_warehouses 
 
 export interface DeleteShippingRate_shippingPriceDelete_shippingZone {
   __typename: "ShippingZone";
+  metadata: (DeleteShippingRate_shippingPriceDelete_shippingZone_metadata | null)[];
+  privateMetadata: (DeleteShippingRate_shippingPriceDelete_shippingZone_privateMetadata | null)[];
   id: string;
   countries: (DeleteShippingRate_shippingPriceDelete_shippingZone_countries | null)[] | null;
   name: string;
-  metadata: (DeleteShippingRate_shippingPriceDelete_shippingZone_metadata | null)[];
-  privateMetadata: (DeleteShippingRate_shippingPriceDelete_shippingZone_privateMetadata | null)[];
   default: boolean;
   shippingMethods: (DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods | null)[] | null;
   warehouses: (DeleteShippingRate_shippingPriceDelete_shippingZone_warehouses | null)[] | null;

--- a/src/shipping/types/DeleteShippingRate.ts
+++ b/src/shipping/types/DeleteShippingRate.ts
@@ -20,6 +20,18 @@ export interface DeleteShippingRate_shippingPriceDelete_shippingZone_countries {
   country: string;
 }
 
+export interface DeleteShippingRate_shippingPriceDelete_shippingZone_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface DeleteShippingRate_shippingPriceDelete_shippingZone_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods_zipCodeRules {
   __typename: "ShippingMethodZipCodeRule";
   id: string;
@@ -95,6 +107,8 @@ export interface DeleteShippingRate_shippingPriceDelete_shippingZone {
   id: string;
   countries: (DeleteShippingRate_shippingPriceDelete_shippingZone_countries | null)[] | null;
   name: string;
+  metadata: (DeleteShippingRate_shippingPriceDelete_shippingZone_metadata | null)[];
+  privateMetadata: (DeleteShippingRate_shippingPriceDelete_shippingZone_privateMetadata | null)[];
   default: boolean;
   shippingMethods: (DeleteShippingRate_shippingPriceDelete_shippingZone_shippingMethods | null)[] | null;
   warehouses: (DeleteShippingRate_shippingPriceDelete_shippingZone_warehouses | null)[] | null;

--- a/src/shipping/types/ShippingMethodChannelListingUpdate.ts
+++ b/src/shipping/types/ShippingMethodChannelListingUpdate.ts
@@ -15,6 +15,18 @@ export interface ShippingMethodChannelListingUpdate_shippingMethodChannelListing
   end: string | null;
 }
 
+export interface ShippingMethodChannelListingUpdate_shippingMethodChannelListingUpdate_shippingMethod_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingMethodChannelListingUpdate_shippingMethodChannelListingUpdate_shippingMethod_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingMethodChannelListingUpdate_shippingMethodChannelListingUpdate_shippingMethod_minimumOrderWeight {
   __typename: "Weight";
   unit: WeightUnitsEnum;
@@ -65,6 +77,8 @@ export interface ShippingMethodChannelListingUpdate_shippingMethodChannelListing
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (ShippingMethodChannelListingUpdate_shippingMethodChannelListingUpdate_shippingMethod_zipCodeRules | null)[] | null;
+  metadata: (ShippingMethodChannelListingUpdate_shippingMethodChannelListingUpdate_shippingMethod_metadata | null)[];
+  privateMetadata: (ShippingMethodChannelListingUpdate_shippingMethodChannelListingUpdate_shippingMethod_privateMetadata | null)[];
   minimumOrderWeight: ShippingMethodChannelListingUpdate_shippingMethodChannelListingUpdate_shippingMethod_minimumOrderWeight | null;
   maximumOrderWeight: ShippingMethodChannelListingUpdate_shippingMethodChannelListingUpdate_shippingMethod_maximumOrderWeight | null;
   name: string;

--- a/src/shipping/types/ShippingZone.ts
+++ b/src/shipping/types/ShippingZone.ts
@@ -33,6 +33,18 @@ export interface ShippingZone_shippingZone_shippingMethods_zipCodeRules {
   end: string | null;
 }
 
+export interface ShippingZone_shippingZone_shippingMethods_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingZone_shippingZone_shippingMethods_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingZone_shippingZone_shippingMethods_minimumOrderWeight {
   __typename: "Weight";
   unit: WeightUnitsEnum;
@@ -114,6 +126,8 @@ export interface ShippingZone_shippingZone_shippingMethods {
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (ShippingZone_shippingZone_shippingMethods_zipCodeRules | null)[] | null;
+  metadata: (ShippingZone_shippingZone_shippingMethods_metadata | null)[];
+  privateMetadata: (ShippingZone_shippingZone_shippingMethods_privateMetadata | null)[];
   minimumOrderWeight: ShippingZone_shippingZone_shippingMethods_minimumOrderWeight | null;
   maximumOrderWeight: ShippingZone_shippingZone_shippingMethods_maximumOrderWeight | null;
   name: string;

--- a/src/shipping/types/ShippingZone.ts
+++ b/src/shipping/types/ShippingZone.ts
@@ -14,6 +14,18 @@ export interface ShippingZone_shippingZone_countries {
   country: string;
 }
 
+export interface ShippingZone_shippingZone_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingZone_shippingZone_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingZone_shippingZone_shippingMethods_zipCodeRules {
   __typename: "ShippingMethodZipCodeRule";
   id: string;
@@ -121,6 +133,8 @@ export interface ShippingZone_shippingZone {
   id: string;
   countries: (ShippingZone_shippingZone_countries | null)[] | null;
   name: string;
+  metadata: (ShippingZone_shippingZone_metadata | null)[];
+  privateMetadata: (ShippingZone_shippingZone_privateMetadata | null)[];
   default: boolean;
   shippingMethods: (ShippingZone_shippingZone_shippingMethods | null)[] | null;
   warehouses: (ShippingZone_shippingZone_warehouses | null)[] | null;

--- a/src/shipping/types/ShippingZone.ts
+++ b/src/shipping/types/ShippingZone.ts
@@ -8,12 +8,6 @@ import { WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTyp
 // GraphQL query operation: ShippingZone
 // ====================================================
 
-export interface ShippingZone_shippingZone_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
 export interface ShippingZone_shippingZone_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -24,6 +18,12 @@ export interface ShippingZone_shippingZone_privateMetadata {
   __typename: "MetadataItem";
   key: string;
   value: string;
+}
+
+export interface ShippingZone_shippingZone_countries {
+  __typename: "CountryDisplay";
+  code: string;
+  country: string;
 }
 
 export interface ShippingZone_shippingZone_shippingMethods_zipCodeRules {
@@ -130,11 +130,11 @@ export interface ShippingZone_shippingZone_warehouses {
 
 export interface ShippingZone_shippingZone {
   __typename: "ShippingZone";
+  metadata: (ShippingZone_shippingZone_metadata | null)[];
+  privateMetadata: (ShippingZone_shippingZone_privateMetadata | null)[];
   id: string;
   countries: (ShippingZone_shippingZone_countries | null)[] | null;
   name: string;
-  metadata: (ShippingZone_shippingZone_metadata | null)[];
-  privateMetadata: (ShippingZone_shippingZone_privateMetadata | null)[];
   default: boolean;
   shippingMethods: (ShippingZone_shippingZone_shippingMethods | null)[] | null;
   warehouses: (ShippingZone_shippingZone_warehouses | null)[] | null;

--- a/src/shipping/types/ShippingZones.ts
+++ b/src/shipping/types/ShippingZones.ts
@@ -6,12 +6,6 @@
 // GraphQL query operation: ShippingZones
 // ====================================================
 
-export interface ShippingZones_shippingZones_edges_node_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
 export interface ShippingZones_shippingZones_edges_node_metadata {
   __typename: "MetadataItem";
   key: string;
@@ -24,13 +18,19 @@ export interface ShippingZones_shippingZones_edges_node_privateMetadata {
   value: string;
 }
 
+export interface ShippingZones_shippingZones_edges_node_countries {
+  __typename: "CountryDisplay";
+  code: string;
+  country: string;
+}
+
 export interface ShippingZones_shippingZones_edges_node {
   __typename: "ShippingZone";
+  metadata: (ShippingZones_shippingZones_edges_node_metadata | null)[];
+  privateMetadata: (ShippingZones_shippingZones_edges_node_privateMetadata | null)[];
   id: string;
   countries: (ShippingZones_shippingZones_edges_node_countries | null)[] | null;
   name: string;
-  metadata: (ShippingZones_shippingZones_edges_node_metadata | null)[];
-  privateMetadata: (ShippingZones_shippingZones_edges_node_privateMetadata | null)[];
 }
 
 export interface ShippingZones_shippingZones_edges {

--- a/src/shipping/types/ShippingZones.ts
+++ b/src/shipping/types/ShippingZones.ts
@@ -12,11 +12,25 @@ export interface ShippingZones_shippingZones_edges_node_countries {
   country: string;
 }
 
+export interface ShippingZones_shippingZones_edges_node_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface ShippingZones_shippingZones_edges_node_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface ShippingZones_shippingZones_edges_node {
   __typename: "ShippingZone";
   id: string;
   countries: (ShippingZones_shippingZones_edges_node_countries | null)[] | null;
   name: string;
+  metadata: (ShippingZones_shippingZones_edges_node_metadata | null)[];
+  privateMetadata: (ShippingZones_shippingZones_edges_node_privateMetadata | null)[];
 }
 
 export interface ShippingZones_shippingZones_edges {

--- a/src/shipping/types/UpdateShippingRate.ts
+++ b/src/shipping/types/UpdateShippingRate.ts
@@ -21,6 +21,18 @@ export interface UpdateShippingRate_shippingPriceUpdate_shippingMethod_zipCodeRu
   end: string | null;
 }
 
+export interface UpdateShippingRate_shippingPriceUpdate_shippingMethod_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface UpdateShippingRate_shippingPriceUpdate_shippingMethod_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
 export interface UpdateShippingRate_shippingPriceUpdate_shippingMethod_minimumOrderWeight {
   __typename: "Weight";
   unit: WeightUnitsEnum;
@@ -71,6 +83,8 @@ export interface UpdateShippingRate_shippingPriceUpdate_shippingMethod {
   __typename: "ShippingMethod";
   id: string;
   zipCodeRules: (UpdateShippingRate_shippingPriceUpdate_shippingMethod_zipCodeRules | null)[] | null;
+  metadata: (UpdateShippingRate_shippingPriceUpdate_shippingMethod_metadata | null)[];
+  privateMetadata: (UpdateShippingRate_shippingPriceUpdate_shippingMethod_privateMetadata | null)[];
   minimumOrderWeight: UpdateShippingRate_shippingPriceUpdate_shippingMethod_minimumOrderWeight | null;
   maximumOrderWeight: UpdateShippingRate_shippingPriceUpdate_shippingMethod_maximumOrderWeight | null;
   name: string;

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -230,7 +230,7 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
   };
 
   const handleSubmit = createMetadataUpdateHandler(
-    data?.shippingZone,
+    rate,
     updateData,
     variables => updateMetadata({ variables }),
     variables => updatePrivateMetadata({ variables })

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -48,6 +48,11 @@ import {
 } from "@saleor/shipping/urls";
 import { ShippingMethodTypeEnum } from "@saleor/types/globalTypes";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
+import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
+import {
+  useMetadataUpdate,
+  usePrivateMetadataUpdate
+} from "@saleor/utils/metadata/updateMetadata";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -201,7 +206,10 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
     }
   });
 
-  const handleSubmit = async (formData: FormData) => {
+  const [updateMetadata] = useMetadataUpdate({});
+  const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
+
+  const updateData = async (formData: FormData): Promise<unknown[]> => {
     const response = await updateShippingRate({
       variables: getUpdateShippingPriceRateVariables(formData, id, rateId)
     });
@@ -217,7 +225,16 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
         )
       });
     }
+
+    return errors;
   };
+
+  const handleSubmit = createMetadataUpdateHandler(
+    data?.shippingZone,
+    updateData,
+    variables => updateMetadata({ variables }),
+    variables => updatePrivateMetadata({ variables })
+  );
 
   const handleProductAssign = (ids: string[]) =>
     assignProduct({

--- a/src/shipping/views/ShippingZoneDetails/index.tsx
+++ b/src/shipping/views/ShippingZoneDetails/index.tsx
@@ -133,8 +133,6 @@ const ShippingZoneDetails: React.FC<ShippingZoneDetailsProps> = ({
   const [updateMetadata] = useMetadataUpdate({});
   const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
 
-  // const handleSubmit
-
   const updateData = async (submitData: FormData) => {
     const warehouseDiff = diff(
       data.shippingZone.warehouses.map(warehouse => warehouse.id),

--- a/src/shipping/views/ShippingZoneDetails/index.tsx
+++ b/src/shipping/views/ShippingZoneDetails/index.tsx
@@ -19,6 +19,11 @@ import {
   useShippingZoneUpdate
 } from "@saleor/shipping/mutations";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
+import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
+import {
+  useMetadataUpdate,
+  usePrivateMetadataUpdate
+} from "@saleor/utils/metadata/updateMetadata";
 import { useWarehouseCreate } from "@saleor/warehouses/mutations";
 import { diff } from "fast-array-diff";
 import React from "react";
@@ -125,7 +130,12 @@ const ShippingZoneDetails: React.FC<ShippingZoneDetailsProps> = ({
     }
   });
 
-  const handleSubmit = async (submitData: FormData) => {
+  const [updateMetadata] = useMetadataUpdate({});
+  const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
+
+  // const handleSubmit
+
+  const updateData = async (submitData: FormData) => {
     const warehouseDiff = diff(
       data.shippingZone.warehouses.map(warehouse => warehouse.id),
       submitData.warehouses
@@ -144,6 +154,13 @@ const ShippingZoneDetails: React.FC<ShippingZoneDetailsProps> = ({
 
     return result.data.shippingZoneUpdate.errors;
   };
+
+  const handleSubmit = createMetadataUpdateHandler(
+    data?.shippingZone,
+    updateData,
+    variables => updateMetadata({ variables }),
+    variables => updatePrivateMetadata({ variables })
+  );
 
   if (data?.shippingZone === null) {
     return <NotFoundPage onBack={() => navigate(shippingZonesListUrl())} />;

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -48,6 +48,11 @@ import {
 } from "@saleor/shipping/urls";
 import { ShippingMethodTypeEnum } from "@saleor/types/globalTypes";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
+import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
+import {
+  useMetadataUpdate,
+  usePrivateMetadataUpdate
+} from "@saleor/utils/metadata/updateMetadata";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -203,7 +208,10 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     }
   });
 
-  const handleSubmit = async (data: FormData) => {
+  const [updateMetadata] = useMetadataUpdate({});
+  const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
+
+  const updateData = async (data: FormData) => {
     const response = await updateShippingRate({
       variables: getUpdateShippingWeightRateVariables(data, id, rateId)
     });
@@ -219,7 +227,16 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
         )
       });
     }
+
+    return errors;
   };
+
+  const handleSubmit = createMetadataUpdateHandler(
+    rate,
+    updateData,
+    variables => updateMetadata({ variables }),
+    variables => updatePrivateMetadata({ variables })
+  );
 
   const handleProductAssign = (ids: string[]) =>
     assignProduct({


### PR DESCRIPTION
I want to merge this change because... it adds "Metadata" and "Private Metadata" panels in:
- `/shipping/[shipping-zone]`
- `/shipping/[shipping-zone]/price/[shipping-method]`
- `/shipping/[shipping-zone]/weight/[shipping-method]`


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
 
<img width="599" alt="image" src="https://user-images.githubusercontent.com/29279389/101659631-952fed80-3a46-11eb-878f-613e25d8bf0c.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
