### PR TITLE
Use proper fragment for price range

### DIFF
--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -112,7 +112,7 @@ export const productFragment = gql`
 `;
 
 export const productVariantAttributesFragment = gql`
-  ${fragmentMoney}
+  ${priceRangeFragment}
   fragment ProductVariantAttributesFragment on Product {
     id
     attributes {


### PR DESCRIPTION
I want to merge this change because the variant creator was using wrong money fragment for wizard query.

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
