### PR TITLE
Saleor 1906 user should be able to delete a channel if there are no orders associated with it

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1165,25 +1165,25 @@
     "context": "channels section name",
     "string": "Channels"
   },
-  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_2257704694": {
-    "context": "delete channel",
-    "string": "All order information from this channel need to be moved to a different channel. Please select channel orders need to be moved to:."
-  },
-  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_2342703674": {
-    "context": "dialog header",
-    "string": "Select Channel"
-  },
-  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_2405647976": {
+  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_deleteChannel": {
     "context": "dialog header",
     "string": "Delete Channel"
   },
-  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_777038435": {
+  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_deletingAllProductData": {
     "context": "delete channel",
     "string": "Deleting channel will delete all product data regarding this channel. Are you sure you want to delete this channel?"
   },
-  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_863901": {
+  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_needToBeMoved": {
+    "context": "delete channel",
+    "string": "All order information from this channel need to be moved to a different channel. Please select channel orders need to be moved to:."
+  },
+  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_noAvailableChannel": {
     "context": "currency channel",
     "string": "There is no available channel to move order information to. Please create a channel with same currency so that information can be moved to it."
+  },
+  "src_dot_channels_dot_components_dot_ChannelDeleteDialog_dot_selectChannel": {
+    "context": "dialog header",
+    "string": "Select Channel"
   },
   "src_dot_channels_dot_components_dot_ChannelForm_dot_1223259680": {
     "context": "channel settings",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1276,6 +1276,9 @@
     "context": "window title",
     "string": "Channel details"
   },
+  "src_dot_channels_dot_views_dot_ChannelDetails_dot_3499322424": {
+    "string": "Channel deleted"
+  },
   "src_dot_channels_dot_views_dot_ChannelsList_dot_3499322424": {
     "string": "Channel deleted"
   },

--- a/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.stories.tsx
+++ b/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.stories.tsx
@@ -12,6 +12,7 @@ const props: ChannelDeleteDialogProps = {
     label: channel.name,
     value: channel.id
   })),
+  hasOrders: true,
   confirmButtonState: "default",
   onBack: () => undefined,
   onClose: () => undefined,

--- a/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.tsx
+++ b/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.tsx
@@ -14,6 +14,7 @@ import { useStyles } from "../styles";
 
 export interface ChannelDeleteDialogProps {
   channelsChoices: Choices;
+  hasOrders: boolean;
   confirmButtonState: ConfirmButtonTransitionState;
   open: boolean;
   onBack: () => void;
@@ -23,6 +24,7 @@ export interface ChannelDeleteDialogProps {
 
 const ChannelDeleteDialog: React.FC<ChannelDeleteDialogProps> = ({
   channelsChoices = [],
+  hasOrders,
   confirmButtonState,
   open,
   onBack,
@@ -42,52 +44,56 @@ const ChannelDeleteDialog: React.FC<ChannelDeleteDialogProps> = ({
       confirmButtonState={confirmButtonState}
       open={open}
       onClose={onClose}
-      onConfirm={() => (hasChannels ? onConfirm(choice) : onBack())}
+      onConfirm={() =>
+        hasChannels || !hasOrders ? onConfirm(choice) : onBack()
+      }
       title={intl.formatMessage({
         defaultMessage: "Delete Channel",
         description: "dialog header"
       })}
       confirmButtonLabel={intl.formatMessage(
-        hasChannels ? buttonMessages.delete : buttonMessages.ok
+        hasChannels || !hasOrders ? buttonMessages.delete : buttonMessages.ok
       )}
-      variant={hasChannels ? "delete" : "default"}
+      variant={hasChannels || !hasOrders ? "delete" : "default"}
     >
       <div>
-        {hasChannels ? (
-          <>
+        {hasOrders ? (
+          hasChannels ? (
+            <>
+              <Typography>
+                <FormattedMessage
+                  defaultMessage="All order information from this channel need to be moved to a different channel. Please select channel orders need to be moved to:."
+                  description="delete channel"
+                />
+              </Typography>
+              <div className={classes.select}>
+                <SingleSelectField
+                  choices={channelsChoices}
+                  name="channels"
+                  label={intl.formatMessage({
+                    defaultMessage: "Select Channel",
+                    description: "dialog header"
+                  })}
+                  value={choice}
+                  onChange={e => setChoice(e.target.value)}
+                />
+              </div>
+              <Typography>
+                <FormattedMessage
+                  defaultMessage="Deleting channel will delete all product data regarding this channel. Are you sure you want to delete this channel?"
+                  description="delete channel"
+                />
+              </Typography>
+            </>
+          ) : (
             <Typography>
               <FormattedMessage
-                defaultMessage="All order information from this channel need to be moved to a different channel. Please select channel orders need to be moved to:."
-                description="delete channel"
+                defaultMessage="There is no available channel to move order information to. Please create a channel with same currency so that information can be moved to it."
+                description="currency channel"
               />
             </Typography>
-            <div className={classes.select}>
-              <SingleSelectField
-                choices={channelsChoices}
-                name="channels"
-                label={intl.formatMessage({
-                  defaultMessage: "Select Channel",
-                  description: "dialog header"
-                })}
-                value={choice}
-                onChange={e => setChoice(e.target.value)}
-              />
-            </div>
-            <Typography>
-              <FormattedMessage
-                defaultMessage="Deleting channel will delete all product data regarding this channel. Are you sure you want to delete this channel?"
-                description="delete channel"
-              />
-            </Typography>
-          </>
-        ) : (
-          <Typography>
-            <FormattedMessage
-              defaultMessage="There is no available channel to move order information to. Please create a channel with same currency so that information can be moved to it."
-              description="currency channel"
-            />
-          </Typography>
-        )}
+          )
+        ) : null}
       </div>
     </ActionDialog>
   );

--- a/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.tsx
+++ b/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.tsx
@@ -39,22 +39,22 @@ const ChannelDeleteDialog: React.FC<ChannelDeleteDialogProps> = ({
   );
   const hasChannels = !!channelsChoices?.length;
 
+  const canBeDeleted = hasChannels || !hasOrders;
+
   return (
     <ActionDialog
       confirmButtonState={confirmButtonState}
       open={open}
       onClose={onClose}
-      onConfirm={() =>
-        hasChannels || !hasOrders ? onConfirm(choice) : onBack()
-      }
+      onConfirm={() => (canBeDeleted ? onConfirm(choice) : onBack())}
       title={intl.formatMessage({
         defaultMessage: "Delete Channel",
         description: "dialog header"
       })}
       confirmButtonLabel={intl.formatMessage(
-        hasChannels || !hasOrders ? buttonMessages.delete : buttonMessages.ok
+        canBeDeleted ? buttonMessages.delete : buttonMessages.ok
       )}
-      variant={hasChannels || !hasOrders ? "delete" : "default"}
+      variant={canBeDeleted ? "delete" : "default"}
     >
       <div>
         {hasOrders ? (

--- a/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.tsx
+++ b/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.tsx
@@ -8,9 +8,35 @@ import {
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { buttonMessages } from "@saleor/intl";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { defineMessages, useIntl } from "react-intl";
 
 import { useStyles } from "../styles";
+
+const messages = defineMessages({
+  needToBeMoved: {
+    defaultMessage:
+      "All order information from this channel need to be moved to a different channel. Please select channel orders need to be moved to:.",
+    description: "delete channel"
+  },
+  deletingAllProductData: {
+    defaultMessage:
+      "Deleting channel will delete all product data regarding this channel. Are you sure you want to delete this channel?",
+    description: "delete channel"
+  },
+  noAvailableChannel: {
+    defaultMessage:
+      "There is no available channel to move order information to. Please create a channel with same currency so that information can be moved to it.",
+    description: "currency channel"
+  },
+  selectChannel: {
+    defaultMessage: "Select Channel",
+    description: "dialog header"
+  },
+  deleteChannel: {
+    defaultMessage: "Delete Channel",
+    description: "dialog header"
+  }
+});
 
 export interface ChannelDeleteDialogProps {
   channelsChoices: Choices;
@@ -47,10 +73,7 @@ const ChannelDeleteDialog: React.FC<ChannelDeleteDialogProps> = ({
       open={open}
       onClose={onClose}
       onConfirm={() => (canBeDeleted ? onConfirm(choice) : onBack())}
-      title={intl.formatMessage({
-        defaultMessage: "Delete Channel",
-        description: "dialog header"
-      })}
+      title={intl.formatMessage(messages.deleteChannel)}
       confirmButtonLabel={intl.formatMessage(
         canBeDeleted ? buttonMessages.delete : buttonMessages.ok
       )}
@@ -61,36 +84,24 @@ const ChannelDeleteDialog: React.FC<ChannelDeleteDialogProps> = ({
           hasChannels ? (
             <>
               <Typography>
-                <FormattedMessage
-                  defaultMessage="All order information from this channel need to be moved to a different channel. Please select channel orders need to be moved to:."
-                  description="delete channel"
-                />
+                {intl.formatMessage(messages.needToBeMoved)}
               </Typography>
               <div className={classes.select}>
                 <SingleSelectField
                   choices={channelsChoices}
                   name="channels"
-                  label={intl.formatMessage({
-                    defaultMessage: "Select Channel",
-                    description: "dialog header"
-                  })}
+                  label={intl.formatMessage(messages.selectChannel)}
                   value={choice}
                   onChange={e => setChoice(e.target.value)}
                 />
               </div>
               <Typography>
-                <FormattedMessage
-                  defaultMessage="Deleting channel will delete all product data regarding this channel. Are you sure you want to delete this channel?"
-                  description="delete channel"
-                />
+                {intl.formatMessage(messages.deletingAllProductData)}
               </Typography>
             </>
           ) : (
             <Typography>
-              <FormattedMessage
-                defaultMessage="There is no available channel to move order information to. Please create a channel with same currency so that information can be moved to it."
-                description="currency channel"
-              />
+              {intl.formatMessage(messages.noAvailableChannel)}
             </Typography>
           )
         ) : null}

--- a/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.tsx
+++ b/src/channels/components/ChannelDeleteDialog/ChannelDeleteDialog.tsx
@@ -104,7 +104,11 @@ const ChannelDeleteDialog: React.FC<ChannelDeleteDialogProps> = ({
               {intl.formatMessage(messages.noAvailableChannel)}
             </Typography>
           )
-        ) : null}
+        ) : (
+          <Typography>
+            {intl.formatMessage(messages.deletingAllProductData)}
+          </Typography>
+        )}
       </div>
     </ActionDialog>
   );

--- a/src/channels/fixtures.ts
+++ b/src/channels/fixtures.ts
@@ -19,6 +19,7 @@ export const channelsList: Channels_channels[] = [
     __typename: "Channel",
     currencyCode: "euro",
     id: "Q2hhbm5lcDoy",
+    hasOrders: false,
     isActive: true,
     name: "Test",
     slug: "test"
@@ -27,6 +28,7 @@ export const channelsList: Channels_channels[] = [
     __typename: "Channel",
     currencyCode: "euro",
     id: "Q2hhbm7lbDoy213",
+    hasOrders: false,
     isActive: true,
     name: "Channel",
     slug: "channel"
@@ -35,6 +37,7 @@ export const channelsList: Channels_channels[] = [
     __typename: "Channel",
     currencyCode: "euro",
     id: "Q2hhbn5lbDoytr",
+    hasOrders: false,
     isActive: true,
     name: "Channel test",
     slug: "channeltest"
@@ -43,6 +46,7 @@ export const channelsList: Channels_channels[] = [
     __typename: "Channel",
     currencyCode: "euro",
     id: "Q2hhbm5lbDo5bot",
+    hasOrders: false,
     isActive: true,
     name: "Channel USD",
     slug: "channel-usd"
@@ -51,6 +55,7 @@ export const channelsList: Channels_channels[] = [
     __typename: "Channel",
     currencyCode: "euro",
     id: "Q2hhbm7lbDoyr0tr",
+    hasOrders: false,
     isActive: true,
     name: "Channel",
     slug: "channel2"
@@ -59,6 +64,7 @@ export const channelsList: Channels_channels[] = [
     __typename: "Channel",
     currencyCode: "euro",
     id: "Q2hhbn5lbDoyya",
+    hasOrders: false,
     isActive: true,
     name: "Channel test",
     slug: "channeltest4"
@@ -67,6 +73,7 @@ export const channelsList: Channels_channels[] = [
     __typename: "Channel",
     currencyCode: "euro",
     id: "Q2hhbm5lbDo5w0z",
+    hasOrders: false,
     isActive: true,
     name: "Channel USD",
     slug: "channel-usd1"
@@ -78,6 +85,7 @@ export const channel: Channel_channel = {
   currencyCode: "zl",
   id: "Q2hhbm5lbDov78",
   isActive: true,
+  hasOrders: false,
   name: "Test",
   slug: "test"
 };

--- a/src/channels/fixtures.ts
+++ b/src/channels/fixtures.ts
@@ -18,8 +18,8 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    id: "Q2hhbm5lcDoy",
     hasOrders: false,
+    id: "Q2hhbm5lcDoy",
     isActive: true,
     name: "Test",
     slug: "test"
@@ -27,8 +27,8 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    id: "Q2hhbm7lbDoy213",
     hasOrders: false,
+    id: "Q2hhbm7lbDoy213",
     isActive: true,
     name: "Channel",
     slug: "channel"
@@ -36,8 +36,8 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    id: "Q2hhbn5lbDoytr",
     hasOrders: false,
+    id: "Q2hhbn5lbDoytr",
     isActive: true,
     name: "Channel test",
     slug: "channeltest"
@@ -45,8 +45,8 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    id: "Q2hhbm5lbDo5bot",
     hasOrders: false,
+    id: "Q2hhbm5lbDo5bot",
     isActive: true,
     name: "Channel USD",
     slug: "channel-usd"
@@ -54,8 +54,8 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    id: "Q2hhbm7lbDoyr0tr",
     hasOrders: false,
+    id: "Q2hhbm7lbDoyr0tr",
     isActive: true,
     name: "Channel",
     slug: "channel2"
@@ -63,8 +63,8 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    id: "Q2hhbn5lbDoyya",
     hasOrders: false,
+    id: "Q2hhbn5lbDoyya",
     isActive: true,
     name: "Channel test",
     slug: "channeltest4"
@@ -83,9 +83,9 @@ export const channelsList: Channels_channels[] = [
 export const channel: Channel_channel = {
   __typename: "Channel",
   currencyCode: "zl",
+  hasOrders: false,
   id: "Q2hhbm5lbDov78",
   isActive: true,
-  hasOrders: false,
   name: "Test",
   slug: "test"
 };

--- a/src/channels/index.tsx
+++ b/src/channels/index.tsx
@@ -11,15 +11,24 @@ import {
   channelPath,
   channelsListPath,
   ChannelsListUrlQueryParams,
-  ChannelsListUrlSortField
+  ChannelsListUrlSortField,
+  ChannelUrlQueryParams
 } from "./urls";
 import ChannelCreateComponent from "./views/ChannelCreate";
 import ChannelDetailsComponent from "./views/ChannelDetails";
 import ChannelsListComponent from "./views/ChannelsList";
 
-const ChannelDetails: React.FC<RouteComponentProps<{ id: string }>> = ({
-  match
-}) => <ChannelDetailsComponent id={decodeURIComponent(match.params.id)} />;
+const ChannelDetails: React.FC<RouteComponentProps<any>> = ({ match }) => {
+  const qs = parseQs(location.search.substr(1));
+  const params: ChannelUrlQueryParams = qs;
+
+  return (
+    <ChannelDetailsComponent
+      id={decodeURIComponent(match.params.id)}
+      params={params}
+    />
+  );
+};
 
 const ChannelsList: React.FC<RouteComponentProps> = ({ location }) => {
   const qs = parseQs(location.search.substr(1));

--- a/src/channels/index.tsx
+++ b/src/channels/index.tsx
@@ -11,16 +11,14 @@ import {
   channelPath,
   channelsListPath,
   ChannelsListUrlQueryParams,
-  ChannelsListUrlSortField,
-  ChannelUrlQueryParams
+  ChannelsListUrlSortField
 } from "./urls";
 import ChannelCreateComponent from "./views/ChannelCreate";
 import ChannelDetailsComponent from "./views/ChannelDetails";
 import ChannelsListComponent from "./views/ChannelsList";
 
 const ChannelDetails: React.FC<RouteComponentProps<any>> = ({ match }) => {
-  const qs = parseQs(location.search.substr(1));
-  const params: ChannelUrlQueryParams = qs;
+  const params = parseQs(location.search.substr(1));
 
   return (
     <ChannelDetailsComponent

--- a/src/channels/mutations.ts
+++ b/src/channels/mutations.ts
@@ -49,12 +49,8 @@ export const channelUpdateMutation = gql`
 
 export const channelDeleteMutation = gql`
   ${channelErrorFragment}
-  ${channelDetailsFragment}
-  mutation ChannelDelete($id: ID!, $input: ChannelDeleteInput!) {
+  mutation ChannelDelete($id: ID!, $input: ChannelDeleteInput) {
     channelDelete(id: $id, input: $input) {
-      channel {
-        ...ChannelDetailsFragment
-      }
       errors: channelErrors {
         ...ChannelErrorFragment
       }

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
@@ -19,6 +19,7 @@ export interface ChannelDetailsPageProps {
   errors: ChannelErrorFragment[];
   saveButtonBarState: ConfirmButtonTransitionState;
   onBack?: () => void;
+  onDelete?: () => void;
   onSubmit?: (data: FormData) => void;
   updateChannelStatus?: () => void;
 }
@@ -37,6 +38,7 @@ export const ChannelDetailsPage: React.FC<ChannelDetailsPageProps> = ({
   errors,
   onBack,
   onSubmit,
+  onDelete,
   saveButtonBarState,
   updateChannelStatus
 }) => {
@@ -79,6 +81,7 @@ export const ChannelDetailsPage: React.FC<ChannelDetailsPageProps> = ({
             <SaveButtonBar
               onCancel={onBack}
               onSave={submit}
+              onDelete={onDelete}
               state={saveButtonBarState}
               disabled={disabled || formDisabled || !onSubmit || !hasChanged}
             />

--- a/src/channels/types/Channel.ts
+++ b/src/channels/types/Channel.ts
@@ -13,6 +13,7 @@ export interface Channel_channel {
   name: string;
   slug: string;
   currencyCode: string;
+  hasOrders: boolean;
 }
 
 export interface Channel {

--- a/src/channels/types/ChannelActivate.ts
+++ b/src/channels/types/ChannelActivate.ts
@@ -15,6 +15,7 @@ export interface ChannelActivate_channelActivate_channel {
   name: string;
   slug: string;
   currencyCode: string;
+  hasOrders: boolean;
 }
 
 export interface ChannelActivate_channelActivate_errors {

--- a/src/channels/types/ChannelCreate.ts
+++ b/src/channels/types/ChannelCreate.ts
@@ -15,6 +15,7 @@ export interface ChannelCreate_channelCreate_channel {
   name: string;
   slug: string;
   currencyCode: string;
+  hasOrders: boolean;
 }
 
 export interface ChannelCreate_channelCreate_errors {

--- a/src/channels/types/ChannelDeactivate.ts
+++ b/src/channels/types/ChannelDeactivate.ts
@@ -15,6 +15,7 @@ export interface ChannelDeactivate_channelDeactivate_channel {
   name: string;
   slug: string;
   currencyCode: string;
+  hasOrders: boolean;
 }
 
 export interface ChannelDeactivate_channelDeactivate_errors {

--- a/src/channels/types/ChannelDelete.ts
+++ b/src/channels/types/ChannelDelete.ts
@@ -8,16 +8,6 @@ import { ChannelDeleteInput, ChannelErrorCode } from "./../../types/globalTypes"
 // GraphQL mutation operation: ChannelDelete
 // ====================================================
 
-export interface ChannelDelete_channelDelete_channel {
-  __typename: "Channel";
-  id: string;
-  isActive: boolean;
-  name: string;
-  slug: string;
-  currencyCode: string;
-  hasOrders: boolean;
-}
-
 export interface ChannelDelete_channelDelete_errors {
   __typename: "ChannelError";
   code: ChannelErrorCode;
@@ -27,7 +17,6 @@ export interface ChannelDelete_channelDelete_errors {
 
 export interface ChannelDelete_channelDelete {
   __typename: "ChannelDelete";
-  channel: ChannelDelete_channelDelete_channel | null;
   errors: ChannelDelete_channelDelete_errors[];
 }
 
@@ -37,5 +26,5 @@ export interface ChannelDelete {
 
 export interface ChannelDeleteVariables {
   id: string;
-  input: ChannelDeleteInput;
+  input?: ChannelDeleteInput | null;
 }

--- a/src/channels/types/ChannelDelete.ts
+++ b/src/channels/types/ChannelDelete.ts
@@ -15,6 +15,7 @@ export interface ChannelDelete_channelDelete_channel {
   name: string;
   slug: string;
   currencyCode: string;
+  hasOrders: boolean;
 }
 
 export interface ChannelDelete_channelDelete_errors {

--- a/src/channels/types/ChannelUpdate.ts
+++ b/src/channels/types/ChannelUpdate.ts
@@ -15,6 +15,7 @@ export interface ChannelUpdate_channelUpdate_channel {
   name: string;
   slug: string;
   currencyCode: string;
+  hasOrders: boolean;
 }
 
 export interface ChannelUpdate_channelUpdate_errors {

--- a/src/channels/types/Channels.ts
+++ b/src/channels/types/Channels.ts
@@ -13,6 +13,7 @@ export interface Channels_channels {
   name: string;
   slug: string;
   currencyCode: string;
+  hasOrders: boolean;
 }
 
 export interface Channels {

--- a/src/channels/urls.ts
+++ b/src/channels/urls.ts
@@ -11,6 +11,8 @@ export enum ChannelsListUrlSortField {
 }
 export type ChannelsListUrlSort = Sort<ChannelsListUrlSortField>;
 export type ChannelsListUrlFilters = Filters<ChannelsListUrlFiltersEnum>;
+export type ChannelUrlDialog = "remove";
+export type ChannelUrlQueryParams = Dialog<ChannelUrlDialog>;
 export type ChannelsListUrlDialog = "remove";
 export type ChannelsListUrlQueryParams = Dialog<ChannelsListUrlDialog> &
   ChannelsListUrlFilters &

--- a/src/channels/utils.ts
+++ b/src/channels/utils.ts
@@ -304,3 +304,21 @@ export const createSortedChannelsDataFromSale = (data?: SaleDetails_sale) =>
   createChannelsDataFromSale(data)?.sort((channel, nextChannel) =>
     channel.name.localeCompare(nextChannel.name)
   );
+
+export const getChannelsCurrencyChoices = (
+  id: string,
+  selectedChannel: Channels_channels,
+  channelsList: Channels_channels[]
+) =>
+  id
+    ? channelsList
+        ?.filter(
+          channel =>
+            channel.id !== id &&
+            channel.currencyCode === selectedChannel?.currencyCode
+        )
+        .map(channel => ({
+          label: channel.name,
+          value: channel.id
+        }))
+    : [];

--- a/src/channels/utils.ts
+++ b/src/channels/utils.ts
@@ -6,6 +6,7 @@ import { RequireOnlyOne } from "@saleor/misc";
 import { ProductDetails_product } from "@saleor/products/types/ProductDetails";
 import { ProductVariantDetails_productVariant } from "@saleor/products/types/ProductVariantDetails";
 import { ShippingZone_shippingZone_shippingMethods_channelListings } from "@saleor/shipping/types/ShippingZone";
+import { mapNodeToChoice } from "@saleor/utils/maps";
 import uniqBy from "lodash-es/uniqBy";
 
 export interface Channel {
@@ -311,14 +312,11 @@ export const getChannelsCurrencyChoices = (
   channelsList: Channels_channels[]
 ) =>
   id
-    ? channelsList
-        ?.filter(
+    ? mapNodeToChoice(
+        channelsList?.filter(
           channel =>
             channel.id !== id &&
             channel.currencyCode === selectedChannel?.currencyCode
         )
-        .map(channel => ({
-          label: channel.name,
-          value: channel.id
-        }))
+      )
     : [];

--- a/src/channels/views/ChannelDetails/ChannelDetails.tsx
+++ b/src/channels/views/ChannelDetails/ChannelDetails.tsx
@@ -1,3 +1,5 @@
+import ChannelDeleteDialog from "@saleor/channels/components/ChannelDeleteDialog";
+import { ChannelDelete } from "@saleor/channels/types/ChannelDelete";
 import AppHeader from "@saleor/components/AppHeader";
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
@@ -8,6 +10,7 @@ import useNotifier from "@saleor/hooks/useNotifier";
 import { commonMessages } from "@saleor/intl";
 import { sectionNames } from "@saleor/intl";
 import getChannelsErrorMessage from "@saleor/utils/errors/channels";
+import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -15,23 +18,40 @@ import { ChannelUpdateInput } from "../../../types/globalTypes";
 import {
   useChannelActivateMutation,
   useChannelDeactivateMutation,
+  useChannelDeleteMutation,
   useChannelUpdateMutation
 } from "../../mutations";
 import ChannelDetailsPage from "../../pages/ChannelDetailsPage";
-import { useChannelDetails } from "../../queries";
+import { useChannelDetails, useChannelsList } from "../../queries";
 import { ChannelUpdate } from "../../types/ChannelUpdate";
-import { channelsListUrl } from "../../urls";
+import {
+  channelsListUrl,
+  channelUrl,
+  ChannelUrlDialog,
+  ChannelUrlQueryParams
+} from "../../urls";
 
 interface ChannelDetailsProps {
   id: string;
+  params: ChannelUrlQueryParams;
 }
 
-export const ChannelDetails: React.FC<ChannelDetailsProps> = ({ id }) => {
+export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
+  id,
+  params
+}) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
 
   const handleBack = () => navigate(channelsListUrl());
+
+  const channelsListData = useChannelsList({ displayLoader: true });
+
+  const [openModal, closeModal] = createDialogActionHandlers<
+    ChannelUrlDialog,
+    ChannelUrlQueryParams
+  >(navigate, params => channelUrl(id, params), params);
 
   const onSubmit = (data: ChannelUpdate) => {
     if (!data.channelUpdate.errors.length) {
@@ -87,6 +107,56 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({ id }) => {
       }
     });
 
+  const onCompleted = (data: ChannelDelete) => {
+    const errors = data.channelDelete.errors;
+    if (errors.length === 0) {
+      notify({
+        status: "success",
+        text: intl.formatMessage({
+          defaultMessage: "Channel deleted"
+        })
+      });
+      closeModal();
+      navigate(channelsListUrl());
+    } else {
+      errors.map(error =>
+        notify({
+          status: "error",
+          text: getChannelsErrorMessage(error, intl)
+        })
+      );
+    }
+  };
+
+  const [deleteChannel, deleteChannelOpts] = useChannelDeleteMutation({
+    onCompleted
+  });
+
+  const channelsChoices = id
+    ? channelsListData?.data?.channels
+        ?.filter(
+          channel =>
+            channel.id !== id &&
+            channel.currencyCode === data?.channel?.currencyCode
+        )
+        .map(channel => ({
+          label: channel.name,
+          value: channel.id
+        }))
+    : [];
+
+  const handleRemoveConfirm = (targetChannelId?: string) => {
+    if (targetChannelId) {
+      deleteChannel({
+        variables: { id, input: { targetChannel: targetChannelId } }
+      });
+    } else {
+      deleteChannel({
+        variables: { id }
+      });
+    }
+  };
+
   return (
     <>
       <WindowTitle
@@ -109,6 +179,7 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({ id }) => {
           errors={updateChannelOpts?.data?.channelUpdate?.errors || []}
           onSubmit={handleSubmit}
           onBack={handleBack}
+          onDelete={() => openModal("remove")}
           updateChannelStatus={() =>
             data?.channel?.isActive
               ? deactivateChannel({ variables: { id } })
@@ -117,6 +188,15 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({ id }) => {
           saveButtonBarState={updateChannelOpts.status}
         />
       </Container>
+      <ChannelDeleteDialog
+        channelsChoices={channelsChoices}
+        hasOrders={data?.channel?.hasOrders}
+        open={params.action === "remove"}
+        confirmButtonState={deleteChannelOpts.status}
+        onBack={() => navigate(channelsListUrl())}
+        onClose={closeModal}
+        onConfirm={handleRemoveConfirm}
+      />
     </>
   );
 };

--- a/src/channels/views/ChannelDetails/ChannelDetails.tsx
+++ b/src/channels/views/ChannelDetails/ChannelDetails.tsx
@@ -1,5 +1,6 @@
 import ChannelDeleteDialog from "@saleor/channels/components/ChannelDeleteDialog";
 import { ChannelDelete } from "@saleor/channels/types/ChannelDelete";
+import { getChannelsCurrencyChoices } from "@saleor/channels/utils";
 import AppHeader from "@saleor/components/AppHeader";
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
@@ -132,18 +133,11 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
     onCompleted
   });
 
-  const channelsChoices = id
-    ? channelsListData?.data?.channels
-        ?.filter(
-          channel =>
-            channel.id !== id &&
-            channel.currencyCode === data?.channel?.currencyCode
-        )
-        .map(channel => ({
-          label: channel.name,
-          value: channel.id
-        }))
-    : [];
+  const channelsChoices = getChannelsCurrencyChoices(
+    id,
+    data?.channel,
+    channelsListData?.data?.channels
+  );
 
   const handleRemoveConfirm = (targetChannelId?: string) => {
     const data = targetChannelId

--- a/src/channels/views/ChannelDetails/ChannelDetails.tsx
+++ b/src/channels/views/ChannelDetails/ChannelDetails.tsx
@@ -146,15 +146,10 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
     : [];
 
   const handleRemoveConfirm = (targetChannelId?: string) => {
-    if (targetChannelId) {
-      deleteChannel({
-        variables: { id, input: { targetChannel: targetChannelId } }
-      });
-    } else {
-      deleteChannel({
-        variables: { id }
-      });
-    }
+    const data = targetChannelId
+      ? { id, input: { targetChannel: targetChannelId } }
+      : { id };
+    deleteChannel({ variables: data });
   };
 
   return (

--- a/src/channels/views/ChannelsList/ChannelsList.tsx
+++ b/src/channels/views/ChannelsList/ChannelsList.tsx
@@ -86,7 +86,7 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ params }) => {
       });
     } else {
       deleteChannel({
-        variables: { id: params.id, input: {} }
+        variables: { id: params.id }
       });
     }
   };

--- a/src/channels/views/ChannelsList/ChannelsList.tsx
+++ b/src/channels/views/ChannelsList/ChannelsList.tsx
@@ -79,10 +79,17 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ params }) => {
 
   const navigateToChannelCreate = () => navigate(channelAddUrl);
 
-  const handleRemoveConfirm = (id: string) =>
-    deleteChannel({
-      variables: { id: params.id, input: { targetChannel: id } }
-    });
+  const handleRemoveConfirm = (targetChannelId?: string) => {
+    if (targetChannelId) {
+      deleteChannel({
+        variables: { id: params.id, input: { targetChannel: targetChannelId } }
+      });
+    } else {
+      deleteChannel({
+        variables: { id: params.id, input: {} }
+      });
+    }
+  };
 
   return (
     <>
@@ -101,6 +108,7 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ params }) => {
       {!!selectedChannel && (
         <ChannelDeleteDialog
           channelsChoices={channelsChoices}
+          hasOrders={selectedChannel.hasOrders}
           open={params.action === "remove"}
           confirmButtonState={deleteChannelOpts.status}
           onBack={() => navigate(channelsListUrl())}

--- a/src/channels/views/ChannelsList/ChannelsList.tsx
+++ b/src/channels/views/ChannelsList/ChannelsList.tsx
@@ -1,3 +1,4 @@
+import { getChannelsCurrencyChoices } from "@saleor/channels/utils";
 import { configurationMenuUrl } from "@saleor/configuration";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
@@ -64,18 +65,11 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ params }) => {
     onCompleted
   });
 
-  const channelsChoices = params.id
-    ? data?.channels
-        ?.filter(
-          channel =>
-            channel.id !== params.id &&
-            channel.currencyCode === selectedChannel.currencyCode
-        )
-        .map(channel => ({
-          label: channel.name,
-          value: channel.id
-        }))
-    : [];
+  const channelsChoices = getChannelsCurrencyChoices(
+    params.id,
+    selectedChannel,
+    data?.channels
+  );
 
   const navigateToChannelCreate = () => navigate(channelAddUrl);
 

--- a/src/fragments/channels.ts
+++ b/src/fragments/channels.ts
@@ -15,5 +15,6 @@ export const channelDetailsFragment = gql`
     name
     slug
     currencyCode
+    hasOrders
   }
 `;

--- a/src/fragments/types/ChannelDetailsFragment.ts
+++ b/src/fragments/types/ChannelDetailsFragment.ts
@@ -13,4 +13,5 @@ export interface ChannelDetailsFragment {
   name: string;
   slug: string;
   currencyCode: string;
+  hasOrders: boolean;
 }


### PR DESCRIPTION
I want to merge this change because... it
- fixes bug with deleting channels when `hasOrders` was `false`
- adds "DELETE" button on detail page of channel

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<img width="998" alt="image" src="https://user-images.githubusercontent.com/29279389/102072668-7c3a8a00-3e02-11eb-8762-137f21001790.png">


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
