### PR TITLE
Update history events for order return / refund / replace

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -42,6 +42,18 @@
   "configurationPluginsPages": {
     "string": "View and update your plugins and their settings."
   },
+  "event products list title refunded": {
+    "context": "event products list title",
+    "string": "Products refunded"
+  },
+  "event products list title replaced": {
+    "context": "event products list title",
+    "string": "Products replaced"
+  },
+  "event products list title returned": {
+    "context": "event products list title",
+    "string": "Products returned"
+  },
   "homeActivityCardHeader": {
     "context": "header",
     "string": "Activity"
@@ -3466,27 +3478,15 @@
     "context": "order history message",
     "string": "Order was cancelled"
   },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentRefundedProductsTitle": {
-    "context": "event products list title",
-    "string": "Products refunded"
-  },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentRefundedTitle": {
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentRefunded": {
     "context": "event title",
     "string": "Products were refunded by "
   },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReplacedProductsTitle": {
-    "context": "event products list title",
-    "string": "Products replaced"
-  },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReplacedTitle": {
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReplaced": {
     "context": "event title",
     "string": "Products were replaced by "
   },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReturnedProductsTitle": {
-    "context": "event products list title",
-    "string": "Products returned"
-  },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReturnedTitle": {
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReturned": {
     "context": "event title",
     "string": "Products were returned by"
   },

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -43,27 +43,27 @@
     "string": "View and update your plugins and their settings."
   },
   "event products list title refunded": {
-    "context": "event products list title",
+    "context": "refunded products list title",
     "string": "Products refunded"
   },
   "event products list title replaced": {
-    "context": "event products list title",
+    "context": "replaced products list title",
     "string": "Products replaced"
   },
   "event products list title returned": {
-    "context": "event products list title",
+    "context": "returned products list title",
     "string": "Products returned"
   },
   "event title refunded": {
-    "context": "event title",
+    "context": "refunded event title",
     "string": "Products were refunded by "
   },
   "event title replaced": {
-    "context": "event title",
+    "context": "replaced event title",
     "string": "Products were replaced by "
   },
   "event title returned": {
-    "context": "event title",
+    "context": "returned event title",
     "string": "Products were returned by"
   },
   "homeActivityCardHeader": {

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -54,6 +54,18 @@
     "context": "event products list title",
     "string": "Products returned"
   },
+  "event title refunded": {
+    "context": "event title",
+    "string": "Products were refunded by "
+  },
+  "event title replaced": {
+    "context": "event title",
+    "string": "Products were replaced by "
+  },
+  "event title returned": {
+    "context": "event title",
+    "string": "Products were returned by"
+  },
   "homeActivityCardHeader": {
     "context": "header",
     "string": "Activity"
@@ -3477,18 +3489,6 @@
   "src_dot_orders_dot_components_dot_OrderHistory_dot_950782935": {
     "context": "order history message",
     "string": "Order was cancelled"
-  },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentRefunded": {
-    "context": "event title",
-    "string": "Products were refunded by "
-  },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReplaced": {
-    "context": "event title",
-    "string": "Products were replaced by "
-  },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReturned": {
-    "context": "event title",
-    "string": "Products were returned by"
   },
   "src_dot_orders_dot_components_dot_OrderHistory_dot_refundedAmount": {
     "context": "amount title",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3327,19 +3327,9 @@
     "context": "dialog header",
     "string": "Add Tracking Code"
   },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_1154330234": {
-    "context": "transaction reference",
-    "string": "Transaction Reference {transactionReference}"
-  },
   "src_dot_orders_dot_components_dot_OrderHistory_dot_1230178536": {
     "context": "order history message",
     "string": "Order address was updated"
-  },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_123236698": {
-    "string": "Shipment was refunded"
-  },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_1322321687": {
-    "string": "Refunded amount"
   },
   "src_dot_orders_dot_components_dot_OrderHistory_dot_1463685940": {
     "context": "order history message",
@@ -3456,9 +3446,6 @@
     "context": "order history message",
     "string": "Payment failed"
   },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_492197448": {
-    "string": "Products refunded"
-  },
   "src_dot_orders_dot_components_dot_OrderHistory_dot_493321552": {
     "context": "order history message",
     "string": "Order cancel information was sent to customer"
@@ -3478,6 +3465,38 @@
   "src_dot_orders_dot_components_dot_OrderHistory_dot_950782935": {
     "context": "order history message",
     "string": "Order was cancelled"
+  },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentRefundedProductsTitle": {
+    "context": "event products list title",
+    "string": "Products refunded"
+  },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentRefundedTitle": {
+    "context": "event title",
+    "string": "Products were refunded by "
+  },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReplacedProductsTitle": {
+    "context": "event products list title",
+    "string": "Products replaced"
+  },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReplacedTitle": {
+    "context": "event title",
+    "string": "Products were replaced by "
+  },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReturnedProductsTitle": {
+    "context": "event products list title",
+    "string": "Products returned"
+  },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_fulfillmentReturnedTitle": {
+    "context": "event title",
+    "string": "Products were returned by"
+  },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_refundedAmount": {
+    "context": "amount title",
+    "string": "Refunded amount"
+  },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_refundedShipment": {
+    "context": "shipment refund title",
+    "string": "Shipment was refunded"
   },
   "src_dot_orders_dot_components_dot_OrderInvoiceEmailSendDialog_dot_1821123638": {
     "string": "Are you sure you want to send this invoice: {invoiceNumber} to the customer?"

--- a/schema.graphql
+++ b/schema.graphql
@@ -638,6 +638,11 @@ input BulkAttributeValueInput {
   values: [String]!
 }
 
+input BulkAttributeValueInput {
+  id: ID
+  values: [String]!
+}
+
 type BulkProductError {
   field: String
   message: String
@@ -2958,7 +2963,6 @@ enum OrderErrorCode {
   VOID_INACTIVE_PAYMENT
   ZERO_QUANTITY
   INVALID_QUANTITY
-  CANNOT_REFUND_FULFILLMENT_LINE
   INSUFFICIENT_STOCK
   DUPLICATED_INPUT_ITEM
   NOT_AVAILABLE_IN_CHANNEL
@@ -2986,7 +2990,7 @@ type OrderEvent implements Node {
   warehouse: Warehouse
   transactionReference: String
   shippingCostsIncluded: Boolean
-  replaceOrder: Order
+  relatedOrder: Order
 }
 
 type OrderEventCountableConnection {
@@ -3029,7 +3033,7 @@ enum OrderEventsEnum {
   CANCELED
   ORDER_MARKED_AS_PAID
   ORDER_FULLY_PAID
-  ORDER_REPLACE_CREATED
+  ORDER_REPLACEMENT_CREATED
   UPDATED_ADDRESS
   EMAIL_SENT
   CONFIRMED

--- a/src/components/Timeline/TimelineEvent.tsx
+++ b/src/components/Timeline/TimelineEvent.tsx
@@ -4,30 +4,12 @@ import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
-import classNames from "classnames";
 import React from "react";
 
-import { DateTime } from "../Date";
+import TimelineEventHeader, { TitleElement } from "./TimelineEventHeader";
 
 const useStyles = makeStyles(
   theme => ({
-    container: {
-      alignItems: "center",
-      display: "flex",
-      flexDirection: "column",
-      justifyContent: "space-between",
-      marginBottom: theme.spacing(),
-      marginLeft: theme.spacing(3),
-      width: "100%"
-    },
-    date: {
-      color: theme.typography.caption.color
-    },
-    dateExpander: {
-      color: theme.typography.caption.color,
-      position: "absolute",
-      right: 0
-    },
     dot: {
       backgroundColor: theme.palette.primary.main,
       borderRadius: "100%",
@@ -37,27 +19,27 @@ const useStyles = makeStyles(
       top: 6,
       width: 8
     },
-    expanded: {},
-    noExpander: {
-      alignItems: "center",
-      display: "flex",
-      justifyContent: "space-between",
-      width: "100%"
-    },
     panel: {
-      "&$expanded": {
-        margin: 0
+      "& .MuiExpansionPanelDetails-root": {
+        padding: 0,
+        paddingTop: theme.spacing(2)
+      },
+      "&.Mui-expanded": {
+        borderColor: "red",
+        margin: 0,
+        minHeight: 0
       },
       "&:before": {
         display: "none"
       },
       background: "none",
+      display: "",
       margin: 0,
+      minHeight: 0,
       width: "100%"
     },
     panelExpander: {
-      "&$expanded": {
-        margin: 0,
+      "&.MuiExpansionPanelSummary-root.Mui-expanded": {
         minHeight: 0
       },
       "&> .MuiExpansionPanelSummary-content": {
@@ -65,9 +47,12 @@ const useStyles = makeStyles(
       },
       "&> .MuiExpansionPanelSummary-expandIcon": {
         padding: 0,
+        position: "absolute",
         right: theme.spacing(18)
       },
-      margin: 0
+      margin: 0,
+      minHeight: 0,
+      padding: 0
     },
     root: {
       "&:last-child:after": {
@@ -82,27 +67,24 @@ const useStyles = makeStyles(
       alignItems: "center",
       display: "flex",
       marginBottom: theme.spacing(3),
+      marginTop: 0,
       position: "relative",
       width: "100%"
-    },
-    secondaryTitle: {
-      color: "#9e9e9e",
-      fontSize: 14,
-      marginTop: theme.spacing(2)
     }
   }),
   { name: "TimelineEvent" }
 );
 
-interface TimelineEventProps {
+export interface TimelineEventProps {
   children?: React.ReactNode;
   date: string;
   secondaryTitle?: string;
-  title: string;
+  title?: string;
+  titleElements?: TitleElement[];
 }
 
 export const TimelineEvent: React.FC<TimelineEventProps> = props => {
-  const { children, date, secondaryTitle, title } = props;
+  const { children, date, secondaryTitle, title, titleElements } = props;
 
   const classes = useStyles(props);
 
@@ -110,39 +92,28 @@ export const TimelineEvent: React.FC<TimelineEventProps> = props => {
     <div className={classes.root}>
       <span className={classes.dot} />
       {children ? (
-        <ExpansionPanel
-          className={classNames(classes.panel, classes.expanded)}
-          elevation={0}
-        >
+        <ExpansionPanel className={classes.panel} elevation={0}>
           <ExpansionPanelSummary
-            className={classNames(classes.panelExpander, classes.expanded)}
+            className={classes.panelExpander}
             expandIcon={<ExpandMoreIcon />}
           >
-            <Typography>{title}</Typography>
-            <Typography className={classes.dateExpander}>
-              <DateTime date={date} />
-            </Typography>
+            <TimelineEventHeader
+              title={title}
+              date={date}
+              titleElements={titleElements}
+            />
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <Typography>{children}</Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
       ) : (
-        <div className={classes.container}>
-          <div className={classes.noExpander}>
-            <Typography>{title}</Typography>
-            <Typography className={classes.date}>
-              <DateTime date={date} />
-            </Typography>
-          </div>
-          {secondaryTitle && (
-            <div className={classes.noExpander}>
-              <Typography className={classes.secondaryTitle}>
-                {secondaryTitle}
-              </Typography>
-            </div>
-          )}
-        </div>
+        <TimelineEventHeader
+          title={title}
+          titleElements={titleElements}
+          secondaryTitle={secondaryTitle}
+          date={date}
+        />
       )}
     </div>
   );

--- a/src/components/Timeline/TimelineEventHeader.tsx
+++ b/src/components/Timeline/TimelineEventHeader.tsx
@@ -1,0 +1,93 @@
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import useNavigator from "@saleor/hooks/useNavigator";
+import React from "react";
+
+import { DateTime } from "../Date";
+import Link from "../Link";
+
+const useStyles = makeStyles(
+  theme => ({
+    container: {
+      alignItems: "center",
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "space-between",
+      width: "100%"
+    },
+    date: {
+      color: theme.typography.caption.color,
+      paddingLeft: 24
+    },
+    elementsContainer: {
+      alignItems: "center",
+      display: "flex",
+      flexDirection: "row",
+      flexWrap: "wrap"
+    },
+    secondaryTitle: {
+      color: "#9e9e9e",
+      fontSize: 14,
+      marginTop: theme.spacing(2)
+    },
+    titleElement: {
+      marginRight: "0.5rem"
+    }
+  }),
+  { name: "TimelineEventHeader" }
+);
+
+export interface TitleElement {
+  text: string;
+  link?: string;
+}
+
+export interface TimelineEventHeaderProps {
+  title?: string;
+  date: string;
+  titleElements?: TitleElement[];
+  secondaryTitle?: string;
+}
+
+export const TimelineEventHeader: React.FC<TimelineEventHeaderProps> = props => {
+  const { title, date, titleElements, secondaryTitle } = props;
+  const navigate = useNavigator();
+
+  const classes = useStyles(props);
+
+  return (
+    <div className={classes.container}>
+      {title && <Typography>{title}</Typography>}
+      {titleElements && (
+        <div className={classes.elementsContainer}>
+          {titleElements.map(({ text, link }) => {
+            if (link) {
+              return (
+                <Link
+                  className={classes.titleElement}
+                  onClick={() => navigate(link)}
+                >
+                  {text}
+                </Link>
+              );
+            }
+
+            return (
+              <Typography className={classes.titleElement}>{text}</Typography>
+            );
+          })}
+        </div>
+      )}
+      <Typography className={classes.date}>
+        <DateTime date={date} />
+      </Typography>
+      {secondaryTitle && (
+        <Typography className={classes.secondaryTitle}>
+          {secondaryTitle}
+        </Typography>
+      )}
+    </div>
+  );
+};
+
+export default TimelineEventHeader;

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -19,6 +19,8 @@ export const fragmentOrderEvent = gql`
     user {
       id
       email
+      firstName
+      lastName
     }
     lines {
       quantity

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -46,6 +46,8 @@ export interface OrderDetailsFragment_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderDetailsFragment_events_lines_orderLine {

--- a/src/fragments/types/OrderEventFragment.ts
+++ b/src/fragments/types/OrderEventFragment.ts
@@ -12,6 +12,8 @@ export interface OrderEventFragment_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderEventFragment_lines_orderLine {

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -1,0 +1,154 @@
+import { makeStyles, Typography } from "@material-ui/core";
+import Money from "@saleor/components/Money";
+import { TimelineEvent } from "@saleor/components/Timeline";
+import { staffMemberDetailsUrl } from "@saleor/staff/urls";
+import classNames from "classnames";
+import camelCase from "lodash/camelCase";
+import React from "react";
+import { defineMessages, useIntl } from "react-intl";
+
+import { OrderDetails_order_events } from "../../types/OrderDetails";
+
+const useStyles = makeStyles(
+  theme => ({
+    eventSubtitle: {
+      marginBottom: theme.spacing(0.5),
+      marginTop: theme.spacing(1)
+    },
+    header: {
+      fontWeight: 500,
+      marginBottom: theme.spacing(1)
+    },
+    linesTableCell: {
+      paddingRight: theme.spacing(3)
+    },
+    root: { marginTop: theme.spacing(4) },
+    topSpacer: {
+      marginTop: theme.spacing(3)
+    },
+    user: {
+      marginBottom: theme.spacing(1)
+    }
+  }),
+  { name: "OrderHistory" }
+);
+
+export const messages = defineMessages({
+  fulfillmentRefundedProductsTitle: {
+    defaultMessage: "Products refunded",
+    description: "event products list title"
+  },
+  fulfillmentRefundedTitle: {
+    defaultMessage: "Products were refunded by ",
+    description: "event title"
+  },
+  fulfillmentReplacedProductsTitle: {
+    defaultMessage: "Products replaced",
+    description: "event products list title"
+  },
+  fulfillmentReplacedTitle: {
+    defaultMessage: "Products were replaced by ",
+    description: "event title"
+  },
+  fulfillmentReturnedProductsTitle: {
+    defaultMessage: "Products returned",
+    description: "event products list title"
+  },
+  fulfillmentReturnedTitle: {
+    defaultMessage: "Products were returned by",
+    description: "event title"
+  },
+  refundedAmount: {
+    defaultMessage: "Refunded amount",
+    description: "amount title"
+  },
+  refundedShipment: {
+    defaultMessage: "Shipment was refunded",
+    description: "shipment refund title"
+  }
+});
+
+interface ExtendedTimelineEventProps {
+  event: OrderDetails_order_events;
+  orderCurrency: string;
+}
+
+const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
+  event,
+  orderCurrency
+}) => {
+  const { id, date, type, user, lines, amount, shippingCostsIncluded } = event;
+  const classes = useStyles({});
+  const intl = useIntl();
+
+  const getTitle = (titleType: "Title" | "ProductsTitle") =>
+    messages[`${camelCase(type)}${titleType}`];
+
+  const employeeName = `${user.firstName} ${user.lastName}`;
+
+  const titleElements = [
+    { text: intl.formatMessage(getTitle("Title")) },
+    { link: staffMemberDetailsUrl(user.id), text: employeeName }
+  ];
+
+  return (
+    <TimelineEvent date={date} titleElements={titleElements} key={id}>
+      {lines && (
+        <>
+          <Typography
+            variant="caption"
+            color="textSecondary"
+            className={classes.eventSubtitle}
+          >
+            {intl.formatMessage(getTitle("ProductsTitle"))}
+          </Typography>
+          <table>
+            <tbody>
+              {event.lines.map(line => (
+                <tr key={line.orderLine.id}>
+                  <td className={classes.linesTableCell}>
+                    {line.orderLine.productName}
+                  </td>
+                  <td className={classes.linesTableCell}>
+                    <Typography variant="caption" color="textSecondary">
+                      {line.orderLine.variantName}
+                    </Typography>
+                  </td>
+                  <td className={classes.linesTableCell}>
+                    <Typography variant="caption" color="textSecondary">
+                      {`qty: ${line.quantity}`}
+                    </Typography>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {(amount || amount === 0) && (
+            <>
+              <Typography
+                variant="caption"
+                color="textSecondary"
+                className={classNames(classes.eventSubtitle, classes.topSpacer)}
+              >
+                {intl.formatMessage(messages.refundedAmount)}
+              </Typography>
+              <Money
+                money={{
+                  amount: event.amount,
+                  currency: orderCurrency
+                }}
+              />
+            </>
+          )}
+          {shippingCostsIncluded && (
+            <Typography>
+              {intl.formatMessage(messages.refundedShipment)}
+            </Typography>
+          )}
+        </>
+      )}
+    </TimelineEvent>
+  );
+};
+
+export default ExtendedTimelineEvent;

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(
 );
 
 export const productTitles = defineMessages({
-  fulfillment: {
+  fulfillmentRefunded: {
     defaultMessage: "Products refunded",
     description: "event products list title",
     id: "event products list title refunded"
@@ -54,15 +54,18 @@ export const productTitles = defineMessages({
 export const titles = defineMessages({
   fulfillmentRefunded: {
     defaultMessage: "Products were refunded by ",
-    description: "event title"
+    description: "event title",
+    id: "event title refunded"
   },
   fulfillmentReplaced: {
     defaultMessage: "Products were replaced by ",
-    description: "event title"
+    description: "event title",
+    id: "event title replaced"
   },
   fulfillmentReturned: {
     defaultMessage: "Products were returned by",
-    description: "event title"
+    description: "event title",
+    id: "event title returned"
   }
 });
 

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -33,31 +33,37 @@ const useStyles = makeStyles(
   { name: "OrderHistory" }
 );
 
-export const messages = defineMessages({
-  fulfillmentRefundedProductsTitle: {
+export const productTitles = defineMessages({
+  fulfillment: {
     defaultMessage: "Products refunded",
     description: "event products list title"
   },
-  fulfillmentRefundedTitle: {
-    defaultMessage: "Products were refunded by ",
-    description: "event title"
-  },
-  fulfillmentReplacedProductsTitle: {
+  fulfillmentReplaced: {
     defaultMessage: "Products replaced",
     description: "event products list title"
   },
-  fulfillmentReplacedTitle: {
+  fulfillmentReturned: {
+    defaultMessage: "Products returned",
+    description: "event products list title"
+  }
+});
+
+export const titles = defineMessages({
+  fulfillmentRefunded: {
+    defaultMessage: "Products were refunded by ",
+    description: "event title"
+  },
+  fulfillmentReplaced: {
     defaultMessage: "Products were replaced by ",
     description: "event title"
   },
-  fulfillmentReturnedProductsTitle: {
-    defaultMessage: "Products returned",
-    description: "event products list title"
-  },
-  fulfillmentReturnedTitle: {
+  fulfillmentReturned: {
     defaultMessage: "Products were returned by",
     description: "event title"
-  },
+  }
+});
+
+export const messages = defineMessages({
   refundedAmount: {
     defaultMessage: "Refunded amount",
     description: "amount title"
@@ -81,13 +87,12 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
   const classes = useStyles({});
   const intl = useIntl();
 
-  const getTitle = (titleType: "Title" | "ProductsTitle") =>
-    messages[`${camelCase(type)}${titleType}`];
+  const eventTypeInCamelCase = camelCase(type);
 
   const employeeName = `${user.firstName} ${user.lastName}`;
 
   const titleElements = [
-    { text: intl.formatMessage(getTitle("Title")) },
+    { text: intl.formatMessage(titles[eventTypeInCamelCase]) },
     { link: staffMemberDetailsUrl(user.id), text: employeeName }
   ];
 
@@ -100,7 +105,7 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
             color="textSecondary"
             className={classes.eventSubtitle}
           >
-            {intl.formatMessage(getTitle("ProductsTitle"))}
+            {intl.formatMessage(productTitles[eventTypeInCamelCase])}
           </Typography>
           <table>
             <tbody>

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -36,17 +36,17 @@ const useStyles = makeStyles(
 export const productTitles = defineMessages({
   fulfillmentRefunded: {
     defaultMessage: "Products refunded",
-    description: "event products list title",
+    description: "refunded products list title",
     id: "event products list title refunded"
   },
   fulfillmentReplaced: {
     defaultMessage: "Products replaced",
-    description: "event products list title",
+    description: "replaced products list title",
     id: "event products list title replaced"
   },
   fulfillmentReturned: {
     defaultMessage: "Products returned",
-    description: "event products list title",
+    description: "returned products list title",
     id: "event products list title returned"
   }
 });
@@ -54,17 +54,17 @@ export const productTitles = defineMessages({
 export const titles = defineMessages({
   fulfillmentRefunded: {
     defaultMessage: "Products were refunded by ",
-    description: "event title",
+    description: "refunded event title",
     id: "event title refunded"
   },
   fulfillmentReplaced: {
     defaultMessage: "Products were replaced by ",
-    description: "event title",
+    description: "replaced event title",
     id: "event title replaced"
   },
   fulfillmentReturned: {
     defaultMessage: "Products were returned by",
-    description: "event title",
+    description: "returned event title",
     id: "event title returned"
   }
 });
@@ -115,19 +115,19 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
           </Typography>
           <table>
             <tbody>
-              {event.lines.map(line => (
-                <tr key={line.orderLine.id}>
+              {event.lines.map(({ orderLine, quantity }) => (
+                <tr key={orderLine.id}>
                   <td className={classes.linesTableCell}>
-                    {line.orderLine.productName}
+                    {orderLine.productName}
                   </td>
                   <td className={classes.linesTableCell}>
                     <Typography variant="caption" color="textSecondary">
-                      {line.orderLine.variantName}
+                      {orderLine.variantName}
                     </Typography>
                   </td>
                   <td className={classes.linesTableCell}>
                     <Typography variant="caption" color="textSecondary">
-                      {`qty: ${line.quantity}`}
+                      {`qty: ${quantity}`}
                     </Typography>
                   </td>
                 </tr>
@@ -145,7 +145,7 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
               </Typography>
               <Money
                 money={{
-                  amount: event.amount,
+                  amount,
                   currency: orderCurrency
                 }}
               />

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -115,7 +115,7 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
           </Typography>
           <table>
             <tbody>
-              {event.lines.map(({ orderLine, quantity }) => (
+              {lines.map(({ orderLine, quantity }) => (
                 <tr key={orderLine.id}>
                   <td className={classes.linesTableCell}>
                     {orderLine.productName}

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -36,15 +36,18 @@ const useStyles = makeStyles(
 export const productTitles = defineMessages({
   fulfillment: {
     defaultMessage: "Products refunded",
-    description: "event products list title"
+    description: "event products list title",
+    id: "event products list title refunded"
   },
   fulfillmentReplaced: {
     defaultMessage: "Products replaced",
-    description: "event products list title"
+    description: "event products list title",
+    id: "event products list title replaced"
   },
   fulfillmentReturned: {
     defaultMessage: "Products returned",
-    description: "event products list title"
+    description: "event products list title",
+    id: "event products list title returned"
   }
 });
 

--- a/src/orders/components/OrderHistory/OrderHistory.tsx
+++ b/src/orders/components/OrderHistory/OrderHistory.tsx
@@ -18,7 +18,7 @@ import React from "react";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 
 import ExtendedTimelineEvent from "./ExtendedTimelineEvent";
-import { getEventSecondaryTitle, isOfType } from "./utils";
+import { getEventSecondaryTitle, isTimelineEventOfType } from "./utils";
 
 export const getEventMessage = (
   event: OrderDetails_order_events,
@@ -288,11 +288,11 @@ const OrderHistory: React.FC<OrderHistoryProps> = props => {
   ): { title: string; secondaryTitle?: string } => {
     const { type, message } = event;
 
-    const title = isOfType("rawMessage", type)
+    const title = isTimelineEventOfType("rawMessage", type)
       ? message
       : getEventMessage(event, intl);
 
-    if (isOfType("secondaryTitle", type)) {
+    if (isTimelineEventOfType("secondaryTitle", type)) {
       return {
         secondaryTitle: intl.formatMessage(...getEventSecondaryTitle(event)),
         title
@@ -326,7 +326,7 @@ const OrderHistory: React.FC<OrderHistoryProps> = props => {
             .map(event => {
               const { id, user, date, message, type } = event;
 
-              if (isOfType("note", type)) {
+              if (isTimelineEventOfType("note", type)) {
                 return (
                   <TimelineNote
                     date={date}
@@ -336,7 +336,7 @@ const OrderHistory: React.FC<OrderHistoryProps> = props => {
                   />
                 );
               }
-              if (isOfType("extendable", type)) {
+              if (isTimelineEventOfType("extendable", type)) {
                 return (
                   <ExtendedTimelineEvent
                     event={event}

--- a/src/orders/components/OrderHistory/utils.tsx
+++ b/src/orders/components/OrderHistory/utils.tsx
@@ -1,0 +1,39 @@
+import { OrderDetails_order_events } from "@saleor/orders/types/OrderDetails";
+import { OrderEventsEnum } from "@saleor/types/globalTypes";
+import { MessageDescriptor } from "react-intl";
+
+export const getEventSecondaryTitle = (
+  event: OrderDetails_order_events
+): [MessageDescriptor, any?] => {
+  switch (event.type) {
+    case OrderEventsEnum.ORDER_MARKED_AS_PAID: {
+      return [
+        {
+          defaultMessage: "Transaction Reference {transactionReference}",
+          description: "transaction reference",
+          id: "transaction-reference-order-history"
+        },
+        { transactionReference: event.transactionReference }
+      ];
+    }
+  }
+};
+
+const timelineEventTypes = {
+  extendableEventStatuses: [
+    OrderEventsEnum.FULFILLMENT_REFUNDED,
+    OrderEventsEnum.FULFILLMENT_REPLACED,
+    OrderEventsEnum.FULFILLMENT_RETURNED
+  ],
+  noteStatuses: [OrderEventsEnum.NOTE_ADDED],
+  rawMessageEventStatuses: [
+    OrderEventsEnum.OTHER,
+    OrderEventsEnum.EXTERNAL_SERVICE_NOTIFICATION
+  ],
+  secondaryTitleEventStatuses: [OrderEventsEnum.ORDER_MARKED_AS_PAID]
+};
+
+export const isOfType = (
+  type: "extendable" | "secondaryTitle" | "rawMessage" | "note",
+  eventType: OrderEventsEnum
+) => !!timelineEventTypes[`${type}EventStatuses`]?.includes(eventType);

--- a/src/orders/components/OrderHistory/utils.tsx
+++ b/src/orders/components/OrderHistory/utils.tsx
@@ -33,7 +33,7 @@ const timelineEventTypes = {
   secondaryTitleEventStatuses: [OrderEventsEnum.ORDER_MARKED_AS_PAID]
 };
 
-export const isOfType = (
+export const isTimelineEventOfType = (
   type: "extendable" | "secondaryTitle" | "rawMessage" | "note",
   eventType: OrderEventsEnum
 ) => !!timelineEventTypes[`${type}EventStatuses`]?.includes(eventType);

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -840,7 +840,9 @@ export const order = (placeholder: string): OrderDetails_order => ({
       user: {
         __typename: "User",
         email: "admin@example.com",
-        id: "QWRkcmVzczoxNQ=="
+        firstName: "John",
+        id: "QWRkcmVzczoxNQ==",
+        lastName: "Doe"
       }
     },
     {
@@ -881,7 +883,9 @@ export const order = (placeholder: string): OrderDetails_order => ({
       user: {
         __typename: "User",
         email: "admin@example.com",
-        id: "QWRkcmVzczoxNQ=="
+        firstName: "Jane",
+        id: "QWRkcmVzczoxNQ==",
+        lastName: "Doe"
       }
     },
     {

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -54,6 +54,8 @@ export interface FulfillOrder_orderFulfill_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface FulfillOrder_orderFulfill_order_events_lines_orderLine {

--- a/src/orders/types/OrderAddNote.ts
+++ b/src/orders/types/OrderAddNote.ts
@@ -18,6 +18,8 @@ export interface OrderAddNote_orderAddNote_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderAddNote_orderAddNote_order_events_lines_orderLine {

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -52,6 +52,8 @@ export interface OrderCancel_orderCancel_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderCancel_orderCancel_order_events_lines_orderLine {

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -52,6 +52,8 @@ export interface OrderCapture_orderCapture_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderCapture_orderCapture_order_events_lines_orderLine {

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -52,6 +52,8 @@ export interface OrderConfirm_orderConfirm_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderConfirm_orderConfirm_order_events_lines_orderLine {

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -46,6 +46,8 @@ export interface OrderDetails_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderDetails_order_events_lines_orderLine {

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -52,6 +52,8 @@ export interface OrderDraftCancel_draftOrderDelete_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order_events_lines_orderLine {

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -52,6 +52,8 @@ export interface OrderDraftFinalize_draftOrderComplete_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order_events_lines_orderLine {

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -52,6 +52,8 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_events_lines_orderLine {

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -52,6 +52,8 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_events_user
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_events_lines_orderLine {

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -117,6 +117,8 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_events_lines_orderLine {

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -52,6 +52,8 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_events_lines_orderLine {

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -52,6 +52,8 @@ export interface OrderLineDelete_draftOrderLineDelete_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderLineDelete_draftOrderLineDelete_order_events_lines_orderLine {

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -52,6 +52,8 @@ export interface OrderLineUpdate_draftOrderLineUpdate_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderLineUpdate_draftOrderLineUpdate_order_events_lines_orderLine {

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -52,6 +52,8 @@ export interface OrderLinesAdd_draftOrderLinesCreate_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderLinesAdd_draftOrderLinesCreate_order_events_lines_orderLine {

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -52,6 +52,8 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_events_lines_orderLine {

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -52,6 +52,8 @@ export interface OrderRefund_orderRefund_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderRefund_orderRefund_order_events_lines_orderLine {

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -52,6 +52,8 @@ export interface OrderUpdate_orderUpdate_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderUpdate_orderUpdate_order_events_lines_orderLine {

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -52,6 +52,8 @@ export interface OrderVoid_orderVoid_order_events_user {
   __typename: "User";
   id: string;
   email: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OrderVoid_orderVoid_order_events_lines_orderLine {

--- a/src/storybook/Decorator.tsx
+++ b/src/storybook/Decorator.tsx
@@ -1,11 +1,13 @@
 import { Locale, RawLocaleProvider } from "@saleor/components/Locale";
 import React from "react";
 import { IntlProvider } from "react-intl";
+import { BrowserRouter } from "react-router-dom";
 
 import { Provider as DateProvider } from "../components/Date/DateContext";
 import MessageManagerProvider from "../components/messages";
 import ThemeProvider from "../components/Theme";
 import { TimezoneProvider } from "../components/Timezone";
+import { APP_MOUNT_URI } from "../config";
 
 export const Decorator = storyFn => (
   <IntlProvider defaultLocale={Locale.EN} locale={Locale.EN}>
@@ -18,15 +20,17 @@ export const Decorator = storyFn => (
       <DateProvider value={+new Date("2018-08-07T14:30:44+00:00")}>
         <TimezoneProvider value="America/New_York">
           <ThemeProvider isDefaultDark={false}>
-            <MessageManagerProvider>
-              <div
-                style={{
-                  padding: 24
-                }}
-              >
-                {storyFn()}
-              </div>
-            </MessageManagerProvider>
+            <BrowserRouter basename={APP_MOUNT_URI}>
+              <MessageManagerProvider>
+                <div
+                  style={{
+                    padding: 24
+                  }}
+                >
+                  {storyFn()}
+                </div>
+              </MessageManagerProvider>
+            </BrowserRouter>
           </ThemeProvider>
         </TimezoneProvider>
       </DateProvider>

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -562,7 +562,6 @@ export enum OrderErrorCode {
   CANNOT_CANCEL_ORDER = "CANNOT_CANCEL_ORDER",
   CANNOT_DELETE = "CANNOT_DELETE",
   CANNOT_REFUND = "CANNOT_REFUND",
-  CANNOT_REFUND_FULFILLMENT_LINE = "CANNOT_REFUND_FULFILLMENT_LINE",
   CAPTURE_INACTIVE_PAYMENT = "CAPTURE_INACTIVE_PAYMENT",
   CHANNEL_INACTIVE = "CHANNEL_INACTIVE",
   DUPLICATED_INPUT_ITEM = "DUPLICATED_INPUT_ITEM",
@@ -622,7 +621,7 @@ export enum OrderEventsEnum {
   NOTE_ADDED = "NOTE_ADDED",
   ORDER_FULLY_PAID = "ORDER_FULLY_PAID",
   ORDER_MARKED_AS_PAID = "ORDER_MARKED_AS_PAID",
-  ORDER_REPLACE_CREATED = "ORDER_REPLACE_CREATED",
+  ORDER_REPLACEMENT_CREATED = "ORDER_REPLACEMENT_CREATED",
   OTHER = "OTHER",
   OVERSOLD_ITEMS = "OVERSOLD_ITEMS",
   PAYMENT_AUTHORIZED = "PAYMENT_AUTHORIZED",
@@ -1093,6 +1092,11 @@ export interface AttributeValueInput {
   values?: (string | null)[] | null;
   file?: string | null;
   contentType?: string | null;
+}
+
+export interface BulkAttributeValueInput {
+  id?: string | null;
+  values: (string | null)[];
 }
 
 export interface BulkAttributeValueInput {


### PR DESCRIPTION
I want to merge this change because it adds:
- updated schema types for order reissue 
- extended timeline event for returned, refunded, and replaced items events
- timeline event header, that allows you to easily display links in the event title
- refactor so it's much easier to add new events to different categories of events components

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://feature-possibility-to-return-products.api.saleor.rocks/graphql/
