### PR TITLE
Saleor 1704 shipping rates rendering issue

### DIFF
--- a/src/shipping/components/ShippingZoneRates/ShippingZoneRates.tsx
+++ b/src/shipping/components/ShippingZoneRates/ShippingZoneRates.tsx
@@ -34,17 +34,18 @@ export interface ShippingZoneRatesProps extends ChannelProps {
 const useStyles = makeStyles(
   theme => ({
     alignRight: {
-      "&:last-child": {
-        paddingRight: 0
-      },
-      paddingRight: 0,
+      paddingRight: 24,
       width: ICONBUTTON_SIZE + theme.spacing(0.5)
     },
     nameColumn: {
-      width: 300
+      width: "auto"
     },
     valueColumn: {
-      width: 300
+      width: "auto"
+    },
+    buttonColumn: {
+      width: "62px",
+      padding: "4px 0"
     }
   }),
   { name: "ShippingZoneRates" }
@@ -113,8 +114,8 @@ const ShippingZoneRates: React.FC<ShippingZoneRatesProps> = props => {
                 description="shipping method price"
               />
             </TableCell>
-            <TableCell />
-            <TableCell />
+            <TableCell className={classes.buttonColumn} />
+            <TableCell className={classes.buttonColumn} />
           </TableRow>
         </TableHead>
         <TableBody>
@@ -166,12 +167,14 @@ const ShippingZoneRates: React.FC<ShippingZoneRatesProps> = props => {
                   <IconButtonTableCell
                     disabled={disabled}
                     onClick={() => onRateEdit(rate.id)}
+                    className={classes.buttonColumn}
                   >
                     <EditIcon />
                   </IconButtonTableCell>
                   <IconButtonTableCell
                     disabled={disabled}
                     onClick={() => onRateRemove(rate.id)}
+                    className={classes.buttonColumn}
                   >
                     <DeleteIcon />
                   </IconButtonTableCell>


### PR DESCRIPTION
I want to merge this change because... it fixes styles on shipping rates.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
Before:
<img width="934" alt="image" src="https://user-images.githubusercontent.com/29279389/102616363-bb851580-4137-11eb-8d85-0a50017940a5.png">

After:
<img width="801" alt="image" src="https://user-images.githubusercontent.com/29279389/102616263-91cbee80-4137-11eb-8eaf-053873f9fd52.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
