### PR TITLE
1425 - Support reference type attribute on attribute details page

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -733,49 +733,49 @@
     "context": "dialog content",
     "string": "Are you sure you want to delete {attributeName}?"
   },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_1005562666": {
-    "context": "attribute's editor component",
-    "string": "Catalog Input type for Store Owner"
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_attributeLabel": {
+    "context": "attribute's label",
+    "string": "Default Label"
   },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_1336738461": {
-    "context": "product attribute type",
-    "string": "Dropdown"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_1376373679": {
-    "context": "file attribute type",
-    "string": "File"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_2592224946": {
-    "context": "check to require attribute to have value",
-    "string": "Value Required"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_2665557428": {
-    "context": "attribute's editor component entity",
-    "string": "Entity"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_3287512325": {
-    "context": "page attribute entity type",
-    "string": "Pages"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_331823601": {
-    "context": "references attribute type",
-    "string": "References"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_3334509011": {
-    "context": "product attribute type",
-    "string": "Multiple Select"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_3605174225": {
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_attributeSlug": {
     "context": "attribute's slug short code label",
     "string": "Attribute Code"
   },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_4107478955": {
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_attributeSlugHelperText": {
     "context": "attribute slug input field helper text",
     "string": "This is used internally. Make sure you don’t use spaces"
   },
-  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_691600601": {
-    "context": "attribute's label",
-    "string": "Default Label"
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_dropdown": {
+    "context": "product attribute type",
+    "string": "Dropdown"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_entityType": {
+    "context": "attribute's editor component entity",
+    "string": "Entity"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_file": {
+    "context": "file attribute type",
+    "string": "File"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_inputType": {
+    "context": "attribute's editor component",
+    "string": "Catalog Input type for Store Owner"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_multiselect": {
+    "context": "product attribute type",
+    "string": "Multiple Select"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_page": {
+    "context": "page attribute entity type",
+    "string": "Pages"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_references": {
+    "context": "references attribute type",
+    "string": "References"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_valueRequired": {
+    "context": "check to require attribute to have value",
+    "string": "Value Required"
   },
   "src_dot_attributes_dot_components_dot_AttributeListPage_dot_2417065806": {
     "context": "tab name",
@@ -856,42 +856,45 @@
     "context": "page title",
     "string": "Create New Attribute"
   },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_1318123158": {
-    "context": "attribute is filterable in storefront",
-    "string": "Use in Faceted Navigation"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_1877630205": {
-    "context": "attribute properties regarding storefront",
-    "string": "Storefront Properties"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_26409543": {
-    "context": "attribute properties regarding dashboard",
-    "string": "Dashboard Properties"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_3135366329": {
-    "context": "attribute visibility in storefront",
-    "string": "Public"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_3590282519": {
-    "context": "attribute position in storefront filters",
-    "string": "Position in faceted navigation"
-  },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_3758203740": {
-    "string": "If enabled, attribute will be accessible to customers."
-  },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_4048785456": {
-    "string": "If enabled this attribute can be used as a column in product table."
-  },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_673770329": {
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_availableInGrid": {
     "context": "add attribute as column in product list table",
     "string": "Add to Column Options"
   },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_714335445": {
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_availableInGridCaption": {
+    "context": "caption",
+    "string": "If enabled this attribute can be used as a column in product table."
+  },
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_dashboardPropertiesTitle": {
+    "context": "attribute properties regarding dashboard",
+    "string": "Dashboard Properties"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_filterableInDashboard": {
     "context": "use attribute in filtering",
     "string": "Use in Filtering"
   },
-  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_787251583": {
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_filterableInDashboardCaption": {
+    "context": "caption",
     "string": "If enabled, you’ll be able to use this attribute to filter products in product list."
+  },
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_filterableInStorefront": {
+    "context": "attribute is filterable in storefront",
+    "string": "Use in Faceted Navigation"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_storefrontPropertiesTitle": {
+    "context": "attribute properties regarding storefront",
+    "string": "Storefront Properties"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_storefrontSearchPosition": {
+    "context": "attribute position in storefront filters",
+    "string": "Position in faceted navigation"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_visibleInStorefront": {
+    "context": "attribute visibility in storefront",
+    "string": "Public"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeProperties_dot_visibleInStorefrontCaption": {
+    "context": "caption",
+    "string": "If enabled, attribute will be accessible to customers."
   },
   "src_dot_attributes_dot_components_dot_AttributeValueDeleteDialog_dot_1326420604": {
     "context": "delete attribute value",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -749,6 +749,18 @@
     "context": "check to require attribute to have value",
     "string": "Value Required"
   },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_2665557428": {
+    "context": "attribute's editor component entity",
+    "string": "Entity"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_3287512325": {
+    "context": "page attribute entity type",
+    "string": "Pages"
+  },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_331823601": {
+    "context": "references attribute type",
+    "string": "References"
+  },
   "src_dot_attributes_dot_components_dot_AttributeDetails_dot_3334509011": {
     "context": "product attribute type",
     "string": "Multiple Select"

--- a/schema.graphql
+++ b/schema.graphql
@@ -393,6 +393,7 @@ type Attribute implements Node & ObjectWithMetadata {
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   inputType: AttributeInputTypeEnum
+  entityType: AttributeEntityTypeEnum
   name: String
   slug: String
   type: AttributeTypeEnum
@@ -431,6 +432,7 @@ type AttributeCreate {
 
 input AttributeCreateInput {
   inputType: AttributeInputTypeEnum
+  entityType: AttributeEntityTypeEnum
   name: String!
   slug: String
   type: AttributeTypeEnum!
@@ -448,6 +450,10 @@ type AttributeDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attributeErrors: [AttributeError!]!
   attribute: Attribute
+}
+
+enum AttributeEntityTypeEnum {
+  PAGE
 }
 
 type AttributeError {
@@ -490,6 +496,7 @@ enum AttributeInputTypeEnum {
   DROPDOWN
   MULTISELECT
   FILE
+  REFERENCE
 }
 
 type AttributeReorderValues {
@@ -566,6 +573,7 @@ type AttributeValue implements Node {
   type: AttributeValueType @deprecated(reason: "Use the `inputType` field to determine the type of attribute's value. This field will be removed after 2020-07-31.")
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
   inputType: AttributeInputTypeEnum
+  reference: ID
   file: File
 }
 
@@ -598,6 +606,7 @@ input AttributeValueInput {
   values: [String]
   file: String
   contentType: String
+  references: [ID!]
 }
 
 type AttributeValueTranslatableContent implements Node {
@@ -672,6 +681,7 @@ type BulkProductError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
   index: Int
   warehouses: [ID!]
   channels: [ID!]
@@ -682,6 +692,7 @@ type BulkStockError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
   index: Int
 }
 
@@ -806,6 +817,7 @@ type Channel implements Node {
   isActive: Boolean!
   slug: String!
   currencyCode: String!
+  hasOrders: Boolean!
 }
 
 type ChannelActivate {
@@ -858,6 +870,7 @@ enum ChannelErrorCode {
   UNIQUE
   CHANNEL_TARGET_ID_MUST_BE_DIFFERENT
   CHANNELS_CURRENCY_MUST_BE_THE_SAME
+  CHANNEL_WITH_ORDERS
 }
 
 type ChannelUpdate {
@@ -1109,6 +1122,7 @@ type CollectionChannelListingError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
   channels: [ID!]
 }
 
@@ -2625,6 +2639,7 @@ type Mutation {
   productTypeBulkDelete(ids: [ID]!): ProductTypeBulkDelete
   productTypeUpdate(id: ID!, input: ProductTypeInput!): ProductTypeUpdate
   productTypeReorderAttributes(moves: [ReorderInput]!, productTypeId: ID!, type: ProductAttributeType!): ProductTypeReorderAttributes
+  productReorderAttributeValues(attributeId: ID!, moves: [ReorderInput]!, productId: ID!): ProductReorderAttributeValues
   digitalContentCreate(input: DigitalContentUploadInput!, variantId: ID!): DigitalContentCreate
   digitalContentDelete(variantId: ID!): DigitalContentDelete
   digitalContentUpdate(input: DigitalContentInput!, variantId: ID!): DigitalContentUpdate
@@ -2640,6 +2655,7 @@ type Mutation {
   productVariantSetDefault(productId: ID!, variantId: ID!): ProductVariantSetDefault
   productVariantTranslate(id: ID!, input: NameTranslationInput!, languageCode: LanguageCodeEnum!): ProductVariantTranslate
   productVariantChannelListingUpdate(id: ID!, input: [ProductVariantChannelListingAddInput!]!): ProductVariantChannelListingUpdate
+  productVariantReorderAttributeValues(attributeId: ID!, moves: [ReorderInput]!, variantId: ID!): ProductVariantReorderAttributeValues
   variantImageAssign(imageId: ID!, variantId: ID!): VariantImageAssign
   variantImageUnassign(imageId: ID!, variantId: ID!): VariantImageUnassign
   paymentCapture(amount: PositiveDecimal, paymentId: ID!): PaymentCapture
@@ -2659,6 +2675,7 @@ type Mutation {
   pageAttributeAssign(attributeIds: [ID!]!, pageTypeId: ID!): PageAttributeAssign
   pageAttributeUnassign(attributeIds: [ID!]!, pageTypeId: ID!): PageAttributeUnassign
   pageTypeReorderAttributes(moves: [ReorderInput!]!, pageTypeId: ID!): PageTypeReorderAttributes
+  pageReorderAttributeValues(attributeId: ID!, moves: [ReorderInput]!, pageId: ID!): PageReorderAttributeValues
   draftOrderComplete(id: ID!): DraftOrderComplete
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
@@ -2742,7 +2759,7 @@ type Mutation {
   checkoutShippingMethodUpdate(checkoutId: ID, shippingMethodId: ID!): CheckoutShippingMethodUpdate
   channelCreate(input: ChannelCreateInput!): ChannelCreate
   channelUpdate(id: ID!, input: ChannelUpdateInput!): ChannelUpdate
-  channelDelete(id: ID!, input: ChannelDeleteInput!): ChannelDelete
+  channelDelete(id: ID!, input: ChannelDeleteInput): ChannelDelete
   channelActivate(id: ID!): ChannelActivate
   channelDeactivate(id: ID!): ChannelDeactivate
   attributeCreate(input: AttributeCreateInput!): AttributeCreate
@@ -3318,6 +3335,7 @@ type PageError {
   message: String
   code: PageErrorCode!
   attributes: [ID!]
+  values: [ID!]
 }
 
 enum PageErrorCode {
@@ -3350,6 +3368,12 @@ input PageInput {
   isPublished: Boolean
   publicationDate: String
   seo: SeoInput
+}
+
+type PageReorderAttributeValues {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  page: Page
+  pageErrors: [PageError!]!
 }
 
 enum PageSortField {
@@ -3849,6 +3873,7 @@ type ProductChannelListingError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
   channels: [ID!]
 }
 
@@ -3907,6 +3932,7 @@ type ProductError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
 }
 
 enum ProductErrorCode {
@@ -4052,6 +4078,12 @@ type ProductPricingInfo {
   priceRange: TaxedMoneyRange
   priceRangeUndiscounted: TaxedMoneyRange
   priceRangeLocalCurrency: TaxedMoneyRange
+}
+
+type ProductReorderAttributeValues {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  product: Product
+  productErrors: [ProductError!]!
 }
 
 input ProductStockFilterInput {
@@ -4200,8 +4232,12 @@ type ProductVariant implements Node & ObjectWithMetadata {
   weight: Weight
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
+  quantity: Int! @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
+  quantityAllocated: Int @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
+  stockQuantity: Int! @deprecated(reason: "Use the quantityAvailable field instead. This field will be removed after 2020-07-31.")
   channelListings: [ProductVariantChannelListing!]
   pricing: VariantPricingInfo
+  isAvailable: Boolean @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
   attributes(variantSelection: VariantAttributeScope): [SelectedAttribute!]!
   costPrice: Money
   margin: Int
@@ -4303,6 +4339,12 @@ input ProductVariantInput {
 type ProductVariantReorder {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
+  productErrors: [ProductError!]!
+}
+
+type ProductVariantReorderAttributeValues {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  productVariant: ProductVariant
   productErrors: [ProductError!]!
 }
 
@@ -4422,7 +4464,7 @@ type Query {
   channel(id: ID): Channel
   channels: [Channel!]
   attributes(filter: AttributeFilterInput, sortBy: AttributeSortingInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
-  attribute(id: ID!): Attribute
+  attribute(id: ID, slug: String): Attribute
   appsInstallations: [AppInstallation!]!
   apps(filter: AppFilterInput, sortBy: AppSortingInput, before: String, after: String, first: Int, last: Int): AppCountableConnection
   app(id: ID!): App

--- a/src/attributes/components/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/components/AttributeDetails/AttributeDetails.tsx
@@ -15,11 +15,64 @@ import {
 import { getFormErrors } from "@saleor/utils/errors";
 import getAttributeErrorMessage from "@saleor/utils/errors/attribute";
 import React from "react";
-import { useIntl } from "react-intl";
+import { defineMessages, useIntl } from "react-intl";
 import slugify from "slugify";
 
 import { getAttributeSlugErrorMessage } from "../../errors";
 import { AttributePageFormData } from "../AttributePage";
+
+const messages = defineMessages({
+  attributeLabel: {
+    defaultMessage: "Default Label",
+    description: "attribute's label"
+  },
+  attributeSlug: {
+    defaultMessage: "Attribute Code",
+    description: "attribute's slug short code label"
+  },
+  attributeSlugHelperText: {
+    defaultMessage: "This is used internally. Make sure you don’t use spaces",
+    description: "attribute slug input field helper text"
+  },
+  entityType: {
+    defaultMessage: "Entity",
+    description: "attribute's editor component entity"
+  },
+  inputType: {
+    defaultMessage: "Catalog Input type for Store Owner",
+    description: "attribute's editor component"
+  },
+  valueRequired: {
+    defaultMessage: "Value Required",
+    description: "check to require attribute to have value"
+  }
+});
+
+const inputTypeMessages = defineMessages({
+  dropdown: {
+    defaultMessage: "Dropdown",
+    description: "product attribute type"
+  },
+  file: {
+    defaultMessage: "File",
+    description: "file attribute type"
+  },
+  multiselect: {
+    defaultMessage: "Multiple Select",
+    description: "product attribute type"
+  },
+  references: {
+    defaultMessage: "References",
+    description: "references attribute type"
+  }
+});
+
+const entityTypeMessages = defineMessages({
+  page: {
+    defaultMessage: "Pages",
+    description: "page attribute entity type"
+  }
+});
 
 const useStyles = makeStyles(
   theme => ({
@@ -49,40 +102,25 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
   const intl = useIntl();
   const inputTypeChoices = [
     {
-      label: intl.formatMessage({
-        defaultMessage: "Dropdown",
-        description: "product attribute type"
-      }),
+      label: intl.formatMessage(inputTypeMessages.dropdown),
       value: AttributeInputTypeEnum.DROPDOWN
     },
     {
-      label: intl.formatMessage({
-        defaultMessage: "Multiple Select",
-        description: "product attribute type"
-      }),
+      label: intl.formatMessage(inputTypeMessages.multiselect),
       value: AttributeInputTypeEnum.MULTISELECT
     },
     {
-      label: intl.formatMessage({
-        defaultMessage: "File",
-        description: "file attribute type"
-      }),
+      label: intl.formatMessage(inputTypeMessages.file),
       value: AttributeInputTypeEnum.FILE
     },
     {
-      label: intl.formatMessage({
-        defaultMessage: "References",
-        description: "references attribute type"
-      }),
+      label: intl.formatMessage(inputTypeMessages.references),
       value: AttributeInputTypeEnum.REFERENCE
     }
   ];
   const entityTypeChoices = [
     {
-      label: intl.formatMessage({
-        defaultMessage: "Pages",
-        description: "page attribute entity type"
-      }),
+      label: intl.formatMessage(entityTypeMessages.page),
       value: AttributeEntityTypeEnum.PAGE
     }
   ];
@@ -101,10 +139,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
         <TextField
           disabled={disabled}
           error={!!formErrors.name}
-          label={intl.formatMessage({
-            defaultMessage: "Default Label",
-            description: "attribute's label"
-          })}
+          label={intl.formatMessage(messages.attributeLabel)}
           name={"name" as keyof AttributePageFormData}
           fullWidth
           helperText={getAttributeErrorMessage(formErrors.name, intl)}
@@ -115,20 +150,13 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
         <TextField
           disabled={disabled}
           error={!!formErrors.slug}
-          label={intl.formatMessage({
-            defaultMessage: "Attribute Code",
-            description: "attribute's slug short code label"
-          })}
+          label={intl.formatMessage(messages.attributeSlug)}
           name={"slug" as keyof AttributePageFormData}
           placeholder={slugify(data.name).toLowerCase()}
           fullWidth
           helperText={
             getAttributeSlugErrorMessage(formErrors.slug, intl) ||
-            intl.formatMessage({
-              defaultMessage:
-                "This is used internally. Make sure you don’t use spaces",
-              description: "attribute slug input field helper text"
-            })
+            intl.formatMessage(messages.attributeSlugHelperText)
           }
           value={data.slug}
           onChange={onChange}
@@ -140,10 +168,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
             disabled={disabled || !canChangeType}
             error={!!formErrors.inputType}
             hint={getAttributeErrorMessage(formErrors.inputType, intl)}
-            label={intl.formatMessage({
-              defaultMessage: "Catalog Input type for Store Owner",
-              description: "attribute's editor component"
-            })}
+            label={intl.formatMessage(messages.inputType)}
             name="inputType"
             onChange={onChange}
             value={data.inputType}
@@ -154,10 +179,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
               disabled={disabled || !canChangeType}
               error={!!formErrors.entityType}
               hint={getAttributeErrorMessage(formErrors.entityType, intl)}
-              label={intl.formatMessage({
-                defaultMessage: "Entity",
-                description: "attribute's editor component entity"
-              })}
+              label={intl.formatMessage(messages.entityType)}
               name="entityType"
               onChange={onChange}
               value={data.entityType}
@@ -167,10 +189,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
         <FormSpacer />
         <ControlledCheckbox
           name={"valueRequired" as keyof AttributePageFormData}
-          label={intl.formatMessage({
-            defaultMessage: "Value Required",
-            description: "check to require attribute to have value"
-          })}
+          label={intl.formatMessage(messages.valueRequired)}
           checked={data.valueRequired}
           onChange={onChange}
           disabled={disabled}

--- a/src/attributes/components/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/components/AttributeDetails/AttributeDetails.tsx
@@ -1,5 +1,6 @@
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
+import { makeStyles } from "@material-ui/core/styles";
 import TextField from "@material-ui/core/TextField";
 import CardTitle from "@saleor/components/CardTitle";
 import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
@@ -7,7 +8,10 @@ import FormSpacer from "@saleor/components/FormSpacer";
 import SingleSelectField from "@saleor/components/SingleSelectField";
 import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import { commonMessages } from "@saleor/intl";
-import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
+import {
+  AttributeEntityTypeEnum,
+  AttributeInputTypeEnum
+} from "@saleor/types/globalTypes";
 import { getFormErrors } from "@saleor/utils/errors";
 import getAttributeErrorMessage from "@saleor/utils/errors/attribute";
 import React from "react";
@@ -17,6 +21,20 @@ import slugify from "slugify";
 import { getAttributeSlugErrorMessage } from "../../errors";
 import { AttributePageFormData } from "../AttributePage";
 
+const useStyles = makeStyles(
+  theme => ({
+    inputTypeSection: {
+      columnGap: theme.spacing(2) + "px",
+      display: "flex",
+      [theme.breakpoints.down("md")]: {
+        flexFlow: "wrap",
+        rowGap: theme.spacing(3) + "px"
+      }
+    }
+  }),
+  { name: "AttributeDetails" }
+);
+
 export interface AttributeDetailsProps {
   canChangeType: boolean;
   data: AttributePageFormData;
@@ -25,13 +43,9 @@ export interface AttributeDetailsProps {
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const AttributeDetails: React.FC<AttributeDetailsProps> = ({
-  canChangeType,
-  data,
-  disabled,
-  errors,
-  onChange
-}) => {
+const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
+  const { canChangeType, data, disabled, errors, onChange } = props;
+  const classes = useStyles(props);
   const intl = useIntl();
   const inputTypeChoices = [
     {
@@ -54,10 +68,29 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({
         description: "file attribute type"
       }),
       value: AttributeInputTypeEnum.FILE
+    },
+    {
+      label: intl.formatMessage({
+        defaultMessage: "References",
+        description: "references attribute type"
+      }),
+      value: AttributeInputTypeEnum.REFERENCE
+    }
+  ];
+  const entityTypeChoices = [
+    {
+      label: intl.formatMessage({
+        defaultMessage: "Pages",
+        description: "page attribute entity type"
+      }),
+      value: AttributeEntityTypeEnum.PAGE
     }
   ];
 
-  const formErrors = getFormErrors(["name", "slug", "inputType"], errors);
+  const formErrors = getFormErrors(
+    ["name", "slug", "inputType", "entityType"],
+    errors
+  );
 
   return (
     <Card>
@@ -101,19 +134,36 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({
           onChange={onChange}
         />
         <FormSpacer />
-        <SingleSelectField
-          choices={inputTypeChoices}
-          disabled={disabled || !canChangeType}
-          error={!!formErrors.inputType}
-          hint={getAttributeErrorMessage(formErrors.inputType, intl)}
-          label={intl.formatMessage({
-            defaultMessage: "Catalog Input type for Store Owner",
-            description: "attribute's editor component"
-          })}
-          name="inputType"
-          onChange={onChange}
-          value={data.inputType}
-        />
+        <div className={classes.inputTypeSection}>
+          <SingleSelectField
+            choices={inputTypeChoices}
+            disabled={disabled || !canChangeType}
+            error={!!formErrors.inputType}
+            hint={getAttributeErrorMessage(formErrors.inputType, intl)}
+            label={intl.formatMessage({
+              defaultMessage: "Catalog Input type for Store Owner",
+              description: "attribute's editor component"
+            })}
+            name="inputType"
+            onChange={onChange}
+            value={data.inputType}
+          />
+          {data.inputType === AttributeInputTypeEnum.REFERENCE && (
+            <SingleSelectField
+              choices={entityTypeChoices}
+              disabled={disabled || !canChangeType}
+              error={!!formErrors.entityType}
+              hint={getAttributeErrorMessage(formErrors.entityType, intl)}
+              label={intl.formatMessage({
+                defaultMessage: "Entity",
+                description: "attribute's editor component entity"
+              })}
+              name="entityType"
+              onChange={onChange}
+              value={data.entityType}
+            />
+          )}
+        </div>
         <FormSpacer />
         <ControlledCheckbox
           name={"valueRequired" as keyof AttributePageFormData}

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -17,6 +17,7 @@ import { sectionNames } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
 import { ReorderAction } from "@saleor/types";
 import {
+  AttributeEntityTypeEnum,
   AttributeInputTypeEnum,
   AttributeTypeEnum
 } from "@saleor/types/globalTypes";
@@ -51,6 +52,7 @@ export interface AttributePageFormData extends MetadataFormData {
   availableInGrid: boolean;
   filterableInDashboard: boolean;
   inputType: AttributeInputTypeEnum;
+  entityType: AttributeEntityTypeEnum;
   filterableInStorefront: boolean;
   name: string;
   slug: string;
@@ -84,6 +86,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
     attribute === null
       ? {
           availableInGrid: true,
+          entityType: null,
           filterableInDashboard: true,
           filterableInStorefront: true,
           inputType: AttributeInputTypeEnum.DROPDOWN,
@@ -98,6 +101,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
         }
       : {
           availableInGrid: maybe(() => attribute.availableInGrid, true),
+          entityType: attribute?.entityType ?? null,
           filterableInDashboard: maybe(
             () => attribute.filterableInDashboard,
             true
@@ -172,7 +176,10 @@ const AttributePage: React.FC<AttributePageProps> = ({
                   errors={errors}
                   onChange={change}
                 />
-                {data.inputType !== AttributeInputTypeEnum.FILE && (
+                {![
+                  AttributeInputTypeEnum.FILE,
+                  AttributeInputTypeEnum.REFERENCE
+                ].includes(data.inputType) && (
                   <>
                     <CardSpacer />
                     <AttributeValues

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -1,3 +1,4 @@
+import { ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES } from "@saleor/attributes/utils/data";
 import AppHeader from "@saleor/components/AppHeader";
 import CardSpacer from "@saleor/components/CardSpacer";
 import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
@@ -176,10 +177,9 @@ const AttributePage: React.FC<AttributePageProps> = ({
                   errors={errors}
                   onChange={change}
                 />
-                {![
-                  AttributeInputTypeEnum.FILE,
-                  AttributeInputTypeEnum.REFERENCE
-                ].includes(data.inputType) && (
+                {ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES.includes(
+                  data.inputType
+                ) && (
                   <>
                     <CardSpacer />
                     <AttributeValues

--- a/src/attributes/components/AttributeProperties/AttributeProperties.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.tsx
@@ -38,6 +38,16 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
 
   const formErrors = getFormErrors(["storefrontSearchPosition"], errors);
 
+  const dashboardProperties = ![
+    AttributeInputTypeEnum.FILE,
+    AttributeInputTypeEnum.REFERENCE
+  ].includes(data.inputType);
+
+  const storefrontFacetedNavigationProperties =
+    ![AttributeInputTypeEnum.FILE, AttributeInputTypeEnum.REFERENCE].includes(
+      data.inputType
+    ) && data.type === AttributeTypeEnum.PRODUCT_TYPE;
+
   return (
     <Card>
       <CardTitle title={intl.formatMessage(commonMessages.properties)} />
@@ -80,44 +90,43 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
           />
         </Typography>
         <Hr />
-        {data.inputType !== AttributeInputTypeEnum.FILE &&
-          data.type === AttributeTypeEnum.PRODUCT_TYPE && (
-            <>
-              <ControlledCheckbox
-                name={"filterableInStorefront" as keyof FormData}
-                label={intl.formatMessage({
-                  defaultMessage: "Use in Faceted Navigation",
-                  description: "attribute is filterable in storefront"
-                })}
-                checked={data.filterableInStorefront}
-                onChange={onChange}
-                disabled={disabled}
-              />
-              {data.filterableInStorefront && (
-                <>
-                  <FormSpacer />
-                  <TextField
-                    disabled={disabled}
-                    error={!!formErrors.storefrontSearchPosition}
-                    fullWidth
-                    helperText={getAttributeErrorMessage(
-                      formErrors.storefrontSearchPosition,
-                      intl
-                    )}
-                    name={
-                      "storefrontSearchPosition" as keyof AttributePageFormData
-                    }
-                    label={intl.formatMessage({
-                      defaultMessage: "Position in faceted navigation",
-                      description: "attribute position in storefront filters"
-                    })}
-                    value={data.storefrontSearchPosition}
-                    onChange={onChange}
-                  />
-                </>
-              )}
-            </>
-          )}
+        {storefrontFacetedNavigationProperties && (
+          <>
+            <ControlledCheckbox
+              name={"filterableInStorefront" as keyof FormData}
+              label={intl.formatMessage({
+                defaultMessage: "Use in Faceted Navigation",
+                description: "attribute is filterable in storefront"
+              })}
+              checked={data.filterableInStorefront}
+              onChange={onChange}
+              disabled={disabled}
+            />
+            {data.filterableInStorefront && (
+              <>
+                <FormSpacer />
+                <TextField
+                  disabled={disabled}
+                  error={!!formErrors.storefrontSearchPosition}
+                  fullWidth
+                  helperText={getAttributeErrorMessage(
+                    formErrors.storefrontSearchPosition,
+                    intl
+                  )}
+                  name={
+                    "storefrontSearchPosition" as keyof AttributePageFormData
+                  }
+                  label={intl.formatMessage({
+                    defaultMessage: "Position in faceted navigation",
+                    description: "attribute position in storefront filters"
+                  })}
+                  value={data.storefrontSearchPosition}
+                  onChange={onChange}
+                />
+              </>
+            )}
+          </>
+        )}
         <FormSpacer />
         <ControlledSwitch
           name={"visibleInStorefront" as keyof FormData}
@@ -136,7 +145,7 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
           onChange={onChange}
           disabled={disabled}
         />
-        {data.inputType !== AttributeInputTypeEnum.FILE && (
+        {dashboardProperties && (
           <>
             <CardSpacer />
             <Typography variant="subtitle1">

--- a/src/attributes/components/AttributeProperties/AttributeProperties.tsx
+++ b/src/attributes/components/AttributeProperties/AttributeProperties.tsx
@@ -2,6 +2,7 @@ import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
+import { ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES } from "@saleor/attributes/utils/data";
 import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
@@ -10,16 +11,58 @@ import FormSpacer from "@saleor/components/FormSpacer";
 import Hr from "@saleor/components/Hr";
 import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import { commonMessages } from "@saleor/intl";
-import {
-  AttributeInputTypeEnum,
-  AttributeTypeEnum
-} from "@saleor/types/globalTypes";
+import { AttributeTypeEnum } from "@saleor/types/globalTypes";
 import { getFormErrors } from "@saleor/utils/errors";
 import getAttributeErrorMessage from "@saleor/utils/errors/attribute";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
 import { AttributePageFormData } from "../AttributePage";
+
+const messages = defineMessages({
+  availableInGrid: {
+    defaultMessage: "Add to Column Options",
+    description: "add attribute as column in product list table"
+  },
+  availableInGridCaption: {
+    defaultMessage:
+      "If enabled this attribute can be used as a column in product table.",
+    description: "caption"
+  },
+  dashboardPropertiesTitle: {
+    defaultMessage: "Dashboard Properties",
+    description: "attribute properties regarding dashboard"
+  },
+  filterableInDashboard: {
+    defaultMessage: "Use in Filtering",
+    description: "use attribute in filtering"
+  },
+  filterableInDashboardCaption: {
+    defaultMessage:
+      "If enabled, you’ll be able to use this attribute to filter products in product list.",
+    description: "caption"
+  },
+  filterableInStorefront: {
+    defaultMessage: "Use in Faceted Navigation",
+    description: "attribute is filterable in storefront"
+  },
+  storefrontPropertiesTitle: {
+    defaultMessage: "Storefront Properties",
+    description: "attribute properties regarding storefront"
+  },
+  storefrontSearchPosition: {
+    defaultMessage: "Position in faceted navigation",
+    description: "attribute position in storefront filters"
+  },
+  visibleInStorefront: {
+    defaultMessage: "Public",
+    description: "attribute visibility in storefront"
+  },
+  visibleInStorefrontCaption: {
+    defaultMessage: "If enabled, attribute will be accessible to customers.",
+    description: "caption"
+  }
+});
 
 export interface AttributePropertiesProps {
   data: AttributePageFormData;
@@ -38,15 +81,13 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
 
   const formErrors = getFormErrors(["storefrontSearchPosition"], errors);
 
-  const dashboardProperties = ![
-    AttributeInputTypeEnum.FILE,
-    AttributeInputTypeEnum.REFERENCE
-  ].includes(data.inputType);
+  const dashboardProperties = ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES.includes(
+    data.inputType
+  );
 
   const storefrontFacetedNavigationProperties =
-    ![AttributeInputTypeEnum.FILE, AttributeInputTypeEnum.REFERENCE].includes(
-      data.inputType
-    ) && data.type === AttributeTypeEnum.PRODUCT_TYPE;
+    ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES.includes(data.inputType) &&
+    data.type === AttributeTypeEnum.PRODUCT_TYPE;
 
   return (
     <Card>
@@ -84,20 +125,14 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
         /> */}
 
         <Typography variant="subtitle1">
-          <FormattedMessage
-            defaultMessage="Storefront Properties"
-            description="attribute properties regarding storefront"
-          />
+          <FormattedMessage {...messages.storefrontPropertiesTitle} />
         </Typography>
         <Hr />
         {storefrontFacetedNavigationProperties && (
           <>
             <ControlledCheckbox
               name={"filterableInStorefront" as keyof FormData}
-              label={intl.formatMessage({
-                defaultMessage: "Use in Faceted Navigation",
-                description: "attribute is filterable in storefront"
-              })}
+              label={intl.formatMessage(messages.filterableInStorefront)}
               checked={data.filterableInStorefront}
               onChange={onChange}
               disabled={disabled}
@@ -116,10 +151,7 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
                   name={
                     "storefrontSearchPosition" as keyof AttributePageFormData
                   }
-                  label={intl.formatMessage({
-                    defaultMessage: "Position in faceted navigation",
-                    description: "attribute position in storefront filters"
-                  })}
+                  label={intl.formatMessage(messages.storefrontSearchPosition)}
                   value={data.storefrontSearchPosition}
                   onChange={onChange}
                 />
@@ -132,12 +164,9 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
           name={"visibleInStorefront" as keyof FormData}
           label={
             <>
-              <FormattedMessage
-                defaultMessage="Public"
-                description="attribute visibility in storefront"
-              />
+              <FormattedMessage {...messages.visibleInStorefront} />
               <Typography variant="caption">
-                <FormattedMessage defaultMessage="If enabled, attribute will be accessible to customers." />
+                <FormattedMessage {...messages.visibleInStorefrontCaption} />
               </Typography>
             </>
           }
@@ -149,10 +178,7 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
           <>
             <CardSpacer />
             <Typography variant="subtitle1">
-              <FormattedMessage
-                defaultMessage="Dashboard Properties"
-                description="attribute properties regarding dashboard"
-              />
+              <FormattedMessage {...messages.dashboardPropertiesTitle} />
             </Typography>
             <Hr />
             <CardSpacer />
@@ -160,12 +186,11 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
               name={"filterableInDashboard" as keyof FormData}
               label={
                 <>
-                  <FormattedMessage
-                    defaultMessage="Use in Filtering"
-                    description="use attribute in filtering"
-                  />
+                  <FormattedMessage {...messages.filterableInDashboard} />
                   <Typography variant="caption">
-                    <FormattedMessage defaultMessage="If enabled, you’ll be able to use this attribute to filter products in product list." />
+                    <FormattedMessage
+                      {...messages.filterableInDashboardCaption}
+                    />
                   </Typography>
                 </>
               }
@@ -178,12 +203,9 @@ const AttributeProperties: React.FC<AttributePropertiesProps> = ({
               name={"availableInGrid" as keyof FormData}
               label={
                 <>
-                  <FormattedMessage
-                    defaultMessage="Add to Column Options"
-                    description="add attribute as column in product list table"
-                  />
+                  <FormattedMessage {...messages.availableInGrid} />
                   <Typography variant="caption">
-                    <FormattedMessage defaultMessage="If enabled this attribute can be used as a column in product table." />
+                    <FormattedMessage {...messages.availableInGridCaption} />
                   </Typography>
                 </>
               }

--- a/src/attributes/fixtures.ts
+++ b/src/attributes/fixtures.ts
@@ -10,6 +10,7 @@ import { AttributeList_attributes_edges_node } from "./types/AttributeList";
 export const attribute: AttributeDetailsFragment = {
   __typename: "Attribute" as "Attribute",
   availableInGrid: true,
+  entityType: null,
   filterableInDashboard: false,
   filterableInStorefront: true,
   id: "UHJvZHVjdEF0dHJpYnV0ZTo5",

--- a/src/attributes/types/AttributeCreate.ts
+++ b/src/attributes/types/AttributeCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeCreate
@@ -47,6 +47,7 @@ export interface AttributeCreate_attributeCreate_attribute {
   privateMetadata: (AttributeCreate_attributeCreate_attribute_privateMetadata | null)[];
   availableInGrid: boolean;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
   values: (AttributeCreate_attributeCreate_attribute_values | null)[] | null;

--- a/src/attributes/types/AttributeDetails.ts
+++ b/src/attributes/types/AttributeDetails.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeTypeEnum, AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: AttributeDetails
@@ -47,6 +47,7 @@ export interface AttributeDetails_attribute {
   privateMetadata: (AttributeDetails_attribute_privateMetadata | null)[];
   availableInGrid: boolean;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
   values: (AttributeDetails_attribute_values | null)[] | null;

--- a/src/attributes/types/AttributeUpdate.ts
+++ b/src/attributes/types/AttributeUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeUpdateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeUpdateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeUpdate
@@ -47,6 +47,7 @@ export interface AttributeUpdate_attributeUpdate_attribute {
   privateMetadata: (AttributeUpdate_attributeUpdate_attribute_privateMetadata | null)[];
   availableInGrid: boolean;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
   values: (AttributeUpdate_attributeUpdate_attribute_values | null)[] | null;

--- a/src/attributes/types/AttributeValueCreate.ts
+++ b/src/attributes/types/AttributeValueCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueCreate
@@ -47,6 +47,7 @@ export interface AttributeValueCreate_attributeValueCreate_attribute {
   privateMetadata: (AttributeValueCreate_attributeValueCreate_attribute_privateMetadata | null)[];
   availableInGrid: boolean;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
   values: (AttributeValueCreate_attributeValueCreate_attribute_values | null)[] | null;

--- a/src/attributes/types/AttributeValueDelete.ts
+++ b/src/attributes/types/AttributeValueDelete.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueDelete
@@ -47,6 +47,7 @@ export interface AttributeValueDelete_attributeValueDelete_attribute {
   privateMetadata: (AttributeValueDelete_attributeValueDelete_attribute_privateMetadata | null)[];
   availableInGrid: boolean;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
   values: (AttributeValueDelete_attributeValueDelete_attribute_values | null)[] | null;

--- a/src/attributes/types/AttributeValueUpdate.ts
+++ b/src/attributes/types/AttributeValueUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueUpdate
@@ -47,6 +47,7 @@ export interface AttributeValueUpdate_attributeValueUpdate_attribute {
   privateMetadata: (AttributeValueUpdate_attributeValueUpdate_attribute_privateMetadata | null)[];
   availableInGrid: boolean;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
   values: (AttributeValueUpdate_attributeValueUpdate_attribute_values | null)[] | null;

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -10,7 +10,52 @@ import {
 } from "@saleor/types/globalTypes";
 import { MutationFetchResult } from "react-apollo";
 
+import { AttributePageFormData } from "../components/AttributePage";
+import { AttributeValueEditDialogFormData } from "../components/AttributeValueEditDialog";
 import { AttributeValueDelete } from "../types/AttributeValueDelete";
+
+export const ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES = [
+  AttributeInputTypeEnum.DROPDOWN,
+  AttributeInputTypeEnum.MULTISELECT
+];
+
+function getSimpleAttributeData(
+  data: AttributePageFormData,
+  values: AttributeValueEditDialogFormData[]
+) {
+  return {
+    ...data,
+    metadata: undefined,
+    privateMetadata: undefined,
+    storefrontSearchPosition: parseInt(data.storefrontSearchPosition, 10),
+    values: values.map(value => ({
+      name: value.name
+    }))
+  };
+}
+
+function getFileOrReferenceAttributeData(
+  data: AttributePageFormData,
+  values: AttributeValueEditDialogFormData[]
+) {
+  return {
+    ...getSimpleAttributeData(data, values),
+    availableInGrid: undefined,
+    filterableInDashboard: undefined,
+    filterableInStorefront: undefined
+  };
+}
+
+export function getAttributeData(
+  data: AttributePageFormData,
+  values: AttributeValueEditDialogFormData[]
+) {
+  if (ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES.includes(data.inputType)) {
+    return getSimpleAttributeData(data, values);
+  } else {
+    return getFileOrReferenceAttributeData(data, values);
+  }
+}
 
 export const isFileValueUnused = (
   attributesWithNewFileValue: FormsetData<null, File>,

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -1,12 +1,10 @@
+import { getAttributeData } from "@saleor/attributes/utils/data";
 import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import { getStringOrPlaceholder } from "@saleor/misc";
 import { ReorderEvent } from "@saleor/types";
-import {
-  AttributeErrorCode,
-  AttributeInputTypeEnum
-} from "@saleor/types/globalTypes";
+import { AttributeErrorCode } from "@saleor/types/globalTypes";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataCreateHandler from "@saleor/utils/handlers/metadataCreateHandler";
 import {
@@ -55,33 +53,6 @@ function areValuesEqual(
   b: AttributeValueEditDialogFormData
 ) {
   return a.name === b.name;
-}
-
-function getSimpleAttributeData(
-  data: AttributePageFormData,
-  values: AttributeValueEditDialogFormData[]
-) {
-  return {
-    ...data,
-    metadata: undefined,
-    privateMetadata: undefined,
-    storefrontSearchPosition: parseInt(data.storefrontSearchPosition, 10),
-    values: values.map(value => ({
-      name: value.name
-    }))
-  };
-}
-
-function getFileOrReferenceAttributeData(
-  data: AttributePageFormData,
-  values: AttributeValueEditDialogFormData[]
-) {
-  return {
-    ...getSimpleAttributeData(data, values),
-    availableInGrid: undefined,
-    filterableInDashboard: undefined,
-    filterableInStorefront: undefined
-  };
 }
 
 const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
@@ -145,12 +116,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
     setValues(move(values[oldIndex], values, areValuesEqual, newIndex));
 
   const handleCreate = async (data: AttributePageFormData) => {
-    const input = [
-      AttributeInputTypeEnum.FILE,
-      AttributeInputTypeEnum.REFERENCE
-    ].includes(data.inputType)
-      ? getFileOrReferenceAttributeData(data, values)
-      : getSimpleAttributeData(data, values);
+    const input = getAttributeData(data, values);
 
     const result = await attributeCreate({
       variables: {

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -72,7 +72,7 @@ function getSimpleAttributeData(
   };
 }
 
-function getFileAttributeData(
+function getFileOrReferenceAttributeData(
   data: AttributePageFormData,
   values: AttributeValueEditDialogFormData[]
 ) {
@@ -145,10 +145,12 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
     setValues(move(values[oldIndex], values, areValuesEqual, newIndex));
 
   const handleCreate = async (data: AttributePageFormData) => {
-    const input =
-      data.inputType === AttributeInputTypeEnum.FILE
-        ? getFileAttributeData(data, values)
-        : getSimpleAttributeData(data, values);
+    const input = [
+      AttributeInputTypeEnum.FILE,
+      AttributeInputTypeEnum.REFERENCE
+    ].includes(data.inputType)
+      ? getFileOrReferenceAttributeData(data, values)
+      : getSimpleAttributeData(data, values);
 
     const result = await attributeCreate({
       variables: {

--- a/src/attributes/views/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/views/AttributeDetails/AttributeDetails.tsx
@@ -178,6 +178,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
   const handleUpdate = async (data: AttributePageFormData) => {
     const input = {
       ...data,
+      entityType: undefined,
       inputType: undefined,
       metadata: undefined,
       privateMetadata: undefined,

--- a/src/fragments/attributes.ts
+++ b/src/fragments/attributes.ts
@@ -12,6 +12,7 @@ export const attributeValueFragment = gql`
     file {
       ...FileFragment
     }
+    reference
   }
 `;
 
@@ -36,6 +37,7 @@ export const attributeDetailsFragment = gql`
     ...MetadataFragment
     availableInGrid
     inputType
+    entityType
     storefrontSearchPosition
     valueRequired
     values {

--- a/src/fragments/types/AttributeDetailsFragment.ts
+++ b/src/fragments/types/AttributeDetailsFragment.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeTypeEnum, AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: AttributeDetailsFragment
@@ -47,6 +47,7 @@ export interface AttributeDetailsFragment {
   privateMetadata: (AttributeDetailsFragment_privateMetadata | null)[];
   availableInGrid: boolean;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
   values: (AttributeDetailsFragment_values | null)[] | null;

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -70,6 +70,10 @@ export enum AppTypeEnum {
   THIRDPARTY = "THIRDPARTY",
 }
 
+export enum AttributeEntityTypeEnum {
+  PAGE = "PAGE",
+}
+
 export enum AttributeErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
@@ -83,6 +87,7 @@ export enum AttributeInputTypeEnum {
   DROPDOWN = "DROPDOWN",
   FILE = "FILE",
   MULTISELECT = "MULTISELECT",
+  REFERENCE = "REFERENCE",
 }
 
 export enum AttributeSortField {
@@ -117,6 +122,7 @@ export enum ChannelErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
   CHANNELS_CURRENCY_MUST_BE_THE_SAME = "CHANNELS_CURRENCY_MUST_BE_THE_SAME",
   CHANNEL_TARGET_ID_MUST_BE_DIFFERENT = "CHANNEL_TARGET_ID_MUST_BE_DIFFERENT",
+  CHANNEL_WITH_ORDERS = "CHANNEL_WITH_ORDERS",
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
   INVALID = "INVALID",
   NOT_FOUND = "NOT_FOUND",
@@ -1026,6 +1032,7 @@ export interface AppTokenInput {
 
 export interface AttributeCreateInput {
   inputType?: AttributeInputTypeEnum | null;
+  entityType?: AttributeEntityTypeEnum | null;
   name: string;
   slug?: string | null;
   type: AttributeTypeEnum;
@@ -1088,6 +1095,7 @@ export interface AttributeValueInput {
   values?: (string | null)[] | null;
   file?: string | null;
   contentType?: string | null;
+  references?: string[] | null;
 }
 
 export interface AuthorizationKeyInput {


### PR DESCRIPTION
I want to merge this change because... it adds support for reference type attribute on attribute details page.

Feature branch: https://github.com/mirumee/saleor-dashboard/pull/917

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> feature/page-reference-attributes
https://github.com/mirumee/saleor/pull/6624

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
![localhost_9000_attributes_add](https://user-images.githubusercontent.com/9825562/102638813-6279a980-4158-11eb-9ff2-035dcf622ce7.png)
![localhost_9000_attributes_QXR0cmlidXRlOjM1](https://user-images.githubusercontent.com/9825562/102638816-64dc0380-4158-11eb-9571-637352734dbf.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://feature-page-reference-attributes.api.saleor.rocks/graphql/
