### PR TITLE
Saleor 1945 adjust adress management to the designs

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2228,6 +2228,14 @@
     "context": "button",
     "string": "Set as default shipping address"
   },
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_2364475135": {
+    "context": "button",
+    "string": "Edit Address"
+  },
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_2657976015": {
+    "context": "button",
+    "string": "Delete Address"
+  },
   "src_dot_customers_dot_components_dot_CustomerAddress_dot_3096438859": {
     "context": "button",
     "string": "Set as default billing address"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2200,48 +2200,48 @@
     "context": "dialog title",
     "string": "Add Address"
   },
-  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_1090326769": {
-    "context": "customer's address book, header",
-    "string": "{fullName}'s Address Book"
-  },
-  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_1428369222": {
-    "string": "This customer doesn’t have any adresses added to his address book. You can add address using the button below."
-  },
-  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_1484733755": {
-    "string": "There is no address to show for this customer"
-  },
-  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_3623935073": {
+  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_addAddress": {
     "context": "button",
     "string": "Add address"
   },
-  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_489918044": {
+  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_doesntHaveAddresses": {
+    "string": "This customer doesn’t have any adresses added to his address book. You can add address using the button below."
+  },
+  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_fullNameAddress": {
+    "context": "customer's address book, header",
+    "string": "{fullName}'s Address Book"
+  },
+  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_fullNameDetail": {
     "context": "customer details, header",
     "string": "{fullName} Details"
   },
-  "src_dot_customers_dot_components_dot_CustomerAddress_dot_1224809208": {
+  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_noAddressToShow": {
+    "string": "There is no address to show for this customer"
+  },
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_defaultAddress": {
     "string": "Default Address"
   },
-  "src_dot_customers_dot_components_dot_CustomerAddress_dot_1578192486": {
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_defaultBillingAddress": {
     "string": "Default Billing Address"
   },
-  "src_dot_customers_dot_components_dot_CustomerAddress_dot_2131178753": {
-    "context": "button",
-    "string": "Set as default shipping address"
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_defaultShippingAddress": {
+    "string": "Default Shipping Address"
   },
-  "src_dot_customers_dot_components_dot_CustomerAddress_dot_2364475135": {
-    "context": "button",
-    "string": "Edit Address"
-  },
-  "src_dot_customers_dot_components_dot_CustomerAddress_dot_2657976015": {
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_deleteAddress": {
     "context": "button",
     "string": "Delete Address"
   },
-  "src_dot_customers_dot_components_dot_CustomerAddress_dot_3096438859": {
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_editAddress": {
+    "context": "button",
+    "string": "Edit Address"
+  },
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_setDefaultBilling": {
     "context": "button",
     "string": "Set as default billing address"
   },
-  "src_dot_customers_dot_components_dot_CustomerAddress_dot_4109348993": {
-    "string": "Default Shipping Address"
+  "src_dot_customers_dot_components_dot_CustomerAddress_dot_setDefaultShipping": {
+    "context": "button",
+    "string": "Set as default shipping address"
   },
   "src_dot_customers_dot_components_dot_CustomerAddresses_dot_1967111456": {
     "context": "header",

--- a/src/components/AddressFormatter/AddressFormatter.tsx
+++ b/src/components/AddressFormatter/AddressFormatter.tsx
@@ -21,6 +21,7 @@ const AddressFormatter: React.FC<AddressFormatterProps> = ({ address }) => {
       <Typography component="p">
         {address.firstName} {address.lastName}
       </Typography>
+      <Typography component="p">{address.phone}</Typography>
       {address.companyName && (
         <Typography component="p">{address.companyName}</Typography>
       )}

--- a/src/customers/components/CustomerAddress/CustomerAddress.tsx
+++ b/src/customers/components/CustomerAddress/CustomerAddress.tsx
@@ -6,7 +6,7 @@ import CardMenu from "@saleor/components/CardMenu";
 import CardTitle from "@saleor/components/CardTitle";
 import Skeleton from "@saleor/components/Skeleton";
 import React from "react";
-import { useIntl } from "react-intl";
+import { defineMessages, useIntl } from "react-intl";
 
 import { AddressTypeEnum } from "../../../types/globalTypes";
 import { CustomerAddresses_user_addresses } from "../../types/CustomerAddresses";
@@ -21,6 +21,34 @@ export interface CustomerAddressProps {
   onRemove: () => void;
   onSetAsDefault: (type: AddressTypeEnum) => void;
 }
+
+const messages = defineMessages({
+  defaultAddress: {
+    defaultMessage: "Default Address"
+  },
+  defaultShippingAddress: {
+    defaultMessage: "Default Shipping Address"
+  },
+  defaultBillingAddress: {
+    defaultMessage: "Default Billing Address"
+  },
+  setDefaultShipping: {
+    defaultMessage: "Set as default shipping address",
+    description: "button"
+  },
+  setDefaultBilling: {
+    defaultMessage: "Set as default billing address",
+    description: "button"
+  },
+  editAddress: {
+    defaultMessage: "Edit Address",
+    description: "button"
+  },
+  deleteAddress: {
+    defaultMessage: "Delete Address",
+    description: "button"
+  }
+});
 
 const useStyles = makeStyles(
   {
@@ -61,17 +89,11 @@ const CustomerAddress: React.FC<CustomerAddressProps> = props => {
           address ? (
             <>
               {isDefaultBillingAddress && isDefaultShippingAddress
-                ? intl.formatMessage({
-                    defaultMessage: "Default Address"
-                  })
+                ? intl.formatMessage(messages.defaultAddress)
                 : isDefaultShippingAddress
-                ? intl.formatMessage({
-                    defaultMessage: "Default Shipping Address"
-                  })
+                ? intl.formatMessage(messages.defaultShippingAddress)
                 : isDefaultBillingAddress
-                ? intl.formatMessage({
-                    defaultMessage: "Default Billing Address"
-                  })
+                ? intl.formatMessage(messages.defaultBillingAddress)
                 : null}
             </>
           ) : (
@@ -84,31 +106,19 @@ const CustomerAddress: React.FC<CustomerAddressProps> = props => {
             disabled={disabled}
             menuItems={[
               {
-                label: intl.formatMessage({
-                  defaultMessage: "Set as default shipping address",
-                  description: "button"
-                }),
+                label: intl.formatMessage(messages.setDefaultShipping),
                 onSelect: () => onSetAsDefault(AddressTypeEnum.SHIPPING)
               },
               {
-                label: intl.formatMessage({
-                  defaultMessage: "Set as default billing address",
-                  description: "button"
-                }),
+                label: intl.formatMessage(messages.setDefaultBilling),
                 onSelect: () => onSetAsDefault(AddressTypeEnum.BILLING)
               },
               {
-                label: intl.formatMessage({
-                  defaultMessage: "Edit Address",
-                  description: "button"
-                }),
+                label: intl.formatMessage(messages.editAddress),
                 onSelect: () => onEdit()
               },
               {
-                label: intl.formatMessage({
-                  defaultMessage: "Delete Address",
-                  description: "button"
-                }),
+                label: intl.formatMessage(messages.deleteAddress),
                 onSelect: () => onRemove()
               }
             ]}

--- a/src/customers/components/CustomerAddress/CustomerAddress.tsx
+++ b/src/customers/components/CustomerAddress/CustomerAddress.tsx
@@ -1,6 +1,4 @@
-import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
-import CardActions from "@material-ui/core/CardActions";
 import CardContent from "@material-ui/core/CardContent";
 import { makeStyles } from "@material-ui/core/styles";
 import AddressFormatter from "@saleor/components/AddressFormatter";
@@ -9,7 +7,7 @@ import CardTitle from "@saleor/components/CardTitle";
 import Skeleton from "@saleor/components/Skeleton";
 import { buttonMessages } from "@saleor/intl";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import { AddressTypeEnum } from "../../../types/globalTypes";
 import { CustomerAddresses_user_addresses } from "../../types/CustomerAddresses";
@@ -99,6 +97,14 @@ const CustomerAddress: React.FC<CustomerAddressProps> = props => {
                   description: "button"
                 }),
                 onSelect: () => onSetAsDefault(AddressTypeEnum.BILLING)
+              },
+              {
+                label: intl.formatMessage(buttonMessages.edit),
+                onSelect: () => onEdit()
+              },
+              {
+                label: intl.formatMessage(buttonMessages.delete),
+                onSelect: () => onRemove()
               }
             ]}
           />
@@ -107,16 +113,6 @@ const CustomerAddress: React.FC<CustomerAddressProps> = props => {
       <CardContent>
         <AddressFormatter address={address} />
       </CardContent>
-      <div className={classes.actionsContainer}>
-        <CardActions className={classes.actions}>
-          <Button color="primary" disabled={disabled} onClick={onEdit}>
-            <FormattedMessage {...buttonMessages.edit} />
-          </Button>
-          <Button color="primary" disabled={disabled} onClick={onRemove}>
-            <FormattedMessage {...buttonMessages.delete} />
-          </Button>
-        </CardActions>
-      </div>
     </Card>
   );
 };

--- a/src/customers/components/CustomerAddress/CustomerAddress.tsx
+++ b/src/customers/components/CustomerAddress/CustomerAddress.tsx
@@ -5,7 +5,6 @@ import AddressFormatter from "@saleor/components/AddressFormatter";
 import CardMenu from "@saleor/components/CardMenu";
 import CardTitle from "@saleor/components/CardTitle";
 import Skeleton from "@saleor/components/Skeleton";
-import { buttonMessages } from "@saleor/intl";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -99,11 +98,17 @@ const CustomerAddress: React.FC<CustomerAddressProps> = props => {
                 onSelect: () => onSetAsDefault(AddressTypeEnum.BILLING)
               },
               {
-                label: intl.formatMessage(buttonMessages.edit),
+                label: intl.formatMessage({
+                  defaultMessage: "Edit Address",
+                  description: "button"
+                }),
                 onSelect: () => onEdit()
               },
               {
-                label: intl.formatMessage(buttonMessages.delete),
+                label: intl.formatMessage({
+                  defaultMessage: "Delete Address",
+                  description: "button"
+                }),
                 onSelect: () => onRemove()
               }
             ]}

--- a/src/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
+++ b/src/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
@@ -14,7 +14,6 @@ import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { buttonMessages } from "@saleor/intl";
-import { maybe } from "@saleor/misc";
 import { AddressInput } from "@saleor/types/globalTypes";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import React from "react";
@@ -59,7 +58,7 @@ const CustomerAddressDialog = withStyles(
     onConfirm
   }: CustomerAddressDialogProps & WithStyles<typeof styles>) => {
     const [countryDisplayName, setCountryDisplayName] = useStateFromProps(
-      maybe(() => address.country.country, "")
+      address?.country.country || ""
     );
     const {
       errors: validationErrors,
@@ -71,27 +70,24 @@ const CustomerAddressDialog = withStyles(
     );
 
     const initialForm: AddressTypeInput = {
-      city: maybe(() => address.city, ""),
-      cityArea: maybe(() => address.cityArea, ""),
-      companyName: maybe(() => address.companyName, ""),
-      country: maybe(() => address.country.code, ""),
-      countryArea: maybe(() => address.countryArea, ""),
-      firstName: maybe(() => address.firstName, ""),
-      lastName: maybe(() => address.lastName, ""),
-      phone: maybe(() => address.phone, ""),
-      postalCode: maybe(() => address.postalCode, ""),
-      streetAddress1: maybe(() => address.streetAddress1, ""),
-      streetAddress2: maybe(() => address.streetAddress2, "")
+      city: address?.city || "",
+      cityArea: address?.cityArea || "",
+      companyName: address?.companyName || "",
+      country: address?.country.code || "",
+      countryArea: address?.countryArea || "",
+      firstName: address?.firstName || "",
+      lastName: address?.lastName || "",
+      phone: address?.phone || "",
+      postalCode: address?.postalCode || "",
+      streetAddress1: address?.streetAddress1 || "",
+      streetAddress2: address?.streetAddress2 || ""
     };
 
-    const countryChoices = maybe(
-      () =>
-        countries.map(country => ({
-          label: country.label,
-          value: country.code
-        })),
-      []
-    );
+    const countryChoices =
+      countries?.map(country => ({
+        label: country.label,
+        value: country.code
+      })) || [];
 
     return (
       <Dialog

--- a/src/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
+++ b/src/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
@@ -6,7 +6,7 @@ import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
 import { renderCollection } from "@saleor/misc";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { defineMessages, useIntl } from "react-intl";
 
 import { AddressTypeEnum } from "../../../types/globalTypes";
 import { CustomerAddresses_user } from "../../types/CustomerAddresses";
@@ -21,6 +21,28 @@ export interface CustomerAddressListPageProps {
   onRemove: (id: string) => void;
   onSetAsDefault: (id: string, type: AddressTypeEnum) => void;
 }
+
+const messages = defineMessages({
+  fullNameAddress: {
+    defaultMessage: "{fullName}'s Address Book",
+    description: "customer's address book, header"
+  },
+  fullNameDetail: {
+    defaultMessage: "{fullName} Details",
+    description: "customer details, header"
+  },
+  addAddress: {
+    defaultMessage: "Add address",
+    description: "button"
+  },
+  noAddressToShow: {
+    defaultMessage: "There is no address to show for this customer"
+  },
+  doesntHaveAddresses: {
+    defaultMessage:
+      "This customer doesn’t have any adresses added to his address book. You can add address using the button below."
+  }
+});
 
 const useStyles = makeStyles(
   theme => ({
@@ -38,7 +60,13 @@ const useStyles = makeStyles(
     root: {
       display: "grid",
       gap: `${theme.spacing(3)}px`,
-      gridTemplateColumns: "repeat(3, 1fr)"
+      gridTemplateColumns: "repeat(3, 1fr)",
+      [theme.breakpoints.down("md")]: {
+        gridTemplateColumns: "repeat(2, 1fr)"
+      },
+      [theme.breakpoints.down("sm")]: {
+        gridTemplateColumns: "repeat(1, 1fr)"
+      }
     }
   }),
   { name: "CustomerAddressListPage" }
@@ -64,41 +92,24 @@ const CustomerAddressListPage: React.FC<CustomerAddressListPageProps> = props =>
   return (
     <Container>
       <AppHeader onBack={onBack}>
-        <FormattedMessage
-          defaultMessage="{fullName} Details"
-          description="customer details, header"
-          values={{
-            fullName
-          }}
-        />
+        {intl.formatMessage(messages.fullNameDetail, { fullName })}
       </AppHeader>
       {!isEmpty && (
         <PageHeader
-          title={intl.formatMessage(
-            {
-              defaultMessage: "{fullName}'s Address Book",
-              description: "customer's address book, header"
-            },
-            {
-              fullName
-            }
-          )}
+          title={intl.formatMessage(messages.fullNameAddress, { fullName })}
         >
           <Button color="primary" variant="contained" onClick={onAdd}>
-            <FormattedMessage
-              defaultMessage="Add address"
-              description="button"
-            />
+            {intl.formatMessage(messages.addAddress)}
           </Button>
         </PageHeader>
       )}
       {isEmpty ? (
         <div className={classes.empty}>
           <Typography variant="h5">
-            <FormattedMessage defaultMessage="There is no address to show for this customer" />
+            {intl.formatMessage(messages.noAddressToShow)}
           </Typography>
           <Typography className={classes.description}>
-            <FormattedMessage defaultMessage="This customer doesn’t have any adresses added to his address book. You can add address using the button below." />
+            {intl.formatMessage(messages.doesntHaveAddresses)}
           </Typography>
           <Button
             className={classes.addButton}
@@ -106,10 +117,7 @@ const CustomerAddressListPage: React.FC<CustomerAddressListPageProps> = props =>
             variant="contained"
             onClick={onAdd}
           >
-            <FormattedMessage
-              defaultMessage="Add address"
-              description="button"
-            />
+            {intl.formatMessage(messages.addAddress)}
           </Button>
         </div>
       ) : (

--- a/src/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
+++ b/src/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
@@ -36,10 +36,9 @@ const useStyles = makeStyles(
       width: 600
     },
     root: {
-      columnGap: theme.spacing(3),
       display: "grid",
-      gridTemplateColumns: "repeat(3, 1fr)",
-      rowGap: theme.spacing(3)
+      gap: `${theme.spacing(3)}px`,
+      gridTemplateColumns: "repeat(3, 1fr)"
     }
   }),
   { name: "CustomerAddressListPage" }

--- a/src/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
+++ b/src/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
@@ -4,10 +4,10 @@ import Typography from "@material-ui/core/Typography";
 import AppHeader from "@saleor/components/AppHeader";
 import Container from "@saleor/components/Container";
 import PageHeader from "@saleor/components/PageHeader";
+import { renderCollection } from "@saleor/misc";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { maybe, renderCollection } from "../../../misc";
 import { AddressTypeEnum } from "../../../types/globalTypes";
 import { CustomerAddresses_user } from "../../types/CustomerAddresses";
 import CustomerAddress from "../CustomerAddress/CustomerAddress";
@@ -58,11 +58,8 @@ const CustomerAddressListPage: React.FC<CustomerAddressListPageProps> = props =>
 
   const intl = useIntl();
 
-  const isEmpty = maybe(() => customer.addresses.length) === 0;
-  const fullName = maybe(
-    () => [customer.firstName, customer.lastName].join(" "),
-    "..."
-  );
+  const isEmpty = customer?.addresses?.length === 0;
+  const fullName = [customer?.firstName, customer?.lastName].join(" ") || "...";
 
   return (
     <Container>
@@ -117,28 +114,23 @@ const CustomerAddressListPage: React.FC<CustomerAddressListPageProps> = props =>
         </div>
       ) : (
         <div className={classes.root}>
-          {renderCollection(
-            maybe(() => customer.addresses),
-            (address, addressNumber) => (
-              <CustomerAddress
-                address={address}
-                addressNumber={addressNumber + 1}
-                disabled={disabled}
-                isDefaultBillingAddress={
-                  maybe(() => customer.defaultBillingAddress.id) ===
-                  maybe(() => address.id)
-                }
-                isDefaultShippingAddress={
-                  maybe(() => customer.defaultShippingAddress.id) ===
-                  maybe(() => address.id)
-                }
-                onEdit={() => onEdit(address.id)}
-                onRemove={() => onRemove(address.id)}
-                onSetAsDefault={type => onSetAsDefault(address.id, type)}
-                key={maybe(() => address.id, "skeleton")}
-              />
-            )
-          )}
+          {renderCollection(customer?.addresses, (address, addressNumber) => (
+            <CustomerAddress
+              address={address}
+              addressNumber={addressNumber + 1}
+              disabled={disabled}
+              isDefaultBillingAddress={
+                customer?.defaultBillingAddress?.id === address?.id
+              }
+              isDefaultShippingAddress={
+                customer?.defaultShippingAddress?.id === address?.id
+              }
+              onEdit={() => onEdit(address.id)}
+              onRemove={() => onRemove(address.id)}
+              onSetAsDefault={type => onSetAsDefault(address.id, type)}
+              key={address?.id || "skeleton"}
+            />
+          ))}
         </div>
       )}
     </Container>

--- a/src/customers/views/CustomerAddresses.tsx
+++ b/src/customers/views/CustomerAddresses.tsx
@@ -9,7 +9,6 @@ import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandl
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { maybe } from "../../misc";
 import CustomerAddressDialog from "../components/CustomerAddressDialog";
 import CustomerAddressListPage from "../components/CustomerAddressListPage";
 import {
@@ -102,23 +101,20 @@ const CustomerAddresses: React.FC<CustomerAddressesProps> = ({
                   {(removeCustomerAddress, removeCustomerAddressOpts) => (
                     <TypedCustomerAddressesQuery variables={{ id }}>
                       {customerData => {
-                        const countryChoices = maybe(
-                          () =>
-                            shop.countries.map(country => ({
-                              code: country.code,
-                              label: country.country
-                            })),
-                          []
-                        );
+                        const countryChoices =
+                          shop?.countries?.map(country => ({
+                            code: country.code,
+                            label: country.country
+                          })) || [];
 
                         return (
                           <>
                             <WindowTitle
-                              title={maybe(() => customerData.data.user.email)}
+                              title={customerData?.data?.user.email}
                             />
                             <CustomerAddressListPage
-                              customer={maybe(() => customerData.data.user)}
-                              disabled={customerData.loading}
+                              customer={customerData?.data?.user}
+                              disabled={customerData?.loading}
                               onAdd={() => openModal("add")}
                               onBack={() => navigate(customerUrl(id))}
                               onEdit={id =>
@@ -143,12 +139,10 @@ const CustomerAddresses: React.FC<CustomerAddressesProps> = ({
                                 createCustomerAddressOpts.status
                               }
                               countries={countryChoices}
-                              errors={maybe(
-                                () =>
-                                  createCustomerAddressOpts.data.addressCreate
-                                    .errors,
-                                []
-                              )}
+                              errors={
+                                createCustomerAddressOpts?.data?.addressCreate
+                                  .errors || []
+                              }
                               open={params.action === "add"}
                               variant="create"
                               onClose={closeModal}
@@ -162,21 +156,17 @@ const CustomerAddresses: React.FC<CustomerAddressesProps> = ({
                               }
                             />
                             <CustomerAddressDialog
-                              address={maybe(() =>
-                                customerData.data.user.addresses.find(
-                                  addr => addr.id === params.id
-                                )
+                              address={customerData?.data?.user.addresses.find(
+                                addr => addr.id === params.id
                               )}
                               confirmButtonState={
                                 updateCustomerAddressOpts.status
                               }
                               countries={countryChoices}
-                              errors={maybe(
-                                () =>
-                                  updateCustomerAddressOpts.data.addressUpdate
-                                    .errors,
-                                []
-                              )}
+                              errors={
+                                updateCustomerAddressOpts?.data?.addressUpdate
+                                  .errors || []
+                              }
                               open={params.action === "edit"}
                               variant="edit"
                               onClose={closeModal}

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -198,17 +198,17 @@ export const transformOrderStatus = (
 };
 
 export const transformAddressToForm = (data: AddressType) => ({
-  city: maybe(() => data.city, ""),
-  cityArea: maybe(() => data.cityArea, ""),
-  companyName: maybe(() => data.companyName, ""),
-  country: maybe(() => data.country.code, ""),
-  countryArea: maybe(() => data.countryArea, ""),
-  firstName: maybe(() => data.firstName, ""),
-  lastName: maybe(() => data.lastName, ""),
-  phone: maybe(() => data.phone, ""),
-  postalCode: maybe(() => data.postalCode, ""),
-  streetAddress1: maybe(() => data.streetAddress1, ""),
-  streetAddress2: maybe(() => data.streetAddress2, "")
+  city: data?.city || "",
+  cityArea: data?.cityArea || "",
+  companyName: data?.companyName || "",
+  country: data?.country?.code || "",
+  countryArea: data?.countryArea || "",
+  firstName: data?.firstName || "",
+  lastName: data?.lastName || "",
+  phone: data?.phone || "",
+  postalCode: data?.postalCode || "",
+  streetAddress1: data?.streetAddress1 || "",
+  streetAddress2: data?.streetAddress2 || ""
 });
 
 export const authorizationKeyTypes = {


### PR DESCRIPTION
I want to merge this change because... it:
- fixes styles on address `dashboard/customers/[ID]/addresses`
- moves `Delete` and `Edit` to dropdown menu
- adds `phone` field
- removes some `maybe()`

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/29279389/102905531-95cb7980-4473-11eb-86d3-89f263bd1327.png)

After:
![image](https://user-images.githubusercontent.com/29279389/102905054-e4c4df00-4472-11eb-86c7-b6857f11d9b9.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
