### PR TITLE
1862 - Add references field to attributes section

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1540,6 +1540,10 @@
   "src_dot_components_dot_AttributeUnassignDialog_dot_2037985699": {
     "string": "Are you sure you want to unassign {attributeName} from {itemTypeName}?"
   },
+  "src_dot_components_dot_Attributes_dot_3824528779": {
+    "context": "button label",
+    "string": "Assign references"
+  },
   "src_dot_components_dot_Attributes_dot_attributesNumber": {
     "context": "number of attributes",
     "string": "{number} Attributes"

--- a/schema.graphql
+++ b/schema.graphql
@@ -393,6 +393,7 @@ type Attribute implements Node & ObjectWithMetadata {
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   inputType: AttributeInputTypeEnum
+  entityType: AttributeEntityTypeEnum
   name: String
   slug: String
   type: AttributeTypeEnum
@@ -431,6 +432,7 @@ type AttributeCreate {
 
 input AttributeCreateInput {
   inputType: AttributeInputTypeEnum
+  entityType: AttributeEntityTypeEnum
   name: String!
   slug: String
   type: AttributeTypeEnum!
@@ -448,6 +450,10 @@ type AttributeDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attributeErrors: [AttributeError!]!
   attribute: Attribute
+}
+
+enum AttributeEntityTypeEnum {
+  PAGE
 }
 
 type AttributeError {
@@ -490,6 +496,7 @@ enum AttributeInputTypeEnum {
   DROPDOWN
   MULTISELECT
   FILE
+  REFERENCE
 }
 
 type AttributeReorderValues {
@@ -566,6 +573,7 @@ type AttributeValue implements Node {
   type: AttributeValueType @deprecated(reason: "Use the `inputType` field to determine the type of attribute's value. This field will be removed after 2020-07-31.")
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
   inputType: AttributeInputTypeEnum
+  reference: ID
   file: File
 }
 
@@ -598,6 +606,7 @@ input AttributeValueInput {
   values: [String]
   file: String
   contentType: String
+  references: [ID!]
 }
 
 type AttributeValueTranslatableContent implements Node {
@@ -672,6 +681,7 @@ type BulkProductError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
   index: Int
   warehouses: [ID!]
   channels: [ID!]
@@ -682,6 +692,7 @@ type BulkStockError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
   index: Int
 }
 
@@ -806,6 +817,7 @@ type Channel implements Node {
   isActive: Boolean!
   slug: String!
   currencyCode: String!
+  hasOrders: Boolean!
 }
 
 type ChannelActivate {
@@ -858,6 +870,7 @@ enum ChannelErrorCode {
   UNIQUE
   CHANNEL_TARGET_ID_MUST_BE_DIFFERENT
   CHANNELS_CURRENCY_MUST_BE_THE_SAME
+  CHANNEL_WITH_ORDERS
 }
 
 type ChannelUpdate {
@@ -1109,6 +1122,7 @@ type CollectionChannelListingError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
   channels: [ID!]
 }
 
@@ -2625,6 +2639,7 @@ type Mutation {
   productTypeBulkDelete(ids: [ID]!): ProductTypeBulkDelete
   productTypeUpdate(id: ID!, input: ProductTypeInput!): ProductTypeUpdate
   productTypeReorderAttributes(moves: [ReorderInput]!, productTypeId: ID!, type: ProductAttributeType!): ProductTypeReorderAttributes
+  productReorderAttributeValues(attributeId: ID!, moves: [ReorderInput]!, productId: ID!): ProductReorderAttributeValues
   digitalContentCreate(input: DigitalContentUploadInput!, variantId: ID!): DigitalContentCreate
   digitalContentDelete(variantId: ID!): DigitalContentDelete
   digitalContentUpdate(input: DigitalContentInput!, variantId: ID!): DigitalContentUpdate
@@ -2640,6 +2655,7 @@ type Mutation {
   productVariantSetDefault(productId: ID!, variantId: ID!): ProductVariantSetDefault
   productVariantTranslate(id: ID!, input: NameTranslationInput!, languageCode: LanguageCodeEnum!): ProductVariantTranslate
   productVariantChannelListingUpdate(id: ID!, input: [ProductVariantChannelListingAddInput!]!): ProductVariantChannelListingUpdate
+  productVariantReorderAttributeValues(attributeId: ID!, moves: [ReorderInput]!, variantId: ID!): ProductVariantReorderAttributeValues
   variantImageAssign(imageId: ID!, variantId: ID!): VariantImageAssign
   variantImageUnassign(imageId: ID!, variantId: ID!): VariantImageUnassign
   paymentCapture(amount: PositiveDecimal, paymentId: ID!): PaymentCapture
@@ -2659,6 +2675,7 @@ type Mutation {
   pageAttributeAssign(attributeIds: [ID!]!, pageTypeId: ID!): PageAttributeAssign
   pageAttributeUnassign(attributeIds: [ID!]!, pageTypeId: ID!): PageAttributeUnassign
   pageTypeReorderAttributes(moves: [ReorderInput!]!, pageTypeId: ID!): PageTypeReorderAttributes
+  pageReorderAttributeValues(attributeId: ID!, moves: [ReorderInput]!, pageId: ID!): PageReorderAttributeValues
   draftOrderComplete(id: ID!): DraftOrderComplete
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
@@ -2742,7 +2759,7 @@ type Mutation {
   checkoutShippingMethodUpdate(checkoutId: ID, shippingMethodId: ID!): CheckoutShippingMethodUpdate
   channelCreate(input: ChannelCreateInput!): ChannelCreate
   channelUpdate(id: ID!, input: ChannelUpdateInput!): ChannelUpdate
-  channelDelete(id: ID!, input: ChannelDeleteInput!): ChannelDelete
+  channelDelete(id: ID!, input: ChannelDeleteInput): ChannelDelete
   channelActivate(id: ID!): ChannelActivate
   channelDeactivate(id: ID!): ChannelDeactivate
   attributeCreate(input: AttributeCreateInput!): AttributeCreate
@@ -3318,6 +3335,7 @@ type PageError {
   message: String
   code: PageErrorCode!
   attributes: [ID!]
+  values: [ID!]
 }
 
 enum PageErrorCode {
@@ -3350,6 +3368,12 @@ input PageInput {
   isPublished: Boolean
   publicationDate: String
   seo: SeoInput
+}
+
+type PageReorderAttributeValues {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  page: Page
+  pageErrors: [PageError!]!
 }
 
 enum PageSortField {
@@ -3849,6 +3873,7 @@ type ProductChannelListingError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
   channels: [ID!]
 }
 
@@ -3907,6 +3932,7 @@ type ProductError {
   message: String
   code: ProductErrorCode!
   attributes: [ID!]
+  values: [ID!]
 }
 
 enum ProductErrorCode {
@@ -4052,6 +4078,12 @@ type ProductPricingInfo {
   priceRange: TaxedMoneyRange
   priceRangeUndiscounted: TaxedMoneyRange
   priceRangeLocalCurrency: TaxedMoneyRange
+}
+
+type ProductReorderAttributeValues {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  product: Product
+  productErrors: [ProductError!]!
 }
 
 input ProductStockFilterInput {
@@ -4200,8 +4232,12 @@ type ProductVariant implements Node & ObjectWithMetadata {
   weight: Weight
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
+  quantity: Int! @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
+  quantityAllocated: Int @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
+  stockQuantity: Int! @deprecated(reason: "Use the quantityAvailable field instead. This field will be removed after 2020-07-31.")
   channelListings: [ProductVariantChannelListing!]
   pricing: VariantPricingInfo
+  isAvailable: Boolean @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
   attributes(variantSelection: VariantAttributeScope): [SelectedAttribute!]!
   costPrice: Money
   margin: Int
@@ -4303,6 +4339,12 @@ input ProductVariantInput {
 type ProductVariantReorder {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
+  productErrors: [ProductError!]!
+}
+
+type ProductVariantReorderAttributeValues {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  productVariant: ProductVariant
   productErrors: [ProductError!]!
 }
 
@@ -4422,7 +4464,7 @@ type Query {
   channel(id: ID): Channel
   channels: [Channel!]
   attributes(filter: AttributeFilterInput, sortBy: AttributeSortingInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
-  attribute(id: ID!): Attribute
+  attribute(id: ID, slug: String): Attribute
   appsInstallations: [AppInstallation!]!
   apps(filter: AppFilterInput, sortBy: AppSortingInput, before: String, after: String, first: Int, last: Int): AppCountableConnection
   app(id: ID!): App

--- a/src/components/Attributes/Attributes.stories.tsx
+++ b/src/components/Attributes/Attributes.stories.tsx
@@ -12,7 +12,10 @@ const props: AttributesProps = {
   loading: false,
   onChange: () => undefined,
   onFileChange: () => undefined,
-  onMultiChange: () => undefined
+  onMultiChange: () => undefined,
+  onReferencesChange: () => undefined,
+  onReferencesChangeClick: () => undefined,
+  onReferencesReorder: () => undefined
 };
 
 storiesOf("Attributes / Attributes", module)

--- a/src/components/Attributes/BasicAttributeRow.tsx
+++ b/src/components/Attributes/BasicAttributeRow.tsx
@@ -1,0 +1,44 @@
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@saleor/components/Grid";
+import React from "react";
+
+const useStyles = makeStyles(
+  theme => ({
+    attributeSection: {
+      "&:last-of-type": {
+        paddingBottom: 0
+      },
+      padding: theme.spacing(2, 0)
+    },
+    attributeSectionLabel: {
+      alignItems: "center",
+      display: "flex"
+    }
+  }),
+  { name: "BasicAttributeRow" }
+);
+
+interface BasicAttributeRowProps {
+  label: string;
+}
+
+const BasicAttributeRow: React.FC<BasicAttributeRowProps> = props => {
+  const { label, children } = props;
+  const classes = useStyles(props);
+
+  return (
+    <Grid className={classes.attributeSection} variant="uniform">
+      <div
+        className={classes.attributeSectionLabel}
+        data-test="attribute-label"
+      >
+        <Typography>{label}</Typography>
+      </div>
+      <div data-test="attribute-value">{children}</div>
+    </Grid>
+  );
+};
+
+BasicAttributeRow.displayName = "BasicAttributeRow";
+export default BasicAttributeRow;

--- a/src/components/Attributes/ExtendedAttributeRow.tsx
+++ b/src/components/Attributes/ExtendedAttributeRow.tsx
@@ -1,0 +1,65 @@
+import Button from "@material-ui/core/Button";
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@saleor/components/Grid";
+import React from "react";
+
+const useStyles = makeStyles(
+  theme => ({
+    attributeSection: {
+      "&:last-of-type": {
+        paddingBottom: 0
+      },
+      padding: theme.spacing(2, 0)
+    },
+    attributeSectionButton: {
+      float: "right"
+    },
+    attributeSectionLabel: {
+      alignItems: "center",
+      display: "flex"
+    }
+  }),
+  { name: "ExtendedAttributeRow" }
+);
+
+interface ExtendedAttributeRowProps {
+  label: string;
+  selectLabel: string;
+  disabled: boolean;
+  onSelect: () => void;
+}
+
+const ExtendedAttributeRow: React.FC<ExtendedAttributeRowProps> = props => {
+  const { label, selectLabel, disabled, onSelect, children } = props;
+  const classes = useStyles(props);
+
+  return (
+    <>
+      <Grid className={classes.attributeSection} variant="uniform">
+        <div
+          className={classes.attributeSectionLabel}
+          data-test="attribute-label"
+        >
+          <Typography>{label}</Typography>
+        </div>
+        <div data-test="attribute-selector">
+          <Button
+            className={classes.attributeSectionButton}
+            disabled={disabled}
+            variant="text"
+            color="primary"
+            data-test="button-attribute-selector"
+            onClick={onSelect}
+          >
+            {selectLabel}
+          </Button>
+        </div>
+      </Grid>
+      <div data-test="attribute-value">{children}</div>
+    </>
+  );
+};
+
+ExtendedAttributeRow.displayName = "ExtendedAttributeRow";
+export default ExtendedAttributeRow;

--- a/src/components/Attributes/fixtures.ts
+++ b/src/components/Attributes/fixtures.ts
@@ -79,15 +79,49 @@ const FILE_ATTRIBUTE: AttributeInput = {
       }
     ]
   },
-  id: "ifudbgidfsb",
+  id: "fguygygugyu",
   label: "File Attribute",
+  value: []
+};
+
+const REFERENCE_ATTRIBUTE: AttributeInput = {
+  data: {
+    inputType: AttributeInputTypeEnum.REFERENCE,
+    isRequired: true,
+    values: [
+      {
+        __typename: "AttributeValue",
+        file: null,
+        id: "vbnhgcvjhbvhj",
+        name: "References First Value",
+        slug: "references-first-value"
+      },
+      {
+        __typename: "AttributeValue",
+        file: null,
+        id: "gucngdfdfvdvd",
+        name: "References Second Value",
+        slug: "references-second-value"
+      },
+      {
+        __typename: "AttributeValue",
+        file: null,
+        id: "dfdfdsfdsfdse",
+        name: "References Third Value",
+        slug: "references-third-value"
+      }
+    ]
+  },
+  id: "kclsmcdsmcs",
+  label: "References Attribute",
   value: []
 };
 
 export const ATTRIBUTES: AttributeInput[] = [
   DROPDOWN_ATTRIBUTE,
   MULTISELECT_ATTRIBUTE,
-  FILE_ATTRIBUTE
+  FILE_ATTRIBUTE,
+  REFERENCE_ATTRIBUTE
 ];
 
 export const ATTRIBUTES_SELECTED: AttributeInput[] = [
@@ -105,5 +139,13 @@ export const ATTRIBUTES_SELECTED: AttributeInput[] = [
   {
     ...FILE_ATTRIBUTE,
     value: [FILE_ATTRIBUTE.data.values[0].slug]
+  },
+  {
+    ...REFERENCE_ATTRIBUTE,
+    value: [
+      REFERENCE_ATTRIBUTE.data.values[0].slug,
+      REFERENCE_ATTRIBUTE.data.values[1].slug,
+      REFERENCE_ATTRIBUTE.data.values[2].slug
+    ]
   }
 ];

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -1,9 +1,8 @@
 import Chip, { ChipProps } from "@saleor/components/Chip";
+import CardDecorator from "@saleor/storybook/CardDecorator";
+import Decorator from "@saleor/storybook/Decorator";
 import { storiesOf } from "@storybook/react";
 import React from "react";
-
-import CardDecorator from "../../CardDecorator";
-import Decorator from "../../Decorator";
 
 const props: ChipProps = {
   label: "Lorem Ipsum"

--- a/src/components/SortableChip/SortableChip.stories.tsx
+++ b/src/components/SortableChip/SortableChip.stories.tsx
@@ -1,0 +1,29 @@
+import SortableChip, {
+  SortableChipProps
+} from "@saleor/components/SortableChip";
+import CardDecorator from "@saleor/storybook/CardDecorator";
+import Decorator from "@saleor/storybook/Decorator";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+import { SortableContainer } from "react-sortable-hoc";
+
+const Container = SortableContainer(props => props.children);
+
+const props: SortableChipProps = {
+  index: 0,
+  label: "Lorem Ipsum"
+};
+
+storiesOf("Generics / Sortable chip", module)
+  .addDecorator(CardDecorator)
+  .addDecorator(Decorator)
+  .add("default", () => (
+    <Container>
+      <SortableChip {...props} />
+    </Container>
+  ))
+  .add("with x", () => (
+    <Container>
+      <SortableChip {...props} onClose={() => undefined} />
+    </Container>
+  ));

--- a/src/components/SortableChip/SortableChip.tsx
+++ b/src/components/SortableChip/SortableChip.tsx
@@ -1,0 +1,68 @@
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import CloseIcon from "@material-ui/icons/Close";
+import classNames from "classnames";
+import React from "react";
+import { SortableElement, SortableElementProps } from "react-sortable-hoc";
+
+import SortableHandle from "./SortableHandle";
+
+export interface SortableChipProps extends SortableElementProps {
+  className?: string;
+  label: React.ReactNode;
+  onClose?: () => void;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    closeIcon: {
+      cursor: "pointer",
+      fontSize: 16,
+      marginLeft: theme.spacing(),
+      verticalAlign: "middle"
+    },
+    content: {
+      alignItems: "center",
+      display: "flex"
+    },
+    root: {
+      border: `1px solid ${theme.palette.divider}`,
+      borderRadius: 18,
+      display: "inline-block",
+      marginRight: theme.spacing(2),
+      padding: "6px 12px"
+    },
+    sortableHandle: {
+      marginRight: theme.spacing(1)
+    }
+  }),
+  { name: "SortableChip" }
+);
+
+const SortableChip = SortableElement<SortableChipProps>(props => {
+  const { className, label, onClose } = props;
+
+  const classes = useStyles(props);
+
+  return (
+    <div className={classNames(classes.root, className)}>
+      <div className={classes.content}>
+        <SortableHandle
+          className={classes.sortableHandle}
+          data-test="button-drag-handle"
+        />
+        <Typography data-test="chip-label">{label}</Typography>
+        {onClose && (
+          <CloseIcon
+            className={classes.closeIcon}
+            onClick={onClose}
+            data-test="button-close"
+          />
+        )}
+      </div>
+    </div>
+  );
+});
+
+SortableChip.displayName = "SortableChip";
+export default SortableChip;

--- a/src/components/SortableChip/SortableHandle.tsx
+++ b/src/components/SortableChip/SortableHandle.tsx
@@ -1,0 +1,29 @@
+import { makeStyles } from "@material-ui/core/styles";
+import Draggable from "@saleor/icons/Draggable";
+import classNames from "classnames";
+import React from "react";
+import { SortableHandle as SortableHandleHoc } from "react-sortable-hoc";
+
+const useStyles = makeStyles(
+  {
+    drag: {
+      cursor: "grab"
+    }
+  },
+  { name: "SortableHandle" }
+);
+
+interface SortableHandle {
+  className?: string;
+}
+
+const SortableHandle = SortableHandleHoc(props => {
+  const { className, ...restProps } = props;
+  const classes = useStyles(props);
+
+  return (
+    <Draggable className={classNames(classes.drag, className)} {...restProps} />
+  );
+});
+
+export default SortableHandle;

--- a/src/components/SortableChip/index.ts
+++ b/src/components/SortableChip/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./SortableChip";
+export * from "./SortableChip";

--- a/src/components/SortableChipsField/SortableChipsField.stories.tsx
+++ b/src/components/SortableChipsField/SortableChipsField.stories.tsx
@@ -1,0 +1,27 @@
+import CardDecorator from "@saleor/storybook/CardDecorator";
+import Decorator from "@saleor/storybook/Decorator";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import SortableChipsField, {
+  SortableChipsFieldProps
+} from "./SortableChipsField";
+
+const props: SortableChipsFieldProps = {
+  onValueDelete: () => undefined,
+  onValueReorder: () => undefined,
+  values: [
+    { label: "Item 1", value: "item-1" },
+    { label: "Item 2", value: "item-2" },
+    { label: "Item 3", value: "item-3" },
+    { label: "Item 4", value: "item-4" },
+    { label: "Item 5", value: "item-5" },
+    { label: "Item 6", value: "item-6" }
+  ]
+};
+
+storiesOf("Generics / Sortable chips field", module)
+  .addDecorator(CardDecorator)
+  .addDecorator(Decorator)
+  .add("default", () => <SortableChipsField {...props} />)
+  .add("loading", () => <SortableChipsField {...props} loading={true} />);

--- a/src/components/SortableChipsField/SortableChipsField.tsx
+++ b/src/components/SortableChipsField/SortableChipsField.tsx
@@ -13,8 +13,7 @@ const useStyles = makeStyles(
       background: "#fff",
       color: theme.palette.primary.dark,
       marginBottom: theme.spacing(1)
-    },
-    chipContainer: {}
+    }
   }),
   {
     name: "SortableChipsField"
@@ -44,7 +43,7 @@ const SortableChipsField: React.FC<SortableChipsFieldProps> = props => {
       useDragHandle
       onSortEnd={onValueReorder}
     >
-      <div className={classes.chipContainer}>
+      <div>
         {loading ? (
           <Skeleton />
         ) : (

--- a/src/components/SortableChipsField/SortableChipsField.tsx
+++ b/src/components/SortableChipsField/SortableChipsField.tsx
@@ -1,0 +1,67 @@
+import { makeStyles } from "@material-ui/core/styles";
+import { ReorderAction } from "@saleor/types";
+import React from "react";
+import { SortableContainerProps } from "react-sortable-hoc";
+
+import Skeleton from "../Skeleton";
+import DraggableChip from "../SortableChip";
+import SortableContainer from "./SortableContainer";
+
+const useStyles = makeStyles(
+  theme => ({
+    chip: {
+      background: "#fff",
+      color: theme.palette.primary.dark,
+      marginBottom: theme.spacing(1)
+    },
+    chipContainer: {}
+  }),
+  {
+    name: "SortableChipsField"
+  }
+);
+
+interface SortableChipsFieldValueType {
+  label: string;
+  value: any;
+}
+
+export interface SortableChipsFieldProps extends SortableContainerProps {
+  loading?: boolean;
+  values: SortableChipsFieldValueType[];
+  onValueDelete: (id: string) => void;
+  onValueReorder: ReorderAction;
+}
+
+const SortableChipsField: React.FC<SortableChipsFieldProps> = props => {
+  const { loading, values, onValueDelete, onValueReorder } = props;
+  const classes = useStyles(props);
+
+  return (
+    <SortableContainer
+      axis="xy"
+      lockAxis="xy"
+      useDragHandle
+      onSortEnd={onValueReorder}
+    >
+      <div className={classes.chipContainer}>
+        {loading ? (
+          <Skeleton />
+        ) : (
+          values.map((value, valueIndex) => (
+            <DraggableChip
+              className={classes.chip}
+              key={valueIndex}
+              index={valueIndex}
+              label={value.label}
+              onClose={() => onValueDelete(value.value)}
+            />
+          ))
+        )}
+      </div>
+    </SortableContainer>
+  );
+};
+
+SortableChipsField.displayName = "SortableChipsField";
+export default SortableChipsField;

--- a/src/components/SortableChipsField/SortableContainer.tsx
+++ b/src/components/SortableChipsField/SortableContainer.tsx
@@ -1,0 +1,5 @@
+import { SortableContainer as SortableContainerHoc } from "react-sortable-hoc";
+
+const SortableContainer = SortableContainerHoc(({ children }) => children);
+
+export default SortableContainer;

--- a/src/components/SortableChipsField/index.ts
+++ b/src/components/SortableChipsField/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./SortableChipsField";
+export * from "./SortableChipsField";

--- a/src/storybook/config.js
+++ b/src/storybook/config.js
@@ -16,7 +16,6 @@ function loadStories() {
   require("./stories/components/AutocompleteSelectMenu");
   require("./stories/components/CardMenu");
   require("./stories/components/Checkbox");
-  require("./stories/components/Chip");
   require("./stories/components/ColumnPicker");
   require("./stories/components/Date");
   require("./stories/components/DateTime");

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -70,6 +70,10 @@ export enum AppTypeEnum {
   THIRDPARTY = "THIRDPARTY",
 }
 
+export enum AttributeEntityTypeEnum {
+  PAGE = "PAGE",
+}
+
 export enum AttributeErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
@@ -83,6 +87,7 @@ export enum AttributeInputTypeEnum {
   DROPDOWN = "DROPDOWN",
   FILE = "FILE",
   MULTISELECT = "MULTISELECT",
+  REFERENCE = "REFERENCE",
 }
 
 export enum AttributeSortField {
@@ -117,6 +122,7 @@ export enum ChannelErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
   CHANNELS_CURRENCY_MUST_BE_THE_SAME = "CHANNELS_CURRENCY_MUST_BE_THE_SAME",
   CHANNEL_TARGET_ID_MUST_BE_DIFFERENT = "CHANNEL_TARGET_ID_MUST_BE_DIFFERENT",
+  CHANNEL_WITH_ORDERS = "CHANNEL_WITH_ORDERS",
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
   INVALID = "INVALID",
   NOT_FOUND = "NOT_FOUND",
@@ -1026,6 +1032,7 @@ export interface AppTokenInput {
 
 export interface AttributeCreateInput {
   inputType?: AttributeInputTypeEnum | null;
+  entityType?: AttributeEntityTypeEnum | null;
   name: string;
   slug?: string | null;
   type: AttributeTypeEnum;
@@ -1088,6 +1095,7 @@ export interface AttributeValueInput {
   values?: (string | null)[] | null;
   file?: string | null;
   contentType?: string | null;
+  references?: string[] | null;
 }
 
 export interface AuthorizationKeyInput {


### PR DESCRIPTION
I want to merge this change because... it adds references field to attributes section.

Feature branch: https://github.com/mirumee/saleor-dashboard/pull/917

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> feature/page-reference-attributes
https://github.com/mirumee/saleor/pull/6624

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="986" alt="Zrzut ekranu 2020-12-22 o 22 15 20" src="https://user-images.githubusercontent.com/9825562/102936109-d3e29080-44a7-11eb-9e11-f86ceb9d87a4.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://feature-page-reference-attributes.api.saleor.rocks/graphql/
