### PR TITLE
Saleor 1712 dashboard unable to handle empty channel list

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3012,6 +3012,9 @@
   "src_dot_home_dot_components_dot_HomeActivityCard_dot_placed": {
     "string": "Order #{orderId} was placed"
   },
+  "src_dot_home_dot_components_dot_HomeNotificationTable_dot_createNewChannel": {
+    "string": "Create new channel"
+  },
   "src_dot_hooks_dot_3382262667": {
     "string": "Variant {name} has been set as default."
   },

--- a/src/categories/views/CategoryDetails.tsx
+++ b/src/categories/views/CategoryDetails.tsx
@@ -6,7 +6,6 @@ import useAppChannel from "@saleor/components/AppLayout/AppChannelContext";
 import NotFoundPage from "@saleor/components/NotFoundPage";
 import Skeleton from "@saleor/components/Skeleton";
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { channelDetailsFragment } from "@saleor/fragments/channels";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";

--- a/src/categories/views/CategoryDetails.tsx
+++ b/src/categories/views/CategoryDetails.tsx
@@ -4,7 +4,9 @@ import DeleteIcon from "@material-ui/icons/Delete";
 import ActionDialog from "@saleor/components/ActionDialog";
 import useAppChannel from "@saleor/components/AppLayout/AppChannelContext";
 import NotFoundPage from "@saleor/components/NotFoundPage";
+import Skeleton from "@saleor/components/Skeleton";
 import { WindowTitle } from "@saleor/components/WindowTitle";
+import { channelDetailsFragment } from "@saleor/fragments/channels";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
@@ -210,166 +212,179 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
   return (
     <>
       <WindowTitle title={maybe(() => data.category.name)} />
-      <CategoryUpdatePage
-        channelsCount={availableChannels.length}
-        channelChoices={channelChoices}
-        changeTab={changeTab}
-        currentTab={params.activeTab}
-        category={maybe(() => data.category)}
-        disabled={loading}
-        errors={updateResult.data?.categoryUpdate.errors || []}
-        onAddCategory={() => navigate(categoryAddUrl(id))}
-        onAddProduct={() => navigate(productAddUrl())}
-        onBack={() =>
-          navigate(
-            maybe(() => categoryUrl(data.category.parent.id), categoryListUrl())
-          )
-        }
-        onCategoryClick={id => () => navigate(categoryUrl(id))}
-        onDelete={() => openModal("delete")}
-        onImageDelete={() =>
-          updateCategory({
-            variables: {
-              id,
-              input: {
-                backgroundImage: null
-              }
-            }
-          })
-        }
-        onImageUpload={file =>
-          updateCategory({
-            variables: {
-              id,
-              input: {
-                backgroundImage: file
-              }
-            }
-          })
-        }
-        onNextPage={loadNextPage}
-        onPreviousPage={loadPreviousPage}
-        pageInfo={pageInfo}
-        onProductClick={id => () => navigate(productUrl(id))}
-        onSubmit={handleSubmit}
-        products={maybe(() =>
-          data.category.products.edges.map(edge => edge.node)
-        )}
-        saveButtonBarState={updateResult.status}
-        selectedChannelId={channel.id}
-        subcategories={maybe(() =>
-          data.category.children.edges.map(edge => edge.node)
-        )}
-        subcategoryListToolbar={
-          <IconButton
-            color="primary"
-            onClick={() =>
-              openModal("delete-categories", {
-                ids: listElements
-              })
-            }
-          >
-            <DeleteIcon />
-          </IconButton>
-        }
-        productListToolbar={
-          <IconButton
-            color="primary"
-            onClick={() =>
-              openModal("delete-products", {
-                ids: listElements
-              })
-            }
-          >
-            <DeleteIcon />
-          </IconButton>
-        }
-        isChecked={isSelected}
-        selected={listElements.length}
-        toggle={toggle}
-        toggleAll={toggleAll}
-      />
-      <ActionDialog
-        confirmButtonState={deleteResult.status}
-        onClose={closeModal}
-        onConfirm={() => deleteCategory({ variables: { id } })}
-        open={params.action === "delete"}
-        title={intl.formatMessage({
-          defaultMessage: "Delete category",
-          description: "dialog title"
-        })}
-        variant="delete"
-      >
-        <DialogContentText>
-          <FormattedMessage
-            defaultMessage="Are you sure you want to delete {categoryName}?"
-            values={{
-              categoryName: (
-                <strong>{maybe(() => data.category.name, "...")}</strong>
+      {typeof channel !== "undefined" ? (
+        <>
+          <CategoryUpdatePage
+            channelsCount={availableChannels.length}
+            channelChoices={channelChoices}
+            changeTab={changeTab}
+            currentTab={params.activeTab}
+            category={maybe(() => data.category)}
+            disabled={loading}
+            errors={updateResult.data?.categoryUpdate.errors || []}
+            onAddCategory={() => navigate(categoryAddUrl(id))}
+            onAddProduct={() => navigate(productAddUrl())}
+            onBack={() =>
+              navigate(
+                maybe(
+                  () => categoryUrl(data.category.parent.id),
+                  categoryListUrl()
+                )
               )
-            }}
+            }
+            onCategoryClick={id => () => navigate(categoryUrl(id))}
+            onDelete={() => openModal("delete")}
+            onImageDelete={() =>
+              updateCategory({
+                variables: {
+                  id,
+                  input: {
+                    backgroundImage: null
+                  }
+                }
+              })
+            }
+            onImageUpload={file =>
+              updateCategory({
+                variables: {
+                  id,
+                  input: {
+                    backgroundImage: file
+                  }
+                }
+              })
+            }
+            onNextPage={loadNextPage}
+            onPreviousPage={loadPreviousPage}
+            pageInfo={pageInfo}
+            onProductClick={id => () => navigate(productUrl(id))}
+            onSubmit={handleSubmit}
+            products={maybe(() =>
+              data.category.products.edges.map(edge => edge.node)
+            )}
+            saveButtonBarState={updateResult.status}
+            selectedChannelId={channel.id}
+            subcategories={maybe(() =>
+              data.category.children.edges.map(edge => edge.node)
+            )}
+            subcategoryListToolbar={
+              <IconButton
+                color="primary"
+                onClick={() =>
+                  openModal("delete-categories", {
+                    ids: listElements
+                  })
+                }
+              >
+                <DeleteIcon />
+              </IconButton>
+            }
+            productListToolbar={
+              <IconButton
+                color="primary"
+                onClick={() =>
+                  openModal("delete-products", {
+                    ids: listElements
+                  })
+                }
+              >
+                <DeleteIcon />
+              </IconButton>
+            }
+            isChecked={isSelected}
+            selected={listElements.length}
+            toggle={toggle}
+            toggleAll={toggleAll}
           />
-        </DialogContentText>
-        <DialogContentText>
-          <FormattedMessage defaultMessage="Remember this will also unpin all products assigned to this category, making them unavailable in storefront." />
-        </DialogContentText>
-      </ActionDialog>
-      <ActionDialog
-        open={
-          params.action === "delete-categories" &&
-          maybe(() => params.ids.length > 0)
-        }
-        confirmButtonState={categoryBulkDeleteOpts.status}
-        onClose={closeModal}
-        onConfirm={() =>
-          categoryBulkDelete({
-            variables: { ids: params.ids }
-          }).then(() => refetch())
-        }
-        title={intl.formatMessage({
-          defaultMessage: "Delete categories",
-          description: "dialog title"
-        })}
-        variant="delete"
-      >
-        <DialogContentText>
-          <FormattedMessage
-            defaultMessage="{counter,plural,one{Are you sure you want to delete this category?} other{Are you sure you want to delete {displayQuantity} categories?}}"
-            values={{
-              counter: maybe(() => params.ids.length),
-              displayQuantity: <strong>{maybe(() => params.ids.length)}</strong>
-            }}
-          />
-        </DialogContentText>
-        <DialogContentText>
-          <FormattedMessage defaultMessage="Remember this will also delete all products assigned to this category." />
-        </DialogContentText>
-      </ActionDialog>
-      <ActionDialog
-        open={params.action === "delete-products"}
-        confirmButtonState={productBulkDeleteOpts.status}
-        onClose={closeModal}
-        onConfirm={() =>
-          productBulkDelete({
-            variables: { ids: params.ids }
-          }).then(() => refetch())
-        }
-        title={intl.formatMessage({
-          defaultMessage: "Delete products",
-          description: "dialog title"
-        })}
-        variant="delete"
-      >
-        <DialogContentText>
-          <FormattedMessage
-            defaultMessage="{counter,plural,one{Are you sure you want to delete this product?} other{Are you sure you want to delete {displayQuantity} products?}}"
-            values={{
-              counter: maybe(() => params.ids.length),
-              displayQuantity: <strong>{maybe(() => params.ids.length)}</strong>
-            }}
-          />
-        </DialogContentText>
-      </ActionDialog>
+          <ActionDialog
+            confirmButtonState={deleteResult.status}
+            onClose={closeModal}
+            onConfirm={() => deleteCategory({ variables: { id } })}
+            open={params.action === "delete"}
+            title={intl.formatMessage({
+              defaultMessage: "Delete category",
+              description: "dialog title"
+            })}
+            variant="delete"
+          >
+            <DialogContentText>
+              <FormattedMessage
+                defaultMessage="Are you sure you want to delete {categoryName}?"
+                values={{
+                  categoryName: (
+                    <strong>{maybe(() => data.category.name, "...")}</strong>
+                  )
+                }}
+              />
+            </DialogContentText>
+            <DialogContentText>
+              <FormattedMessage defaultMessage="Remember this will also unpin all products assigned to this category, making them unavailable in storefront." />
+            </DialogContentText>
+          </ActionDialog>
+          <ActionDialog
+            open={
+              params.action === "delete-categories" &&
+              maybe(() => params.ids.length > 0)
+            }
+            confirmButtonState={categoryBulkDeleteOpts.status}
+            onClose={closeModal}
+            onConfirm={() =>
+              categoryBulkDelete({
+                variables: { ids: params.ids }
+              }).then(() => refetch())
+            }
+            title={intl.formatMessage({
+              defaultMessage: "Delete categories",
+              description: "dialog title"
+            })}
+            variant="delete"
+          >
+            <DialogContentText>
+              <FormattedMessage
+                defaultMessage="{counter,plural,one{Are you sure you want to delete this category?} other{Are you sure you want to delete {displayQuantity} categories?}}"
+                values={{
+                  counter: maybe(() => params.ids.length),
+                  displayQuantity: (
+                    <strong>{maybe(() => params.ids.length)}</strong>
+                  )
+                }}
+              />
+            </DialogContentText>
+            <DialogContentText>
+              <FormattedMessage defaultMessage="Remember this will also delete all products assigned to this category." />
+            </DialogContentText>
+          </ActionDialog>
+          <ActionDialog
+            open={params.action === "delete-products"}
+            confirmButtonState={productBulkDeleteOpts.status}
+            onClose={closeModal}
+            onConfirm={() =>
+              productBulkDelete({
+                variables: { ids: params.ids }
+              }).then(() => refetch())
+            }
+            title={intl.formatMessage({
+              defaultMessage: "Delete products",
+              description: "dialog title"
+            })}
+            variant="delete"
+          >
+            <DialogContentText>
+              <FormattedMessage
+                defaultMessage="{counter,plural,one{Are you sure you want to delete this product?} other{Are you sure you want to delete {displayQuantity} products?}}"
+                values={{
+                  counter: maybe(() => params.ids.length),
+                  displayQuantity: (
+                    <strong>{maybe(() => params.ids.length)}</strong>
+                  )
+                }}
+              />
+            </DialogContentText>
+          </ActionDialog>
+        </>
+      ) : (
+        <Skeleton />
+      )}
     </>
   );
 };

--- a/src/categories/views/CategoryDetails.tsx
+++ b/src/categories/views/CategoryDetails.tsx
@@ -208,182 +208,173 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
     variables => updatePrivateMetadata({ variables })
   );
 
+  if (typeof channel === "undefined") {
+    return <Skeleton />;
+  }
+
   return (
     <>
       <WindowTitle title={maybe(() => data.category.name)} />
-      {typeof channel !== "undefined" ? (
-        <>
-          <CategoryUpdatePage
-            channelsCount={availableChannels.length}
-            channelChoices={channelChoices}
-            changeTab={changeTab}
-            currentTab={params.activeTab}
-            category={maybe(() => data.category)}
-            disabled={loading}
-            errors={updateResult.data?.categoryUpdate.errors || []}
-            onAddCategory={() => navigate(categoryAddUrl(id))}
-            onAddProduct={() => navigate(productAddUrl())}
-            onBack={() =>
-              navigate(
-                maybe(
-                  () => categoryUrl(data.category.parent.id),
-                  categoryListUrl()
-                )
+      <CategoryUpdatePage
+        channelsCount={availableChannels.length}
+        channelChoices={channelChoices}
+        changeTab={changeTab}
+        currentTab={params.activeTab}
+        category={maybe(() => data.category)}
+        disabled={loading}
+        errors={updateResult.data?.categoryUpdate.errors || []}
+        onAddCategory={() => navigate(categoryAddUrl(id))}
+        onAddProduct={() => navigate(productAddUrl())}
+        onBack={() =>
+          navigate(
+            maybe(() => categoryUrl(data.category.parent.id), categoryListUrl())
+          )
+        }
+        onCategoryClick={id => () => navigate(categoryUrl(id))}
+        onDelete={() => openModal("delete")}
+        onImageDelete={() =>
+          updateCategory({
+            variables: {
+              id,
+              input: {
+                backgroundImage: null
+              }
+            }
+          })
+        }
+        onImageUpload={file =>
+          updateCategory({
+            variables: {
+              id,
+              input: {
+                backgroundImage: file
+              }
+            }
+          })
+        }
+        onNextPage={loadNextPage}
+        onPreviousPage={loadPreviousPage}
+        pageInfo={pageInfo}
+        onProductClick={id => () => navigate(productUrl(id))}
+        onSubmit={handleSubmit}
+        products={maybe(() =>
+          data.category.products.edges.map(edge => edge.node)
+        )}
+        saveButtonBarState={updateResult.status}
+        selectedChannelId={channel.id}
+        subcategories={maybe(() =>
+          data.category.children.edges.map(edge => edge.node)
+        )}
+        subcategoryListToolbar={
+          <IconButton
+            color="primary"
+            onClick={() =>
+              openModal("delete-categories", {
+                ids: listElements
+              })
+            }
+          >
+            <DeleteIcon />
+          </IconButton>
+        }
+        productListToolbar={
+          <IconButton
+            color="primary"
+            onClick={() =>
+              openModal("delete-products", {
+                ids: listElements
+              })
+            }
+          >
+            <DeleteIcon />
+          </IconButton>
+        }
+        isChecked={isSelected}
+        selected={listElements.length}
+        toggle={toggle}
+        toggleAll={toggleAll}
+      />
+      <ActionDialog
+        confirmButtonState={deleteResult.status}
+        onClose={closeModal}
+        onConfirm={() => deleteCategory({ variables: { id } })}
+        open={params.action === "delete"}
+        title={intl.formatMessage({
+          defaultMessage: "Delete category",
+          description: "dialog title"
+        })}
+        variant="delete"
+      >
+        <DialogContentText>
+          <FormattedMessage
+            defaultMessage="Are you sure you want to delete {categoryName}?"
+            values={{
+              categoryName: (
+                <strong>{maybe(() => data.category.name, "...")}</strong>
               )
-            }
-            onCategoryClick={id => () => navigate(categoryUrl(id))}
-            onDelete={() => openModal("delete")}
-            onImageDelete={() =>
-              updateCategory({
-                variables: {
-                  id,
-                  input: {
-                    backgroundImage: null
-                  }
-                }
-              })
-            }
-            onImageUpload={file =>
-              updateCategory({
-                variables: {
-                  id,
-                  input: {
-                    backgroundImage: file
-                  }
-                }
-              })
-            }
-            onNextPage={loadNextPage}
-            onPreviousPage={loadPreviousPage}
-            pageInfo={pageInfo}
-            onProductClick={id => () => navigate(productUrl(id))}
-            onSubmit={handleSubmit}
-            products={maybe(() =>
-              data.category.products.edges.map(edge => edge.node)
-            )}
-            saveButtonBarState={updateResult.status}
-            selectedChannelId={channel.id}
-            subcategories={maybe(() =>
-              data.category.children.edges.map(edge => edge.node)
-            )}
-            subcategoryListToolbar={
-              <IconButton
-                color="primary"
-                onClick={() =>
-                  openModal("delete-categories", {
-                    ids: listElements
-                  })
-                }
-              >
-                <DeleteIcon />
-              </IconButton>
-            }
-            productListToolbar={
-              <IconButton
-                color="primary"
-                onClick={() =>
-                  openModal("delete-products", {
-                    ids: listElements
-                  })
-                }
-              >
-                <DeleteIcon />
-              </IconButton>
-            }
-            isChecked={isSelected}
-            selected={listElements.length}
-            toggle={toggle}
-            toggleAll={toggleAll}
+            }}
           />
-          <ActionDialog
-            confirmButtonState={deleteResult.status}
-            onClose={closeModal}
-            onConfirm={() => deleteCategory({ variables: { id } })}
-            open={params.action === "delete"}
-            title={intl.formatMessage({
-              defaultMessage: "Delete category",
-              description: "dialog title"
-            })}
-            variant="delete"
-          >
-            <DialogContentText>
-              <FormattedMessage
-                defaultMessage="Are you sure you want to delete {categoryName}?"
-                values={{
-                  categoryName: (
-                    <strong>{maybe(() => data.category.name, "...")}</strong>
-                  )
-                }}
-              />
-            </DialogContentText>
-            <DialogContentText>
-              <FormattedMessage defaultMessage="Remember this will also unpin all products assigned to this category, making them unavailable in storefront." />
-            </DialogContentText>
-          </ActionDialog>
-          <ActionDialog
-            open={
-              params.action === "delete-categories" &&
-              maybe(() => params.ids.length > 0)
-            }
-            confirmButtonState={categoryBulkDeleteOpts.status}
-            onClose={closeModal}
-            onConfirm={() =>
-              categoryBulkDelete({
-                variables: { ids: params.ids }
-              }).then(() => refetch())
-            }
-            title={intl.formatMessage({
-              defaultMessage: "Delete categories",
-              description: "dialog title"
-            })}
-            variant="delete"
-          >
-            <DialogContentText>
-              <FormattedMessage
-                defaultMessage="{counter,plural,one{Are you sure you want to delete this category?} other{Are you sure you want to delete {displayQuantity} categories?}}"
-                values={{
-                  counter: maybe(() => params.ids.length),
-                  displayQuantity: (
-                    <strong>{maybe(() => params.ids.length)}</strong>
-                  )
-                }}
-              />
-            </DialogContentText>
-            <DialogContentText>
-              <FormattedMessage defaultMessage="Remember this will also delete all products assigned to this category." />
-            </DialogContentText>
-          </ActionDialog>
-          <ActionDialog
-            open={params.action === "delete-products"}
-            confirmButtonState={productBulkDeleteOpts.status}
-            onClose={closeModal}
-            onConfirm={() =>
-              productBulkDelete({
-                variables: { ids: params.ids }
-              }).then(() => refetch())
-            }
-            title={intl.formatMessage({
-              defaultMessage: "Delete products",
-              description: "dialog title"
-            })}
-            variant="delete"
-          >
-            <DialogContentText>
-              <FormattedMessage
-                defaultMessage="{counter,plural,one{Are you sure you want to delete this product?} other{Are you sure you want to delete {displayQuantity} products?}}"
-                values={{
-                  counter: maybe(() => params.ids.length),
-                  displayQuantity: (
-                    <strong>{maybe(() => params.ids.length)}</strong>
-                  )
-                }}
-              />
-            </DialogContentText>
-          </ActionDialog>
-        </>
-      ) : (
-        <Skeleton />
-      )}
+        </DialogContentText>
+        <DialogContentText>
+          <FormattedMessage defaultMessage="Remember this will also unpin all products assigned to this category, making them unavailable in storefront." />
+        </DialogContentText>
+      </ActionDialog>
+      <ActionDialog
+        open={
+          params.action === "delete-categories" &&
+          maybe(() => params.ids.length > 0)
+        }
+        confirmButtonState={categoryBulkDeleteOpts.status}
+        onClose={closeModal}
+        onConfirm={() =>
+          categoryBulkDelete({
+            variables: { ids: params.ids }
+          }).then(() => refetch())
+        }
+        title={intl.formatMessage({
+          defaultMessage: "Delete categories",
+          description: "dialog title"
+        })}
+        variant="delete"
+      >
+        <DialogContentText>
+          <FormattedMessage
+            defaultMessage="{counter,plural,one{Are you sure you want to delete this category?} other{Are you sure you want to delete {displayQuantity} categories?}}"
+            values={{
+              counter: maybe(() => params.ids.length),
+              displayQuantity: <strong>{maybe(() => params.ids.length)}</strong>
+            }}
+          />
+        </DialogContentText>
+        <DialogContentText>
+          <FormattedMessage defaultMessage="Remember this will also delete all products assigned to this category." />
+        </DialogContentText>
+      </ActionDialog>
+      <ActionDialog
+        open={params.action === "delete-products"}
+        confirmButtonState={productBulkDeleteOpts.status}
+        onClose={closeModal}
+        onConfirm={() =>
+          productBulkDelete({
+            variables: { ids: params.ids }
+          }).then(() => refetch())
+        }
+        title={intl.formatMessage({
+          defaultMessage: "Delete products",
+          description: "dialog title"
+        })}
+        variant="delete"
+      >
+        <DialogContentText>
+          <FormattedMessage
+            defaultMessage="{counter,plural,one{Are you sure you want to delete this product?} other{Are you sure you want to delete {displayQuantity} products?}}"
+            values={{
+              counter: maybe(() => params.ids.length),
+              displayQuantity: <strong>{maybe(() => params.ids.length)}</strong>
+            }}
+          />
+        </DialogContentText>
+      </ActionDialog>
     </>
   );
 };

--- a/src/categories/views/CategoryDetails.tsx
+++ b/src/categories/views/CategoryDetails.tsx
@@ -261,7 +261,7 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
           data.category.products.edges.map(edge => edge.node)
         )}
         saveButtonBarState={updateResult.status}
-        selectedChannelId={channel.id}
+        selectedChannelId={channel?.id}
         subcategories={maybe(() =>
           data.category.children.edges.map(edge => edge.node)
         )}

--- a/src/collections/components/CollectionList/CollectionList.tsx
+++ b/src/collections/components/CollectionList/CollectionList.tsx
@@ -146,8 +146,8 @@ const CollectionList: React.FC<CollectionListProps> = props => {
           collections,
           collection => {
             const isSelected = collection ? isChecked(collection.id) : false;
-            const channel = collection?.channelListings.find(
-              listing => listing.channel.id === selectedChannelId
+            const channel = collection?.channelListings?.find(
+              listing => listing?.channel?.id === selectedChannelId
             );
             return (
               <TableRow
@@ -184,11 +184,13 @@ const CollectionList: React.FC<CollectionListProps> = props => {
                   {collection && !collection?.channelListings?.length ? (
                     "-"
                   ) : collection?.channelListings !== undefined ? (
-                    <ChannelsAvailabilityDropdown
-                      allChannelsCount={channelsCount}
-                      currentChannel={channel}
-                      channels={collection?.channelListings}
-                    />
+                    channel ? (
+                      <ChannelsAvailabilityDropdown
+                        allChannelsCount={channelsCount}
+                        currentChannel={channel}
+                        channels={collection?.channelListings}
+                      />
+                    ) : null
                   ) : (
                     <Skeleton />
                   )}

--- a/src/collections/views/CollectionList/CollectionList.tsx
+++ b/src/collections/views/CollectionList/CollectionList.tsx
@@ -184,7 +184,7 @@ export const CollectionList: React.FC<CollectionListProps> = ({ params }) => {
         toggle={toggle}
         toggleAll={toggleAll}
         channelsCount={availableChannels?.length}
-        selectedChannelId={channel.id}
+        selectedChannelId={channel?.id}
       />
       <ActionDialog
         open={params.action === "remove" && maybe(() => params.ids.length > 0)}

--- a/src/components/AppLayout/AppChannelContext.tsx
+++ b/src/components/AppLayout/AppChannelContext.tsx
@@ -30,6 +30,10 @@ export const AppChannelProvider: React.FC = ({ children }) => {
   const { data: channelData, refetch } = useChannelsList({
     skip: !isAuthenticated
   });
+
+  // TODO mockup
+  // channelData= {channels: []};
+
   const [isPickerActive, setPickerActive] = React.useState(false);
   React.useEffect(() => {
     if (!selectedChannel) {
@@ -38,9 +42,10 @@ export const AppChannelProvider: React.FC = ({ children }) => {
   }, [channelData]);
 
   const availableChannels = channelData?.channels || [];
-  const channel = availableChannels.find(
-    channel => channel.id === selectedChannel
-  );
+
+  const channel =
+    channelData &&
+    (availableChannels.find(channel => channel.id === selectedChannel) || null);
 
   return (
     <AppChannelContext.Provider
@@ -57,6 +62,7 @@ export const AppChannelProvider: React.FC = ({ children }) => {
     </AppChannelContext.Provider>
   );
 };
+
 AppChannelProvider.displayName = "AppChannelProvider";
 
 function useAppChannel(enablePicker = true): UseAppChannel {

--- a/src/components/AppLayout/AppChannelContext.tsx
+++ b/src/components/AppLayout/AppChannelContext.tsx
@@ -31,9 +31,6 @@ export const AppChannelProvider: React.FC = ({ children }) => {
     skip: !isAuthenticated
   });
 
-  // TODO mockup
-  // channelData= {channels: []};
-
   const [isPickerActive, setPickerActive] = React.useState(false);
   React.useEffect(() => {
     if (!selectedChannel) {

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -215,12 +215,14 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                               .includes("mac")}
                             onClick={() => setNavigatorVisibility(true)}
                           />
-                          <AppChannelSelect
-                            channels={availableChannels}
-                            disabled={!isPickerActive}
-                            selectedChannelId={channel.id}
-                            onChannelSelect={setChannel}
-                          />
+                          {channel && (
+                            <AppChannelSelect
+                              channels={availableChannels}
+                              disabled={!isPickerActive}
+                              selectedChannelId={channel.id}
+                              onChannelSelect={setChannel}
+                            />
+                          )}
                           <UserChip
                             isDarkThemeEnabled={isDark}
                             user={user}

--- a/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
+++ b/src/discounts/components/SaleCreatePage/SaleCreatePage.tsx
@@ -78,7 +78,7 @@ const SaleCreatePage: React.FC<SaleCreatePageProps> = ({
           triggerChange
         );
         const formDisabled = data.channelListings?.some(channel =>
-          validatePrice(channel.discountValue)
+          validatePrice(channel?.discountValue)
         );
         return (
           <Container>

--- a/src/discounts/components/SaleSummary/SaleSummary.tsx
+++ b/src/discounts/components/SaleSummary/SaleSummary.tsx
@@ -51,12 +51,12 @@ const SaleSummary: React.FC<SaleSummaryProps> = ({
             sale.type === SaleType.FIXED && channel?.discountValue ? (
               <Money
                 money={{
-                  amount: channel.discountValue,
-                  currency: channel.currency
+                  amount: channel?.discountValue,
+                  currency: channel?.currency
                 }}
               />
             ) : channel?.discountValue ? (
-              <Percent amount={channel.discountValue} />
+              <Percent amount={channel?.discountValue} />
             ) : (
               "-"
             )

--- a/src/discounts/components/VoucherSummary/VoucherSummary.tsx
+++ b/src/discounts/components/VoucherSummary/VoucherSummary.tsx
@@ -69,12 +69,12 @@ const VoucherSummary: React.FC<VoucherSummaryProps> = ({
             channel?.discountValue ? (
               <Money
                 money={{
-                  amount: channel.discountValue,
-                  currency: channel.channel.currencyCode
+                  amount: channel?.discountValue,
+                  currency: channel?.channel.currencyCode
                 }}
               />
             ) : channel?.discountValue ? (
-              <Percent amount={channel.discountValue} />
+              <Percent amount={channel?.discountValue} />
             ) : (
               "-"
             )

--- a/src/discounts/views/SaleList/SaleList.tsx
+++ b/src/discounts/views/SaleList/SaleList.tsx
@@ -199,7 +199,7 @@ export const SaleList: React.FC<SaleListProps> = ({ params }) => {
                   <DeleteIcon />
                 </IconButton>
               }
-              selectedChannelId={channel.id}
+              selectedChannelId={channel?.id}
             />
             <ActionDialog
               confirmButtonState={saleBulkDeleteOpts.status}

--- a/src/discounts/views/VoucherDetails/VoucherDetails.tsx
+++ b/src/discounts/views/VoucherDetails/VoucherDetails.tsx
@@ -298,7 +298,7 @@ export const VoucherDetails: React.FC<VoucherDetailsProps> = ({
                               ...(updateChannelsOpts.data
                                 ?.voucherChannelListingUpdate.errors || [])
                             ]}
-                            selectedChannelId={channel.id}
+                            selectedChannelId={channel?.id}
                             pageInfo={pageInfo}
                             onNextPage={loadNextPage}
                             onPreviousPage={loadPreviousPage}

--- a/src/discounts/views/VoucherList/VoucherList.tsx
+++ b/src/discounts/views/VoucherList/VoucherList.tsx
@@ -200,7 +200,7 @@ export const VoucherList: React.FC<VoucherListProps> = ({ params }) => {
                   <DeleteIcon />
                 </IconButton>
               }
-              selectedChannelId={channel.id}
+              selectedChannelId={channel?.id}
             />
             <ActionDialog
               confirmButtonState={voucherBulkDeleteOpts.status}

--- a/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -21,23 +21,23 @@ const messages = defineMessages({
     defaultMessage: "No orders ready to fulfill",
     id: "homeNotificationTableNoOrders"
   },
+  noPaymentWaiting: {
+    defaultMessage: "No payments waiting for capture",
+    id: "homeNotificationsNoPayments"
+  },
+  noProductsOut: {
+    defaultMessage: "No products out of stock",
+    id: "homeNotificationsTableNoProducts"
+  },
   orderReady: {
     defaultMessage:
       "{amount, plural,one {One order is ready to fulfill} other {{amount} Orders are ready to fulfill}}",
     id: "homeNotificationTableOrders"
   },
-  noPaymentWaiting: {
-    defaultMessage: "No payments waiting for capture",
-    id: "homeNotificationsNoPayments"
-  },
   paymentCapture: {
     defaultMessage:
       "{amount, plural,one {One payment to capture}other {{amount} Payments to capture}}",
     id: "homeNotificationTablePayments"
-  },
-  noProductsOut: {
-    defaultMessage: "No products out of stock",
-    id: "homeNotificationsTableNoProducts"
   },
   productOut: {
     defaultMessage:

--- a/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -11,7 +11,40 @@ import Skeleton from "@saleor/components/Skeleton";
 import { UserPermissionProps } from "@saleor/types";
 import { PermissionEnum } from "@saleor/types/globalTypes";
 import React from "react";
-import { FormattedMessage } from "react-intl";
+import { defineMessages, useIntl } from "react-intl";
+
+const messages = defineMessages({
+  createNewChannel: {
+    defaultMessage: "Create new channel"
+  },
+  noOrders: {
+    defaultMessage: "No orders ready to fulfill",
+    id: "homeNotificationTableNoOrders"
+  },
+  orderReady: {
+    defaultMessage:
+      "{amount, plural,one {One order is ready to fulfill} other {{amount} Orders are ready to fulfill}}",
+    id: "homeNotificationTableOrders"
+  },
+  noPaymentWaiting: {
+    defaultMessage: "No payments waiting for capture",
+    id: "homeNotificationsNoPayments"
+  },
+  paymentCapture: {
+    defaultMessage:
+      "{amount, plural,one {One payment to capture}other {{amount} Payments to capture}}",
+    id: "homeNotificationTablePayments"
+  },
+  noProductsOut: {
+    defaultMessage: "No products out of stock",
+    id: "homeNotificationsTableNoProducts"
+  },
+  productOut: {
+    defaultMessage:
+      "{amount, plural,one {One product out of stock}other {{amount} Products out of stock}}",
+    id: "homeNotificationTableProducts"
+  }
+});
 
 const useStyles = makeStyles(
   () => ({
@@ -55,6 +88,8 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
 
   const classes = useStyles(props);
 
+  const intl = useIntl();
+
   return (
     <Card className={classes.tableCard}>
       <ResponsiveTable>
@@ -63,11 +98,7 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
             <TableRow hover={true} onClick={onCreateNewChannelClick}>
               <TableCell>
                 <Typography>
-                  {/* <FormattedMessage
-                      defaultMessage="Create new channel"
-                      id="homeNotificationTableNoOrders"
-                    /> */}
-                  Create new channel
+                  {intl.formatMessage(messages.createNewChannel)}
                 </Typography>
               </TableCell>
               <TableCell className={classes.arrowIcon}>
@@ -85,20 +116,13 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
                   <Skeleton />
                 ) : ordersToFulfill === 0 ? (
                   <Typography>
-                    <FormattedMessage
-                      defaultMessage="No orders ready to fulfill"
-                      id="homeNotificationTableNoOrders"
-                    />
+                    {intl.formatMessage(messages.noOrders)}
                   </Typography>
                 ) : (
                   <Typography>
-                    <FormattedMessage
-                      defaultMessage="{amount, plural,one {One order is ready to fulfill} other {{amount} Orders are ready to fulfill}}"
-                      id="homeNotificationTableOrders"
-                      values={{
-                        amount: <strong>{ordersToFulfill}</strong>
-                      }}
-                    />
+                    {intl.formatMessage(messages.orderReady, {
+                      amount: <strong>{ordersToFulfill}</strong>
+                    })}
                   </Typography>
                 )}
               </TableCell>
@@ -112,20 +136,13 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
                   <Skeleton />
                 ) : ordersToCapture === 0 ? (
                   <Typography>
-                    <FormattedMessage
-                      defaultMessage="No payments waiting for capture"
-                      id="homeNotificationsNoPayments"
-                    />
+                    {intl.formatMessage(messages.noPaymentWaiting)}
                   </Typography>
                 ) : (
                   <Typography>
-                    <FormattedMessage
-                      defaultMessage="{amount, plural,one {One payment to capture}other {{amount} Payments to capture}}"
-                      id="homeNotificationTablePayments"
-                      values={{
-                        amount: <strong>{ordersToCapture}</strong>
-                      }}
-                    />
+                    {intl.formatMessage(messages.paymentCapture, {
+                      amount: <strong>{ordersToCapture}</strong>
+                    })}
                   </Typography>
                 )}
               </TableCell>
@@ -144,20 +161,13 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
                   <Skeleton />
                 ) : productsOutOfStock === 0 ? (
                   <Typography>
-                    <FormattedMessage
-                      defaultMessage="No products out of stock"
-                      id="homeNotificationsTableNoProducts"
-                    />
+                    {intl.formatMessage(messages.noProductsOut)}
                   </Typography>
                 ) : (
                   <Typography>
-                    <FormattedMessage
-                      defaultMessage="{amount, plural,one {One product out of stock}other {{amount} Products out of stock}}"
-                      id="homeNotificationTableProducts"
-                      values={{
-                        amount: <strong>{productsOutOfStock}</strong>
-                      }}
-                    />
+                    {intl.formatMessage(messages.productOut, {
+                      amount: <strong>{productsOutOfStock}</strong>
+                    })}
                   </Typography>
                 )}
               </TableCell>

--- a/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -36,6 +36,7 @@ interface HomeNotificationTableProps extends UserPermissionProps {
   onOrdersToFulfillClick: () => void;
   onOrdersToCaptureClick: () => void;
   onProductsOutOfStockClick: () => void;
+  noChannel: boolean;
 }
 
 const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
@@ -46,7 +47,8 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
     ordersToCapture,
     ordersToFulfill,
     productsOutOfStock,
-    userPermissions
+    userPermissions,
+    noChannel
   } = props;
 
   const classes = useStyles(props);
@@ -55,6 +57,22 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
     <Card className={classes.tableCard}>
       <ResponsiveTable>
         <TableBody className={classes.tableRow}>
+          {noChannel && (
+            <TableRow hover={true} onClick={onOrdersToFulfillClick}>
+              <TableCell>
+                <Typography>
+                  {/* <FormattedMessage
+                      defaultMessage="Create new channel"
+                      id="homeNotificationTableNoOrders"
+                    /> */}
+                  Create new channel
+                </Typography>
+              </TableCell>
+              <TableCell className={classes.arrowIcon}>
+                <KeyboardArrowRight />
+              </TableCell>
+            </TableRow>
+          )}
           <RequirePermissions
             userPermissions={userPermissions}
             requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}

--- a/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/src/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -33,6 +33,7 @@ interface HomeNotificationTableProps extends UserPermissionProps {
   ordersToCapture: number;
   ordersToFulfill: number;
   productsOutOfStock: number;
+  onCreateNewChannelClick: () => void;
   onOrdersToFulfillClick: () => void;
   onOrdersToCaptureClick: () => void;
   onProductsOutOfStockClick: () => void;
@@ -41,6 +42,7 @@ interface HomeNotificationTableProps extends UserPermissionProps {
 
 const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
   const {
+    onCreateNewChannelClick,
     onOrdersToCaptureClick,
     onOrdersToFulfillClick,
     onProductsOutOfStockClick,
@@ -58,7 +60,7 @@ const HomeNotificationTable: React.FC<HomeNotificationTableProps> = props => {
       <ResponsiveTable>
         <TableBody className={classes.tableRow}>
           {noChannel && (
-            <TableRow hover={true} onClick={onOrdersToFulfillClick}>
+            <TableRow hover={true} onClick={onCreateNewChannelClick}>
               <TableCell>
                 <Typography>
                   {/* <FormattedMessage

--- a/src/home/components/HomePage/HomePage.tsx
+++ b/src/home/components/HomePage/HomePage.tsx
@@ -53,6 +53,7 @@ export interface HomePageProps extends UserPermissionProps {
   sales: Home_salesToday_gross;
   topProducts: Home_productTopToday_edges_node[] | null;
   userName: string;
+  onCreateNewChannelClick: () => void;
   onOrdersToCaptureClick: () => void;
   onOrdersToFulfillClick: () => void;
   onProductClick: (productId: string, variantId: string) => void;
@@ -68,6 +69,7 @@ const HomePage: React.FC<HomePageProps> = props => {
     topProducts,
     onProductClick,
     activities,
+    onCreateNewChannelClick,
     onOrdersToCaptureClick,
     onOrdersToFulfillClick,
     onProductsOutOfStockClick,
@@ -128,6 +130,7 @@ const HomePage: React.FC<HomePageProps> = props => {
             </div>
           </RequirePermissions>
           <HomeNotificationTable
+            onCreateNewChannelClick={onCreateNewChannelClick}
             onOrdersToCaptureClick={onOrdersToCaptureClick}
             onOrdersToFulfillClick={onOrdersToFulfillClick}
             onProductsOutOfStockClick={onProductsOutOfStockClick}

--- a/src/home/components/HomePage/HomePage.tsx
+++ b/src/home/components/HomePage/HomePage.tsx
@@ -46,17 +46,18 @@ const useStyles = makeStyles(
 
 export interface HomePageProps extends UserPermissionProps {
   activities: Home_activities_edges_node[];
-  orders: number;
-  ordersToCapture: number;
-  ordersToFulfill: number;
+  orders: number | null;
+  ordersToCapture: number | null;
+  ordersToFulfill: number | null;
   productsOutOfStock: number;
   sales: Home_salesToday_gross;
-  topProducts: Home_productTopToday_edges_node[];
+  topProducts: Home_productTopToday_edges_node[] | null;
   userName: string;
   onOrdersToCaptureClick: () => void;
   onOrdersToFulfillClick: () => void;
   onProductClick: (productId: string, variantId: string) => void;
   onProductsOutOfStockClick: () => void;
+  noChannel: boolean;
 }
 
 const HomePage: React.FC<HomePageProps> = props => {
@@ -73,7 +74,8 @@ const HomePage: React.FC<HomePageProps> = props => {
     ordersToCapture,
     ordersToFulfill,
     productsOutOfStock,
-    userPermissions
+    userPermissions,
+    noChannel
   } = props;
 
   const classes = useStyles(props);
@@ -131,30 +133,35 @@ const HomePage: React.FC<HomePageProps> = props => {
             ordersToFulfill={ordersToFulfill}
             productsOutOfStock={productsOutOfStock}
             userPermissions={userPermissions}
+            noChannel={noChannel}
           />
           <CardSpacer />
-          <RequirePermissions
-            userPermissions={userPermissions}
-            requiredPermissions={[
-              PermissionEnum.MANAGE_ORDERS,
-              PermissionEnum.MANAGE_PRODUCTS
-            ]}
-          >
-            <HomeProductListCard
-              onRowClick={onProductClick}
-              topProducts={topProducts}
-            />
-            <CardSpacer />
-          </RequirePermissions>
+          {topProducts && (
+            <RequirePermissions
+              userPermissions={userPermissions}
+              requiredPermissions={[
+                PermissionEnum.MANAGE_ORDERS,
+                PermissionEnum.MANAGE_PRODUCTS
+              ]}
+            >
+              <HomeProductListCard
+                onRowClick={onProductClick}
+                topProducts={topProducts}
+              />
+              <CardSpacer />
+            </RequirePermissions>
+          )}
         </div>
-        <div>
-          <RequirePermissions
-            userPermissions={userPermissions}
-            requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
-          >
-            <HomeActivityCard activities={activities} />
-          </RequirePermissions>
-        </div>
+        {activities && (
+          <div>
+            <RequirePermissions
+              userPermissions={userPermissions}
+              requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}
+            >
+              <HomeActivityCard activities={activities} />
+            </RequirePermissions>
+          </div>
+        )}
       </Grid>
     </Container>
   );

--- a/src/home/components/HomePage/HomePage.tsx
+++ b/src/home/components/HomePage/HomePage.tsx
@@ -101,7 +101,9 @@ const HomePage: React.FC<HomePageProps> = props => {
                   />
                 }
               >
-                {sales ? (
+                {noChannel ? (
+                  0
+                ) : sales ? (
                   <Money money={sales} />
                 ) : (
                   <Skeleton style={{ width: "5em" }} />

--- a/src/home/components/HomePage/HomePage.tsx
+++ b/src/home/components/HomePage/HomePage.tsx
@@ -73,10 +73,10 @@ const HomePage: React.FC<HomePageProps> = props => {
     onOrdersToCaptureClick,
     onOrdersToFulfillClick,
     onProductsOutOfStockClick,
-    ordersToCapture,
-    ordersToFulfill,
-    productsOutOfStock,
-    userPermissions,
+    ordersToCapture = 0,
+    ordersToFulfill = 0,
+    productsOutOfStock = 0,
+    userPermissions = [],
     noChannel
   } = props;
 
@@ -121,10 +121,12 @@ const HomePage: React.FC<HomePageProps> = props => {
                   />
                 }
               >
-                {orders === undefined ? (
-                  <Skeleton style={{ width: "5em" }} />
-                ) : (
+                {noChannel ? (
+                  0
+                ) : orders !== undefined ? (
                   orders
+                ) : (
+                  <Skeleton style={{ width: "5em" }} />
                 )}
               </HomeAnalyticsCard>
             </div>

--- a/src/home/queries.ts
+++ b/src/home/queries.ts
@@ -1,7 +1,7 @@
+import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
 
-import { TypedQuery } from "../queries";
-import { Home } from "./types/Home";
+import { Home, HomeVariables } from "./types/Home";
 
 const home = gql`
   query Home($channel: String!) {
@@ -80,4 +80,5 @@ const home = gql`
     }
   }
 `;
-export const HomePageQuery = TypedQuery<Home, {}>(home);
+
+export const useHomePage = makeQuery<Home, HomeVariables>(home);

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -1,3 +1,4 @@
+import { channelsListUrl } from "@saleor/channels/urls";
 import useAppChannel from "@saleor/components/AppLayout/AppChannelContext";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useUser from "@saleor/hooks/useUser";
@@ -35,6 +36,9 @@ const HomeSection = () => {
       onProductClick={(productId, variantId) =>
         navigate(productVariantEditUrl(productId, variantId))
       }
+      onCreateNewChannelClick={() => {
+        navigate(channelsListUrl());
+      }}
       onOrdersToCaptureClick={() =>
         navigate(
           orderListUrl({

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -17,10 +17,12 @@ const HomeSection = () => {
 
   const noChannel = !channel && typeof channel !== "undefined";
 
-  const { data } = useHomePage({
-    displayLoader: true,
-    variables: { channel: channel?.slug }
-  });
+  const { data } = !noChannel
+    ? useHomePage({
+        displayLoader: true,
+        variables: { channel: channel?.slug }
+      })
+    : { data: null };
 
   return (
     <HomePage

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -15,21 +15,21 @@ const HomeSection = () => {
   const { user } = useUser();
   const { channel } = useAppChannel();
 
+  const noChannel = !channel && typeof channel !== "undefined";
+
   const { data } = useHomePage({
     displayLoader: true,
-    variables: { channel: channel.slug }
+    variables: { channel: channel?.slug }
   });
 
   return (
     <HomePage
-      activities={maybe(() =>
-        data.activities.edges.map(edge => edge.node).reverse()
-      )}
-      orders={maybe(() => data.ordersToday.totalCount)}
-      sales={maybe(() => data.salesToday.gross)}
-      topProducts={maybe(() =>
-        data.productTopToday.edges.map(edge => edge.node)
-      )}
+      activities={data?.activities.edges.map(edge => edge.node).reverse()}
+      orders={!noChannel ? data?.ordersToday.totalCount : 0}
+      sales={maybe(() => data?.salesToday.gross)}
+      topProducts={
+        !noChannel ? data?.productTopToday.edges.map(edge => edge.node) : null
+      }
       onProductClick={(productId, variantId) =>
         navigate(productVariantEditUrl(productId, variantId))
       }
@@ -54,11 +54,12 @@ const HomeSection = () => {
           })
         )
       }
-      ordersToCapture={maybe(() => data.ordersToCapture.totalCount)}
-      ordersToFulfill={maybe(() => data.ordersToFulfill.totalCount)}
-      productsOutOfStock={maybe(() => data.productsOutOfStock.totalCount)}
+      ordersToCapture={!noChannel ? data?.ordersToCapture.totalCount : 0}
+      ordersToFulfill={!noChannel ? data?.ordersToFulfill.totalCount : 0}
+      productsOutOfStock={!noChannel ? data?.productsOutOfStock.totalCount : 0}
       userName={getUserName(user, true)}
       userPermissions={user?.userPermissions || []}
+      noChannel={noChannel}
     />
   );
 };

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -8,57 +8,58 @@ import { orderListUrl } from "../../orders/urls";
 import { productListUrl, productVariantEditUrl } from "../../products/urls";
 import { OrderStatusFilter, StockAvailability } from "../../types/globalTypes";
 import HomePage from "../components/HomePage";
-import { HomePageQuery } from "../queries";
+import { useHomePage } from "../queries";
 
 const HomeSection = () => {
   const navigate = useNavigator();
   const { user } = useUser();
   const { channel } = useAppChannel();
 
+  const { data } = useHomePage({
+    displayLoader: true,
+    variables: { channel: channel.slug }
+  });
+
   return (
-    <HomePageQuery displayLoader variables={{ channel: channel.slug }}>
-      {({ data }) => (
-        <HomePage
-          activities={maybe(() =>
-            data.activities.edges.map(edge => edge.node).reverse()
-          )}
-          orders={maybe(() => data.ordersToday.totalCount)}
-          sales={maybe(() => data.salesToday.gross)}
-          topProducts={maybe(() =>
-            data.productTopToday.edges.map(edge => edge.node)
-          )}
-          onProductClick={(productId, variantId) =>
-            navigate(productVariantEditUrl(productId, variantId))
-          }
-          onOrdersToCaptureClick={() =>
-            navigate(
-              orderListUrl({
-                status: [OrderStatusFilter.READY_TO_CAPTURE]
-              })
-            )
-          }
-          onOrdersToFulfillClick={() =>
-            navigate(
-              orderListUrl({
-                status: [OrderStatusFilter.READY_TO_FULFILL]
-              })
-            )
-          }
-          onProductsOutOfStockClick={() =>
-            navigate(
-              productListUrl({
-                stockStatus: StockAvailability.OUT_OF_STOCK
-              })
-            )
-          }
-          ordersToCapture={maybe(() => data.ordersToCapture.totalCount)}
-          ordersToFulfill={maybe(() => data.ordersToFulfill.totalCount)}
-          productsOutOfStock={maybe(() => data.productsOutOfStock.totalCount)}
-          userName={getUserName(user, true)}
-          userPermissions={user?.userPermissions || []}
-        />
+    <HomePage
+      activities={maybe(() =>
+        data.activities.edges.map(edge => edge.node).reverse()
       )}
-    </HomePageQuery>
+      orders={maybe(() => data.ordersToday.totalCount)}
+      sales={maybe(() => data.salesToday.gross)}
+      topProducts={maybe(() =>
+        data.productTopToday.edges.map(edge => edge.node)
+      )}
+      onProductClick={(productId, variantId) =>
+        navigate(productVariantEditUrl(productId, variantId))
+      }
+      onOrdersToCaptureClick={() =>
+        navigate(
+          orderListUrl({
+            status: [OrderStatusFilter.READY_TO_CAPTURE]
+          })
+        )
+      }
+      onOrdersToFulfillClick={() =>
+        navigate(
+          orderListUrl({
+            status: [OrderStatusFilter.READY_TO_FULFILL]
+          })
+        )
+      }
+      onProductsOutOfStockClick={() =>
+        navigate(
+          productListUrl({
+            stockStatus: StockAvailability.OUT_OF_STOCK
+          })
+        )
+      }
+      ordersToCapture={maybe(() => data.ordersToCapture.totalCount)}
+      ordersToFulfill={maybe(() => data.ordersToFulfill.totalCount)}
+      productsOutOfStock={maybe(() => data.productsOutOfStock.totalCount)}
+      userName={getUserName(user, true)}
+      userPermissions={user?.userPermissions || []}
+    />
   );
 };
 

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -20,8 +20,8 @@ const HomeSection = () => {
 
   const { data } = useHomePage({
     displayLoader: true,
-    variables: { channel: channel?.slug },
-    skip: false
+    skip: noChannel,
+    variables: { channel: channel?.slug }
   });
 
   return (

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -4,7 +4,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import useUser from "@saleor/hooks/useUser";
 import React from "react";
 
-import { getUserName, maybe } from "../../misc";
+import { getUserName } from "../../misc";
 import { orderListUrl } from "../../orders/urls";
 import { productListUrl, productVariantEditUrl } from "../../products/urls";
 import { OrderStatusFilter, StockAvailability } from "../../types/globalTypes";
@@ -18,21 +18,18 @@ const HomeSection = () => {
 
   const noChannel = !channel && typeof channel !== "undefined";
 
-  const { data } = !noChannel
-    ? useHomePage({
-        displayLoader: true,
-        variables: { channel: channel?.slug }
-      })
-    : { data: null };
+  const { data } = useHomePage({
+    displayLoader: true,
+    variables: { channel: channel?.slug },
+    skip: false
+  });
 
   return (
     <HomePage
       activities={data?.activities.edges.map(edge => edge.node).reverse()}
-      orders={!noChannel ? data?.ordersToday.totalCount : 0}
-      sales={maybe(() => data?.salesToday.gross)}
-      topProducts={
-        !noChannel ? data?.productTopToday.edges.map(edge => edge.node) : null
-      }
+      orders={data?.ordersToday.totalCount}
+      sales={data?.salesToday.gross}
+      topProducts={data?.productTopToday.edges.map(edge => edge.node)}
       onProductClick={(productId, variantId) =>
         navigate(productVariantEditUrl(productId, variantId))
       }
@@ -60,11 +57,11 @@ const HomeSection = () => {
           })
         )
       }
-      ordersToCapture={!noChannel ? data?.ordersToCapture.totalCount : 0}
-      ordersToFulfill={!noChannel ? data?.ordersToFulfill.totalCount : 0}
-      productsOutOfStock={!noChannel ? data?.productsOutOfStock.totalCount : 0}
+      ordersToCapture={data?.ordersToCapture.totalCount}
+      ordersToFulfill={data?.ordersToFulfill.totalCount}
+      productsOutOfStock={data?.productsOutOfStock.totalCount}
       userName={getUserName(user, true)}
-      userPermissions={user?.userPermissions || []}
+      userPermissions={user?.userPermissions}
       noChannel={noChannel}
     />
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -145,7 +145,7 @@ const Routes: React.FC = () => {
   return (
     <>
       <WindowTitle title={intl.formatMessage(commonMessages.dashboard)} />
-      {channel &&
+      {typeof channel !== "undefined" &&
       isAuthenticated &&
       !tokenAuthLoading &&
       !tokenVerifyLoading ? (
@@ -284,7 +284,8 @@ const Routes: React.FC = () => {
             </Switch>
           </ErrorBoundary>
         </AppLayout>
-      ) : (isAuthenticated && !channel) || (hasToken && tokenVerifyLoading) ? (
+      ) : (isAuthenticated && typeof channel === "undefined") ||
+        (hasToken && tokenVerifyLoading) ? (
         <LoginLoading />
       ) : (
         <Auth />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -142,13 +142,21 @@ const Routes: React.FC = () => {
   } = useAuth();
   const { channel } = useAppChannel(false);
 
+  const channelLoaded = typeof channel !== "undefined";
+
+  const homePageLoaded =
+    channelLoaded &&
+    isAuthenticated &&
+    !tokenAuthLoading &&
+    !tokenVerifyLoading;
+
+  const homePageLoading =
+    (isAuthenticated && !channelLoaded) || (hasToken && tokenVerifyLoading);
+
   return (
     <>
       <WindowTitle title={intl.formatMessage(commonMessages.dashboard)} />
-      {typeof channel !== "undefined" &&
-      isAuthenticated &&
-      !tokenAuthLoading &&
-      !tokenVerifyLoading ? (
+      {homePageLoaded ? (
         <AppLayout>
           <ErrorBoundary
             onError={() =>
@@ -284,8 +292,7 @@ const Routes: React.FC = () => {
             </Switch>
           </ErrorBoundary>
         </AppLayout>
-      ) : (isAuthenticated && typeof channel === "undefined") ||
-        (hasToken && tokenVerifyLoading) ? (
+      ) : homePageLoading ? (
         <LoginLoading />
       ) : (
         <Auth />

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -20,6 +20,7 @@ import { ListViews } from "@saleor/types";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createFilterHandlers from "@saleor/utils/handlers/filterHandlers";
 import createSortHandler from "@saleor/utils/handlers/sortHandler";
+import { mapNodeToChoice } from "@saleor/utils/maps";
 import { getSortParams } from "@saleor/utils/sort";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -259,12 +260,9 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
                 tabName={maybe(() => tabs[currentTab - 1].name, "...")}
               />
               <ChannelPickerDialog
-                channelsChoices={availableChannels.map(channel => ({
-                  label: channel.name,
-                  value: channel.id
-                }))}
+                channelsChoices={mapNodeToChoice(availableChannels)}
                 confirmButtonState="success"
-                defaultChoice={channel.id}
+                defaultChoice={channel?.id}
                 open={params.action === "create-order"}
                 onClose={closeModal}
                 onConfirm={channel =>

--- a/src/orders/views/OrderList/OrderList.tsx
+++ b/src/orders/views/OrderList/OrderList.tsx
@@ -71,6 +71,8 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
 
   const { channel, availableChannels } = useAppChannel();
 
+  const noChannel = !channel && typeof channel !== "undefined";
+
   const tabs = getFilterTabs();
 
   const currentTab =
@@ -176,23 +178,25 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
         onSubmit={handleFilterTabDelete}
         tabName={getStringOrPlaceholder(tabs[currentTab - 1]?.name)}
       />
-      <ChannelPickerDialog
-        channelsChoices={availableChannels.map(channel => ({
-          label: channel.name,
-          value: channel.id
-        }))}
-        confirmButtonState="success"
-        defaultChoice={channel.id}
-        open={params.action === "create-order"}
-        onClose={closeModal}
-        onConfirm={channel =>
-          createOrder({
-            variables: {
-              input: { channel }
-            }
-          })
-        }
-      />
+      {!noChannel && (
+        <ChannelPickerDialog
+          channelsChoices={availableChannels.map(channel => ({
+            label: channel.name,
+            value: channel.id
+          }))}
+          confirmButtonState="success"
+          defaultChoice={channel.id}
+          open={params.action === "create-order"}
+          onClose={closeModal}
+          onConfirm={channel =>
+            createOrder({
+              variables: {
+                input: { channel }
+              }
+            })
+          }
+        />
+      )}
     </>
   );
 };

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -127,6 +127,8 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
   });
   const { availableChannels, channel } = useAppChannel();
 
+  const noChannel = !channel && typeof channel !== "undefined";
+
   const [openModal, closeModal] = createDialogActionHandlers<
     ProductListUrlDialog,
     ProductListUrlQueryParams
@@ -222,8 +224,8 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
     );
 
   const paginationState = createPaginationState(settings.rowNumber, params);
-  const filter = getFilterVariables(params, channel.slug);
-  const sort = getSortQueryVariables(params, channel.slug);
+  const filter = !noChannel ? getFilterVariables(params, channel.slug) : null;
+  const sort = !noChannel ? getSortQueryVariables(params, channel.slug) : null;
   const queryVariables = React.useMemo<ProductListVariables>(
     () => ({
       ...paginationState,
@@ -302,7 +304,7 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
           () => attributes.data.availableInGrid.edges.map(edge => edge.node),
           []
         )}
-        currencySymbol={channel?.currencyCode}
+        currencySymbol={channel?.currencyCode || ""}
         currentTab={currentTab}
         defaultSettings={defaultListSettings[ListViews.PRODUCT_LIST]}
         filterOpts={filterOpts}
@@ -380,7 +382,7 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
         tabs={getFilterTabs().map(tab => tab.name)}
         onExport={() => openModal("export")}
         channelsCount={availableChannels?.length}
-        selectedChannelId={channel.id}
+        selectedChannelId={channel?.id}
       />
       <ActionDialog
         open={params.action === "delete"}

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -423,7 +423,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
           loading: searchCollectionsOpts.loading,
           onFetchMore: loadMoreCollections
         }}
-        selectedChannelId={channel.id}
+        selectedChannelId={channel?.id}
         openChannelsModal={handleChannelsModalOpen}
         onChannelsChange={setCurrentChannels}
       />

--- a/src/storybook/stories/home/HomePage.tsx
+++ b/src/storybook/stories/home/HomePage.tsx
@@ -13,6 +13,8 @@ const shop = shopFixture(placeholderImage);
 
 const homePageProps: Omit<HomePageProps, "classes"> = {
   activities: shop.activities.edges.map(edge => edge.node),
+  noChannel: false,
+  onCreateNewChannelClick: () => undefined,
   onOrdersToCaptureClick: () => undefined,
   onOrdersToFulfillClick: () => undefined,
   onProductClick: () => undefined,


### PR DESCRIPTION
I want to merge this change because... it handles empty channels on:
- homepage
- `/dashboard/channels`
- `/dashboard/orders`
- `/dashboard/products`

NOTE: Tested by mocking up response to `[{"data": {"channels": []}}]` on `AppChannelContext.tsx`.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

![image](https://user-images.githubusercontent.com/29279389/103229147-bfcce200-4932-11eb-9725-10a1fb005209.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
