### PR TITLE
Refactor ZIP Codes to postal codes

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -5380,12 +5380,12 @@
   "src_dot_shipping_dot_components_dot_ShippingMethodProducts_dot_4190792473": {
     "string": "Actions"
   },
-  "src_dot_shipping_dot_components_dot_ShippingRateZipCodeRangeRemoveDialog_dot_1083561409": {
-    "string": "Are you sure you want to remove this ZIP-code rule?"
+  "src_dot_shipping_dot_components_dot_ShippingRateZipCodeRangeRemoveDialog_dot_3640694505": {
+    "string": "Are you sure you want to remove this postal code rule?"
   },
-  "src_dot_shipping_dot_components_dot_ShippingRateZipCodeRangeRemoveDialog_dot_2944856644": {
+  "src_dot_shipping_dot_components_dot_ShippingRateZipCodeRangeRemoveDialog_dot_76039652": {
     "context": "header",
-    "string": "Remove ZIP-codes from Shipping Rate"
+    "string": "Remove postal codes from Shipping Rate"
   },
   "src_dot_shipping_dot_components_dot_ShippingWeightUnitForm_dot_2863708228": {
     "string": "This unit will be used as default shipping weight"
@@ -5518,53 +5518,53 @@
     "context": "input placeholder",
     "string": "Select Warehouse"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_1938537617": {
-    "string": "Please provide range of ZIP codes you want to add to the include/exclude list."
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_3070993206": {
+    "context": "range input label",
+    "string": "Postal codes (end)"
   },
   "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_3099331554": {
-    "context": "add zip code range, button",
+    "context": "add postal code range, button",
     "string": "Add"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_3529644799": {
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_3419096551": {
     "context": "range input label",
-    "string": "Zip Codes (Start)"
+    "string": "Postal codes (start)"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_4196919717": {
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_3668595137": {
+    "string": "Please provide range of postal codes you want to add to the include/exclude list."
+  },
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_3849853790": {
     "context": "dialog header",
-    "string": "Add ZIP-Codes"
+    "string": "Add postal codes"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodeRangeDialog_dot_551327109": {
-    "context": "range input label",
-    "string": "Zip Codes (End)"
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_1301350004": {
+    "string": "This shipping rate has no postal codes assigned"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_1462092303": {
-    "string": "Added ZIP-codes will be excluded from using this delivery methods. If none are added all ZIP-Codes will be able to use that shipping rate"
-  },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_1605967697": {
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_1680649143": {
     "context": "action",
-    "string": "Exclude ZIP-codes"
+    "string": "Include postal codes"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_2728850129": {
-    "string": "Only added ZIP-codes will be able to use this shipping rate"
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_1779803917": {
+    "string": "Added postal codes will be excluded from using this delivery methods. If none are added all postal codes will be able to use that shipping rate"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_2850315665": {
-    "context": "number of zip code ranges",
-    "string": "{number} ZIP-Code ranges"
-  },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_3795380518": {
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_1909179974": {
     "context": "button",
-    "string": "Add ZIP-Code range"
+    "string": "Add postal code range"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_4288715411": {
-    "string": "This shipping rate has no ZIP-codes assigned"
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_2274108851": {
+    "context": "number of postal code ranges",
+    "string": "{number} postal code ranges"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_529495587": {
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_2965119249": {
+    "string": "Only added postal codes will be able to use this shipping rate"
+  },
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_3782353530": {
     "context": "postal codes, header",
-    "string": "ZIP-Codes"
+    "string": "Postal codes"
   },
-  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_671838332": {
+  "src_dot_shipping_dot_components_dot_ShippingZoneZipCodes_dot_399764149": {
     "context": "action",
-    "string": "Include ZIP-codes"
+    "string": "Exclude postal codes"
   },
   "src_dot_shipping_dot_components_dot_ShippingZonesListPage_dot_1325966144": {
     "context": "header",
@@ -5622,12 +5622,12 @@
   "src_dot_shipping_dot_views_dot_PriceRatesCreate_dot_3823295269": {
     "string": "Manage Channel Availability"
   },
-  "src_dot_shipping_dot_views_dot_PriceRatesUpdate_dot_2710215007": {
-    "context": "zip code range add error text",
-    "string": "Cannot add specified zip codes range."
-  },
   "src_dot_shipping_dot_views_dot_PriceRatesUpdate_dot_3823295269": {
     "string": "Manage Channel Availability"
+  },
+  "src_dot_shipping_dot_views_dot_PriceRatesUpdate_dot_4243341946": {
+    "context": "postal code range add error text",
+    "string": "Cannot add specified postal codes range."
   },
   "src_dot_shipping_dot_views_dot_PriceRatesUpdate_dot_870815507": {
     "context": "unassign products from shipping method, button",
@@ -5648,12 +5648,12 @@
   "src_dot_shipping_dot_views_dot_WeightRatesCreate_dot_3014453080": {
     "string": "Manage Channels Availability"
   },
-  "src_dot_shipping_dot_views_dot_WeightRatesUpdate_dot_2710215007": {
-    "context": "zip code range add error text",
-    "string": "Cannot add specified zip codes range."
-  },
   "src_dot_shipping_dot_views_dot_WeightRatesUpdate_dot_3014453080": {
     "string": "Manage Channels Availability"
+  },
+  "src_dot_shipping_dot_views_dot_WeightRatesUpdate_dot_4243341946": {
+    "context": "postal code range add error text",
+    "string": "Cannot add specified postal codes range."
   },
   "src_dot_shipping_dot_views_dot_WeightRatesUpdate_dot_870815507": {
     "context": "unassign products from shipping method, button",

--- a/src/shipping/components/ShippingRateZipCodeRangeRemoveDialog/ShippingRateZipCodeRangeRemoveDialog.tsx
+++ b/src/shipping/components/ShippingRateZipCodeRangeRemoveDialog/ShippingRateZipCodeRangeRemoveDialog.tsx
@@ -25,13 +25,13 @@ const ShippingRateZipCodeRangeRemoveDialog: React.FC<ShippingRateZipCodeRangeRem
       onClose={onClose}
       onConfirm={onConfirm}
       title={intl.formatMessage({
-        defaultMessage: "Remove ZIP-codes from Shipping Rate",
+        defaultMessage: "Remove postal codes from Shipping Rate",
         description: "header"
       })}
       variant="delete"
     >
       <DialogContentText>
-        <FormattedMessage defaultMessage="Are you sure you want to remove this ZIP-code rule?" />
+        <FormattedMessage defaultMessage="Are you sure you want to remove this postal code rule?" />
       </DialogContentText>
     </ActionDialog>
   );

--- a/src/shipping/components/ShippingZoneZipCodeRangeDialog/ShippingZoneZipCodeRangeDialog.stories.tsx
+++ b/src/shipping/components/ShippingZoneZipCodeRangeDialog/ShippingZoneZipCodeRangeDialog.stories.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import ShippingZoneZipCodeRangeDialog from "./ShippingZoneZipCodeRangeDialog";
 
-storiesOf("Shipping / Add zip code range", module)
+storiesOf("Shipping / Add postal code range", module)
   .addDecorator(Decorator)
   .add("default", () => (
     <ShippingZoneZipCodeRangeDialog

--- a/src/shipping/components/ShippingZoneZipCodeRangeDialog/ShippingZoneZipCodeRangeDialog.tsx
+++ b/src/shipping/components/ShippingZoneZipCodeRangeDialog/ShippingZoneZipCodeRangeDialog.tsx
@@ -50,7 +50,7 @@ const ShippingZoneZipCodeRangeDialog: React.FC<ShippingZoneZipCodeRangeDialogPro
     <Dialog open={open}>
       <DialogTitle>
         <FormattedMessage
-          defaultMessage="Add ZIP-Codes"
+          defaultMessage="Add postal codes"
           description="dialog header"
         />
       </DialogTitle>
@@ -59,12 +59,12 @@ const ShippingZoneZipCodeRangeDialog: React.FC<ShippingZoneZipCodeRangeDialogPro
           <>
             <DialogContent>
               <Typography className={classes.info}>
-                <FormattedMessage defaultMessage="Please provide range of ZIP codes you want to add to the include/exclude list." />
+                <FormattedMessage defaultMessage="Please provide range of postal codes you want to add to the include/exclude list." />
               </Typography>
               <Grid variant="uniform">
                 <TextField
                   label={intl.formatMessage({
-                    defaultMessage: "Zip Codes (Start)",
+                    defaultMessage: "Postal codes (start)",
                     description: "range input label"
                   })}
                   name="min"
@@ -73,7 +73,7 @@ const ShippingZoneZipCodeRangeDialog: React.FC<ShippingZoneZipCodeRangeDialogPro
                 />
                 <TextField
                   label={intl.formatMessage({
-                    defaultMessage: "Zip Codes (End)",
+                    defaultMessage: "Postal codes (end)",
                     description: "range input label"
                   })}
                   name="max"
@@ -94,7 +94,7 @@ const ShippingZoneZipCodeRangeDialog: React.FC<ShippingZoneZipCodeRangeDialogPro
               >
                 <FormattedMessage
                   defaultMessage="Add"
-                  description="add zip code range, button"
+                  description="add postal code range, button"
                 />
               </ConfirmButton>
             </DialogActions>

--- a/src/shipping/components/ShippingZoneZipCodes/ShippingZoneZipCodes.tsx
+++ b/src/shipping/components/ShippingZoneZipCodes/ShippingZoneZipCodes.tsx
@@ -48,9 +48,6 @@ const useStyles = makeStyles(
       width: 80
     },
     colCode: {},
-    hide: {
-      display: "none"
-    },
     option: {
       marginBottom: theme.spacing(2),
       width: 400
@@ -84,7 +81,7 @@ const ShippingZoneZipCodes: React.FC<ShippingZoneZipCodesProps> = ({
     <Card>
       <CardTitle
         title={intl.formatMessage({
-          defaultMessage: "ZIP-Codes",
+          defaultMessage: "Postal codes",
           description: "postal codes, header"
         })}
         toolbar={
@@ -94,13 +91,13 @@ const ShippingZoneZipCodes: React.FC<ShippingZoneZipCodesProps> = ({
             data-test="add-zip-code-range"
           >
             <FormattedMessage
-              defaultMessage="Add ZIP-Code range"
+              defaultMessage="Add postal code range"
               description="button"
             />
           </Button>
         }
       />
-      <CardContent className={classNames(classes.radioContainer, classes.hide)}>
+      <CardContent className={classNames(classes.radioContainer)}>
         <RadioGroupField
           alignTop
           choices={[
@@ -110,12 +107,12 @@ const ShippingZoneZipCodes: React.FC<ShippingZoneZipCodesProps> = ({
                 <div className={classes.option}>
                   <Typography color="textSecondary" variant="body1">
                     <FormattedMessage
-                      defaultMessage="Exclude ZIP-codes"
+                      defaultMessage="Exclude postal codes"
                       description="action"
                     />
                   </Typography>
                   <Typography color="textSecondary" variant="caption">
-                    <FormattedMessage defaultMessage="Added ZIP-codes will be excluded from using this delivery methods. If none are added all ZIP-Codes will be able to use that shipping rate" />
+                    <FormattedMessage defaultMessage="Added postal codes will be excluded from using this delivery methods. If none are added all postal codes will be able to use that shipping rate" />
                   </Typography>
                 </div>
               ),
@@ -126,12 +123,12 @@ const ShippingZoneZipCodes: React.FC<ShippingZoneZipCodesProps> = ({
                 <div className={classes.option}>
                   <Typography variant="body1">
                     <FormattedMessage
-                      defaultMessage="Include ZIP-codes"
+                      defaultMessage="Include postal codes"
                       description="action"
                     />
                   </Typography>
                   <Typography color="textSecondary" variant="caption">
-                    <FormattedMessage defaultMessage="Only added ZIP-codes will be able to use this shipping rate" />
+                    <FormattedMessage defaultMessage="Only added postal codes will be able to use this shipping rate" />
                   </Typography>
                 </div>
               ),
@@ -158,8 +155,8 @@ const ShippingZoneZipCodes: React.FC<ShippingZoneZipCodesProps> = ({
                   ) : (
                     <Typography variant="caption">
                       <FormattedMessage
-                        defaultMessage="{number} ZIP-Code ranges"
-                        description="number of zip code ranges"
+                        defaultMessage="{number} postal code ranges"
+                        description="number of postal code ranges"
                         values={{
                           number: zipCodes.length
                         }}
@@ -213,7 +210,7 @@ const ShippingZoneZipCodes: React.FC<ShippingZoneZipCodesProps> = ({
                 <TableRow>
                   <TableCell colSpan={2}>
                     <Typography color="textSecondary">
-                      <FormattedMessage defaultMessage="This shipping rate has no ZIP-codes assigned" />
+                      <FormattedMessage defaultMessage="This shipping rate has no postal codes assigned" />
                     </Typography>
                   </TableCell>
                 </TableRow>

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -125,8 +125,8 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
         notify({
           status: "error",
           text: intl.formatMessage({
-            defaultMessage: "Cannot add specified zip codes range.",
-            description: "zip code range add error text"
+            defaultMessage: "Cannot add specified postal codes range.",
+            description: "postal code range add error text"
           })
         });
       }

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -186,8 +186,8 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
         notify({
           status: "error",
           text: intl.formatMessage({
-            defaultMessage: "Cannot add specified zip codes range.",
-            description: "zip code range add error text"
+            defaultMessage: "Cannot add specified postal codes range.",
+            description: "postal code range add error text"
           })
         });
       }


### PR DESCRIPTION
I want to merge this change because it switches the name of zip codes to postal codes. ZIP Codes is a name that is US specific.
It also un-hides the hidden radio button switch which should be visible to user - even if we don't support inclusion for now, end user MUST see that he is EXCLUDING that codes and it wasn't exposed before.

Related ticket: [SALEOR-2013](https://app.clickup.com/t/2549495/SALEOR-2013)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
![image](https://user-images.githubusercontent.com/12252472/103892821-86dbfc80-50ec-11eb-9f1e-3dfa2ab3b6f8.png)



<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
