### PR TITLE
Handle new order statuses - returned & partially returned

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4301,6 +4301,10 @@
     "context": "payment status",
     "string": "Partially refunded"
   },
+  "src_dot_partiallyReturned": {
+    "context": "order status",
+    "string": "Partially returned"
+  },
   "src_dot_permissionGroups": {
     "context": "permission groups section name",
     "string": "Permission Groups"
@@ -5335,6 +5339,10 @@
   },
   "src_dot_requiredField": {
     "string": "This field is required"
+  },
+  "src_dot_returned": {
+    "context": "order status",
+    "string": "Returned"
   },
   "src_dot_sales": {
     "context": "sales section name",

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -136,12 +136,20 @@ export const orderStatusMessages = defineMessages({
     defaultMessage: "Partially fulfilled",
     description: "order status"
   },
+  partiallyReturned: {
+    defaultMessage: "Partially returned",
+    description: "order status"
+  },
   readyToCapture: {
     defaultMessage: "Ready to capture",
     description: "order status"
   },
   readyToFulfill: {
     defaultMessage: "Ready to fulfill",
+    description: "order status"
+  },
+  returned: {
+    defaultMessage: "Returned",
     description: "order status"
   },
   unconfirmed: {
@@ -188,6 +196,16 @@ export const transformOrderStatus = (
       return {
         localized: intl.formatMessage(orderStatusMessages.unconfirmed),
         status: StatusType.NEUTRAL
+      };
+    case OrderStatus.PARTIALLY_RETURNED:
+      return {
+        localized: intl.formatMessage(orderStatusMessages.partiallyReturned),
+        status: StatusType.NEUTRAL
+      };
+    case OrderStatus.RETURNED:
+      return {
+        localized: intl.formatMessage(orderStatusMessages.returned),
+        status: StatusType.ERROR
       };
   }
   return {

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -205,7 +205,7 @@ export const transformOrderStatus = (
     case OrderStatus.RETURNED:
       return {
         localized: intl.formatMessage(orderStatusMessages.returned),
-        status: StatusType.ERROR
+        status: StatusType.NEUTRAL
       };
   }
   return {


### PR DESCRIPTION
I want to merge this change because it adds displaying of new order statuses - returned & partially returned

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
