### PR TITLE
Fix bug with uncomplete publish date

### DIFF
--- a/src/components/ChannelsAvailability/ChannelsAvailability.tsx
+++ b/src/components/ChannelsAvailability/ChannelsAvailability.tsx
@@ -230,7 +230,7 @@ const Channel: React.FC<ChannelProps> = ({
                           )
                         : ""
                     }
-                    value={publicationDate}
+                    value={publicationDate || ""}
                     onChange={e =>
                       onChange(id, {
                         ...formData,

--- a/src/components/ChannelsAvailability/ChannelsAvailability.tsx
+++ b/src/components/ChannelsAvailability/ChannelsAvailability.tsx
@@ -230,11 +230,11 @@ const Channel: React.FC<ChannelProps> = ({
                           )
                         : ""
                     }
-                    value={publicationDate ? publicationDate : ""}
+                    value={publicationDate}
                     onChange={e =>
                       onChange(id, {
                         ...formData,
-                        publicationDate: e.target.value
+                        publicationDate: e.target.value || null
                       })
                     }
                     className={classes.date}


### PR DESCRIPTION
I want to merge this change because... it fixes error when trying to save uncomplete publish date.

**Explanation:**
Empty `publicationDate` should be `""` in `ChannelsAvailability` component, but need to be sent as `null` in query.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
