### PR TITLE
[FIX] product add stock

### DIFF
--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -274,7 +274,6 @@ function useProductUpdateForm(
     ...data,
     ...getStocksData(product, stocks.data),
     ...getMetadata(data, isMetadataModified, isPrivateMetadataModified),
-    addStocks: [],
     attributes: attributes.data,
     attributesWithNewFileValue: attributesWithNewFileValue.data,
     description: description.current


### PR DESCRIPTION
I want to merge this change because, when updating a simple product, and we want to add a new stock, it is not saved.

as you can see in the code delete item addStocks: [],

because it is already over writing what it returns ... getStocksData (product, stocks.data),

for this reason, it is not saved when adding a stock to an already registered product..


**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
