### PR TITLE
Make sure invoices card is visible only on orders other than unconfirmed

### DIFF
--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -254,13 +254,17 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
                   selectedChannelName={order?.channel?.name}
                 />
                 <CardSpacer />
-                <OrderInvoiceList
-                  invoices={order?.invoices}
-                  onInvoiceClick={onInvoiceClick}
-                  onInvoiceGenerate={onInvoiceGenerate}
-                  onInvoiceSend={onInvoiceSend}
-                />
-                <CardSpacer />
+                {order?.status !== OrderStatus.UNCONFIRMED && (
+                  <div>
+                    <OrderInvoiceList
+                      invoices={order?.invoices}
+                      onInvoiceClick={onInvoiceClick}
+                      onInvoiceGenerate={onInvoiceGenerate}
+                      onInvoiceSend={onInvoiceSend}
+                    />
+                    <CardSpacer />
+                  </div>
+                )}
                 <OrderCustomerNote note={maybe(() => order.customerNote)} />
               </div>
             </Grid>


### PR DESCRIPTION
I want to merge this change because the invoices card was visible in order details for unconfirmed order.
Backend is blocking that, frontend should hide the card as well.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** master

### Screenshots
what is conditionally hidden:
![image](https://user-images.githubusercontent.com/12252472/104441472-04dc4f80-5594-11eb-83db-c37133f3de36.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [X] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
