### PR TITLE
Saleor 1861 - add error handling to returns form

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3911,6 +3911,10 @@
     "context": "cancelled fulfillment, section header",
     "string": "Cancelled ({quantity})"
   },
+  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_description": {
+    "context": "product no longer exists error description",
+    "string": "This product is no longer in database so it can’t be replaced, nor returned"
+  },
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_fulfilled": {
     "context": "section header",
     "string": "Fulfilled ({quantity})"
@@ -3934,6 +3938,10 @@
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_returned": {
     "context": "refunded fulfillment, section header",
     "string": "Returned ({quantity})"
+  },
+  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_title": {
+    "context": "product no longer exists error title",
+    "string": "Product no longer exists"
   },
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_titleFulfilled": {
     "context": "section header",
@@ -4071,7 +4079,15 @@
     "context": "order refunded success message",
     "string": "Refunded Items"
   },
-  "src_dot_orders_dot_views_dot_OrderReturn_dot_3262896749": {
+  "src_dot_orders_dot_views_dot_OrderReturn_dot_cannotRefundDescription": {
+    "context": "order return error description when cannot refund",
+    "string": "We’ve encountered a problem while refunding the products. Product’s were not refunded. Please try again."
+  },
+  "src_dot_orders_dot_views_dot_OrderReturn_dot_cannotRefundTitle": {
+    "context": "order return error title when cannot refund",
+    "string": "Couldn't refund products"
+  },
+  "src_dot_orders_dot_views_dot_OrderReturn_dot_successAlert": {
     "context": "order returned success message",
     "string": "Successfully returned products!"
   },

--- a/src/components/Theme/themes.ts
+++ b/src/components/Theme/themes.ts
@@ -77,7 +77,7 @@ export const light: IThemeColors = {
     default: "#616161"
   },
   divider: "#EAEAEA",
-  error: "#C22D74",
+  error: "#FE6D76",
   font: {
     button: "#FFFFFF",
     default: "#3D3D3D",

--- a/src/icons/ErrorExclamationCircle.tsx
+++ b/src/icons/ErrorExclamationCircle.tsx
@@ -1,0 +1,25 @@
+import createSvgIcon from "@material-ui/icons/utils/createSvgIcon";
+import React from "react";
+
+const ErrorExclamationCircle = createSvgIcon(
+  <>
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="12" r="12" fill="#FE6D76" />
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M12.75 6H11.25V15H12.75V6ZM12.75 16.5H11.25V18H12.75V16.5Z"
+        fill="white"
+      />
+    </svg>
+  </>,
+  "ErrorExclamationCircle"
+);
+
+export default ErrorExclamationCircle;

--- a/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
@@ -63,6 +63,7 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
               {!!data.unfulfiledItemsQuantities.length && (
                 <>
                   <ItemsCard
+                    errors={errors}
                     order={order}
                     lines={getUnfulfilledLines(order)}
                     itemsQuantities={data.unfulfiledItemsQuantities}
@@ -81,6 +82,7 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
                 ({ id, lines }) => (
                   <React.Fragment key={id}>
                     <ItemsCard
+                      errors={errors}
                       order={order}
                       fulfilmentId={id}
                       lines={getParsedFulfiledLines(lines)}

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
@@ -1,0 +1,98 @@
+import { makeStyles, TableCell, Typography } from "@material-ui/core";
+import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
+import ErrorExclamationCircleIcon from "@saleor/icons/ErrorExclamationCircle";
+import React, { useState } from "react";
+import { defineMessages } from "react-intl";
+import { useIntl } from "react-intl";
+
+const useStyles = makeStyles(
+  theme => ({
+    container: {
+      position: "relative"
+    },
+    errorBox: {
+      backgroundColor: "#FE6D76",
+      borderRadius: 8,
+      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
+      position: "absolute",
+      right: theme.spacing(3),
+      textAlign: "left",
+      top: `calc(100% - 8px)`,
+      width: 280,
+      zIndex: 1000
+    },
+    errorText: {
+      color: "white",
+      fontSize: 14
+    },
+    errorTextHighlighted: {
+      color: "#FE6D76",
+      fontSize: 12,
+      marginRight: theme.spacing(1)
+    },
+    titleContainer: {
+      alignItems: "center",
+      display: "flex",
+      flexDirection: "row",
+      justifyContent: "flex-end"
+    }
+  }),
+  { name: "ProductErrorCell" }
+);
+
+const messages = defineMessages({
+  description: {
+    defaultMessage:
+      "This product is no longer in database so it can’t be replaced, nor returned",
+    description: "product no longer exists error description"
+  },
+  title: {
+    defaultMessage: "Product no longer exists",
+    description: "product no longer exists error title"
+  }
+});
+
+interface ProductErrorCellProps {
+  lineId: string;
+  errors: OrderErrorFragment[];
+}
+
+const ProductErrorCell: React.FC<ProductErrorCellProps> = (
+  {
+    //   errors,
+    //   lineId
+  }
+) => {
+  const classes = useStyles({});
+  const intl = useIntl();
+
+  const [showErrorBox, setShowErrorBox] = useState<boolean>(false);
+
+  // replace with proper find from errors
+  const hasProductError = true;
+  const shouldShowErrorBox = showErrorBox && hasProductError;
+
+  return (
+    <TableCell align="right" className={classes.container}>
+      <div
+        className={classes.titleContainer}
+        onMouseEnter={() => setShowErrorBox(true)}
+        onMouseLeave={() => setShowErrorBox(false)}
+      >
+        <Typography className={classes.errorTextHighlighted}>
+          {intl.formatMessage(messages.title)}
+        </Typography>
+        <ErrorExclamationCircleIcon />
+      </div>
+      {shouldShowErrorBox && (
+        <div className={classes.errorBox}>
+          <Typography className={classes.errorText}>
+            {intl.formatMessage(messages.description)}
+          </Typography>
+        </div>
+      )}
+    </TableCell>
+  );
+};
+
+export default ProductErrorCell;

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles(
       position: "relative"
     },
     errorBox: {
-      backgroundColor: "#FE6D76",
+      backgroundColor: theme.palette.error.main,
       borderRadius: 8,
       marginRight: theme.spacing(3),
       padding: theme.spacing(2, 3),
@@ -25,7 +25,7 @@ const useStyles = makeStyles(
       fontSize: 14
     },
     errorTextHighlighted: {
-      color: "#FE6D76",
+      color: theme.palette.error.main,
       fontSize: 12,
       marginRight: theme.spacing(1)
     },

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
@@ -1,4 +1,5 @@
 import { makeStyles, TableCell, Typography } from "@material-ui/core";
+import Popper from "@material-ui/core/Popper";
 import ErrorExclamationCircleIcon from "@saleor/icons/ErrorExclamationCircle";
 import React, { useState } from "react";
 import { defineMessages } from "react-intl";
@@ -12,11 +13,8 @@ const useStyles = makeStyles(
     errorBox: {
       backgroundColor: "#FE6D76",
       borderRadius: 8,
-      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`,
-      position: "absolute",
-      right: theme.spacing(3),
-      textAlign: "left",
-      top: `calc(100% - 8px)`,
+      marginRight: theme.spacing(3),
+      padding: theme.spacing(2, 3),
       width: 280,
       zIndex: 1000
     },
@@ -58,6 +56,7 @@ interface ProductErrorCellProps {
 const ProductErrorCell: React.FC<ProductErrorCellProps> = ({ hasVariant }) => {
   const classes = useStyles({});
   const intl = useIntl();
+  const popperAnchorRef = React.useRef<HTMLButtonElement | null>(null);
 
   const [showErrorBox, setShowErrorBox] = useState<boolean>(false);
 
@@ -66,7 +65,11 @@ const ProductErrorCell: React.FC<ProductErrorCellProps> = ({ hasVariant }) => {
   }
 
   return (
-    <TableCell align="right" className={classes.container}>
+    <TableCell
+      align="right"
+      className={classes.container}
+      ref={popperAnchorRef}
+    >
       <div
         className={classes.titleContainer}
         onMouseEnter={() => setShowErrorBox(true)}
@@ -77,13 +80,17 @@ const ProductErrorCell: React.FC<ProductErrorCellProps> = ({ hasVariant }) => {
         </Typography>
         <ErrorExclamationCircleIcon />
       </div>
-      {showErrorBox && (
+      <Popper
+        placement="bottom-end"
+        open={showErrorBox}
+        anchorEl={popperAnchorRef.current}
+      >
         <div className={classes.errorBox}>
           <Typography className={classes.errorText}>
             {intl.formatMessage(messages.description)}
           </Typography>
         </div>
-      )}
+      </Popper>
     </TableCell>
   );
 };

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
@@ -1,5 +1,7 @@
-import { makeStyles, TableCell, Typography } from "@material-ui/core";
 import Popper from "@material-ui/core/Popper";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import TableCell from "@material-ui/core/TableCell";
+import Typography from "@material-ui/core/Typography";
 import ErrorExclamationCircleIcon from "@saleor/icons/ErrorExclamationCircle";
 import React, { useState } from "react";
 import { defineMessages } from "react-intl";

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
@@ -1,6 +1,5 @@
 import { makeStyles, TableCell, Typography } from "@material-ui/core";
 import ErrorExclamationCircleIcon from "@saleor/icons/ErrorExclamationCircle";
-import { OrderDetails_order_lines } from "@saleor/orders/types/OrderDetails";
 import React, { useState } from "react";
 import { defineMessages } from "react-intl";
 import { useIntl } from "react-intl";

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ProductErrorCell.tsx
@@ -1,6 +1,6 @@
 import { makeStyles, TableCell, Typography } from "@material-ui/core";
-import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
 import ErrorExclamationCircleIcon from "@saleor/icons/ErrorExclamationCircle";
+import { OrderDetails_order_lines } from "@saleor/orders/types/OrderDetails";
 import React, { useState } from "react";
 import { defineMessages } from "react-intl";
 import { useIntl } from "react-intl";
@@ -53,24 +53,18 @@ const messages = defineMessages({
 });
 
 interface ProductErrorCellProps {
-  lineId: string;
-  errors: OrderErrorFragment[];
+  hasVariant: boolean;
 }
 
-const ProductErrorCell: React.FC<ProductErrorCellProps> = (
-  {
-    //   errors,
-    //   lineId
-  }
-) => {
+const ProductErrorCell: React.FC<ProductErrorCellProps> = ({ hasVariant }) => {
   const classes = useStyles({});
   const intl = useIntl();
 
   const [showErrorBox, setShowErrorBox] = useState<boolean>(false);
 
-  // replace with proper find from errors
-  const hasProductError = true;
-  const shouldShowErrorBox = showErrorBox && hasProductError;
+  if (hasVariant) {
+    return <TableCell />;
+  }
 
   return (
     <TableCell align="right" className={classes.container}>
@@ -84,7 +78,7 @@ const ProductErrorCell: React.FC<ProductErrorCellProps> = (
         </Typography>
         <ErrorExclamationCircleIcon />
       </div>
-      {shouldShowErrorBox && (
+      {showErrorBox && (
         <div className={classes.errorBox}>
           <Typography className={classes.errorText}>
             {intl.formatMessage(messages.description)}

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
@@ -13,6 +13,7 @@ import {
 import Money from "@saleor/components/Money";
 import Skeleton from "@saleor/components/Skeleton";
 import TableCellAvatar from "@saleor/components/TableCellAvatar";
+import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
 import { FormsetChange } from "@saleor/hooks/useFormset";
 import { renderCollection } from "@saleor/misc";
 import {
@@ -83,6 +84,7 @@ interface OrderReturnRefundLinesCardProps {
   onChangeQuantity: FormsetChange<number>;
   fulfilmentId?: string;
   canReplace?: boolean;
+  errors: OrderErrorFragment[];
   lines: OrderDetails_order_lines[];
   order: OrderDetails_order;
   itemsSelections: FormsetReplacementData;
@@ -100,6 +102,7 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
   itemsQuantities,
   fulfilmentId,
   order
+  // errors
 }) => {
   const classes = useStyles({});
   const intl = useIntl();

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
@@ -8,8 +8,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  TextField,
-  Typography
+  TextField
 } from "@material-ui/core";
 import Money from "@saleor/components/Money";
 import Skeleton from "@saleor/components/Skeleton";
@@ -21,7 +20,7 @@ import {
   OrderDetails_order,
   OrderDetails_order_lines
 } from "@saleor/orders/types/OrderDetails";
-import React, { CSSProperties, useState } from "react";
+import React, { CSSProperties } from "react";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
 import { FormsetQuantityData, FormsetReplacementData } from "../form";
@@ -106,8 +105,7 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
   itemsSelections,
   itemsQuantities,
   fulfilmentId,
-  order,
-  errors
+  order
 }) => {
   const classes = useStyles({});
   const intl = useIntl();
@@ -162,34 +160,42 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
         <TableBody>
           {renderCollection(
             lines,
-            ({
-              quantity,
-              quantityFulfilled,
-              id,
-              thumbnail,
-              unitPrice,
-              productName,
-              variant
-            }) => {
+            line => {
+              const {
+                quantity,
+                quantityFulfilled,
+                id,
+                thumbnail,
+                unitPrice,
+                productName,
+                variant
+              } = line;
               const isValueError = false;
               const isRefunded = itemsQuantities.find(getById(id)).data
                 .isRefunded;
               const isReplacable = !!variant && !isRefunded;
+              const isReturnable = !!variant;
               const lineQuantity = fulfilmentId
                 ? quantity
                 : quantity - quantityFulfilled;
               const isSelected = itemsSelections.find(getById(id))?.value;
               const currentQuantity = itemsQuantities.find(getById(id))?.value;
+              const anyLineWithoutVariant = lines.some(
+                ({ variant }) => !variant
+              );
+              const productNameCellWidth = anyLineWithoutVariant
+                ? "30%"
+                : "50%";
 
               return (
                 <TableRow key={id}>
                   <TableCellAvatar
                     thumbnail={thumbnail?.url}
-                    style={{ width: "30%" }}
+                    style={{ width: productNameCellWidth }}
                   >
                     {productName || <Skeleton />}
                   </TableCellAvatar>
-                  <ProductErrorCell lineId={id} errors={errors} />
+                  <ProductErrorCell hasVariant={isReturnable} />
                   <TableCell align="right">
                     <Money
                       money={{
@@ -199,32 +205,34 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
                     />
                   </TableCell>
                   <TableCell align="right">
-                    <TextField
-                      type="number"
-                      inputProps={{
-                        className: classes.quantityInnerInput,
-                        "data-test": "quantityInput",
-                        "data-test-id": id,
-                        max: lineQuantity.toString(),
-                        min: 0,
-                        style: { textAlign: "right" }
-                      }}
-                      fullWidth
-                      value={currentQuantity}
-                      onChange={handleChangeQuantity(id)}
-                      InputProps={{
-                        endAdornment: lineQuantity && (
-                          <div className={classes.remainingQuantity}>
-                            / {lineQuantity}
-                          </div>
-                        )
-                      }}
-                      error={isValueError}
-                      helperText={
-                        isValueError &&
-                        intl.formatMessage(messages.improperValue)
-                      }
-                    />
+                    {isReturnable && (
+                      <TextField
+                        type="number"
+                        inputProps={{
+                          className: classes.quantityInnerInput,
+                          "data-test": "quantityInput",
+                          "data-test-id": id,
+                          max: lineQuantity.toString(),
+                          min: 0,
+                          style: { textAlign: "right" }
+                        }}
+                        fullWidth
+                        value={currentQuantity}
+                        onChange={handleChangeQuantity(id)}
+                        InputProps={{
+                          endAdornment: lineQuantity && (
+                            <div className={classes.remainingQuantity}>
+                              / {lineQuantity}
+                            </div>
+                          )
+                        }}
+                        error={isValueError}
+                        helperText={
+                          isValueError &&
+                          intl.formatMessage(messages.improperValue)
+                        }
+                      />
+                    )}
                   </TableCell>
                   <TableCell align="center">
                     {isReplacable && (

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
@@ -8,7 +8,8 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  TextField
+  TextField,
+  Typography
 } from "@material-ui/core";
 import Money from "@saleor/components/Money";
 import Skeleton from "@saleor/components/Skeleton";
@@ -20,13 +21,14 @@ import {
   OrderDetails_order,
   OrderDetails_order_lines
 } from "@saleor/orders/types/OrderDetails";
-import React, { CSSProperties } from "react";
+import React, { CSSProperties, useState } from "react";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
 import { FormsetQuantityData, FormsetReplacementData } from "../form";
 import { getById } from "../utils";
 import CardTitle from "./CardTitle";
 import MaximalButton from "./MaximalButton";
+import ProductErrorCell from "./ProductErrorCell";
 
 const useStyles = makeStyles(
   theme => {
@@ -40,10 +42,12 @@ const useStyles = makeStyles(
         paddingBottom: 0,
         paddingTop: 0
       },
+
       notice: {
         marginBottom: theme.spacing(1),
         marginTop: theme.spacing(2)
       },
+
       quantityInnerInput: {
         ...inputPadding
       },
@@ -70,6 +74,7 @@ const messages = defineMessages({
     defaultMessage: "Improper value",
     description: "error message"
   },
+
   titleFulfilled: {
     defaultMessage: "Fulfillment - #{fulfilmentId}",
     description: "section header"
@@ -101,8 +106,8 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
   itemsSelections,
   itemsQuantities,
   fulfilmentId,
-  order
-  // errors
+  order,
+  errors
 }) => {
   const classes = useStyles({});
   const intl = useIntl();
@@ -133,6 +138,7 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
                 description="table column header"
               />
             </TableCell>
+            <TableCell />
             <TableCell align="right">
               <FormattedMessage
                 defaultMessage="Price"
@@ -165,7 +171,7 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
               productName,
               variant
             }) => {
-              const isError = false;
+              const isValueError = false;
               const isRefunded = itemsQuantities.find(getById(id)).data
                 .isRefunded;
               const isReplacable = !!variant && !isRefunded;
@@ -179,10 +185,11 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
                 <TableRow key={id}>
                   <TableCellAvatar
                     thumbnail={thumbnail?.url}
-                    style={{ width: "50%" }}
+                    style={{ width: "30%" }}
                   >
                     {productName || <Skeleton />}
                   </TableCellAvatar>
+                  <ProductErrorCell lineId={id} errors={errors} />
                   <TableCell align="right">
                     <Money
                       money={{
@@ -212,9 +219,10 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
                           </div>
                         )
                       }}
-                      error={isError}
+                      error={isValueError}
                       helperText={
-                        isError && intl.formatMessage(messages.improperValue)
+                        isValueError &&
+                        intl.formatMessage(messages.improperValue)
                       }
                     />
                   </TableCell>

--- a/src/orders/views/OrderReturn/OrderReturn.tsx
+++ b/src/orders/views/OrderReturn/OrderReturn.tsx
@@ -1,14 +1,28 @@
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
+import { commonMessages } from "@saleor/intl";
 import OrderReturnPage from "@saleor/orders/components/OrderReturnPage";
 import { OrderReturnFormData } from "@saleor/orders/components/OrderReturnPage/form";
 import { useOrderReturnCreateMutation } from "@saleor/orders/mutations";
 import { useOrderQuery } from "@saleor/orders/queries";
 import { orderUrl } from "@saleor/orders/urls";
+import { OrderErrorCode } from "@saleor/types/globalTypes";
 import React from "react";
+import { defineMessages } from "react-intl";
 import { useIntl } from "react-intl";
 
 import { getParsedData } from "./utils";
+
+export const messages = defineMessages({
+  cannotRefund: {
+    defaultMessage: "Cannot refund some of the items",
+    description: "order return error message when cannot refund"
+  },
+  successAlert: {
+    defaultMessage: "Successfully returned products!",
+    description: "order returned success message"
+  }
+});
 
 interface OrderReturnProps {
   orderId: string;
@@ -33,13 +47,26 @@ const OrderReturn: React.FC<OrderReturnProps> = ({ orderId }) => {
       if (!errors.length) {
         notify({
           status: "success",
-          text: intl.formatMessage({
-            defaultMessage: "Successfully returned products!",
-            description: "order returned success message"
-          })
+          text: intl.formatMessage(messages.successAlert)
         });
         navigateToOrder(replaceOrder?.id);
       }
+
+      if (errors[0].code === OrderErrorCode.CANNOT_REFUND) {
+        notify({
+          autohide: 5000,
+          status: "error",
+          text: intl.formatMessage(messages.cannotRefund)
+        });
+
+        return;
+      }
+
+      notify({
+        autohide: 5000,
+        status: "error",
+        text: intl.formatMessage(commonMessages.somethingWentWrong)
+      });
     }
   });
 

--- a/src/orders/views/OrderReturn/OrderReturn.tsx
+++ b/src/orders/views/OrderReturn/OrderReturn.tsx
@@ -14,9 +14,14 @@ import { useIntl } from "react-intl";
 import { getParsedData } from "./utils";
 
 export const messages = defineMessages({
-  cannotRefund: {
-    defaultMessage: "Cannot refund some of the items",
-    description: "order return error message when cannot refund"
+  cannotRefundDescription: {
+    defaultMessage:
+      "We’ve encountered a problem while refunding the products. Product’s were not refunded. Please try again.",
+    description: "order return error description when cannot refund"
+  },
+  cannotRefundTitle: {
+    defaultMessage: "Couldn't refund products",
+    description: "order return error title when cannot refund"
   },
   successAlert: {
     defaultMessage: "Successfully returned products!",
@@ -56,7 +61,8 @@ const OrderReturn: React.FC<OrderReturnProps> = ({ orderId }) => {
         notify({
           autohide: 5000,
           status: "error",
-          text: intl.formatMessage(messages.cannotRefund)
+          text: intl.formatMessage(messages.cannotRefundDescription),
+          title: intl.formatMessage(messages.cannotRefundTitle)
         });
 
         return;


### PR DESCRIPTION
I want to merge this change because it adds error handling to returns page

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
