### PR TITLE
2068 - Add product reference type to attributes

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -769,6 +769,10 @@
     "context": "page attribute entity type",
     "string": "Pages"
   },
+  "src_dot_attributes_dot_components_dot_AttributeDetails_dot_product": {
+    "context": "product attribute entity type",
+    "string": "Products"
+  },
   "src_dot_attributes_dot_components_dot_AttributeDetails_dot_references": {
     "context": "references attribute type",
     "string": "References"

--- a/schema.graphql
+++ b/schema.graphql
@@ -454,6 +454,7 @@ type AttributeDelete {
 
 enum AttributeEntityTypeEnum {
   PAGE
+  PRODUCT
 }
 
 type AttributeError {

--- a/src/attributes/components/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/components/AttributeDetails/AttributeDetails.tsx
@@ -71,6 +71,10 @@ const entityTypeMessages = defineMessages({
   page: {
     defaultMessage: "Pages",
     description: "page attribute entity type"
+  },
+  product: {
+    defaultMessage: "Products",
+    description: "product attribute entity type"
   }
 });
 
@@ -122,6 +126,10 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = props => {
     {
       label: intl.formatMessage(entityTypeMessages.page),
       value: AttributeEntityTypeEnum.PAGE
+    },
+    {
+      label: intl.formatMessage(entityTypeMessages.product),
+      value: AttributeEntityTypeEnum.PRODUCT
     }
   ];
 

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -208,9 +208,15 @@ export const getReferenceAttributeDisplayData = (
     ...attribute.data,
     references:
       referencePages?.length > 0 && attribute.value?.length > 0
-        ? attribute.value.map(value =>
-            referencePages.find(reference => reference.id === value)
-          )
+        ? attribute.value.map(value => {
+            const reference = referencePages.find(
+              reference => reference.id === value
+            );
+            return {
+              label: reference.title,
+              value: reference.id
+            };
+          })
         : []
   }
 });

--- a/src/components/Attributes/Attributes.tsx
+++ b/src/components/Attributes/Attributes.tsx
@@ -16,9 +16,11 @@ import { AttributeValueFragment } from "@saleor/fragments/types/AttributeValueFr
 import { PageErrorWithAttributesFragment } from "@saleor/fragments/types/PageErrorWithAttributesFragment";
 import { ProductErrorWithAttributesFragment } from "@saleor/fragments/types/ProductErrorWithAttributesFragment";
 import { FormsetAtomicData, FormsetChange } from "@saleor/hooks/useFormset";
-import { SearchPages_search_edges_node } from "@saleor/searches/types/SearchPages";
 import { ReorderEvent } from "@saleor/types";
-import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
+import {
+  AttributeEntityTypeEnum,
+  AttributeInputTypeEnum
+} from "@saleor/types/globalTypes";
 import { getProductErrorMessage } from "@saleor/utils/errors";
 import getPageErrorMessage from "@saleor/utils/errors/page";
 import classNames from "classnames";
@@ -38,13 +40,19 @@ import BasicAttributeRow from "./BasicAttributeRow";
 import ExtendedAttributeRow from "./ExtendedAttributeRow";
 import { VariantAttributeScope } from "./types";
 
+export interface AttributeReference {
+  label: string;
+  value: string;
+}
+
 export interface AttributeInputData {
   inputType: AttributeInputTypeEnum;
+  entityType?: AttributeEntityTypeEnum;
   variantAttributeScope?: VariantAttributeScope;
   isRequired: boolean;
   values: AttributeValueFragment[];
   selectedValues?: AttributeValueFragment[];
-  references?: SearchPages_search_edges_node[];
+  references?: AttributeReference[];
 }
 export type AttributeInput = FormsetAtomicData<AttributeInputData, string[]>;
 export type AttributeFileInput = FormsetAtomicData<AttributeInputData, File[]>;
@@ -175,14 +183,11 @@ function getReferenceDisplayValue(
     }
 
     const definedAttributeReference = attribute.data.references?.find(
-      reference => reference.id === attributeValue
+      reference => reference.value === attributeValue
     );
     // If value has not been yet assigned, use data of reference
     if (!!definedAttributeReference) {
-      return {
-        label: definedAttributeReference.title,
-        value: definedAttributeReference.id
-      };
+      return definedAttributeReference;
     }
 
     return {

--- a/src/components/Attributes/fixtures.ts
+++ b/src/components/Attributes/fixtures.ts
@@ -1,4 +1,7 @@
-import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
+import {
+  AttributeEntityTypeEnum,
+  AttributeInputTypeEnum
+} from "@saleor/types/globalTypes";
 
 import { AttributeInput } from "./Attributes";
 
@@ -92,23 +95,21 @@ const FILE_ATTRIBUTE: AttributeInput = {
 
 const REFERENCE_ATTRIBUTE: AttributeInput = {
   data: {
+    entityType: AttributeEntityTypeEnum.PAGE,
     inputType: AttributeInputTypeEnum.REFERENCE,
     isRequired: true,
     references: [
       {
-        __typename: "Page",
-        id: "vbnhgcvjhbvhj",
-        title: "References First Value"
+        label: "References First Value",
+        value: "vbnhgcvjhbvhj"
       },
       {
-        __typename: "Page",
-        id: "gucngdfdfvdvd",
-        title: "References Second Value"
+        label: "References Second Value",
+        value: "gucngdfdfvdvd"
       },
       {
-        __typename: "Page",
-        id: "dfdfdsfdsfdse",
-        title: "References Third Value"
+        label: "References Third Value",
+        value: "dfdfdsfdsfdse"
       }
     ],
     values: [

--- a/src/fragments/pages.ts
+++ b/src/fragments/pages.ts
@@ -21,6 +21,7 @@ export const pageAttributesFragment = gql`
         slug
         name
         inputType
+        entityType
         valueRequired
         values {
           ...AttributeValueFragment
@@ -37,6 +38,7 @@ export const pageAttributesFragment = gql`
         id
         name
         inputType
+        entityType
         valueRequired
         values {
           ...AttributeValueFragment

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -123,6 +123,7 @@ export const productVariantAttributesFragment = gql`
         slug
         name
         inputType
+        entityType
         valueRequired
         values {
           ...AttributeValueFragment
@@ -231,6 +232,7 @@ export const variantAttributeFragment = gql`
     name
     slug
     inputType
+    entityType
     valueRequired
     values {
       ...AttributeValueFragment

--- a/src/fragments/types/PageAttributesFragment.ts
+++ b/src/fragments/types/PageAttributesFragment.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: PageAttributesFragment
@@ -29,6 +29,7 @@ export interface PageAttributesFragment_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageAttributesFragment_attributes_attribute_values | null)[] | null;
 }
@@ -74,6 +75,7 @@ export interface PageAttributesFragment_pageType_attributes {
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageAttributesFragment_pageType_attributes_values | null)[] | null;
 }

--- a/src/fragments/types/PageDetailsFragment.ts
+++ b/src/fragments/types/PageDetailsFragment.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: PageDetailsFragment
@@ -29,6 +29,7 @@ export interface PageDetailsFragment_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageDetailsFragment_attributes_attribute_values | null)[] | null;
 }
@@ -74,6 +75,7 @@ export interface PageDetailsFragment_pageType_attributes {
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageDetailsFragment_pageType_attributes_values | null)[] | null;
 }

--- a/src/fragments/types/Product.ts
+++ b/src/fragments/types/Product.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: Product
@@ -29,6 +29,7 @@ export interface Product_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (Product_attributes_attribute_values | null)[] | null;
 }

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: ProductVariant
@@ -41,6 +41,7 @@ export interface ProductVariant_selectionAttributes_attribute {
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -87,6 +88,7 @@ export interface ProductVariant_nonSelectionAttributes_attribute {
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }

--- a/src/fragments/types/ProductVariantAttributesFragment.ts
+++ b/src/fragments/types/ProductVariantAttributesFragment.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: ProductVariantAttributesFragment
@@ -29,6 +29,7 @@ export interface ProductVariantAttributesFragment_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantAttributesFragment_attributes_attribute_values | null)[] | null;
 }

--- a/src/fragments/types/SelectedVariantAttributeFragment.ts
+++ b/src/fragments/types/SelectedVariantAttributeFragment.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: SelectedVariantAttributeFragment
@@ -29,6 +29,7 @@ export interface SelectedVariantAttributeFragment_attribute {
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SelectedVariantAttributeFragment_attribute_values | null)[] | null;
 }

--- a/src/fragments/types/VariantAttributeFragment.ts
+++ b/src/fragments/types/VariantAttributeFragment.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: VariantAttributeFragment
@@ -29,6 +29,7 @@ export interface VariantAttributeFragment {
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantAttributeFragment_values | null)[] | null;
 }

--- a/src/pages/fixtures.ts
+++ b/src/pages/fixtures.ts
@@ -45,6 +45,7 @@ export const page: PageDetails_page = {
         id: "QXR0cmlidXRlOjI3",
         slug: "author",
         name: "Author",
+        entityType: null,
         inputType: AttributeInputTypeEnum.DROPDOWN,
         valueRequired: false,
         values: [
@@ -92,6 +93,7 @@ export const page: PageDetails_page = {
         id: "QXR0cmlidXRlOjI5",
         slug: "tag",
         name: "Tag",
+        entityType: null,
         inputType: AttributeInputTypeEnum.MULTISELECT,
         valueRequired: false,
         values: [
@@ -161,6 +163,7 @@ export const page: PageDetails_page = {
       {
         id: "QXR0cmlidXRlOjI3",
         name: "Author",
+        entityType: null,
         inputType: AttributeInputTypeEnum.DROPDOWN,
         valueRequired: false,
         values: [
@@ -194,6 +197,7 @@ export const page: PageDetails_page = {
       {
         id: "QXR0cmlidXRlOjI5",
         name: "Tag",
+        entityType: null,
         inputType: AttributeInputTypeEnum.MULTISELECT,
         valueRequired: false,
         values: [

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { PageCreateInput, PageErrorCode, AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { PageCreateInput, PageErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: PageCreate
@@ -37,6 +37,7 @@ export interface PageCreate_pageCreate_page_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageCreate_pageCreate_page_attributes_attribute_values | null)[] | null;
 }
@@ -82,6 +83,7 @@ export interface PageCreate_pageCreate_page_pageType_attributes {
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageCreate_pageCreate_page_pageType_attributes_values | null)[] | null;
 }

--- a/src/pages/types/PageDetails.ts
+++ b/src/pages/types/PageDetails.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: PageDetails
@@ -29,6 +29,7 @@ export interface PageDetails_page_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageDetails_page_attributes_attribute_values | null)[] | null;
 }
@@ -74,6 +75,7 @@ export interface PageDetails_page_pageType_attributes {
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageDetails_page_pageType_attributes_values | null)[] | null;
 }

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { PageInput, PageErrorCode, AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { PageInput, PageErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: PageUpdate
@@ -36,6 +36,7 @@ export interface PageUpdate_pageUpdate_page_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageUpdate_pageUpdate_page_attributes_attribute_values | null)[] | null;
 }
@@ -81,6 +82,7 @@ export interface PageUpdate_pageUpdate_page_pageType_attributes {
   id: string;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (PageUpdate_pageUpdate_page_pageType_attributes_values | null)[] | null;
 }

--- a/src/pages/utils/data.ts
+++ b/src/pages/utils/data.ts
@@ -12,6 +12,7 @@ export function getAttributeInputFromPage(
 ): AttributeInput[] {
   return page?.attributes.map(attribute => ({
     data: {
+      entityType: attribute.attribute.entityType,
       inputType: attribute.attribute.inputType,
       isRequired: attribute.attribute.valueRequired,
       selectedValues: attribute.values,
@@ -28,6 +29,7 @@ export function getAttributeInputFromPageType(
 ): AttributeInput[] {
   return pageType?.attributes.map(attribute => ({
     data: {
+      entityType: attribute.entityType,
       inputType: attribute.inputType,
       isRequired: attribute.valueRequired,
       values: attribute.values

--- a/src/productTypes/fixtures.ts
+++ b/src/productTypes/fixtures.ts
@@ -15,6 +15,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZTo5",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Author",
@@ -49,6 +50,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZTo2",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Box Size",
@@ -105,6 +107,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZToz",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Brand",
@@ -128,6 +131,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZTo4",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Candy Box Size",
@@ -173,6 +177,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZTo1",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Coffee Genre",
@@ -207,6 +212,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZToy",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Collar",
@@ -252,6 +258,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZTox",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Color",
@@ -286,6 +293,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZToxMg==",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Cover",
@@ -364,6 +372,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZTo3",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Flavor",
@@ -398,6 +407,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZToxMQ==",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Language",
@@ -432,6 +442,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZToxMA==",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Publisher",
@@ -466,6 +477,7 @@ export const attributes: SearchProductTypes_search_edges_node_productAttributes[
   {
     node: {
       __typename: "Attribute" as "Attribute",
+      entityType: null,
       id: "UHJvZHVjdEF0dHJpYnV0ZTo0",
       inputType: AttributeInputTypeEnum.DROPDOWN,
       name: "Size",

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -22,6 +22,7 @@ export const product: (
       __typename: "SelectedAttribute",
       attribute: {
         __typename: "Attribute" as "Attribute",
+        entityType: null,
         id: "pta18161",
         inputType: AttributeInputTypeEnum.DROPDOWN,
         name: "Borders",
@@ -61,6 +62,7 @@ export const product: (
       __typename: "SelectedAttribute",
       attribute: {
         __typename: "Attribute" as "Attribute",
+        entityType: null,
         id: "pta22785",
         inputType: AttributeInputTypeEnum.MULTISELECT,
         name: "Legacy",
@@ -262,6 +264,7 @@ export const product: (
     nonSelectionVariantAttributes: [
       {
         __typename: "Attribute",
+        entityType: null,
         id: "isdugfhud",
         inputType: AttributeInputTypeEnum.FILE,
         name: "Attachment",
@@ -286,6 +289,7 @@ export const product: (
     selectionVariantAttributes: [
       {
         __typename: "Attribute",
+        entityType: null,
         id: "pta18161",
         inputType: AttributeInputTypeEnum.DROPDOWN,
         name: "Color",
@@ -2710,6 +2714,7 @@ export const variant = (placeholderImage: string): ProductVariant => ({
       __typename: "SelectedAttribute",
       attribute: {
         __typename: "Attribute",
+        entityType: null,
         id: "nfnyffcf8eyfm",
         inputType: AttributeInputTypeEnum.FILE,
         name: "Attachment",
@@ -2945,6 +2950,7 @@ export const variant = (placeholderImage: string): ProductVariant => ({
       __typename: "SelectedAttribute",
       attribute: {
         __typename: "Attribute" as "Attribute",
+        entityType: null,
         id: "pta18161",
         inputType: AttributeInputTypeEnum.DROPDOWN,
         name: "Borders",
@@ -2984,6 +2990,7 @@ export const variant = (placeholderImage: string): ProductVariant => ({
       __typename: "SelectedAttribute",
       attribute: {
         __typename: "Attribute" as "Attribute",
+        entityType: null,
         id: "pta22785",
         inputType: AttributeInputTypeEnum.DROPDOWN,
         name: "Legacy",

--- a/src/products/types/CreateMultipleVariantsData.ts
+++ b/src/products/types/CreateMultipleVariantsData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: CreateMultipleVariantsData
@@ -29,6 +29,7 @@ export interface CreateMultipleVariantsData_product_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (CreateMultipleVariantsData_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductChannelListingUpdate.ts
+++ b/src/products/types/ProductChannelListingUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductChannelListingUpdateInput, AttributeInputTypeEnum, WeightUnitsEnum, ProductErrorCode } from "./../../types/globalTypes";
+import { ProductChannelListingUpdateInput, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum, ProductErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ProductChannelListingUpdate
@@ -29,6 +29,7 @@ export interface ProductChannelListingUpdate_productChannelListingUpdate_product
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductChannelListingUpdate_productChannelListingUpdate_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductCreate.ts
+++ b/src/products/types/ProductCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductCreateInput, ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ProductCreateInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ProductCreate
@@ -36,6 +36,7 @@ export interface ProductCreate_productCreate_product_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductCreate_productCreate_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: ProductDetails
@@ -29,6 +29,7 @@ export interface ProductDetails_product_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductDetails_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductImageCreate.ts
+++ b/src/products/types/ProductImageCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ProductImageCreate
@@ -35,6 +35,7 @@ export interface ProductImageCreate_productImageCreate_product_attributes_attrib
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductImageCreate_productImageCreate_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductImageUpdate.ts
+++ b/src/products/types/ProductImageUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ProductImageUpdate
@@ -35,6 +35,7 @@ export interface ProductImageUpdate_productImageUpdate_product_attributes_attrib
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductImageUpdate_productImageUpdate_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductInput, ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ProductInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ProductUpdate
@@ -36,6 +36,7 @@ export interface ProductUpdate_productUpdate_product_attributes_attribute {
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductUpdate_productUpdate_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductVariantChannelListingUpdate.ts
+++ b/src/products/types/ProductVariantChannelListingUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductVariantChannelListingAddInput, AttributeInputTypeEnum, WeightUnitsEnum, ProductErrorCode } from "./../../types/globalTypes";
+import { ProductVariantChannelListingAddInput, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum, ProductErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ProductVariantChannelListingUpdate
@@ -41,6 +41,7 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -87,6 +88,7 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_nonSelectionAttributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductVariantCreateData.ts
+++ b/src/products/types/ProductVariantCreateData.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: ProductVariantCreateData
@@ -48,6 +48,7 @@ export interface ProductVariantCreateData_product_productType_selectionVariantAt
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantCreateData_product_productType_selectionVariantAttributes_values | null)[] | null;
 }
@@ -73,6 +74,7 @@ export interface ProductVariantCreateData_product_productType_nonSelectionVarian
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantCreateData_product_productType_nonSelectionVariantAttributes_values | null)[] | null;
 }

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: ProductVariantDetails
@@ -41,6 +41,7 @@ export interface ProductVariantDetails_productVariant_selectionAttributes_attrib
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantDetails_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -87,6 +88,7 @@ export interface ProductVariantDetails_productVariant_nonSelectionAttributes_att
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantDetails_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductVariantReorder.ts
+++ b/src/products/types/ProductVariantReorder.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ReorderInput, ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ReorderInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ProductVariantReorder
@@ -35,6 +35,7 @@ export interface ProductVariantReorder_productVariantReorder_product_attributes_
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantReorder_productVariantReorder_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/ProductVariantSetDefault.ts
+++ b/src/products/types/ProductVariantSetDefault.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ProductVariantSetDefault
@@ -35,6 +35,7 @@ export interface ProductVariantSetDefault_productVariantSetDefault_product_attri
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (ProductVariantSetDefault_productVariantSetDefault_product_attributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductInput, ProductVariantInput, StockInput, ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum, StockErrorCode } from "./../../types/globalTypes";
+import { ProductInput, ProductVariantInput, StockInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum, StockErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: SimpleProductUpdate
@@ -36,6 +36,7 @@ export interface SimpleProductUpdate_productUpdate_product_attributes_attribute 
   slug: string | null;
   name: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productUpdate_product_attributes_attribute_values | null)[] | null;
 }
@@ -320,6 +321,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_selecti
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productVariantUpdate_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -366,6 +368,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_nonSele
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productVariantUpdate_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }
@@ -595,6 +598,7 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_s
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productVariantStocksCreate_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -641,6 +645,7 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_n
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productVariantStocksCreate_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }
@@ -869,6 +874,7 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_s
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productVariantStocksDelete_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -915,6 +921,7 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_n
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productVariantStocksDelete_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }
@@ -1144,6 +1151,7 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_s
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -1190,6 +1198,7 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_n
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductVariantCreateInput, ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ProductVariantCreateInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: VariantCreate
@@ -48,6 +48,7 @@ export interface VariantCreate_productVariantCreate_productVariant_selectionAttr
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantCreate_productVariantCreate_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -94,6 +95,7 @@ export interface VariantCreate_productVariantCreate_productVariant_nonSelectionA
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantCreate_productVariantCreate_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/VariantImageAssign.ts
+++ b/src/products/types/VariantImageAssign.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: VariantImageAssign
@@ -47,6 +47,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_selectionA
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantImageAssign_variantImageAssign_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -93,6 +94,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_nonSelecti
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantImageAssign_variantImageAssign_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/VariantImageUnassign.ts
+++ b/src/products/types/VariantImageUnassign.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
+import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: VariantImageUnassign
@@ -47,6 +47,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_select
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantImageUnassign_variantImageUnassign_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -93,6 +94,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_nonSel
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantImageUnassign_variantImageUnassign_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { StockInput, AttributeValueInput, ProductErrorCode, AttributeInputTypeEnum, WeightUnitsEnum, StockErrorCode } from "./../../types/globalTypes";
+import { StockInput, AttributeValueInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, WeightUnitsEnum, StockErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: VariantUpdate
@@ -48,6 +48,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_selectionAttr
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantUpdate_productVariantUpdate_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -94,6 +95,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_nonSelectionA
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantUpdate_productVariantUpdate_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }
@@ -323,6 +325,7 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_selecti
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantUpdate_productVariantStocksUpdate_productVariant_selectionAttributes_attribute_values | null)[] | null;
 }
@@ -369,6 +372,7 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_nonSele
   name: string | null;
   slug: string | null;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   values: (VariantUpdate_productVariantStocksUpdate_productVariant_nonSelectionAttributes_attribute_values | null)[] | null;
 }

--- a/src/products/utils/data.ts
+++ b/src/products/utils/data.ts
@@ -47,6 +47,7 @@ export function getAttributeInputFromProduct(
     (): AttributeInput[] =>
       product.attributes.map(attribute => ({
         data: {
+          entityType: attribute.attribute.entityType,
           inputType: attribute.attribute.inputType,
           isRequired: attribute.attribute.valueRequired,
           selectedValues: attribute.values,
@@ -65,6 +66,7 @@ export function getAttributeInputFromProductType(
 ): AttributeInput[] {
   return productType.productAttributes.map(attribute => ({
     data: {
+      entityType: attribute.entityType,
       inputType: attribute.inputType,
       isRequired: attribute.valueRequired,
       values: attribute.values
@@ -81,6 +83,7 @@ export function getAttributeInputFromAttributes(
 ): AttributeInput[] {
   return variantAttributes?.map(attribute => ({
     data: {
+      entityType: attribute.entityType,
       inputType: attribute.inputType,
       isRequired: attribute.valueRequired,
       values: attribute.values,
@@ -98,6 +101,7 @@ export function getAttributeInputFromSelectedAttributes(
 ): AttributeInput[] {
   return variantAttributes?.map(attribute => ({
     data: {
+      entityType: attribute.attribute.entityType,
       inputType: attribute.attribute.inputType,
       isRequired: attribute.attribute.valueRequired,
       selectedValues: attribute.values,

--- a/src/searches/types/SearchPageTypes.ts
+++ b/src/searches/types/SearchPageTypes.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: SearchPageTypes
@@ -27,6 +27,7 @@ export interface SearchPageTypes_search_edges_node_attributes {
   __typename: "Attribute";
   id: string;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   slug: string | null;
   name: string | null;
   valueRequired: boolean;

--- a/src/searches/types/SearchProductTypes.ts
+++ b/src/searches/types/SearchProductTypes.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum } from "./../../types/globalTypes";
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: SearchProductTypes
@@ -27,6 +27,7 @@ export interface SearchProductTypes_search_edges_node_productAttributes {
   __typename: "Attribute";
   id: string;
   inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
   slug: string | null;
   name: string | null;
   valueRequired: boolean;

--- a/src/searches/usePageTypeSearch.ts
+++ b/src/searches/usePageTypeSearch.ts
@@ -24,6 +24,7 @@ export const searchPageTypes = gql`
           attributes {
             id
             inputType
+            entityType
             slug
             name
             valueRequired

--- a/src/searches/useProductTypeSearch.ts
+++ b/src/searches/useProductTypeSearch.ts
@@ -27,6 +27,7 @@ export const searchProductTypes = gql`
           productAttributes {
             id
             inputType
+            entityType
             slug
             name
             valueRequired

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -72,6 +72,7 @@ export enum AppTypeEnum {
 
 export enum AttributeEntityTypeEnum {
   PAGE = "PAGE",
+  PRODUCT = "PRODUCT",
 }
 
 export enum AttributeErrorCode {


### PR DESCRIPTION
I want to merge this change because... it adds product reference type support to attributes implementation.
Feature branch: https://github.com/mirumee/saleor-dashboard/pull/948

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> master

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
