### PR TITLE
Add returned items card to refund

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3776,6 +3776,10 @@
     "context": "order line total price",
     "string": "Total"
   },
+  "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_1097582574": {
+    "context": "section header returned",
+    "string": "Fulfillment returned"
+  },
   "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_1134347598": {
     "context": "tabel column header",
     "string": "Price"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -70,6 +70,10 @@
     "context": "draft created from replace event title",
     "string": "Draft was reissued from order "
   },
+  "event title marked as paid": {
+    "context": "order marked as paid event title",
+    "string": "Order was marked as paid by"
+  },
   "event title refunded": {
     "context": "refunded event title",
     "string": "Products were refunded by "
@@ -6884,6 +6888,10 @@
   "tableColQuantity": {
     "context": "table column header",
     "string": "Quantity"
+  },
+  "transaction reference subtitle": {
+    "context": "transaction reference subtitle",
+    "string": "Transaction reference"
   },
   "voucherDetailsUnassignCategory": {
     "context": "unassign category from voucher, button",

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -78,6 +78,11 @@ export const titles = defineMessages({
     defaultMessage: "Products were returned by",
     description: "returned event title",
     id: "event title returned"
+  },
+  orderMarkedAsPaid: {
+    defaultMessage: "Order was marked as paid by",
+    description: "order marked as paid event title",
+    id: "event title marked as paid"
   }
 });
 
@@ -96,6 +101,11 @@ export const messages = defineMessages({
     defaultMessage: "Shipment was refunded",
     description: "shipment refund title",
     id: "shipment refund title"
+  },
+  transactionReference: {
+    defaultMessage: "Transaction reference",
+    description: "transaction reference subtitle",
+    id: "transaction reference subtitle"
   }
 });
 
@@ -115,6 +125,7 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
     user,
     lines,
     amount,
+    transactionReference,
     shippingCostsIncluded,
     relatedOrder
   } = event;
@@ -202,6 +213,19 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
               {intl.formatMessage(messages.refundedShipment)}
             </Typography>
           )}
+        </>
+      )}
+
+      {!!transactionReference && (
+        <>
+          <Typography
+            variant="caption"
+            color="textSecondary"
+            className={classNames(classes.eventSubtitle)}
+          >
+            {intl.formatMessage(messages.transactionReference)}
+          </Typography>
+          <Typography>{transactionReference}</Typography>
         </>
       )}
     </TimelineEvent>

--- a/src/orders/components/OrderHistory/utils.tsx
+++ b/src/orders/components/OrderHistory/utils.tsx
@@ -24,7 +24,8 @@ const timelineEventTypes = {
     OrderEventsEnum.FULFILLMENT_REFUNDED,
     OrderEventsEnum.FULFILLMENT_REPLACED,
     OrderEventsEnum.FULFILLMENT_RETURNED,
-    OrderEventsEnum.DRAFT_CREATED_FROM_REPLACE
+    OrderEventsEnum.DRAFT_CREATED_FROM_REPLACE,
+    OrderEventsEnum.ORDER_MARKED_AS_PAID
   ],
   linked: [OrderEventsEnum.ORDER_REPLACEMENT_CREATED],
   note: [OrderEventsEnum.NOTE_ADDED],

--- a/src/orders/components/OrderRefundFulfilledProducts/OrderRefundFulfilledProducts.tsx
+++ b/src/orders/components/OrderRefundFulfilledProducts/OrderRefundFulfilledProducts.tsx
@@ -17,6 +17,7 @@ import TableCellAvatar from "@saleor/components/TableCellAvatar";
 import { FormsetChange } from "@saleor/hooks/useFormset";
 import { renderCollection } from "@saleor/misc";
 import { OrderRefundData_order_fulfillments } from "@saleor/orders/types/OrderRefundData";
+import { FulfillmentStatus } from "@saleor/types/globalTypes";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -91,10 +92,15 @@ const OrderRefundFulfilledProducts: React.FC<OrderRefundFulfilledProductsProps> 
       <CardTitle
         title={
           <>
-            {intl.formatMessage({
-              defaultMessage: "Fulfillment",
-              description: "section header"
-            })}
+            {fulfillment.status === FulfillmentStatus.RETURNED
+              ? intl.formatMessage({
+                  defaultMessage: "Fulfillment returned",
+                  description: "section header returned"
+                })
+              : intl.formatMessage({
+                  defaultMessage: "Fulfillment",
+                  description: "section header"
+                })}
             {fulfillment && (
               <Typography className={classes.orderNumber} variant="body1">
                 {`#${orderNumber}-${fulfillment?.fulfillmentOrder}`}

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
@@ -24,6 +24,11 @@ import OrderRefundForm, {
   OrderRefundType
 } from "./form";
 
+export const refundFulfilledStatuses = [
+  FulfillmentStatus.FULFILLED,
+  FulfillmentStatus.RETURNED
+];
+
 export interface OrderRefundPageProps {
   order: OrderRefundData_order;
   defaultType?: OrderRefundType;
@@ -48,9 +53,10 @@ const OrderRefundPage: React.FC<OrderRefundPageProps> = props => {
   const unfulfilledLines = order?.lines.filter(
     line => line.quantity !== line.quantityFulfilled
   );
+
   const fulfilledFulfillemnts =
-    order?.fulfillments.filter(
-      fulfillment => fulfillment.status === FulfillmentStatus.FULFILLED
+    order?.fulfillments.filter(({ status }) =>
+      refundFulfilledStatuses.includes(status)
     ) || [];
 
   return (

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -8,6 +8,8 @@ import { FulfillmentStatus } from "@saleor/types/globalTypes";
 import handleFormSubmit from "@saleor/utils/handlers/handleFormSubmit";
 import React from "react";
 
+import { refundFulfilledStatuses } from "./OrderRefundPage";
+
 export enum OrderRefundType {
   MISCELLANEOUS = "miscellaneous",
   PRODUCTS = "products"
@@ -87,7 +89,7 @@ function useOrderRefundForm(
   );
   const refundedFulfilledProductQuantities = useFormset<null, string>(
     order?.fulfillments
-      .filter(fulfillment => fulfillment.status === FulfillmentStatus.FULFILLED)
+      .filter(({ status }) => refundFulfilledStatuses.includes(status))
       .reduce(
         (linesQty, fulfillemnt) =>
           linesQty.concat(

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -4,7 +4,6 @@ import useFormset, {
   FormsetData
 } from "@saleor/hooks/useFormset";
 import { OrderRefundData_order } from "@saleor/orders/types/OrderRefundData";
-import { FulfillmentStatus } from "@saleor/types/globalTypes";
 import handleFormSubmit from "@saleor/utils/handlers/handleFormSubmit";
 import React from "react";
 


### PR DESCRIPTION
I want to merge this change because it's friday 4PM and I have no life. And it adds returned items card to refund. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.cloud/graphql/
