### PR TITLE
Add missing error

### DIFF
--- a/src/apps/mutations.ts
+++ b/src/apps/mutations.ts
@@ -79,6 +79,7 @@ export const appDeleteFailedInstallationMutation = gql`
 `;
 
 export const appFetchMutation = gql`
+  ${appErrorFragment}
   mutation AppFetch($manifestUrl: String!) {
     appFetchManifest(manifestUrl: $manifestUrl) {
       manifest {


### PR DESCRIPTION
Calling the /app/install/ triggers the error `Unknown fragment "AppErrorFragment`