### PR TITLE
Add multiline field plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Remove mailing settings - #1027 by @dominik-zeglen
 - Update schema to contain email plugin changes - #1029 by @dominik-zeglen
 - Unconfirmed order manipulation - #967 by @tomaszszymanski129
+- Add multiline field plugins - #974 by @dominik-zeglen
 
 # 2.11.1
 

--- a/src/plugins/components/PluginSettings/PluginSettings.tsx
+++ b/src/plugins/components/PluginSettings/PluginSettings.tsx
@@ -107,6 +107,12 @@ const PluginSettings: React.FC<PluginSettingsProps> = ({
                   helperText={fieldData.helpText}
                   label={fieldData.label}
                   name={field.name}
+                  multiline={
+                    fieldData.type === ConfigurationTypeFieldEnum.MULTILINE
+                  }
+                  InputProps={{
+                    rowsMax: 6
+                  }}
                   fullWidth
                   value={field.value}
                   onChange={onChange}

--- a/src/plugins/fixtures.ts
+++ b/src/plugins/fixtures.ts
@@ -72,6 +72,15 @@ export const plugin: Plugin_plugin = {
       name: "Use sandbox",
       type: ConfigurationTypeFieldEnum.BOOLEAN,
       value: "true"
+    },
+    {
+      __typename: "ConfigurationItem",
+      helpText: "This is a multiline field",
+      label: "Multiline Field",
+      name: "multiline-field",
+      type: ConfigurationTypeFieldEnum.MULTILINE,
+      value:
+        "Lorem ipsum\ndolor sit\namet enim.\nEtiam ullamcorper.\nSuspendisse a\npellentesque dui,\nnon felis."
     }
   ],
   description:


### PR DESCRIPTION
I want to merge this change because it adds multiline field support.

**PR intended to be tested with API branch:** master

### Screenshots
<img width="854" alt="Screenshot 2021-02-05 at 11 38 06" src="https://user-images.githubusercontent.com/6833443/107023370-d0c90880-67a6-11eb-969a-d2b4159bff38.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/
