### PR TITLE
fix: Use STATIC_URL in development server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,8 +44,8 @@ module.exports = (env, argv) => {
     throw new Error("Environment variable API_URI not set");
   }
 
+  const publicPath = process.env.STATIC_URL || "/";
   if (!devMode) {
-    const publicPath = process.env.STATIC_URL || "/";
     output = {
       chunkFilename: "[name].[chunkhash].js",
       filename: "[name].[chunkhash].js",
@@ -58,7 +58,7 @@ module.exports = (env, argv) => {
       chunkFilename: "[name].js",
       filename: "[name].js",
       path: resolve(dashboardBuildPath),
-      publicPath: "/"
+      publicPath
     };
     fileLoaderPath = "file-loader?name=[name].[ext]";
   }


### PR DESCRIPTION
`publicPath` was not set to STATIC_URL when making use
of development server. This prevented properly put dashboard
under subdir in some cases in development mode.

Without it, it was always served form under `/`

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** n/a

### Screenshots

n/a

### Pull Request Checklist

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [] Changes are mentioned in the changelog. => IMHO not important enough.
1. [x] The changes are tested in different browsers (Chrome, Firefox, Safari).
1. [x] The changes are tested in light and dark mode.

### Test environment config

n/a

API_URI=https://master.staging.saleor.cloud/graphql/
