### PR TITLE
Skip cypress test if PR from private fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
           npm run test
 
   cypress-run:
+    if: github.event.pull_request.head.repo.full_name == 'mirumee/saleor-dashboard'
     runs-on: ubuntu-16.04
     steps:
       - name: Checkout


### PR DESCRIPTION
I want to merge this change because cypress tests are failing when new PR comes from other fork. This change will skip step for run cypress tests in that situation.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
1. [ ] The changes are tested in different browsers (Chrome, Firefox, Safari).
1. [ ] The changes are tested in light and dark mode.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.cloud/graphql/
