### PR TITLE
Saleor 2539 Use sortBy RANK for search products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix no channels crash - #984 by @dominik-zeglen
 - Update webhooks - #982 by @piotrgrundas
 - Fix trigger form change when collections are being added to list of product collections - #987 by @gax97
+- Use default sort for search products list - #997 by @orzechdev
 
 # 2.11.1
 

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -48,7 +48,8 @@ export enum ProductListUrlSortField {
   name = "name",
   productType = "productType",
   status = "status",
-  price = "price"
+  price = "price",
+  rank = "rank"
 }
 export type ProductListUrlSort = Sort<ProductListUrlSortField>;
 export interface ProductListUrlQueryParams

--- a/src/products/views/ProductList/ProductList.tsx
+++ b/src/products/views/ProductList/ProductList.tsx
@@ -53,7 +53,7 @@ import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandl
 import createFilterHandlers from "@saleor/utils/handlers/filterHandlers";
 import { getSortUrlVariables } from "@saleor/utils/sort";
 import { useWarehouseList } from "@saleor/warehouses/queries";
-import React from "react";
+import React, { useEffect } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import ProductListPage from "../../components/ProductListPage";
@@ -191,6 +191,21 @@ export const ProductList: React.FC<ProductListProps> = ({ params }) => {
     navigate,
     params
   });
+
+  useEffect(() => {
+    const sortWithQuery = ProductListUrlSortField.rank;
+    const sortWithoutQuery =
+      params.sort === ProductListUrlSortField.rank
+        ? ProductListUrlSortField.name
+        : params.sort;
+    navigate(
+      productListUrl({
+        ...params,
+        asc: params.query ? undefined : params.asc,
+        sort: params.query ? sortWithQuery : sortWithoutQuery
+      })
+    );
+  }, [params.query]);
 
   const handleTabChange = (tab: number) => {
     reset();

--- a/src/products/views/ProductList/sort.ts
+++ b/src/products/views/ProductList/sort.ts
@@ -17,6 +17,8 @@ export function getSortQueryField(
       return ProductOrderField.TYPE;
     case ProductListUrlSortField.status:
       return ProductOrderField.PUBLISHED;
+    case ProductListUrlSortField.rank:
+      return ProductOrderField.RANK;
     default:
       return undefined;
   }
@@ -26,15 +28,17 @@ export function getSortQueryVariables(
   params: ProductListUrlQueryParams,
   channel: string
 ): ProductOrder {
+  const direction = getOrderDirection(params.asc);
   if (params.sort === ProductListUrlSortField.attribute) {
     return {
       attributeId: params.attributeId,
-      direction: getOrderDirection(params.asc)
+      direction
     };
   }
+  const field = getSortQueryField(params.sort);
   return {
     channel,
-    direction: getOrderDirection(params.asc),
-    field: getSortQueryField(params.sort)
+    direction,
+    field
   };
 }


### PR DESCRIPTION
I want to merge this change because... it changes product list sorting and uses sortBy RANK for search products

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> master

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Translated strings are extracted.
1. [x] Number of API calls is optimized.
1. [x] The changes are tested.
1. [x] Data-test are added for new elements.
1. [x] Type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
1. [x] The changes are tested in different browsers (Chrome, Firefox, Safari).
1. [x] The changes are tested in light and dark mode.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.cloud/graphql/
