### PR TITLE
Refactor of postalCodes related components

### DIFF
--- a/src/orders/components/OrderReturnPage/utils.tsx
+++ b/src/orders/components/OrderReturnPage/utils.tsx
@@ -91,3 +91,7 @@ export const getParsedFulfiledLines = (
 
 export const getById = (idToCompare: string) => (obj: { id: string }) =>
   obj.id === idToCompare;
+
+export const getByUnmatchingId = (idToCompare: string) => (obj: {
+  id: string;
+}) => obj.id !== idToCompare;

--- a/src/shipping/components/ShippingZonePostalCodes/ShippingZonePostalCodes.tsx
+++ b/src/shipping/components/ShippingZonePostalCodes/ShippingZonePostalCodes.tsx
@@ -73,11 +73,14 @@ const ShippingZonePostalCodes: React.FC<ShippingZonePostalCodesProps> = ({
   const intl = useIntl();
   const classes = useStyles({});
 
-  const getInclusionType = () =>
-    inclusionType ||
-    (postalCodes?.length > 0
-      ? postalCodes[0]?.inclusionType
-      : PostalCodeRuleInclusionTypeEnum.EXCLUDE);
+  const getInclusionType = () => {
+    if (inclusionType) {
+      return inclusionType;
+    }
+    return (
+      postalCodes[0]?.inclusionType || PostalCodeRuleInclusionTypeEnum.EXCLUDE
+    );
+  };
 
   const onInclusionRadioChange = (event: React.ChangeEvent<any>) => {
     const value = event.target.value;

--- a/src/shipping/components/ShippingZonePostalCodes/ShippingZonePostalCodes.tsx
+++ b/src/shipping/components/ShippingZonePostalCodes/ShippingZonePostalCodes.tsx
@@ -24,7 +24,6 @@ import { FormattedMessage, useIntl } from "react-intl";
 export interface ShippingZonePostalCodesProps {
   disabled: boolean;
   initialExpanded?: boolean;
-  initialInclusionType?: PostalCodeRuleInclusionTypeEnum;
   postalCodes: ShippingMethodFragment_postalCodeRules[] | undefined;
   onPostalCodeInclusionChange: (
     inclusion: PostalCodeRuleInclusionTypeEnum
@@ -64,7 +63,6 @@ const useStyles = makeStyles(
 const ShippingZonePostalCodes: React.FC<ShippingZonePostalCodesProps> = ({
   disabled,
   initialExpanded = true,
-  initialInclusionType = PostalCodeRuleInclusionTypeEnum.EXCLUDE,
   postalCodes,
   onPostalCodeDelete,
   onPostalCodeInclusionChange,
@@ -74,6 +72,12 @@ const ShippingZonePostalCodes: React.FC<ShippingZonePostalCodesProps> = ({
   const [inclusionType, setInclusionType] = React.useState(null);
   const intl = useIntl();
   const classes = useStyles({});
+
+  const getInclusionType = () =>
+    inclusionType ||
+    (postalCodes?.length > 0
+      ? postalCodes[0]?.inclusionType
+      : PostalCodeRuleInclusionTypeEnum.EXCLUDE);
 
   const onInclusionRadioChange = (event: React.ChangeEvent<any>) => {
     const value = event.target.value;
@@ -92,9 +96,6 @@ const ShippingZonePostalCodes: React.FC<ShippingZonePostalCodesProps> = ({
     }
     return postalCodeRange.start;
   };
-
-  const getInlcusionType = () =>
-    inclusionType === null ? initialInclusionType : inclusionType;
 
   return (
     <Card>
@@ -154,7 +155,7 @@ const ShippingZonePostalCodes: React.FC<ShippingZonePostalCodesProps> = ({
             }
           ]}
           name="includePostalCodes"
-          value={getInlcusionType()}
+          value={getInclusionType()}
           onChange={onInclusionRadioChange}
         />
       </CardContent>

--- a/src/shipping/components/ShippingZoneRatesCreatePage/ShippingZoneRatesCreatePage.tsx
+++ b/src/shipping/components/ShippingZoneRatesCreatePage/ShippingZoneRatesCreatePage.tsx
@@ -91,12 +91,6 @@ export const ShippingZoneRatesCreatePage: React.FC<ShippingZoneRatesCreatePagePr
     type: null
   };
 
-  const postalCodeInclusionChange = (
-    inclusion: PostalCodeRuleInclusionTypeEnum
-  ) => {
-    onPostalCodeInclusionChange(inclusion);
-  };
-
   return (
     <Form initial={initialForm} onSubmit={onSubmit}>
       {({ change, data, hasChanged, submit, triggerChange }) => {
@@ -166,7 +160,7 @@ export const ShippingZoneRatesCreatePage: React.FC<ShippingZoneRatesCreatePagePr
                 <ShippingZonePostalCodes
                   disabled={disabled}
                   onPostalCodeDelete={onPostalCodeUnassign}
-                  onPostalCodeInclusionChange={postalCodeInclusionChange}
+                  onPostalCodeInclusionChange={onPostalCodeInclusionChange}
                   onPostalCodeRangeAdd={onPostalCodeAssign}
                   postalCodes={postalCodes}
                 />

--- a/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.stories.tsx
+++ b/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.stories.tsx
@@ -56,6 +56,7 @@ const props: ShippingZoneRatesPageProps = {
   onProductUnassign: () => undefined,
   onSubmit: () => undefined,
   openChannelsModal: () => undefined,
+  postalCodeRules: [],
   rate: shippingZone.shippingMethods[0],
   saveButtonBarState: "default",
   selected: 0,

--- a/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
+++ b/src/shipping/components/ShippingZoneRatesPage/ShippingZoneRatesPage.tsx
@@ -20,7 +20,10 @@ import PricingCard from "@saleor/shipping/components/PricingCard";
 import ShippingMethodProducts from "@saleor/shipping/components/ShippingMethodProducts";
 import ShippingRateInfo from "@saleor/shipping/components/ShippingRateInfo";
 import { createChannelsChangeHandler } from "@saleor/shipping/handlers";
-import { ShippingZone_shippingZone_shippingMethods } from "@saleor/shipping/types/ShippingZone";
+import {
+  ShippingZone_shippingZone_shippingMethods,
+  ShippingZone_shippingZone_shippingMethods_postalCodeRules
+} from "@saleor/shipping/types/ShippingZone";
 import { ListActions, ListProps } from "@saleor/types";
 import {
   PostalCodeRuleInclusionTypeEnum,
@@ -56,6 +59,7 @@ export interface ShippingZoneRatesPageProps
   channelErrors: ShippingChannelsErrorFragment[];
   errors: ShippingErrorFragment[];
   saveButtonBarState: ConfirmButtonTransitionState;
+  postalCodeRules: ShippingZone_shippingZone_shippingMethods_postalCodeRules[];
   onBack: () => void;
   onDelete?: () => void;
   onSubmit: (data: FormData) => void;
@@ -91,6 +95,7 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
   openChannelsModal,
   rate,
   saveButtonBarState,
+  postalCodeRules,
   variant,
   ...listProps
 }) => {
@@ -106,14 +111,6 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
     noLimits: false,
     privateMetadata: rate?.privateMetadata.map(mapMetadataItemToInput),
     type: rate?.type || null
-  };
-
-  const postalCodesInclusionType = rate?.postalCodeRules[0]?.inclusionType;
-
-  const postalCodeInclusionChange = (
-    inclusion: PostalCodeRuleInclusionTypeEnum
-  ) => {
-    onPostalCodeInclusionChange(inclusion);
   };
 
   const {
@@ -181,10 +178,9 @@ export const ShippingZoneRatesPage: React.FC<ShippingZoneRatesPageProps> = ({
                 <ShippingZonePostalCodes
                   disabled={disabled}
                   onPostalCodeDelete={onPostalCodeUnassign}
-                  onPostalCodeInclusionChange={postalCodeInclusionChange}
+                  onPostalCodeInclusionChange={onPostalCodeInclusionChange}
                   onPostalCodeRangeAdd={onPostalCodeAssign}
-                  postalCodes={rate?.postalCodeRules}
-                  initialInclusionType={postalCodesInclusionType}
+                  postalCodes={postalCodeRules}
                 />
                 <CardSpacer />
                 <ShippingMethodProducts

--- a/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
+++ b/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
@@ -15,7 +15,11 @@ import {
   shippingZoneUrl
 } from "@saleor/shipping/urls";
 import postalCodesReducer from "@saleor/shipping/views/reducer";
-import filterPostalCodes from "@saleor/shipping/views/utils";
+import {
+  filterPostalCodes,
+  getPostalCodeRuleByMinMax,
+  getRuleObject
+} from "@saleor/shipping/views/utils";
 import { MinMax } from "@saleor/types";
 import {
   PostalCodeRuleInclusionTypeEnum,
@@ -83,21 +87,13 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
 
   const onPostalCodeAssign = (rule: MinMax) => {
     if (
-      state.postalCodeRules.filter(
-        item => item.start === rule.min && item.end === rule.max
-      ).length > 0
+      state.postalCodeRules.filter(getPostalCodeRuleByMinMax(rule)).length > 0
     ) {
       closeModal();
       return;
     }
 
-    const newCode = {
-      __typename: undefined,
-      end: rule.max,
-      id: undefined,
-      inclusionType: state.inclusionType,
-      start: rule.min
-    };
+    const newCode = getRuleObject(rule, state.inclusionType);
     dispatch({
       updateStateProps: {
         havePostalCodesChanged: true,

--- a/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
+++ b/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
@@ -95,10 +95,8 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
 
     const newCode = getRuleObject(rule, state.inclusionType);
     dispatch({
-      updateStateProps: {
-        havePostalCodesChanged: true,
-        postalCodeRules: [...state.postalCodeRules, newCode]
-      }
+      havePostalCodesChanged: true,
+      postalCodeRules: [...state.postalCodeRules, newCode]
     });
     closeModal();
   };
@@ -107,19 +105,15 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
     inclusion: PostalCodeRuleInclusionTypeEnum
   ) => {
     dispatch({
-      updateStateProps: {
-        inclusionType: inclusion,
-        postalCodeRules: []
-      }
+      inclusionType: inclusion,
+      postalCodeRules: []
     });
   };
 
   const onPostalCodeUnassign = code => {
     dispatch({
-      updateStateProps: {
-        havePostalCodesChanged: true,
-        postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
-      }
+      havePostalCodesChanged: true,
+      postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
     });
   };
 

--- a/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
+++ b/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
@@ -14,6 +14,7 @@ import {
   ShippingRateCreateUrlQueryParams,
   shippingZoneUrl
 } from "@saleor/shipping/urls";
+import postalCodesReducer from "@saleor/shipping/views/reducer";
 import filterPostalCodes from "@saleor/shipping/views/utils";
 import { MinMax } from "@saleor/types";
 import {
@@ -35,11 +36,6 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
 }) => {
   const navigate = useNavigator();
   const intl = useIntl();
-
-  const [postalCodes, setPostalCodes] = React.useState([]);
-  const [radioInclusionType, setRadioInclusionType] = React.useState(
-    PostalCodeRuleInclusionTypeEnum.EXCLUDE
-  );
 
   const { data: channelsData, loading: channelsLoading } = useChannelsList({});
 
@@ -63,6 +59,14 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
     toggleAllChannels
   } = useChannels(allChannels, params?.action, { closeModal, openModal });
 
+  const [state, dispatch] = React.useReducer(postalCodesReducer, {
+    codesToDelete: [],
+    havePostalCodesChanged: false,
+    inclusionType: PostalCodeRuleInclusionTypeEnum.EXCLUDE,
+    originalCodes: [],
+    postalCodeRules: []
+  });
+
   const {
     channelErrors,
     createShippingRate,
@@ -71,33 +75,56 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
   } = useShippingRateCreator(
     id,
     ShippingMethodTypeEnum.PRICE,
-    postalCodes,
-    radioInclusionType
+    state.postalCodeRules,
+    state.inclusionType
   );
 
   const handleBack = () => navigate(shippingZoneUrl(id));
 
-  const handlePostalCodeRangeAdd = (data: MinMax) => {
-    setPostalCodes(postalCodes => [
-      ...postalCodes,
-      {
-        end: data.max,
-        start: data.min
+  const onPostalCodeAssign = (rule: MinMax) => {
+    if (
+      state.postalCodeRules.filter(
+        item => item.start === rule.min && item.end === rule.max
+      ).length > 0
+    ) {
+      closeModal();
+      return;
+    }
+
+    const newCode = {
+      __typename: undefined,
+      end: rule.max,
+      id: undefined,
+      inclusionType: state.inclusionType,
+      start: rule.min
+    };
+    dispatch({
+      updateStateProps: {
+        havePostalCodesChanged: true,
+        postalCodeRules: [...state.postalCodeRules, newCode]
       }
-    ]);
+    });
     closeModal();
   };
 
   const onPostalCodeInclusionChange = (
     inclusion: PostalCodeRuleInclusionTypeEnum
   ) => {
-    setRadioInclusionType(inclusion);
-    setPostalCodes([]);
+    dispatch({
+      updateStateProps: {
+        inclusionType: inclusion,
+        postalCodeRules: []
+      }
+    });
   };
 
   const onPostalCodeUnassign = code => {
-    setPostalCodes(filterPostalCodes(postalCodes, code));
-    closeModal();
+    dispatch({
+      updateStateProps: {
+        havePostalCodesChanged: true,
+        postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
+      }
+    });
   };
 
   return (
@@ -130,7 +157,7 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
         onBack={handleBack}
         errors={errors}
         channelErrors={channelErrors}
-        postalCodes={postalCodes}
+        postalCodes={state.postalCodeRules}
         openChannelsModal={handleChannelsModalOpen}
         onChannelsChange={setCurrentChannels}
         onPostalCodeAssign={() => openModal("add-range")}
@@ -141,7 +168,7 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
       <ShippingZonePostalCodeRangeDialog
         confirmButtonState="default"
         onClose={closeModal}
-        onSubmit={handlePostalCodeRangeAdd}
+        onSubmit={onPostalCodeAssign}
         open={params.action === "add-range"}
       />
     </>

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -197,19 +197,17 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
     rate.postalCodeRules?.length;
 
   if (postalCodeRulesLoaded) {
-    dispatch({ updateStateProps: { postalCodeRules: rate.postalCodeRules } });
+    dispatch({ postalCodeRules: rate.postalCodeRules });
   }
 
   const onPostalCodeInclusionChange = (
     inclusion: PostalCodeRuleInclusionTypeEnum
   ) => {
     dispatch({
-      updateStateProps: {
-        codesToDelete: rate.postalCodeRules.map(code => code.id),
-        havePostalCodesChanged: true,
-        inclusionType: inclusion,
-        postalCodeRules: []
-      }
+      codesToDelete: rate.postalCodeRules.map(code => code.id),
+      havePostalCodesChanged: true,
+      inclusionType: inclusion,
+      postalCodeRules: []
     });
   };
 
@@ -223,11 +221,11 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
         state.codesToDelete
       )
     });
-    dispatch({ updateStateProps: { codesToDelete: [] } });
+    dispatch({ codesToDelete: [] });
     const errors = response.data.shippingPriceUpdate.errors;
     if (errors.length === 0) {
       handleSuccess();
-      dispatch({ updateStateProps: { havePostalCodesChanged: false } });
+      dispatch({ havePostalCodesChanged: false });
       updateShippingMethodChannelListing({
         variables: getShippingMethodChannelVariables(
           rateId,
@@ -262,7 +260,7 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
 
   const onPostalCodeAssign = (rule: MinMax) => {
     if (!state.originalCodes.length) {
-      dispatch({ updateStateProps: { originalCodes: rate.postalCodeRules } });
+      dispatch({ originalCodes: rate.postalCodeRules });
     }
 
     if (
@@ -274,10 +272,8 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
 
     const newCode = getRuleObject(rule, state.inclusionType);
     dispatch({
-      updateStateProps: {
-        havePostalCodesChanged: true,
-        postalCodeRules: [...state.postalCodeRules, newCode]
-      }
+      havePostalCodesChanged: true,
+      postalCodeRules: [...state.postalCodeRules, newCode]
     });
     closeModal();
   };
@@ -285,20 +281,16 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
   const onPostalCodeUnassign = code => {
     if (code.id !== undefined) {
       dispatch({
-        updateStateProps: {
-          codesToDelete: [...state.codesToDelete, code.id],
-          havePostalCodesChanged: true,
-          postalCodeRules: state.postalCodeRules.filter(
-            getByUnmatchingId(code.id)
-          )
-        }
+        codesToDelete: [...state.codesToDelete, code.id],
+        havePostalCodesChanged: true,
+        postalCodeRules: state.postalCodeRules.filter(
+          getByUnmatchingId(code.id)
+        )
       });
     } else {
       dispatch({
-        updateStateProps: {
-          havePostalCodesChanged: true,
-          postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
-        }
+        havePostalCodesChanged: true,
+        postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
       });
     }
   };

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -43,6 +43,7 @@ import {
   ShippingRateUrlQueryParams,
   shippingZoneUrl
 } from "@saleor/shipping/urls";
+import postalCodesReducer from "@saleor/shipping/views/reducer";
 import filterPostalCodes from "@saleor/shipping/views/utils";
 import { MinMax } from "@saleor/types";
 import {
@@ -80,6 +81,11 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
     displayLoader: true,
     variables: { id, ...paginationState }
   });
+
+  const rate = data?.shippingZone?.shippingMethods.find(
+    rate => rate.id === rateId
+  );
+
   const {
     loadMore,
     search: productsSearch,
@@ -90,10 +96,6 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
     ShippingRateUrlDialog,
     ShippingRateUrlQueryParams
   >(navigate, params => shippingPriceRatesEditUrl(id, rateId, params), params);
-
-  const rate = data?.shippingZone?.shippingMethods.find(
-    rate => rate.id === rateId
-  );
 
   const { isSelected, listElements, reset, toggle, toggleAll } = useBulkActions(
     []
@@ -174,26 +176,34 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
   const [updateMetadata] = useMetadataUpdate({});
   const [updatePrivateMetadata] = usePrivateMetadataUpdate({});
 
-  const [codesToDelete, setCodesToDelete] = React.useState([]);
-  const [havePostalCodesChanged, setHavePostalCodesChanged] = React.useState(
-    false
-  );
-  const [originalCodes, setOriginalCodes] = React.useState([]);
-  const [inclusionType, setInclusionType] = React.useState(
-    rate?.postalCodeRules[0]?.inclusionType
-  );
+  const [state, dispatch] = React.useReducer(postalCodesReducer, {
+    codesToDelete: [],
+    havePostalCodesChanged: false,
+    inclusionType: rate?.postalCodeRules[0]?.inclusionType,
+    originalCodes: [],
+    postalCodeRules: rate?.postalCodeRules || []
+  });
+
+  if (
+    !loading &&
+    !state.postalCodeRules?.length &&
+    !state.codesToDelete?.length &&
+    rate.postalCodeRules?.length
+  ) {
+    dispatch({ updateStateProps: { postalCodeRules: rate.postalCodeRules } });
+  }
 
   const onPostalCodeInclusionChange = (
     inclusion: PostalCodeRuleInclusionTypeEnum
   ) => {
-    setInclusionType(inclusion);
-    setCodesToDelete(
-      rate.postalCodeRules
-        .filter(code => code.id !== undefined)
-        .map(code => code.id)
-    );
-    setHavePostalCodesChanged(true);
-    rate.postalCodeRules = [];
+    dispatch({
+      updateStateProps: {
+        codesToDelete: rate.postalCodeRules.map(code => code.id),
+        havePostalCodesChanged: true,
+        inclusionType: inclusion,
+        postalCodeRules: []
+      }
+    });
   };
 
   const updateData = async (formData: FormData): Promise<unknown[]> => {
@@ -202,15 +212,15 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
         formData,
         id,
         rateId,
-        rate.postalCodeRules,
-        codesToDelete
+        state.postalCodeRules,
+        state.codesToDelete
       )
     });
-    setCodesToDelete([]);
-    setHavePostalCodesChanged(false);
+    dispatch({ updateStateProps: { codesToDelete: [] } });
     const errors = response.data.shippingPriceUpdate.errors;
     if (errors.length === 0) {
       handleSuccess();
+      dispatch({ updateStateProps: { havePostalCodesChanged: false } });
       updateShippingMethodChannelListing({
         variables: getShippingMethodChannelVariables(
           rateId,
@@ -244,38 +254,54 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
   };
 
   const onPostalCodeAssign = (rule: MinMax) => {
-    if (!originalCodes.length) {
-      setOriginalCodes([...rate.postalCodeRules]);
+    if (!state.originalCodes.length) {
+      dispatch({ updateStateProps: { originalCodes: rate.postalCodeRules } });
     }
+
     if (
-      rate.postalCodeRules.filter(
+      state.postalCodeRules.filter(
         item => item.start === rule.min && item.end === rule.max
       ).length > 0
     ) {
       closeModal();
       return;
     }
+
     const newCode = {
       __typename: undefined,
       end: rule.max,
       id: undefined,
-      inclusionType,
+      inclusionType: state.inclusionType,
       start: rule.min
     };
-    rate.postalCodeRules.push(newCode);
+    dispatch({
+      updateStateProps: {
+        havePostalCodesChanged: true,
+        postalCodeRules: [...state.postalCodeRules, newCode]
+      }
+    });
     closeModal();
   };
 
   const onPostalCodeUnassign = code => {
     if (code.id !== undefined) {
-      setCodesToDelete([...codesToDelete, code.id]);
-      rate.postalCodeRules = rate.postalCodeRules.filter(
-        rule => rule.id !== code.id
-      );
+      dispatch({
+        updateStateProps: {
+          codesToDelete: [...state.codesToDelete, code.id],
+          havePostalCodesChanged: true,
+          postalCodeRules: state.postalCodeRules.filter(
+            rule => rule.id !== code.id
+          )
+        }
+      });
     } else {
-      rate.postalCodeRules = filterPostalCodes(rate.postalCodeRules, code);
+      dispatch({
+        updateStateProps: {
+          havePostalCodesChanged: true,
+          postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
+        }
+      });
     }
-    setHavePostalCodesChanged(true);
   };
 
   const handleBack = () => navigate(shippingZoneUrl(id));
@@ -344,7 +370,7 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
           assignProductOpts?.status === "loading"
         }
         hasChannelChanged={shippingChannels?.length !== currentChannels?.length}
-        havePostalCodesChanged={havePostalCodesChanged}
+        havePostalCodesChanged={state.havePostalCodesChanged}
         saveButtonBarState={updateShippingRateOpts.status}
         onDelete={() => openModal("remove")}
         onSubmit={handleSubmit}
@@ -378,13 +404,13 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
         onPostalCodeInclusionChange={onPostalCodeInclusionChange}
         onPostalCodeAssign={() => openModal("add-range")}
         onPostalCodeUnassign={onPostalCodeUnassign}
+        postalCodeRules={state.postalCodeRules}
       />
       <ShippingZonePostalCodeRangeDialog
         confirmButtonState={"default"}
         onClose={closeModal}
         onSubmit={code => {
           onPostalCodeAssign(code);
-          setHavePostalCodesChanged(true);
         }}
         open={params.action === "add-range"}
       />

--- a/src/shipping/views/ShippingZoneDetails/index.tsx
+++ b/src/shipping/views/ShippingZoneDetails/index.tsx
@@ -9,6 +9,7 @@ import useNotifier from "@saleor/hooks/useNotifier";
 import { createPaginationState } from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
 import { commonMessages } from "@saleor/intl";
+import { getById } from "@saleor/orders/components/OrderReturnPage/utils";
 import useWarehouseSearch from "@saleor/searches/useWarehouseSearch";
 import DeleteShippingRateDialog from "@saleor/shipping/components/DeleteShippingRateDialog";
 import ShippingZoneAddWarehouseDialog from "@saleor/shipping/components/ShippingZoneAddWarehouseDialog";
@@ -78,9 +79,7 @@ const ShippingZoneDetails: React.FC<ShippingZoneDetailsProps> = ({
     ShippingZoneUrlDialog,
     ShippingZoneUrlQueryParams
   >(navigate, params => shippingZoneUrl(id, params), params);
-  const rate = data?.shippingZone?.shippingMethods?.find(
-    rate => rate.id === params.id
-  );
+  const rate = data?.shippingZone?.shippingMethods?.find(getById(params.id));
 
   const [deleteShippingRate, deleteShippingRateOpts] = useShippingRateDelete({
     onCompleted: data => {

--- a/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
+++ b/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
@@ -17,6 +17,7 @@ import {
   shippingWeightRatesUrl,
   shippingZoneUrl
 } from "@saleor/shipping/urls";
+import postalCodesReducer from "@saleor/shipping/views/reducer";
 import filterPostalCodes from "@saleor/shipping/views/utils";
 import { MinMax } from "@saleor/types";
 import {
@@ -38,11 +39,6 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
 }) => {
   const navigate = useNavigator();
   const intl = useIntl();
-
-  const [postalCodes, setPostalCodes] = React.useState([]);
-  const [radioInclusionType, setRadioInclusionType] = React.useState(
-    PostalCodeRuleInclusionTypeEnum.EXCLUDE
-  );
 
   const { data: channelsData, loading: channelsLoading } = useChannelsList({});
 
@@ -67,6 +63,14 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
     toggleAllChannels
   } = useChannels(shippingChannels, params?.action, { closeModal, openModal });
 
+  const [state, dispatch] = React.useReducer(postalCodesReducer, {
+    codesToDelete: [],
+    havePostalCodesChanged: false,
+    inclusionType: PostalCodeRuleInclusionTypeEnum.EXCLUDE,
+    originalCodes: [],
+    postalCodeRules: []
+  });
+
   const {
     channelErrors,
     createShippingRate,
@@ -75,36 +79,56 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
   } = useShippingRateCreator(
     id,
     ShippingMethodTypeEnum.WEIGHT,
-    postalCodes,
-    radioInclusionType
+    state.postalCodeRules,
+    state.inclusionType
   );
 
   const handleBack = () => navigate(shippingZoneUrl(id));
 
-  const handlePostalCodeRangeAdd = (data: MinMax) => {
-    setPostalCodes(postalCodes => [
-      ...postalCodes,
-      {
-        __typename: "ShippingMethodPostalCodeRule",
-        end: data.max,
-        id: postalCodes.length.toString(),
-        inclusionType: postalCodes?.[0]?.inclusionType,
-        start: data.min
+  const onPostalCodeAssign = (rule: MinMax) => {
+    if (
+      state.postalCodeRules.filter(
+        item => item.start === rule.min && item.end === rule.max
+      ).length > 0
+    ) {
+      closeModal();
+      return;
+    }
+
+    const newCode = {
+      __typename: undefined,
+      end: rule.max,
+      id: undefined,
+      inclusionType: state.inclusionType,
+      start: rule.min
+    };
+    dispatch({
+      updateStateProps: {
+        havePostalCodesChanged: true,
+        postalCodeRules: [...state.postalCodeRules, newCode]
       }
-    ]);
+    });
     closeModal();
   };
 
   const onPostalCodeInclusionChange = (
     inclusion: PostalCodeRuleInclusionTypeEnum
   ) => {
-    setRadioInclusionType(inclusion);
-    setPostalCodes([]);
+    dispatch({
+      updateStateProps: {
+        inclusionType: inclusion,
+        postalCodeRules: []
+      }
+    });
   };
 
   const onPostalCodeUnassign = code => {
-    setPostalCodes(filterPostalCodes(postalCodes, code));
-    closeModal();
+    dispatch({
+      updateStateProps: {
+        havePostalCodesChanged: true,
+        postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
+      }
+    });
   };
 
   return (
@@ -136,7 +160,7 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
         onBack={handleBack}
         errors={errors}
         channelErrors={channelErrors}
-        postalCodes={postalCodes}
+        postalCodes={state.postalCodeRules}
         openChannelsModal={handleChannelsModalOpen}
         onChannelsChange={setCurrentChannels}
         onPostalCodeAssign={() => openModal("add-range")}
@@ -147,7 +171,7 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
       <ShippingZonePostalCodeRangeDialog
         confirmButtonState="default"
         onClose={closeModal}
-        onSubmit={handlePostalCodeRangeAdd}
+        onSubmit={onPostalCodeAssign}
         open={params.action === "add-range"}
       />
     </>

--- a/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
+++ b/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
@@ -99,10 +99,8 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
 
     const newCode = getRuleObject(rule, state.inclusionType);
     dispatch({
-      updateStateProps: {
-        havePostalCodesChanged: true,
-        postalCodeRules: [...state.postalCodeRules, newCode]
-      }
+      havePostalCodesChanged: true,
+      postalCodeRules: [...state.postalCodeRules, newCode]
     });
     closeModal();
   };
@@ -111,19 +109,15 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
     inclusion: PostalCodeRuleInclusionTypeEnum
   ) => {
     dispatch({
-      updateStateProps: {
-        inclusionType: inclusion,
-        postalCodeRules: []
-      }
+      inclusionType: inclusion,
+      postalCodeRules: []
     });
   };
 
   const onPostalCodeUnassign = code => {
     dispatch({
-      updateStateProps: {
-        havePostalCodesChanged: true,
-        postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
-      }
+      havePostalCodesChanged: true,
+      postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
     });
   };
 

--- a/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
+++ b/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
@@ -18,7 +18,11 @@ import {
   shippingZoneUrl
 } from "@saleor/shipping/urls";
 import postalCodesReducer from "@saleor/shipping/views/reducer";
-import filterPostalCodes from "@saleor/shipping/views/utils";
+import {
+  filterPostalCodes,
+  getPostalCodeRuleByMinMax,
+  getRuleObject
+} from "@saleor/shipping/views/utils";
 import { MinMax } from "@saleor/types";
 import {
   PostalCodeRuleInclusionTypeEnum,
@@ -87,21 +91,13 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
 
   const onPostalCodeAssign = (rule: MinMax) => {
     if (
-      state.postalCodeRules.filter(
-        item => item.start === rule.min && item.end === rule.max
-      ).length > 0
+      state.postalCodeRules.filter(getPostalCodeRuleByMinMax(rule)).length > 0
     ) {
       closeModal();
       return;
     }
 
-    const newCode = {
-      __typename: undefined,
-      end: rule.max,
-      id: undefined,
-      inclusionType: state.inclusionType,
-      start: rule.min
-    };
+    const newCode = getRuleObject(rule, state.inclusionType);
     dispatch({
       updateStateProps: {
         havePostalCodesChanged: true,

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -17,6 +17,10 @@ import usePaginator, {
 } from "@saleor/hooks/usePaginator";
 import { sectionNames } from "@saleor/intl";
 import { commonMessages } from "@saleor/intl";
+import {
+  getById,
+  getByUnmatchingId
+} from "@saleor/orders/components/OrderReturnPage/utils";
 import useProductSearch from "@saleor/searches/useProductSearch";
 import DeleteShippingRateDialog from "@saleor/shipping/components/DeleteShippingRateDialog";
 import ShippingMethodProductsAddDialog from "@saleor/shipping/components/ShippingMethodProductsAddDialog";
@@ -44,7 +48,11 @@ import {
   shippingZoneUrl
 } from "@saleor/shipping/urls";
 import postalCodesReducer from "@saleor/shipping/views/reducer";
-import filterPostalCodes from "@saleor/shipping/views/utils";
+import {
+  filterPostalCodes,
+  getPostalCodeRuleByMinMax,
+  getRuleObject
+} from "@saleor/shipping/views/utils";
 import { MinMax } from "@saleor/types";
 import {
   PostalCodeRuleInclusionTypeEnum,
@@ -82,9 +90,7 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     variables: { id, ...paginationState }
   });
 
-  const rate = data?.shippingZone?.shippingMethods.find(
-    rate => rate.id === rateId
-  );
+  const rate = data?.shippingZone?.shippingMethods?.find(getById(rateId));
 
   const [openModal, closeModal] = createDialogActionHandlers<
     ShippingRateUrlDialog,
@@ -99,12 +105,13 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     postalCodeRules: rate?.postalCodeRules || []
   });
 
-  if (
+  const postalCodeRulesLoaded =
     !loading &&
     !state.postalCodeRules?.length &&
     !state.codesToDelete?.length &&
-    rate.postalCodeRules?.length
-  ) {
+    rate.postalCodeRules?.length;
+
+  if (postalCodeRulesLoaded) {
     dispatch({ updateStateProps: { postalCodeRules: rate.postalCodeRules } });
   }
 
@@ -127,21 +134,13 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     }
 
     if (
-      state.postalCodeRules.filter(
-        item => item.start === rule.min && item.end === rule.max
-      ).length > 0
+      state.postalCodeRules.filter(getPostalCodeRuleByMinMax(rule)).length > 0
     ) {
       closeModal();
       return;
     }
 
-    const newCode = {
-      __typename: undefined,
-      end: rule.max,
-      id: undefined,
-      inclusionType: state.inclusionType,
-      start: rule.min
-    };
+    const newCode = getRuleObject(rule, state.inclusionType);
     dispatch({
       updateStateProps: {
         havePostalCodesChanged: true,
@@ -271,7 +270,7 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
           codesToDelete: [...state.codesToDelete, code.id],
           havePostalCodesChanged: true,
           postalCodeRules: state.postalCodeRules.filter(
-            rule => rule.id !== code.id
+            getByUnmatchingId(code.id)
           )
         }
       });
@@ -409,9 +408,7 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
       <ShippingZonePostalCodeRangeDialog
         confirmButtonState={"default"}
         onClose={closeModal}
-        onSubmit={code => {
-          onPostalCodeAssign(code);
-        }}
+        onSubmit={code => onPostalCodeAssign(code)}
         open={params.action === "add-range"}
       />
     </>

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -112,25 +112,23 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     rate.postalCodeRules?.length;
 
   if (postalCodeRulesLoaded) {
-    dispatch({ updateStateProps: { postalCodeRules: rate.postalCodeRules } });
+    dispatch({ postalCodeRules: rate.postalCodeRules });
   }
 
   const onPostalCodeInclusionChange = (
     inclusion: PostalCodeRuleInclusionTypeEnum
   ) => {
     dispatch({
-      updateStateProps: {
-        codesToDelete: rate.postalCodeRules.map(code => code.id),
-        havePostalCodesChanged: true,
-        inclusionType: inclusion,
-        postalCodeRules: []
-      }
+      codesToDelete: rate.postalCodeRules.map(code => code.id),
+      havePostalCodesChanged: true,
+      inclusionType: inclusion,
+      postalCodeRules: []
     });
   };
 
   const onPostalCodeAssign = (rule: MinMax) => {
     if (!state.originalCodes.length) {
-      dispatch({ updateStateProps: { originalCodes: rate.postalCodeRules } });
+      dispatch({ originalCodes: rate.postalCodeRules });
     }
 
     if (
@@ -142,10 +140,8 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
 
     const newCode = getRuleObject(rule, state.inclusionType);
     dispatch({
-      updateStateProps: {
-        havePostalCodesChanged: true,
-        postalCodeRules: [...state.postalCodeRules, newCode]
-      }
+      havePostalCodesChanged: true,
+      postalCodeRules: [...state.postalCodeRules, newCode]
     });
     closeModal();
   };
@@ -249,7 +245,7 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     const errors = response.data.shippingPriceUpdate.errors;
     if (errors.length === 0) {
       handleSuccess();
-      dispatch({ updateStateProps: { havePostalCodesChanged: false } });
+      dispatch({ havePostalCodesChanged: false });
       updateShippingMethodChannelListing({
         variables: getShippingMethodChannelVariables(
           rateId,
@@ -266,20 +262,16 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
   const onPostalCodeUnassign = code => {
     if (code.id !== undefined) {
       dispatch({
-        updateStateProps: {
-          codesToDelete: [...state.codesToDelete, code.id],
-          havePostalCodesChanged: true,
-          postalCodeRules: state.postalCodeRules.filter(
-            getByUnmatchingId(code.id)
-          )
-        }
+        codesToDelete: [...state.codesToDelete, code.id],
+        havePostalCodesChanged: true,
+        postalCodeRules: state.postalCodeRules.filter(
+          getByUnmatchingId(code.id)
+        )
       });
     } else {
       dispatch({
-        updateStateProps: {
-          havePostalCodesChanged: true,
-          postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
-        }
+        havePostalCodesChanged: true,
+        postalCodeRules: filterPostalCodes(state.postalCodeRules, code)
       });
     }
   };

--- a/src/shipping/views/reducer.tsx
+++ b/src/shipping/views/reducer.tsx
@@ -1,0 +1,29 @@
+import { ShippingZone_shippingZone_shippingMethods_postalCodeRules } from "@saleor/shipping/types/ShippingZone";
+import { PostalCodeRuleInclusionTypeEnum } from "@saleor/types/globalTypes";
+
+export interface PostalCodesState {
+  codesToDelete: string[];
+  havePostalCodesChanged: boolean;
+  inclusionType: PostalCodeRuleInclusionTypeEnum;
+  originalCodes: ShippingZone_shippingZone_shippingMethods_postalCodeRules[];
+  postalCodeRules: ShippingZone_shippingZone_shippingMethods_postalCodeRules[];
+}
+
+function setPostalCodes(
+  state: PostalCodesState,
+  newStateProps: any
+): PostalCodesState {
+  return {
+    ...state,
+    ...newStateProps
+  };
+}
+
+function postalCodesReducer(prevState: PostalCodesState, newProps: any) {
+  if (newProps?.updateStateProps) {
+    return setPostalCodes(prevState, newProps.updateStateProps);
+  }
+  return prevState;
+}
+
+export default postalCodesReducer;

--- a/src/shipping/views/reducer.tsx
+++ b/src/shipping/views/reducer.tsx
@@ -2,14 +2,17 @@ import { ShippingZone_shippingZone_shippingMethods_postalCodeRules } from "@sale
 import { PostalCodeRuleInclusionTypeEnum } from "@saleor/types/globalTypes";
 
 export interface PostalCodesState {
-  codesToDelete: string[];
-  havePostalCodesChanged: boolean;
-  inclusionType: PostalCodeRuleInclusionTypeEnum;
-  originalCodes: ShippingZone_shippingZone_shippingMethods_postalCodeRules[];
-  postalCodeRules: ShippingZone_shippingZone_shippingMethods_postalCodeRules[];
+  codesToDelete?: string[];
+  havePostalCodesChanged?: boolean;
+  inclusionType?: PostalCodeRuleInclusionTypeEnum;
+  originalCodes?: ShippingZone_shippingZone_shippingMethods_postalCodeRules[];
+  postalCodeRules?: ShippingZone_shippingZone_shippingMethods_postalCodeRules[];
 }
 
-function postalCodesReducer(prevState: PostalCodesState, newState: any) {
+function postalCodesReducer(
+  prevState: PostalCodesState,
+  newState: PostalCodesState
+) {
   return { ...prevState, ...newState };
 }
 

--- a/src/shipping/views/reducer.tsx
+++ b/src/shipping/views/reducer.tsx
@@ -9,21 +9,8 @@ export interface PostalCodesState {
   postalCodeRules: ShippingZone_shippingZone_shippingMethods_postalCodeRules[];
 }
 
-function setPostalCodes(
-  state: PostalCodesState,
-  newStateProps: any
-): PostalCodesState {
-  return {
-    ...state,
-    ...newStateProps
-  };
-}
-
-function postalCodesReducer(prevState: PostalCodesState, newProps: any) {
-  if (newProps?.updateStateProps) {
-    return setPostalCodes(prevState, newProps.updateStateProps);
-  }
-  return prevState;
+function postalCodesReducer(prevState: PostalCodesState, newState: any) {
+  return { ...prevState, ...newState };
 }
 
 export default postalCodesReducer;

--- a/src/shipping/views/utils.tsx
+++ b/src/shipping/views/utils.tsx
@@ -1,7 +1,22 @@
-const filterPostalCodes = (postalCodes, codeToFilterOut) =>
+import { MinMax } from "@saleor/types";
+import { PostalCodeRuleInclusionTypeEnum } from "@saleor/types/globalTypes";
+
+export const filterPostalCodes = (postalCodes, codeToFilterOut) =>
   postalCodes.filter(
     rule =>
       rule.start !== codeToFilterOut.start && rule.end !== codeToFilterOut.end
   );
 
-export default filterPostalCodes;
+export const getPostalCodeRuleByMinMax = ({ min, max }) => ({ start, end }) =>
+  start === min && end === max;
+
+export const getRuleObject = (
+  rule: MinMax,
+  inclusionType: PostalCodeRuleInclusionTypeEnum
+) => ({
+  __typename: undefined,
+  end: rule.max,
+  id: undefined,
+  inclusionType,
+  start: rule.min
+});


### PR DESCRIPTION
I want to merge this change because it refactors postal codes related components.
Clears up potential issues raised in https://github.com/mirumee/saleor-dashboard/pull/983
Testing:
- check shippingRatePrice update page
- check shippingRateWeight update page
- check shippingRatePrice create page
- check shippingRateWeight create page

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
1. [ ] The changes are tested in different browsers (Chrome, Firefox, Safari).
1. [ ] The changes are tested in light and dark mode.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.cloud/graphql/
