### PR TITLE
Handle null orderLine item on Extended Event

### DIFF
--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -28,6 +28,7 @@ export const fragmentOrderEvent = gql`
     }
     lines {
       quantity
+      itemName
       orderLine {
         id
         productName

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -66,6 +66,7 @@ export interface OrderDetailsFragment_events_lines_orderLine {
 export interface OrderDetailsFragment_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderDetailsFragment_events_lines_orderLine | null;
 }
 

--- a/src/fragments/types/OrderEventFragment.ts
+++ b/src/fragments/types/OrderEventFragment.ts
@@ -32,6 +32,7 @@ export interface OrderEventFragment_lines_orderLine {
 export interface OrderEventFragment_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderEventFragment_lines_orderLine | null;
 }
 

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -138,7 +138,10 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
 
   const titleElements = {
     by: { text: intl.formatMessage(messages.by) },
-    employeeName: { link: staffMemberDetailsUrl(user.id), text: employeeName },
+    employeeName: {
+      link: staffMemberDetailsUrl(user.id),
+      text: employeeName.trim() ? employeeName : user.email
+    },
     orderNumber: {
       link: orderUrl(relatedOrder?.id),
       text: `#${relatedOrder?.number}`
@@ -172,14 +175,14 @@ const ExtendedTimelineEvent: React.FC<ExtendedTimelineEventProps> = ({
           </Typography>
           <table>
             <tbody>
-              {lines.map(({ orderLine, quantity }) => (
-                <tr key={orderLine.id}>
+              {lines.map(({ orderLine, quantity, itemName }, i) => (
+                <tr key={`${itemName}-${i}`}>
                   <td className={classes.linesTableCell}>
-                    {orderLine.productName}
+                    {orderLine?.productName || itemName}
                   </td>
                   <td className={classes.linesTableCell}>
                     <Typography variant="caption" color="textSecondary">
-                      {orderLine.variantName}
+                      {orderLine?.variantName}
                     </Typography>
                   </td>
                   <td className={classes.linesTableCell}>

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -857,6 +857,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
       lines: [
         {
           __typename: "OrderEventOrderLineObject",
+          itemName: "Milk Cow's milk",
           orderLine: {
             __typename: "OrderLine",
             id: "h47gfncfgwegfehfhj",
@@ -867,6 +868,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
         },
         {
           __typename: "OrderEventOrderLineObject",
+          itemName: "Milk Goat's milk",
           orderLine: {
             __typename: "OrderLine",
             id: "7846f857t4t84y8fgh",

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -74,6 +74,7 @@ export interface FulfillOrder_orderFulfill_order_events_lines_orderLine {
 export interface FulfillOrder_orderFulfill_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: FulfillOrder_orderFulfill_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderAddNote.ts
+++ b/src/orders/types/OrderAddNote.ts
@@ -38,6 +38,7 @@ export interface OrderAddNote_orderAddNote_order_events_lines_orderLine {
 export interface OrderAddNote_orderAddNote_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderAddNote_orderAddNote_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -72,6 +72,7 @@ export interface OrderCancel_orderCancel_order_events_lines_orderLine {
 export interface OrderCancel_orderCancel_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderCancel_orderCancel_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -72,6 +72,7 @@ export interface OrderCapture_orderCapture_order_events_lines_orderLine {
 export interface OrderCapture_orderCapture_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderCapture_orderCapture_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -72,6 +72,7 @@ export interface OrderConfirm_orderConfirm_order_events_lines_orderLine {
 export interface OrderConfirm_orderConfirm_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderConfirm_orderConfirm_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -66,6 +66,7 @@ export interface OrderDetails_order_events_lines_orderLine {
 export interface OrderDetails_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderDetails_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -72,6 +72,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_events_lines_orderLine 
 export interface OrderDraftCancel_draftOrderDelete_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderDraftCancel_draftOrderDelete_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -72,6 +72,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_events_lines_orderL
 export interface OrderDraftFinalize_draftOrderComplete_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderDraftFinalize_draftOrderComplete_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -72,6 +72,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_events_lines_orderLine 
 export interface OrderDraftUpdate_draftOrderUpdate_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderDraftUpdate_draftOrderUpdate_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -72,6 +72,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_events_line
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderFulfillmentCancel_orderFulfillmentCancel_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -137,6 +137,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -72,6 +72,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -72,6 +72,7 @@ export interface OrderLineDelete_draftOrderLineDelete_order_events_lines_orderLi
 export interface OrderLineDelete_draftOrderLineDelete_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderLineDelete_draftOrderLineDelete_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -72,6 +72,7 @@ export interface OrderLineUpdate_draftOrderLineUpdate_order_events_lines_orderLi
 export interface OrderLineUpdate_draftOrderLineUpdate_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderLineUpdate_draftOrderLineUpdate_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -72,6 +72,7 @@ export interface OrderLinesAdd_draftOrderLinesCreate_order_events_lines_orderLin
 export interface OrderLinesAdd_draftOrderLinesCreate_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderLinesAdd_draftOrderLinesCreate_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -72,6 +72,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_events_lines_orderLine {
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderMarkAsPaid_orderMarkAsPaid_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -72,6 +72,7 @@ export interface OrderRefund_orderRefund_order_events_lines_orderLine {
 export interface OrderRefund_orderRefund_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderRefund_orderRefund_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -72,6 +72,7 @@ export interface OrderUpdate_orderUpdate_order_events_lines_orderLine {
 export interface OrderUpdate_orderUpdate_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderUpdate_orderUpdate_order_events_lines_orderLine | null;
 }
 

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -72,6 +72,7 @@ export interface OrderVoid_orderVoid_order_events_lines_orderLine {
 export interface OrderVoid_orderVoid_order_events_lines {
   __typename: "OrderEventOrderLineObject";
   quantity: number | null;
+  itemName: string | null;
   orderLine: OrderVoid_orderVoid_order_events_lines_orderLine | null;
 }
 


### PR DESCRIPTION
I want to merge this change because it fixes a bug where properties are trying to be accessed on null orderLine item

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
1. [ ] The changes are tested in different browsers (Chrome, Firefox, Safari).
1. [ ] The changes are tested in light and dark mode.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.cloud/graphql/
