### PR TITLE
Fix failing page translations

### DIFF
--- a/src/translations/utils.ts
+++ b/src/translations/utils.ts
@@ -19,7 +19,7 @@ export const getParsedTranslationInputData = ({
 
   if (fieldsToParse.includes(fieldName)) {
     return {
-      description: getParsedDataForJsonStringField(data as OutputData)
+      [fieldName]: getParsedDataForJsonStringField(data as OutputData)
     };
   }
 

--- a/src/translations/views/TranslationsPages.tsx
+++ b/src/translations/views/TranslationsPages.tsx
@@ -10,7 +10,7 @@ import { LanguageCodeEnum } from "../../types/globalTypes";
 import TranslationsPagesPage from "../components/TranslationsPagesPage";
 import { TypedUpdatePageTranslations } from "../mutations";
 import { usePageTranslationDetails } from "../queries";
-import { TranslationInputFieldName } from "../types";
+import { PageTranslationInputFieldName } from "../types";
 import { UpdatePageTranslations } from "../types/UpdatePageTranslations";
 import {
   languageEntitiesUrl,
@@ -68,7 +68,7 @@ const TranslationsPages: React.FC<TranslationsPagesProps> = ({
     <TypedUpdatePageTranslations onCompleted={onUpdate}>
       {(updateTranslations, updateTranslationsOpts) => {
         const handleSubmit = (
-          fieldName: TranslationInputFieldName,
+          fieldName: PageTranslationInputFieldName,
           data: string
         ) => {
           updateTranslations({


### PR DESCRIPTION
I want to merge this change because currenlty we are not able to save translation for pages. Pages uses different field name than the rest of the fields. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Translated strings are extracted.
1. [ ] Number of API calls is optimized.
1. [ ] The changes are tested.
1. [ ] Data-test are added for new elements.
1. [ ] Type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
1. [ ] The changes are tested in different browsers (Chrome, Firefox, Safari).
1. [ ] The changes are tested in light and dark mode.

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/