### PR TITLE
Create GH workflow for UI review assignment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,13 +14,10 @@ greatly reduce the amount of work needed to review your work. -->
 <!-- Please keep this section. It will make maintainer's life easier. -->
 
 1. [ ] This code contains UI changes
-2. [ ] All visible strings are translated with proper context.
-3. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
-4. [ ] Attributes `[data-test-id]` are added for new elements.
-5. [ ] Code is properly typed.
-6. [ ] Changes are mentioned in the changelog.
-7. [ ] The changes are tested in different browsers (Chrome, Firefox, Safari).
-8. [ ] The changes are tested in light and dark mode.
+2. [ ] All visible strings are translated with proper context including data-formatting
+3. [ ] Attributes `[data-test-id]` are added for new elements
+4. [ ] Changes are mentioned in the changelog
+5. [ ] The changes are tested in different browsers and in light/dark mode
 
 ### Test environment config
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,16 +13,14 @@ greatly reduce the amount of work needed to review your work. -->
 
 <!-- Please keep this section. It will make maintainer's life easier. -->
 
-1. [ ] All visible strings are translated with proper context.
-1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
-1. [ ] Translated strings are extracted.
-1. [ ] Number of API calls is optimized.
-1. [ ] The changes are tested.
-1. [ ] Data-test are added for new elements.
-1. [ ] Type definitions are up to date.
-1. [ ] Changes are mentioned in the changelog.
-1. [ ] The changes are tested in different browsers (Chrome, Firefox, Safari).
-1. [ ] The changes are tested in light and dark mode.
+1. [ ] This code contains UI changes
+2. [ ] All visible strings are translated with proper context.
+3. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
+4. [ ] Attributes `[data-test-id]` are added for new elements.
+5. [ ] Code is properly typed.
+6. [ ] Changes are mentioned in the changelog.
+7. [ ] The changes are tested in different browsers (Chrome, Firefox, Safari).
+8. [ ] The changes are tested in light and dark mode.
 
 ### Test environment config
 

--- a/.github/workflows/review-assignment.yml
+++ b/.github/workflows/review-assignment.yml
@@ -1,0 +1,27 @@
+name: Review assignment
+
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review]
+
+jobs:
+  assign_ui:
+    runs-on: ubuntu-latest
+    name: Add UI Reviewer
+    if: ${{ !contains(github.event.pull_request.requested_reviewers , 'pwgryglak') }}
+    steps:
+      - name: Check UI changes checkbox
+        id: ui_changes_check
+        # Search for API_URI in PR description
+        env:
+          pull_request_body: ${{ github.event.pull_request.body }}
+          pattern: \[x\] This code contains UI changes
+        run: |
+          echo "::set-output name=is_checked::$(echo $pull_request_body | grep -Eo  "$pattern")"
+
+      - name: Assign UI reviewer
+        if: steps.ui_changes_check.outputs.is_checked
+        uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+        with:
+          reviewers: "pwgryglak"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-assignment.yml
+++ b/.github/workflows/review-assignment.yml
@@ -2,17 +2,17 @@ name: Review assignment
 
 on:
   pull_request:
-    types: [opened, edited, ready_for_review]
+    types: [opened, edited]
 
 jobs:
   assign_ui:
     runs-on: ubuntu-latest
-    name: Add UI Reviewer
-    # if: ${{ !contains(github.event.pull_request.requested_reviewers , 'pwgryglak') && contains(github.event.pull_request.body , '[x] This code contains UI changes') }}
+    name: Assign UI Reviewer
+    if: contains(github.event.pull_request.body , 'This code contains UI changes')
     steps:
-      - name: Assign UI reviewer
-        uses: jwm0/add-reviewer-gh-action@7a5823b78f69fff30cf31ce836785e95330fa603
+      - name: Add/Remove UI reviewer
+        uses: jwm0/add-reviewer-gh-action@1.0.4
         with:
           reviewers: "pwgryglak"
           token: ${{ secrets.GITHUB_TOKEN }}
-          remove: true
+          remove: ${{ !contains(github.event.pull_request.body , '[x] This code contains UI changes') }}

--- a/.github/workflows/review-assignment.yml
+++ b/.github/workflows/review-assignment.yml
@@ -8,20 +8,11 @@ jobs:
   assign_ui:
     runs-on: ubuntu-latest
     name: Add UI Reviewer
-    if: ${{ !contains(github.event.pull_request.requested_reviewers , 'pwgryglak') }}
+    # if: ${{ !contains(github.event.pull_request.requested_reviewers , 'pwgryglak') && contains(github.event.pull_request.body , '[x] This code contains UI changes') }}
     steps:
-      - name: Check UI changes checkbox
-        id: ui_changes_check
-        # Search for API_URI in PR description
-        env:
-          pull_request_body: ${{ github.event.pull_request.body }}
-          pattern: \[x\] This code contains UI changes
-        run: |
-          echo "::set-output name=is_checked::$(echo $pull_request_body | grep -Eo  "$pattern")"
-
       - name: Assign UI reviewer
-        if: steps.ui_changes_check.outputs.is_checked
-        uses: AveryCameronUofR/add-reviewer-gh-action@1.0.3
+        uses: jwm0/add-reviewer-gh-action@7a5823b78f69fff30cf31ce836785e95330fa603
         with:
           reviewers: "pwgryglak"
           token: ${{ secrets.GITHUB_TOKEN }}
+          remove: true


### PR DESCRIPTION
I want to merge this change because it automates UI reviewer assignment by using an item in Pull Request Checklist called "This code contains UI changes".

How it works:
1. It uses an [extended (forked) version](https://github.com/jwm0/add-reviewer-gh-action/releases/tag/1.0.4) of this simple [GH Action](https://github.com/marketplace/actions/add-pull-request-reviewer)
2. It checks if the PR description contains `This code contains UI changes` keyword and skips the job if it's not present
3. If the checkbox is checked it will auto-assign @pwgryglak and remove him from reviewers if unchecked (as we should not be assigning UI reviewers to PRs that do not have anything to do with UI)
4. The job is run on initial PR creation and every PR edit, clicking the checkbox at any state will retrigger the run.

Additionally, new, shorter and more to-the-point Pull Request Checklist has been introduced as seen below.

### Screenshots
![image](https://user-images.githubusercontent.com/28310983/113412907-bf246b80-93b9-11eb-9904-8f335a5aea7e.png)
![image](https://user-images.githubusercontent.com/28310983/113412932-d400ff00-93b9-11eb-8b09-c80e19bbec43.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/