### PR TITLE
Make price rates views use parent shipping method channels instead of all

### DIFF
--- a/src/apps/types/App.ts
+++ b/src/apps/types/App.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppTypeEnum, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppActivate.ts
+++ b/src/apps/types/AppActivate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppCreate.ts
+++ b/src/apps/types/AppCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppInput, AppTypeEnum, AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppDeactivate.ts
+++ b/src/apps/types/AppDeactivate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppDelete.ts
+++ b/src/apps/types/AppDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppTypeEnum, AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppDeleteFailedInstallation.ts
+++ b/src/apps/types/AppDeleteFailedInstallation.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { JobStatusEnum, AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppFetch.ts
+++ b/src/apps/types/AppFetch.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum, AppErrorCode } from "./../../types/globalTypes";

--- a/src/apps/types/AppInstall.ts
+++ b/src/apps/types/AppInstall.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppInstallInput, JobStatusEnum, AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppRetryInstall.ts
+++ b/src/apps/types/AppRetryInstall.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { JobStatusEnum, AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppTokenCreate.ts
+++ b/src/apps/types/AppTokenCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppTokenInput, AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppTokenDelete.ts
+++ b/src/apps/types/AppTokenDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppUpdate.ts
+++ b/src/apps/types/AppUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppInput, AppTypeEnum, PermissionEnum, AppErrorCode } from "./../../types/globalTypes";

--- a/src/apps/types/AppsInstallations.ts
+++ b/src/apps/types/AppsInstallations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { JobStatusEnum } from "./../../types/globalTypes";

--- a/src/apps/types/AppsList.ts
+++ b/src/apps/types/AppsList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppSortingInput, AppFilterInput, AppTypeEnum } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeBulkDelete.ts
+++ b/src/attributes/types/AttributeBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeCreate.ts
+++ b/src/attributes/types/AttributeCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeDelete.ts
+++ b/src/attributes/types/AttributeDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeDetails.ts
+++ b/src/attributes/types/AttributeDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeList.ts
+++ b/src/attributes/types/AttributeList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeFilterInput, AttributeSortingInput, AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeUpdate.ts
+++ b/src/attributes/types/AttributeUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeUpdateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeValueCreate.ts
+++ b/src/attributes/types/AttributeValueCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeValueDelete.ts
+++ b/src/attributes/types/AttributeValueDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeValueReorder.ts
+++ b/src/attributes/types/AttributeValueReorder.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ReorderInput, AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/attributes/types/AttributeValueUpdate.ts
+++ b/src/attributes/types/AttributeValueUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeValueCreateInput, AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/auth/types/AvailableExternalAuthentications.ts
+++ b/src/auth/types/AvailableExternalAuthentications.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/auth/types/ExternalAuthenticationUrl.ts
+++ b/src/auth/types/ExternalAuthenticationUrl.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/auth/types/ExternalObtainAccessTokens.ts
+++ b/src/auth/types/ExternalObtainAccessTokens.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum, AccountErrorCode } from "./../../types/globalTypes";

--- a/src/auth/types/ExternalRefreshToken.ts
+++ b/src/auth/types/ExternalRefreshToken.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/auth/types/ExternalVerifyToken.ts
+++ b/src/auth/types/ExternalVerifyToken.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/auth/types/RefreshToken.ts
+++ b/src/auth/types/RefreshToken.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/auth/types/RequestPasswordReset.ts
+++ b/src/auth/types/RequestPasswordReset.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/auth/types/SetPassword.ts
+++ b/src/auth/types/SetPassword.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/auth/types/TokenAuth.ts
+++ b/src/auth/types/TokenAuth.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/auth/types/VerifyToken.ts
+++ b/src/auth/types/VerifyToken.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/categories/types/CategoryBulkDelete.ts
+++ b/src/categories/types/CategoryBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/categories/types/CategoryCreate.ts
+++ b/src/categories/types/CategoryCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CategoryInput, ProductErrorCode } from "./../../types/globalTypes";

--- a/src/categories/types/CategoryDelete.ts
+++ b/src/categories/types/CategoryDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/categories/types/CategoryDetails.ts
+++ b/src/categories/types/CategoryDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/categories/types/CategoryUpdate.ts
+++ b/src/categories/types/CategoryUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CategoryInput, ProductErrorCode } from "./../../types/globalTypes";

--- a/src/categories/types/RootCategories.ts
+++ b/src/categories/types/RootCategories.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CategoryFilterInput, CategorySortingInput } from "./../../types/globalTypes";

--- a/src/channels/types/BaseChannels.ts
+++ b/src/channels/types/BaseChannels.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/channels/types/Channel.ts
+++ b/src/channels/types/Channel.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/channels/types/ChannelActivate.ts
+++ b/src/channels/types/ChannelActivate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ChannelErrorCode } from "./../../types/globalTypes";

--- a/src/channels/types/ChannelCreate.ts
+++ b/src/channels/types/ChannelCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ChannelCreateInput, ChannelErrorCode } from "./../../types/globalTypes";

--- a/src/channels/types/ChannelDeactivate.ts
+++ b/src/channels/types/ChannelDeactivate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ChannelErrorCode } from "./../../types/globalTypes";

--- a/src/channels/types/ChannelDelete.ts
+++ b/src/channels/types/ChannelDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ChannelDeleteInput, ChannelErrorCode } from "./../../types/globalTypes";

--- a/src/channels/types/ChannelUpdate.ts
+++ b/src/channels/types/ChannelUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ChannelUpdateInput, ChannelErrorCode } from "./../../types/globalTypes";

--- a/src/channels/types/Channels.ts
+++ b/src/channels/types/Channels.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/channels/utils.ts
+++ b/src/channels/utils.ts
@@ -5,7 +5,10 @@ import { VoucherDetails_voucher } from "@saleor/discounts/types/VoucherDetails";
 import { RequireOnlyOne } from "@saleor/misc";
 import { ProductDetails_product } from "@saleor/products/types/ProductDetails";
 import { ProductVariantDetails_productVariant } from "@saleor/products/types/ProductVariantDetails";
-import { ShippingZone_shippingZone_shippingMethods_channelListings } from "@saleor/shipping/types/ShippingZone";
+import {
+  ShippingZone_shippingZone_channels,
+  ShippingZone_shippingZone_shippingMethods_channelListings
+} from "@saleor/shipping/types/ShippingZone";
 import { mapNodeToChoice } from "@saleor/utils/maps";
 import uniqBy from "lodash-es/uniqBy";
 
@@ -168,7 +171,7 @@ export const createChannelsDataWithPrice = (
 };
 
 export const createShippingChannels = (
-  data?: Channels_channels[]
+  data?: ShippingZone_shippingZone_channels[]
 ): ChannelShippingData[] =>
   data?.map(channel => ({
     currency: channel.currencyCode,
@@ -272,7 +275,9 @@ export const createSortedChannelsData = (data?: Channels_channels[]) =>
     channel.name.localeCompare(nextChannel.name)
   );
 
-export const createSortedShippingChannels = (data?: Channels_channels[]) =>
+export const createSortedShippingChannels = (
+  data?: ShippingZone_shippingZone_channels[]
+) =>
   createShippingChannels(data)?.sort((channel, nextChannel) =>
     channel.name.localeCompare(nextChannel.name)
   );

--- a/src/collections/types/CollectionAssignProduct.ts
+++ b/src/collections/types/CollectionAssignProduct.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CollectionErrorCode } from "./../../types/globalTypes";

--- a/src/collections/types/CollectionBulkDelete.ts
+++ b/src/collections/types/CollectionBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/collections/types/CollectionChannelListingUpdate.ts
+++ b/src/collections/types/CollectionChannelListingUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CollectionChannelListingUpdateInput, ProductErrorCode } from "./../../types/globalTypes";

--- a/src/collections/types/CollectionDetails.ts
+++ b/src/collections/types/CollectionDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/collections/types/CollectionList.ts
+++ b/src/collections/types/CollectionList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CollectionFilterInput, CollectionSortingInput } from "./../../types/globalTypes";

--- a/src/collections/types/CollectionUpdate.ts
+++ b/src/collections/types/CollectionUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CollectionInput, CollectionErrorCode } from "./../../types/globalTypes";

--- a/src/collections/types/CreateCollection.ts
+++ b/src/collections/types/CreateCollection.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CollectionCreateInput, CollectionErrorCode } from "./../../types/globalTypes";

--- a/src/collections/types/RemoveCollection.ts
+++ b/src/collections/types/RemoveCollection.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CollectionErrorCode } from "./../../types/globalTypes";

--- a/src/collections/types/UnassignCollectionProduct.ts
+++ b/src/collections/types/UnassignCollectionProduct.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CollectionErrorCode } from "./../../types/globalTypes";

--- a/src/components/Navigator/queries/types/CheckIfOrderExists.ts
+++ b/src/components/Navigator/queries/types/CheckIfOrderExists.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderStatus } from "./../../../../types/globalTypes";

--- a/src/components/Navigator/queries/types/SearchCatalog.ts
+++ b/src/components/Navigator/queries/types/SearchCatalog.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/components/Shop/types/ShopInfo.ts
+++ b/src/components/Shop/types/ShopInfo.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WeightUnitsEnum, LanguageCodeEnum, PermissionEnum } from "./../../../types/globalTypes";

--- a/src/containers/BackgroundTasks/types/CheckExportFileStatus.ts
+++ b/src/containers/BackgroundTasks/types/CheckExportFileStatus.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { JobStatusEnum } from "./../../../types/globalTypes";

--- a/src/containers/BackgroundTasks/types/CheckOrderInvoicesStatus.ts
+++ b/src/containers/BackgroundTasks/types/CheckOrderInvoicesStatus.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { JobStatusEnum } from "./../../../types/globalTypes";

--- a/src/customers/types/BulkRemoveCustomers.ts
+++ b/src/customers/types/BulkRemoveCustomers.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/customers/types/CreateCustomer.ts
+++ b/src/customers/types/CreateCustomer.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { UserCreateInput, AccountErrorCode } from "./../../types/globalTypes";

--- a/src/customers/types/CreateCustomerAddress.ts
+++ b/src/customers/types/CreateCustomerAddress.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AddressInput, AccountErrorCode } from "./../../types/globalTypes";

--- a/src/customers/types/CustomerAddresses.ts
+++ b/src/customers/types/CustomerAddresses.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/customers/types/CustomerCreateData.ts
+++ b/src/customers/types/CustomerCreateData.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/customers/types/CustomerDetails.ts
+++ b/src/customers/types/CustomerDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PaymentChargeStatusEnum } from "./../../types/globalTypes";

--- a/src/customers/types/ListCustomers.ts
+++ b/src/customers/types/ListCustomers.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CustomerFilterInput, UserSortingInput } from "./../../types/globalTypes";

--- a/src/customers/types/RemoveCustomer.ts
+++ b/src/customers/types/RemoveCustomer.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/customers/types/RemoveCustomerAddress.ts
+++ b/src/customers/types/RemoveCustomerAddress.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/customers/types/SetCustomerDefaultAddress.ts
+++ b/src/customers/types/SetCustomerDefaultAddress.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AddressTypeEnum, AccountErrorCode } from "./../../types/globalTypes";

--- a/src/customers/types/UpdateCustomer.ts
+++ b/src/customers/types/UpdateCustomer.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CustomerInput, AccountErrorCode } from "./../../types/globalTypes";

--- a/src/customers/types/UpdateCustomerAddress.ts
+++ b/src/customers/types/UpdateCustomerAddress.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AddressInput, AccountErrorCode } from "./../../types/globalTypes";

--- a/src/discounts/types/SaleBulkDelete.ts
+++ b/src/discounts/types/SaleBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/discounts/types/SaleCataloguesAdd.ts
+++ b/src/discounts/types/SaleCataloguesAdd.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CatalogueInput, DiscountErrorCode, SaleType } from "./../../types/globalTypes";

--- a/src/discounts/types/SaleCataloguesRemove.ts
+++ b/src/discounts/types/SaleCataloguesRemove.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CatalogueInput, DiscountErrorCode, SaleType } from "./../../types/globalTypes";

--- a/src/discounts/types/SaleChannelListingUpdate.ts
+++ b/src/discounts/types/SaleChannelListingUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { SaleChannelListingInput, DiscountErrorCode, SaleType } from "./../../types/globalTypes";

--- a/src/discounts/types/SaleCreate.ts
+++ b/src/discounts/types/SaleCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { SaleInput, DiscountErrorCode, SaleType } from "./../../types/globalTypes";

--- a/src/discounts/types/SaleDelete.ts
+++ b/src/discounts/types/SaleDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DiscountErrorCode } from "./../../types/globalTypes";

--- a/src/discounts/types/SaleDetails.ts
+++ b/src/discounts/types/SaleDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { SaleType } from "./../../types/globalTypes";

--- a/src/discounts/types/SaleList.ts
+++ b/src/discounts/types/SaleList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { SaleFilterInput, SaleSortingInput, SaleType } from "./../../types/globalTypes";

--- a/src/discounts/types/SaleUpdate.ts
+++ b/src/discounts/types/SaleUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { SaleInput, DiscountErrorCode, SaleType } from "./../../types/globalTypes";

--- a/src/discounts/types/VoucherBulkDelete.ts
+++ b/src/discounts/types/VoucherBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/discounts/types/VoucherCataloguesAdd.ts
+++ b/src/discounts/types/VoucherCataloguesAdd.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CatalogueInput, DiscountErrorCode, DiscountValueTypeEnum, VoucherTypeEnum } from "./../../types/globalTypes";

--- a/src/discounts/types/VoucherCataloguesRemove.ts
+++ b/src/discounts/types/VoucherCataloguesRemove.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CatalogueInput, DiscountErrorCode, DiscountValueTypeEnum, VoucherTypeEnum } from "./../../types/globalTypes";

--- a/src/discounts/types/VoucherChannelListingUpdate.ts
+++ b/src/discounts/types/VoucherChannelListingUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { VoucherChannelListingInput, DiscountErrorCode, DiscountValueTypeEnum } from "./../../types/globalTypes";

--- a/src/discounts/types/VoucherCreate.ts
+++ b/src/discounts/types/VoucherCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { VoucherInput, DiscountErrorCode, DiscountValueTypeEnum } from "./../../types/globalTypes";

--- a/src/discounts/types/VoucherDelete.ts
+++ b/src/discounts/types/VoucherDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DiscountErrorCode } from "./../../types/globalTypes";

--- a/src/discounts/types/VoucherDetails.ts
+++ b/src/discounts/types/VoucherDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DiscountValueTypeEnum, VoucherTypeEnum } from "./../../types/globalTypes";

--- a/src/discounts/types/VoucherList.ts
+++ b/src/discounts/types/VoucherList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { VoucherFilterInput, VoucherSortingInput, DiscountValueTypeEnum } from "./../../types/globalTypes";

--- a/src/discounts/types/VoucherUpdate.ts
+++ b/src/discounts/types/VoucherUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { VoucherInput, DiscountErrorCode, DiscountValueTypeEnum } from "./../../types/globalTypes";

--- a/src/files/types/FileUpload.ts
+++ b/src/files/types/FileUpload.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { UploadErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/AccountErrorFragment.ts
+++ b/src/fragments/types/AccountErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/AddressFragment.ts
+++ b/src/fragments/types/AddressFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/AppErrorFragment.ts
+++ b/src/fragments/types/AppErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/AppFragment.ts
+++ b/src/fragments/types/AppFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AppTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/AttributeDetailsFragment.ts
+++ b/src/fragments/types/AttributeDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/AttributeErrorFragment.ts
+++ b/src/fragments/types/AttributeErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/AttributeFragment.ts
+++ b/src/fragments/types/AttributeFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/AttributeTranslationFragment.ts
+++ b/src/fragments/types/AttributeTranslationFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/AttributeValueFragment.ts
+++ b/src/fragments/types/AttributeValueFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/AvailableAttributeFragment.ts
+++ b/src/fragments/types/AvailableAttributeFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/BulkProductErrorFragment.ts
+++ b/src/fragments/types/BulkProductErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/BulkStockErrorFragment.ts
+++ b/src/fragments/types/BulkStockErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/CategoryDetailsFragment.ts
+++ b/src/fragments/types/CategoryDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CategoryFragment.ts
+++ b/src/fragments/types/CategoryFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CategoryTranslationFragment.ts
+++ b/src/fragments/types/CategoryTranslationFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ChannelDetailsFragment.ts
+++ b/src/fragments/types/ChannelDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ChannelErrorFragment.ts
+++ b/src/fragments/types/ChannelErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ChannelErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ChannelFragment.ts
+++ b/src/fragments/types/ChannelFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ChannelListingProductFragment.ts
+++ b/src/fragments/types/ChannelListingProductFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ChannelListingProductVariantFragment.ts
+++ b/src/fragments/types/ChannelListingProductVariantFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ChannelListingProductWithoutPricingFragment.ts
+++ b/src/fragments/types/ChannelListingProductWithoutPricingFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CollectionChannelListingErrorFragment.ts
+++ b/src/fragments/types/CollectionChannelListingErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/CollectionDetailsFragment.ts
+++ b/src/fragments/types/CollectionDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CollectionErrorFragment.ts
+++ b/src/fragments/types/CollectionErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { CollectionErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/CollectionFragment.ts
+++ b/src/fragments/types/CollectionFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CollectionProductFragment.ts
+++ b/src/fragments/types/CollectionProductFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CollectionTranslationFragment.ts
+++ b/src/fragments/types/CollectionTranslationFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CountryFragment.ts
+++ b/src/fragments/types/CountryFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CountryWithTaxesFragment.ts
+++ b/src/fragments/types/CountryWithTaxesFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType } from "./../../types/globalTypes";

--- a/src/fragments/types/CustomerAddressesFragment.ts
+++ b/src/fragments/types/CustomerAddressesFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CustomerDetailsFragment.ts
+++ b/src/fragments/types/CustomerDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/CustomerFragment.ts
+++ b/src/fragments/types/CustomerFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/DiscountErrorFragment.ts
+++ b/src/fragments/types/DiscountErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DiscountErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ExportErrorFragment.ts
+++ b/src/fragments/types/ExportErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ExportErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ExportFileFragment.ts
+++ b/src/fragments/types/ExportFileFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { JobStatusEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/FileFragment.ts
+++ b/src/fragments/types/FileFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/FulfillmentFragment.ts
+++ b/src/fragments/types/FulfillmentFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DiscountValueTypeEnum, FulfillmentStatus } from "./../../types/globalTypes";

--- a/src/fragments/types/InvoiceErrorFragment.ts
+++ b/src/fragments/types/InvoiceErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { InvoiceErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/InvoiceFragment.ts
+++ b/src/fragments/types/InvoiceFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { JobStatusEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/MenuDetailsFragment.ts
+++ b/src/fragments/types/MenuDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/MenuErrorFragment.ts
+++ b/src/fragments/types/MenuErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MenuErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/MenuFragment.ts
+++ b/src/fragments/types/MenuFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/MenuItemFragment.ts
+++ b/src/fragments/types/MenuItemFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/MenuItemNestedFragment.ts
+++ b/src/fragments/types/MenuItemNestedFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/MetadataErrorFragment.ts
+++ b/src/fragments/types/MetadataErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MetadataErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/MetadataFragment.ts
+++ b/src/fragments/types/MetadataFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/MetadataItem.ts
+++ b/src/fragments/types/MetadataItem.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/Money.ts
+++ b/src/fragments/types/Money.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/OrderErrorFragment.ts
+++ b/src/fragments/types/OrderErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/OrderEventFragment.ts
+++ b/src/fragments/types/OrderEventFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmailsEnum, DiscountValueTypeEnum, OrderEventsEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/OrderLineFragment.ts
+++ b/src/fragments/types/OrderLineFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DiscountValueTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/OrderSettingsErrorFragment.ts
+++ b/src/fragments/types/OrderSettingsErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderSettingsErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/OrderSettingsFragment.ts
+++ b/src/fragments/types/OrderSettingsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/PageAttributesFragment.ts
+++ b/src/fragments/types/PageAttributesFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/PageDetailsFragment.ts
+++ b/src/fragments/types/PageDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/PageErrorFragment.ts
+++ b/src/fragments/types/PageErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/PageErrorWithAttributesFragment.ts
+++ b/src/fragments/types/PageErrorWithAttributesFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/PageFragment.ts
+++ b/src/fragments/types/PageFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/PageInfoFragment.ts
+++ b/src/fragments/types/PageInfoFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/PageTranslatableFragment.ts
+++ b/src/fragments/types/PageTranslatableFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/PageTranslationFragment.ts
+++ b/src/fragments/types/PageTranslationFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/PageTypeDetailsFragment.ts
+++ b/src/fragments/types/PageTypeDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/PageTypeFragment.ts
+++ b/src/fragments/types/PageTypeFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/PermissionFragment.ts
+++ b/src/fragments/types/PermissionFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/PermissionGroupDetailsFragment.ts
+++ b/src/fragments/types/PermissionGroupDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/PermissionGroupErrorFragment.ts
+++ b/src/fragments/types/PermissionGroupErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionGroupErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/PermissionGroupFragment.ts
+++ b/src/fragments/types/PermissionGroupFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/PluginErrorFragment.ts
+++ b/src/fragments/types/PluginErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PluginErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/PluginFragment.ts
+++ b/src/fragments/types/PluginFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/PluginsDetailsFragment.ts
+++ b/src/fragments/types/PluginsDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ConfigurationTypeFieldEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/PriceRangeFragment.ts
+++ b/src/fragments/types/PriceRangeFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/Product.ts
+++ b/src/fragments/types/Product.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ProductChannelListingErrorFragment.ts
+++ b/src/fragments/types/ProductChannelListingErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ProductErrorFragment.ts
+++ b/src/fragments/types/ProductErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ProductErrorWithAttributesFragment.ts
+++ b/src/fragments/types/ProductErrorWithAttributesFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ProductFragment.ts
+++ b/src/fragments/types/ProductFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ProductMediaFragment.ts
+++ b/src/fragments/types/ProductMediaFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductMediaType } from "./../../types/globalTypes";

--- a/src/fragments/types/ProductTranslationFragment.ts
+++ b/src/fragments/types/ProductTranslationFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ProductTypeDetailsFragment.ts
+++ b/src/fragments/types/ProductTypeDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ProductTypeFragment.ts
+++ b/src/fragments/types/ProductTypeFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ProductVariantAttributesFragment.ts
+++ b/src/fragments/types/ProductVariantAttributesFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/RefundOrderLineFragment.ts
+++ b/src/fragments/types/RefundOrderLineFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/SaleDetailsFragment.ts
+++ b/src/fragments/types/SaleDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { SaleType } from "./../../types/globalTypes";

--- a/src/fragments/types/SaleFragment.ts
+++ b/src/fragments/types/SaleFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { SaleType } from "./../../types/globalTypes";

--- a/src/fragments/types/SaleTranslationFragment.ts
+++ b/src/fragments/types/SaleTranslationFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/SelectedVariantAttributeFragment.ts
+++ b/src/fragments/types/SelectedVariantAttributeFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ShippingChannelsErrorFragment.ts
+++ b/src/fragments/types/ShippingChannelsErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ShippingErrorFragment.ts
+++ b/src/fragments/types/ShippingErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ShippingMethodFragment.ts
+++ b/src/fragments/types/ShippingMethodFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PostalCodeRuleInclusionTypeEnum, WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ShippingMethodTranslationFragment.ts
+++ b/src/fragments/types/ShippingMethodTranslationFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ShippingMethodWithExcludedProductsFragment.ts
+++ b/src/fragments/types/ShippingMethodWithExcludedProductsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PostalCodeRuleInclusionTypeEnum, WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ShippingMethodWithPostalCodesFragment.ts
+++ b/src/fragments/types/ShippingMethodWithPostalCodesFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PostalCodeRuleInclusionTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ShippingZoneDetailsFragment.ts
+++ b/src/fragments/types/ShippingZoneDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PostalCodeRuleInclusionTypeEnum, WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/ShippingZoneFragment.ts
+++ b/src/fragments/types/ShippingZoneFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ShopErrorFragment.ts
+++ b/src/fragments/types/ShopErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShopErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/ShopFragment.ts
+++ b/src/fragments/types/ShopFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/ShopTaxesFragment.ts
+++ b/src/fragments/types/ShopTaxesFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/StaffErrorFragment.ts
+++ b/src/fragments/types/StaffErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/StaffMemberDetailsFragment.ts
+++ b/src/fragments/types/StaffMemberDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/StaffMemberFragment.ts
+++ b/src/fragments/types/StaffMemberFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/StockErrorFragment.ts
+++ b/src/fragments/types/StockErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { StockErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/StockFragment.ts
+++ b/src/fragments/types/StockFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/TaxTypeFragment.ts
+++ b/src/fragments/types/TaxTypeFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/UploadErrorFragment.ts
+++ b/src/fragments/types/UploadErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { UploadErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/User.ts
+++ b/src/fragments/types/User.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/VariantAttributeFragment.ts
+++ b/src/fragments/types/VariantAttributeFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/VoucherDetailsFragment.ts
+++ b/src/fragments/types/VoucherDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DiscountValueTypeEnum, VoucherTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/VoucherFragment.ts
+++ b/src/fragments/types/VoucherFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DiscountValueTypeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/VoucherTranslationFragment.ts
+++ b/src/fragments/types/VoucherTranslationFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/fragments/types/WarehouseDetailsFragment.ts
+++ b/src/fragments/types/WarehouseDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/WarehouseErrorFragment.ts
+++ b/src/fragments/types/WarehouseErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WarehouseErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/WarehouseFragment.ts
+++ b/src/fragments/types/WarehouseFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/WarehouseWithShippingFragment.ts
+++ b/src/fragments/types/WarehouseWithShippingFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/WebhookErrorFragment.ts
+++ b/src/fragments/types/WebhookErrorFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WebhookErrorCode } from "./../../types/globalTypes";

--- a/src/fragments/types/WebhookFragment.ts
+++ b/src/fragments/types/WebhookFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/WebhooksDetailsFragment.ts
+++ b/src/fragments/types/WebhooksDetailsFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/fragments/types/WeightFragment.ts
+++ b/src/fragments/types/WeightFragment.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/home/types/Home.ts
+++ b/src/home/types/Home.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmailsEnum, OrderEventsEnum } from "./../../types/globalTypes";

--- a/src/navigation/types/MenuBulkDelete.ts
+++ b/src/navigation/types/MenuBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MenuErrorCode } from "./../../types/globalTypes";

--- a/src/navigation/types/MenuCreate.ts
+++ b/src/navigation/types/MenuCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MenuCreateInput, MenuErrorCode } from "./../../types/globalTypes";

--- a/src/navigation/types/MenuDelete.ts
+++ b/src/navigation/types/MenuDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MenuErrorCode } from "./../../types/globalTypes";

--- a/src/navigation/types/MenuDetails.ts
+++ b/src/navigation/types/MenuDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/navigation/types/MenuItemCreate.ts
+++ b/src/navigation/types/MenuItemCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MenuItemCreateInput, MenuErrorCode } from "./../../types/globalTypes";

--- a/src/navigation/types/MenuItemUpdate.ts
+++ b/src/navigation/types/MenuItemUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MenuItemInput, MenuErrorCode } from "./../../types/globalTypes";

--- a/src/navigation/types/MenuList.ts
+++ b/src/navigation/types/MenuList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MenuSortingInput } from "./../../types/globalTypes";

--- a/src/navigation/types/MenuUpdate.ts
+++ b/src/navigation/types/MenuUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MenuItemMoveInput, MenuErrorCode } from "./../../types/globalTypes";

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderFulfillInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/FulfillmentReturnProducts.ts
+++ b/src/orders/types/FulfillmentReturnProducts.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderReturnProductsInput, OrderErrorCode } from "./../../types/globalTypes";

--- a/src/orders/types/InvoiceEmailSend.ts
+++ b/src/orders/types/InvoiceEmailSend.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { InvoiceErrorCode, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/InvoiceRequest.ts
+++ b/src/orders/types/InvoiceRequest.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { InvoiceErrorCode, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderAddNote.ts
+++ b/src/orders/types/OrderAddNote.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderAddNoteInput, OrderErrorCode, OrderEventsEmailsEnum, DiscountValueTypeEnum, OrderEventsEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderDiscountCommonInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderDiscountCommonInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDraftBulkCancel.ts
+++ b/src/orders/types/OrderDraftBulkCancel.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDraftCreate.ts
+++ b/src/orders/types/OrderDraftCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DraftOrderCreateInput, OrderErrorCode } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDraftList.ts
+++ b/src/orders/types/OrderDraftList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderDraftFilterInput, OrderSortingInput, PaymentChargeStatusEnum, OrderStatus } from "./../../types/globalTypes";

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { DraftOrderInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderFulfillData.ts
+++ b/src/orders/types/OrderFulfillData.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { FulfillmentCancelInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderRefundProductsInput, OrderErrorCode, DiscountValueTypeEnum, FulfillmentStatus, OrderDiscountType, OrderEventsEmailsEnum, OrderEventsEnum, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { FulfillmentUpdateTrackingInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderDiscountCommonInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderLineInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderLineCreateInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderList.ts
+++ b/src/orders/types/OrderList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderFilterInput, OrderSortingInput, PaymentChargeStatusEnum, OrderStatus } from "./../../types/globalTypes";

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderRefundData.ts
+++ b/src/orders/types/OrderRefundData.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { FulfillmentStatus } from "./../../types/globalTypes";

--- a/src/orders/types/OrderSettings.ts
+++ b/src/orders/types/OrderSettings.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/orders/types/OrderSettingsUpdate.ts
+++ b/src/orders/types/OrderSettingsUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderSettingsUpdateInput, OrderSettingsErrorCode } from "./../../types/globalTypes";

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderUpdateShippingInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderUpdateInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";

--- a/src/orders/types/SearchOrderVariant.ts
+++ b/src/orders/types/SearchOrderVariant.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/pageTypes/hooks/useAvailablePageAttributeSearch/types/SearchAvailablePageAttributes.ts
+++ b/src/pageTypes/hooks/useAvailablePageAttributeSearch/types/SearchAvailablePageAttributes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/pageTypes/types/AssignPageAttribute.ts
+++ b/src/pageTypes/types/AssignPageAttribute.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageErrorCode, AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/pageTypes/types/PageTypeAttributeReorder.ts
+++ b/src/pageTypes/types/PageTypeAttributeReorder.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ReorderInput, PageErrorCode, AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/pageTypes/types/PageTypeBulkDelete.ts
+++ b/src/pageTypes/types/PageTypeBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/pageTypes/types/PageTypeCreate.ts
+++ b/src/pageTypes/types/PageTypeCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageTypeCreateInput, PageErrorCode, AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/pageTypes/types/PageTypeDelete.ts
+++ b/src/pageTypes/types/PageTypeDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/pageTypes/types/PageTypeDetails.ts
+++ b/src/pageTypes/types/PageTypeDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/pageTypes/types/PageTypeList.ts
+++ b/src/pageTypes/types/PageTypeList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageTypeFilterInput, PageTypeSortingInput } from "./../../types/globalTypes";

--- a/src/pageTypes/types/PageTypeUpdate.ts
+++ b/src/pageTypes/types/PageTypeUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageTypeUpdateInput, PageErrorCode, AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/pageTypes/types/UnassignPageAttribute.ts
+++ b/src/pageTypes/types/UnassignPageAttribute.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageErrorCode, AttributeTypeEnum } from "./../../types/globalTypes";

--- a/src/pages/types/PageBulkPublish.ts
+++ b/src/pages/types/PageBulkPublish.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/pages/types/PageBulkRemove.ts
+++ b/src/pages/types/PageBulkRemove.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageCreateInput, PageErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/pages/types/PageDetails.ts
+++ b/src/pages/types/PageDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/pages/types/PageList.ts
+++ b/src/pages/types/PageList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageSortingInput } from "./../../types/globalTypes";

--- a/src/pages/types/PageRemove.ts
+++ b/src/pages/types/PageRemove.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageErrorCode } from "./../../types/globalTypes";

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageInput, PageErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/permissionGroups/types/PermissionGroupCreate.ts
+++ b/src/permissionGroups/types/PermissionGroupCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionGroupCreateInput, PermissionGroupErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/permissionGroups/types/PermissionGroupDelete.ts
+++ b/src/permissionGroups/types/PermissionGroupDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionGroupErrorCode } from "./../../types/globalTypes";

--- a/src/permissionGroups/types/PermissionGroupDetails.ts
+++ b/src/permissionGroups/types/PermissionGroupDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/permissionGroups/types/PermissionGroupList.ts
+++ b/src/permissionGroups/types/PermissionGroupList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionGroupFilterInput, PermissionGroupSortingInput } from "./../../types/globalTypes";

--- a/src/permissionGroups/types/PermissionGroupUpdate.ts
+++ b/src/permissionGroups/types/PermissionGroupUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionGroupUpdateInput, PermissionGroupErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/plugins/types/Plugin.ts
+++ b/src/plugins/types/Plugin.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ConfigurationTypeFieldEnum } from "./../../types/globalTypes";

--- a/src/plugins/types/PluginUpdate.ts
+++ b/src/plugins/types/PluginUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PluginUpdateInput, PluginErrorCode, ConfigurationTypeFieldEnum } from "./../../types/globalTypes";

--- a/src/plugins/types/Plugins.ts
+++ b/src/plugins/types/Plugins.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PluginFilterInput, PluginSortingInput } from "./../../types/globalTypes";

--- a/src/productTypes/hooks/useAvailableProductAttributeSearch/types/SearchAvailableProductAttributes.ts
+++ b/src/productTypes/hooks/useAvailableProductAttributeSearch/types/SearchAvailableProductAttributes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/productTypes/types/AssignProductAttribute.ts
+++ b/src/productTypes/types/AssignProductAttribute.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductAttributeAssignInput, AttributeTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/productTypes/types/ProductTypeAttributeReorder.ts
+++ b/src/productTypes/types/ProductTypeAttributeReorder.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ReorderInput, ProductAttributeType, AttributeTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/productTypes/types/ProductTypeBulkDelete.ts
+++ b/src/productTypes/types/ProductTypeBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/productTypes/types/ProductTypeCreate.ts
+++ b/src/productTypes/types/ProductTypeCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductTypeInput, AttributeTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/productTypes/types/ProductTypeCreateData.ts
+++ b/src/productTypes/types/ProductTypeCreateData.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/productTypes/types/ProductTypeDelete.ts
+++ b/src/productTypes/types/ProductTypeDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/productTypes/types/ProductTypeDetails.ts
+++ b/src/productTypes/types/ProductTypeDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/productTypes/types/ProductTypeList.ts
+++ b/src/productTypes/types/ProductTypeList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductTypeFilterInput, ProductTypeSortingInput } from "./../../types/globalTypes";

--- a/src/productTypes/types/ProductTypeUpdate.ts
+++ b/src/productTypes/types/ProductTypeUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductTypeInput, AttributeTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/productTypes/types/UnassignProductAttribute.ts
+++ b/src/productTypes/types/UnassignProductAttribute.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeTypeEnum, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/CountAllProducts.ts
+++ b/src/products/types/CountAllProducts.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/products/types/CreateMultipleVariantsData.ts
+++ b/src/products/types/CreateMultipleVariantsData.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/products/types/GridAttributes.ts
+++ b/src/products/types/GridAttributes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/products/types/InitialProductFilterData.ts
+++ b/src/products/types/InitialProductFilterData.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/products/types/ProductChannelListingUpdate.ts
+++ b/src/products/types/ProductChannelListingUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductChannelListingUpdateInput, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum, ProductErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/ProductCreate.ts
+++ b/src/products/types/ProductCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductCreateInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/ProductDelete.ts
+++ b/src/products/types/ProductDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/ProductExport.ts
+++ b/src/products/types/ProductExport.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ExportProductsInput, JobStatusEnum, ExportErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/ProductList.ts
+++ b/src/products/types/ProductList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductFilterInput, ProductOrder } from "./../../types/globalTypes";

--- a/src/products/types/ProductMediaById.ts
+++ b/src/products/types/ProductMediaById.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductMediaType } from "./../../types/globalTypes";

--- a/src/products/types/ProductMediaCreate.ts
+++ b/src/products/types/ProductMediaCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/ProductMediaDelete.ts
+++ b/src/products/types/ProductMediaDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/ProductMediaReorder.ts
+++ b/src/products/types/ProductMediaReorder.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/ProductMediaUpdate.ts
+++ b/src/products/types/ProductMediaUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/ProductVariantBulkCreate.ts
+++ b/src/products/types/ProductVariantBulkCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductVariantBulkCreateInput, ProductErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/ProductVariantBulkDelete.ts
+++ b/src/products/types/ProductVariantBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/ProductVariantChannelListingUpdate.ts
+++ b/src/products/types/ProductVariantChannelListingUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductVariantChannelListingAddInput, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum, ProductErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/ProductVariantCreateData.ts
+++ b/src/products/types/ProductVariantCreateData.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType } from "./../../types/globalTypes";

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/ProductVariantReorder.ts
+++ b/src/products/types/ProductVariantReorder.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ReorderInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/ProductVariantSetDefault.ts
+++ b/src/products/types/ProductVariantSetDefault.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductInput, ProductVariantInput, StockInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum, StockErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductVariantCreateInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/VariantDelete.ts
+++ b/src/products/types/VariantDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/VariantMediaAssign.ts
+++ b/src/products/types/VariantMediaAssign.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/VariantMediaUnassign.ts
+++ b/src/products/types/VariantMediaUnassign.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { StockInput, AttributeValueInput, ProductErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, ProductMediaType, WeightUnitsEnum, StockErrorCode } from "./../../types/globalTypes";

--- a/src/products/types/productBulkDelete.ts
+++ b/src/products/types/productBulkDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ProductErrorCode } from "./../../types/globalTypes";

--- a/src/searches/types/SearchAttributes.ts
+++ b/src/searches/types/SearchAttributes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchCategories.ts
+++ b/src/searches/types/SearchCategories.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchCollections.ts
+++ b/src/searches/types/SearchCollections.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchCustomers.ts
+++ b/src/searches/types/SearchCustomers.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchPageTypes.ts
+++ b/src/searches/types/SearchPageTypes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/searches/types/SearchPages.ts
+++ b/src/searches/types/SearchPages.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchPermissionGroups.ts
+++ b/src/searches/types/SearchPermissionGroups.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchProductTypes.ts
+++ b/src/searches/types/SearchProductTypes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";

--- a/src/searches/types/SearchProducts.ts
+++ b/src/searches/types/SearchProducts.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchShippingZones.ts
+++ b/src/searches/types/SearchShippingZones.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchStaffMembers.ts
+++ b/src/searches/types/SearchStaffMembers.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/searches/types/SearchWarehouses.ts
+++ b/src/searches/types/SearchWarehouses.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/shipping/fixtures.ts
+++ b/src/shipping/fixtures.ts
@@ -1304,6 +1304,11 @@ export const shippingZones: ShippingZoneFragment[] = [
 
 export const shippingZone: ShippingZone_shippingZone = {
   __typename: "ShippingZone",
+  channels: [
+    { __typename: "Channel", id: "channel1", name: "GBP", currencyCode: "GBP" },
+
+    { __typename: "Channel", id: "channel2", name: "PLN", currencyCode: "PLN" }
+  ],
   countries: [
     {
       __typename: "CountryDisplay",

--- a/src/shipping/queries.ts
+++ b/src/shipping/queries.ts
@@ -7,6 +7,10 @@ import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
 
 import { ShippingZone, ShippingZoneVariables } from "./types/ShippingZone";
+import {
+  ShippingZoneChannels,
+  ShippingZoneChannelsVariables
+} from "./types/ShippingZoneChannels";
 import { ShippingZones, ShippingZonesVariables } from "./types/ShippingZones";
 
 const shippingZones = gql`
@@ -51,6 +55,11 @@ const shippingZone = gql`
       shippingMethods {
         ...ShippingMethodWithExcludedProductsFragment
       }
+      channels {
+        id
+        name
+        currencyCode
+      }
       warehouses {
         id
         name
@@ -61,3 +70,21 @@ const shippingZone = gql`
 export const useShippingZone = makeQuery<ShippingZone, ShippingZoneVariables>(
   shippingZone
 );
+
+const shippingZoneChannels = gql`
+  query ShippingZoneChannels($id: ID!) {
+    shippingZone(id: $id) {
+      id
+      channels {
+        id
+        name
+        currencyCode
+      }
+    }
+  }
+`;
+
+export const useShippingZoneChannels = makeQuery<
+  ShippingZoneChannels,
+  ShippingZoneChannelsVariables
+>(shippingZoneChannels);

--- a/src/shipping/types/BulkDeleteShippingRate.ts
+++ b/src/shipping/types/BulkDeleteShippingRate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/shipping/types/BulkDeleteShippingZone.ts
+++ b/src/shipping/types/BulkDeleteShippingZone.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/shipping/types/CreateShippingRate.ts
+++ b/src/shipping/types/CreateShippingRate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingPriceInput, ShippingErrorCode, PostalCodeRuleInclusionTypeEnum, WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/src/shipping/types/CreateShippingZone.ts
+++ b/src/shipping/types/CreateShippingZone.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingZoneCreateInput, ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/shipping/types/DeleteShippingRate.ts
+++ b/src/shipping/types/DeleteShippingRate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingErrorCode, PostalCodeRuleInclusionTypeEnum, WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/src/shipping/types/DeleteShippingZone.ts
+++ b/src/shipping/types/DeleteShippingZone.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/shipping/types/ShippingMethodChannelListingUpdate.ts
+++ b/src/shipping/types/ShippingMethodChannelListingUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingMethodChannelListingInput, PostalCodeRuleInclusionTypeEnum, WeightUnitsEnum, ShippingMethodTypeEnum, ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/shipping/types/ShippingPriceExcludeProduct.ts
+++ b/src/shipping/types/ShippingPriceExcludeProduct.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingPriceExcludeProductsInput, ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/shipping/types/ShippingPriceRemoveProductFromExclude.ts
+++ b/src/shipping/types/ShippingPriceRemoveProductFromExclude.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/shipping/types/ShippingZone.ts
+++ b/src/shipping/types/ShippingZone.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PostalCodeRuleInclusionTypeEnum, WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTypes";
@@ -162,6 +163,7 @@ export interface ShippingZone_shippingZone {
   description: string | null;
   default: boolean;
   shippingMethods: (ShippingZone_shippingZone_shippingMethods | null)[] | null;
+  channels: ShippingZone_shippingZone_channels[];
   warehouses: ShippingZone_shippingZone_warehouses[];
 }
 

--- a/src/shipping/types/ShippingZone.ts
+++ b/src/shipping/types/ShippingZone.ts
@@ -139,6 +139,13 @@ export interface ShippingZone_shippingZone_shippingMethods {
   excludedProducts: ShippingZone_shippingZone_shippingMethods_excludedProducts | null;
 }
 
+export interface ShippingZone_shippingZone_channels {
+  __typename: "Channel";
+  id: string;
+  name: string;
+  currencyCode: string;
+}
+
 export interface ShippingZone_shippingZone_warehouses {
   __typename: "Warehouse";
   id: string;

--- a/src/shipping/types/ShippingZoneChannels.ts
+++ b/src/shipping/types/ShippingZoneChannels.ts
@@ -1,0 +1,29 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: ShippingZoneChannels
+// ====================================================
+
+export interface ShippingZoneChannels_shippingZone_channels {
+  __typename: "Channel";
+  id: string;
+  name: string;
+  currencyCode: string;
+}
+
+export interface ShippingZoneChannels_shippingZone {
+  __typename: "ShippingZone";
+  id: string;
+  channels: ShippingZoneChannels_shippingZone_channels[];
+}
+
+export interface ShippingZoneChannels {
+  shippingZone: ShippingZoneChannels_shippingZone | null;
+}
+
+export interface ShippingZoneChannelsVariables {
+  id: string;
+}

--- a/src/shipping/types/ShippingZones.ts
+++ b/src/shipping/types/ShippingZones.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/shipping/types/UpdateDefaultWeightUnit.ts
+++ b/src/shipping/types/UpdateDefaultWeightUnit.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WeightUnitsEnum } from "./../../types/globalTypes";

--- a/src/shipping/types/UpdateShippingRate.ts
+++ b/src/shipping/types/UpdateShippingRate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingPriceInput, ShippingErrorCode, PostalCodeRuleInclusionTypeEnum, WeightUnitsEnum, ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/src/shipping/types/UpdateShippingZone.ts
+++ b/src/shipping/types/UpdateShippingZone.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShippingZoneUpdateInput, ShippingErrorCode } from "./../../types/globalTypes";

--- a/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
+++ b/src/shipping/views/PriceRatesCreate/PriceRatesCreate.tsx
@@ -1,4 +1,3 @@
-import { useChannelsList } from "@saleor/channels/queries";
 import { createSortedShippingChannels } from "@saleor/channels/utils";
 import ChannelsAvailabilityDialog from "@saleor/components/ChannelsAvailabilityDialog";
 import { WindowTitle } from "@saleor/components/WindowTitle";
@@ -8,6 +7,7 @@ import { sectionNames } from "@saleor/intl";
 import ShippingZonePostalCodeRangeDialog from "@saleor/shipping/components/ShippingZonePostalCodeRangeDialog";
 import ShippingZoneRatesCreatePage from "@saleor/shipping/components/ShippingZoneRatesCreatePage";
 import { useShippingRateCreator } from "@saleor/shipping/handlers";
+import { useShippingZoneChannels } from "@saleor/shipping/queries";
 import {
   shippingPriceRatesUrl,
   ShippingRateCreateUrlDialog,
@@ -41,14 +41,22 @@ export const PriceRatesCreate: React.FC<PriceRatesCreateProps> = ({
   const navigate = useNavigator();
   const intl = useIntl();
 
-  const { data: channelsData, loading: channelsLoading } = useChannelsList({});
-
   const [openModal, closeModal] = createDialogActionHandlers<
     ShippingRateCreateUrlDialog,
     ShippingRateCreateUrlQueryParams
   >(navigate, params => shippingPriceRatesUrl(id, params), params);
 
-  const allChannels = createSortedShippingChannels(channelsData?.channels);
+  const {
+    data: shippingZoneData,
+    loading: channelsLoading
+  } = useShippingZoneChannels({
+    displayLoader: true,
+    variables: { id }
+  });
+
+  const allChannels = createSortedShippingChannels(
+    shippingZoneData?.shippingZone?.channels
+  );
 
   const {
     channelListElements,

--- a/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
+++ b/src/shipping/views/PriceRatesUpdate/PriceRatesUpdate.tsx
@@ -1,5 +1,4 @@
 import Button from "@material-ui/core/Button";
-import { useChannelsList } from "@saleor/channels/queries";
 import {
   createShippingChannelsFromRate,
   createSortedShippingChannels
@@ -90,6 +89,8 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
     variables: { id, ...paginationState }
   });
 
+  const channelsData = data?.shippingZone?.channels;
+
   const rate = data?.shippingZone?.shippingMethods?.find(getById(rateId));
 
   const {
@@ -112,8 +113,6 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
     paginationState,
     params
   );
-
-  const { data: channelsData } = useChannelsList({});
 
   const [
     updateShippingMethodChannelListing,
@@ -145,7 +144,7 @@ export const PriceRatesUpdate: React.FC<PriceRatesUpdateProps> = ({
   const shippingChannels = createShippingChannelsFromRate(
     rate?.channelListings
   );
-  const allChannels = createSortedShippingChannels(channelsData?.channels);
+  const allChannels = createSortedShippingChannels(channelsData);
 
   const {
     channelListElements,

--- a/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
+++ b/src/shipping/views/WeightRatesCreate/WeightRatesCreate.tsx
@@ -1,4 +1,3 @@
-import { useChannelsList } from "@saleor/channels/queries";
 import {
   createShippingChannels,
   createSortedShippingChannels
@@ -11,6 +10,7 @@ import { sectionNames } from "@saleor/intl";
 import ShippingZonePostalCodeRangeDialog from "@saleor/shipping/components/ShippingZonePostalCodeRangeDialog";
 import ShippingZoneRatesCreatePage from "@saleor/shipping/components/ShippingZoneRatesCreatePage";
 import { useShippingRateCreator } from "@saleor/shipping/handlers";
+import { useShippingZoneChannels } from "@saleor/shipping/queries";
 import {
   ShippingRateCreateUrlDialog,
   ShippingRateCreateUrlQueryParams,
@@ -44,15 +44,25 @@ export const WeightRatesCreate: React.FC<WeightRatesCreateProps> = ({
   const navigate = useNavigator();
   const intl = useIntl();
 
-  const { data: channelsData, loading: channelsLoading } = useChannelsList({});
+  const {
+    data: shippingZoneData,
+    loading: channelsLoading
+  } = useShippingZoneChannels({
+    displayLoader: true,
+    variables: { id }
+  });
 
   const [openModal, closeModal] = createDialogActionHandlers<
     ShippingRateCreateUrlDialog,
     ShippingRateCreateUrlQueryParams
   >(navigate, params => shippingWeightRatesUrl(id, params), params);
 
-  const shippingChannels = createShippingChannels(channelsData?.channels);
-  const allChannels = createSortedShippingChannels(channelsData?.channels);
+  const shippingChannels = createShippingChannels(
+    shippingZoneData?.shippingZone?.channels
+  );
+  const allChannels = createSortedShippingChannels(
+    shippingZoneData?.shippingZone?.channels
+  );
 
   const {
     channelListElements,

--- a/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
+++ b/src/shipping/views/WeightRatesUpdate/WeightRatesUpdate.tsx
@@ -1,5 +1,4 @@
 import Button from "@material-ui/core/Button";
-import { useChannelsList } from "@saleor/channels/queries";
 import {
   createShippingChannelsFromRate,
   createSortedShippingChannels
@@ -90,6 +89,8 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     variables: { id, ...paginationState }
   });
 
+  const channelsData = data?.shippingZone?.channels;
+
   const rate = data?.shippingZone?.shippingMethods?.find(getById(rateId));
 
   const [openModal, closeModal] = createDialogActionHandlers<
@@ -162,7 +163,6 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
     params
   );
 
-  const { data: channelsData } = useChannelsList({});
   const [
     updateShippingMethodChannelListing,
     updateShippingMethodChannelListingOpts
@@ -194,7 +194,7 @@ export const WeightRatesUpdate: React.FC<WeightRatesUpdateProps> = ({
   const shippingChannels = createShippingChannelsFromRate(
     rate?.channelListings
   );
-  const allChannels = createSortedShippingChannels(channelsData?.channels);
+  const allChannels = createSortedShippingChannels(channelsData);
 
   const {
     channelListElements,

--- a/src/siteSettings/types/ShopSettingsUpdate.ts
+++ b/src/siteSettings/types/ShopSettingsUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { SiteDomainInput, ShopSettingsInput, AddressInput, ShopErrorCode } from "./../../types/globalTypes";

--- a/src/siteSettings/types/SiteSettings.ts
+++ b/src/siteSettings/types/SiteSettings.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/staff/types/ChangeStaffPassword.ts
+++ b/src/staff/types/ChangeStaffPassword.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/staff/types/StaffAvatarDelete.ts
+++ b/src/staff/types/StaffAvatarDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/staff/types/StaffAvatarUpdate.ts
+++ b/src/staff/types/StaffAvatarUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/staff/types/StaffList.ts
+++ b/src/staff/types/StaffList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { StaffUserInput, UserSortingInput } from "./../../types/globalTypes";

--- a/src/staff/types/StaffMemberAdd.ts
+++ b/src/staff/types/StaffMemberAdd.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { StaffCreateInput, AccountErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/staff/types/StaffMemberDelete.ts
+++ b/src/staff/types/StaffMemberDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { AccountErrorCode } from "./../../types/globalTypes";

--- a/src/staff/types/StaffMemberDetails.ts
+++ b/src/staff/types/StaffMemberDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/src/staff/types/StaffMemberUpdate.ts
+++ b/src/staff/types/StaffMemberUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { StaffUpdateInput, AccountErrorCode, PermissionEnum } from "./../../types/globalTypes";

--- a/src/taxes/types/CountryList.ts
+++ b/src/taxes/types/CountryList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType } from "./../../types/globalTypes";

--- a/src/taxes/types/FetchTaxes.ts
+++ b/src/taxes/types/FetchTaxes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/taxes/types/TaxTypeList.ts
+++ b/src/taxes/types/TaxTypeList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/taxes/types/UpdateTaxSettings.ts
+++ b/src/taxes/types/UpdateTaxSettings.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { ShopSettingsInput } from "./../../types/globalTypes";

--- a/src/translations/types/AttributeTranslationDetails.ts
+++ b/src/translations/types/AttributeTranslationDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/AttributeTranslations.ts
+++ b/src/translations/types/AttributeTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/CategoryTranslationDetails.ts
+++ b/src/translations/types/CategoryTranslationDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/CategoryTranslations.ts
+++ b/src/translations/types/CategoryTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/CollectionTranslationDetails.ts
+++ b/src/translations/types/CollectionTranslationDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/CollectionTranslations.ts
+++ b/src/translations/types/CollectionTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/PageTranslationDetails.ts
+++ b/src/translations/types/PageTranslationDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/PageTranslations.ts
+++ b/src/translations/types/PageTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/ProductTranslationDetails.ts
+++ b/src/translations/types/ProductTranslationDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/ProductTranslations.ts
+++ b/src/translations/types/ProductTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/SaleTranslationDetails.ts
+++ b/src/translations/types/SaleTranslationDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/SaleTranslations.ts
+++ b/src/translations/types/SaleTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/ShippingMethodTranslationDetails.ts
+++ b/src/translations/types/ShippingMethodTranslationDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/ShippingMethodTranslations.ts
+++ b/src/translations/types/ShippingMethodTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdateAttributeTranslations.ts
+++ b/src/translations/types/UpdateAttributeTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdateAttributeValueTranslations.ts
+++ b/src/translations/types/UpdateAttributeValueTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdateCategoryTranslations.ts
+++ b/src/translations/types/UpdateCategoryTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { TranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdateCollectionTranslations.ts
+++ b/src/translations/types/UpdateCollectionTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { TranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdatePageTranslations.ts
+++ b/src/translations/types/UpdatePageTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { PageTranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdateProductTranslations.ts
+++ b/src/translations/types/UpdateProductTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { TranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdateSaleTranslations.ts
+++ b/src/translations/types/UpdateSaleTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdateShippingMethodTranslations.ts
+++ b/src/translations/types/UpdateShippingMethodTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/UpdateVoucherTranslations.ts
+++ b/src/translations/types/UpdateVoucherTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/VoucherTranslationDetails.ts
+++ b/src/translations/types/VoucherTranslationDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/translations/types/VoucherTranslations.ts
+++ b/src/translations/types/VoucherTranslations.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { LanguageCodeEnum } from "./../../types/globalTypes";

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 //==============================================================

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MetadataInput, MetadataErrorCode } from "./../../../types/globalTypes";

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { MetadataInput, MetadataErrorCode } from "./../../../types/globalTypes";

--- a/src/warehouses/types/WarehouseCreate.ts
+++ b/src/warehouses/types/WarehouseCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WarehouseCreateInput, WarehouseErrorCode } from "./../../types/globalTypes";

--- a/src/warehouses/types/WarehouseDelete.ts
+++ b/src/warehouses/types/WarehouseDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WarehouseErrorCode } from "./../../types/globalTypes";

--- a/src/warehouses/types/WarehouseDetails.ts
+++ b/src/warehouses/types/WarehouseDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/src/warehouses/types/WarehouseList.ts
+++ b/src/warehouses/types/WarehouseList.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WarehouseFilterInput, WarehouseSortingInput } from "./../../types/globalTypes";

--- a/src/warehouses/types/WarehouseUpdate.ts
+++ b/src/warehouses/types/WarehouseUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WarehouseUpdateInput, WarehouseErrorCode } from "./../../types/globalTypes";

--- a/src/webhooks/types/WebhookCreate.ts
+++ b/src/webhooks/types/WebhookCreate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WebhookCreateInput, WebhookErrorCode } from "./../../types/globalTypes";

--- a/src/webhooks/types/WebhookDelete.ts
+++ b/src/webhooks/types/WebhookDelete.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WebhookErrorCode } from "./../../types/globalTypes";

--- a/src/webhooks/types/WebhookDetails.ts
+++ b/src/webhooks/types/WebhookDetails.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WebhookEventTypeEnum } from "./../../types/globalTypes";

--- a/src/webhooks/types/WebhookUpdate.ts
+++ b/src/webhooks/types/WebhookUpdate.ts
@@ -1,5 +1,6 @@
 /* tslint:disable */
 /* eslint-disable */
+// @generated
 // This file was automatically generated and should not be edited.
 
 import { WebhookUpdateInput, WebhookErrorCode } from "./../../types/globalTypes";


### PR DESCRIPTION
I want to merge this change because it makes the price / weight rates views use parent shipping zone channels instead of all. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://feature-variants-and-shipping-zones-per-channel.api.saleor.rocks/graphql/