### PR TITLE
Update adding draft order products per channel

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3938,8 +3938,8 @@
   "src_dot_orders_dot_components_dot_OrderProductAddDialog_dot_2850255786": {
     "string": "Search Products"
   },
-  "src_dot_orders_dot_components_dot_OrderProductAddDialog_dot_353369701": {
-    "string": "No products matching given query"
+  "src_dot_orders_dot_components_dot_OrderProductAddDialog_dot_3284796469": {
+    "string": "No products available in order channel matching given query"
   },
   "src_dot_orders_dot_components_dot_OrderProductsCardElements_dot_1134347598": {
     "context": "product price",
@@ -5462,6 +5462,18 @@
     "context": "variant name",
     "string": "New Variant"
   },
+  "src_dot_products_dot_components_dot_ProductVariantPage_dot_itemSubtitleHidden": {
+    "context": "VariantDetailsChannelsAvailabilityCard item subtitle hidden",
+    "string": "Hidden"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantPage_dot_itemSubtitlePublished": {
+    "context": "VariantDetailsChannelsAvailabilityCard item subtitle published",
+    "string": "Published since {publicationDate}"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantPage_dot_noItemsAvailable": {
+    "context": "VariantDetailsChannelsAvailabilityCard no items available",
+    "string": "This variant is not available at any of the channels"
+  },
   "src_dot_products_dot_components_dot_ProductVariantPage_dot_nonSelectionAttributes": {
     "context": "attributes, section header",
     "string": "Variant Attributes"
@@ -5470,12 +5482,24 @@
     "context": "attributes, section header",
     "string": "Variant Selection Attributes"
   },
+  "src_dot_products_dot_components_dot_ProductVariantPage_dot_subtitle": {
+    "context": "VariantDetailsChannelsAvailabilityCard subtitle",
+    "string": "Available in {publishedInChannelsCount} out of {availableChannelsCount}"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantPage_dot_title": {
+    "context": "VariantDetailsChannelsAvailabilityCard title",
+    "string": "Availability"
+  },
   "src_dot_products_dot_components_dot_ProductVariantPrice_dot_1099355007": {
     "context": "product pricing, section header",
     "string": "Pricing"
   },
   "src_dot_products_dot_components_dot_ProductVariantPrice_dot_1134347598": {
     "string": "Price"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantPrice_dot_1309465788": {
+    "context": "variant pricing section subtitle",
+    "string": "There is no channel to define prices for"
   },
   "src_dot_products_dot_components_dot_ProductVariantPrice_dot_1387754199": {
     "context": "tabel column header",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -5310,6 +5310,10 @@
     "context": "button",
     "string": "Delete Variant"
   },
+  "src_dot_products_dot_components_dot_ProductVariantCreatePage_dot_pricingCardSubtitle": {
+    "context": "variant pricing section subtitle",
+    "string": "There is no channel to define prices for. You need to first add variant to channels to define prices."
+  },
   "src_dot_products_dot_components_dot_ProductVariantCreatePage_dot_saveVariant": {
     "context": "button",
     "string": "Save variant"
@@ -5496,10 +5500,6 @@
   },
   "src_dot_products_dot_components_dot_ProductVariantPrice_dot_1134347598": {
     "string": "Price"
-  },
-  "src_dot_products_dot_components_dot_ProductVariantPrice_dot_1309465788": {
-    "context": "variant pricing section subtitle",
-    "string": "There is no channel to define prices for"
   },
   "src_dot_products_dot_components_dot_ProductVariantPrice_dot_1387754199": {
     "context": "tabel column header",

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -272,6 +272,7 @@ export const fragmentOrderDetails = gql`
       id
       name
       currencyCode
+      slug
     }
     isPaid
   }

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -298,6 +298,8 @@ export const fragmentVariant = gql`
         url
       }
       channelListings {
+        publicationDate
+        isPublished
         channel {
           id
           name

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -471,6 +471,7 @@ export interface OrderDetailsFragment_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderDetailsFragment {

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -189,6 +189,8 @@ export interface ProductVariant_product_channelListings_pricing {
 
 export interface ProductVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: ProductVariant_product_channelListings_channel;
   pricing: ProductVariant_product_channelListings_pricing | null;
 }

--- a/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
+++ b/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
@@ -363,7 +363,7 @@ const OrderProductAddDialog: React.FC<OrderProductAddDialogProps> = props => {
                 () => (
                   <TableRow>
                     <TableCell colSpan={4}>
-                      <FormattedMessage defaultMessage="No products matching given query" />
+                      <FormattedMessage defaultMessage="No products available in order channel matching given query" />
                     </TableCell>
                   </TableRow>
                 )

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -814,6 +814,7 @@ export const order = (placeholder: string): OrderDetails_order => ({
   canFinalize: true,
   channel: {
     __typename: "Channel",
+    slug: "channel-default",
     currencyCode: "USD",
     id: "123454",
     isActive: true,
@@ -1371,6 +1372,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
   canFinalize: true,
   channel: {
     __typename: "Channel",
+    slug: "channel-default",
     currencyCode: "USD",
     id: "123454",
     isActive: true,

--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -164,8 +164,18 @@ export const useOrderQuery = makeQuery<OrderDetails, OrderDetailsVariables>(
 );
 
 export const searchOrderVariant = gql`
-  query SearchOrderVariant($first: Int!, $query: String!, $after: String) {
-    search: products(first: $first, after: $after, filter: { search: $query }) {
+  query SearchOrderVariant(
+    $channel: String!
+    $first: Int!
+    $query: String!
+    $after: String
+  ) {
+    search: products(
+      first: $first
+      after: $after
+      filter: { search: $query }
+      channel: $channel
+    ) {
       edges {
         node {
           id

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -479,6 +479,7 @@ export interface FulfillOrder_orderFulfill_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface FulfillOrder_orderFulfill_order {

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -477,6 +477,7 @@ export interface OrderCancel_orderCancel_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderCancel_orderCancel_order {

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -477,6 +477,7 @@ export interface OrderCapture_orderCapture_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderCapture_orderCapture_order {

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -477,6 +477,7 @@ export interface OrderConfirm_orderConfirm_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderConfirm_orderConfirm_order {

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -471,6 +471,7 @@ export interface OrderDetails_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderDetails_order {

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -477,6 +477,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderDiscountAdd_orderDiscountAdd_order {

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -477,6 +477,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderDiscountDelete_orderDiscountDelete_order {

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -477,6 +477,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order {

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -477,6 +477,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order {

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -477,6 +477,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order {

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -477,6 +477,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order {

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -477,6 +477,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order {

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -572,6 +572,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order {

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -477,6 +477,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order {

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -477,6 +477,7 @@ export interface OrderLineDelete_orderLineDelete_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderLineDelete_orderLineDelete_order {

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -477,6 +477,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order {

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -477,6 +477,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order {

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -477,6 +477,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderLineUpdate_orderLineUpdate_order {

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -477,6 +477,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderLinesAdd_orderLinesCreate_order {

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -477,6 +477,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order {

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -477,6 +477,7 @@ export interface OrderRefund_orderRefund_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderRefund_orderRefund_order {

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -485,6 +485,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order {

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -477,6 +477,7 @@ export interface OrderUpdate_orderUpdate_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderUpdate_orderUpdate_order {

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -477,6 +477,7 @@ export interface OrderVoid_orderVoid_order_channel {
   id: string;
   name: string;
   currencyCode: string;
+  slug: string;
 }
 
 export interface OrderVoid_orderVoid_order {

--- a/src/orders/types/SearchOrderVariant.ts
+++ b/src/orders/types/SearchOrderVariant.ts
@@ -72,6 +72,7 @@ export interface SearchOrderVariant {
 }
 
 export interface SearchOrderVariantVariables {
+  channel: string;
   first: number;
   query: string;
   after?: string | null;

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -61,7 +61,7 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
     search: variantSearch,
     result: variantSearchOpts
   } = useOrderVariantSearch({
-    variables: DEFAULT_INITIAL_SEARCH_DATA
+    variables: { ...DEFAULT_INITIAL_SEARCH_DATA, channel: order.channel.slug }
   });
 
   const {

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -89,7 +89,7 @@ export const OrderUnconfirmedDetails: React.FC<OrderUnconfirmedDetailsProps> = (
     search: variantSearch,
     result: variantSearchOpts
   } = useOrderVariantSearch({
-    variables: DEFAULT_INITIAL_SEARCH_DATA
+    variables: { ...DEFAULT_INITIAL_SEARCH_DATA, channel: order.channel.slug }
   });
   const warehouses = useWarehouseList({
     displayLoader: true,

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -16,7 +16,6 @@ import Grid from "@saleor/components/Grid";
 import Metadata from "@saleor/components/Metadata";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
-import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
 import { ProductErrorWithAttributesFragment } from "@saleor/fragments/types/ProductErrorWithAttributesFragment";
 import { SearchPages_search_edges_node } from "@saleor/searches/types/SearchPages";
 import { SearchProducts_search_edges_node } from "@saleor/searches/types/SearchProducts";
@@ -56,7 +55,6 @@ const messages = defineMessages({
 
 interface ProductVariantCreatePageProps {
   channels: ChannelPriceData[];
-  channelErrors: ProductChannelListingErrorFragment[] | undefined;
   disabled: boolean;
   errors: ProductErrorWithAttributesFragment[];
   header: string;
@@ -82,7 +80,6 @@ interface ProductVariantCreatePageProps {
 
 const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
   channels,
-  channelErrors = [],
   disabled,
   errors,
   header,
@@ -208,17 +205,7 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
                 onChange={change}
               />
               <CardSpacer />
-              <ProductVariantPrice
-                ProductVariantChannelListings={data.channelListings.map(
-                  channel => ({
-                    ...channel.data,
-                    ...channel.value
-                  })
-                )}
-                errors={channelErrors}
-                loading={disabled}
-                onChange={handlers.changeChannels}
-              />
+              <ProductVariantPrice />
               <CardSpacer />
               <ProductStocks
                 data={data}

--- a/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/src/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -50,6 +50,11 @@ const messages = defineMessages({
   saveVariant: {
     defaultMessage: "Save variant",
     description: "button"
+  },
+  pricingCardSubtitle: {
+    defaultMessage:
+      "There is no channel to define prices for. You need to first add variant to channels to define prices.",
+    description: "variant pricing section subtitle"
   }
 });
 
@@ -205,7 +210,9 @@ const ProductVariantCreatePage: React.FC<ProductVariantCreatePageProps> = ({
                 onChange={change}
               />
               <CardSpacer />
-              <ProductVariantPrice />
+              <ProductVariantPrice
+                disabledMessage={messages.pricingCardSubtitle}
+              />
               <CardSpacer />
               <ProductStocks
                 data={data}

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -41,6 +41,7 @@ import ProductVariantUpdateForm, {
   ProductVariantUpdateHandlers,
   ProductVariantUpdateSubmitData
 } from "./form";
+import VariantDetailsChannelsAvailabilityCard from "./VariantDetailsChannelsAvailabilityCard";
 
 const messages = defineMessages({
   nonSelectionAttributes: {
@@ -217,6 +218,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                   />
                 </div>
                 <div>
+                  <VariantDetailsChannelsAvailabilityCard variant={variant} />
                   <Attributes
                     title={intl.formatMessage(messages.nonSelectionAttributes)}
                     attributes={data.attributes.filter(

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -265,6 +265,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                   />
                   <CardSpacer />
                   <ProductVariantPrice
+                    variant={variant}
                     ProductVariantChannelListings={data.channelListings.map(
                       channel => ({
                         ...channel.data,

--- a/src/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/src/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -265,7 +265,7 @@ const ProductVariantPage: React.FC<ProductVariantPageProps> = ({
                   />
                   <CardSpacer />
                   <ProductVariantPrice
-                    variant={variant}
+                    disabled={!variant}
                     ProductVariantChannelListings={data.channelListings.map(
                       channel => ({
                         ...channel.data,

--- a/src/products/components/ProductVariantPage/VariantDetailsChannelsAvailabilityCard/VariantDetailsChannelsAvailabilityCardContainer.tsx
+++ b/src/products/components/ProductVariantPage/VariantDetailsChannelsAvailabilityCard/VariantDetailsChannelsAvailabilityCardContainer.tsx
@@ -1,0 +1,25 @@
+import { Card } from "@material-ui/core";
+import CardSpacer from "@saleor/components/CardSpacer";
+import CardTitle from "@saleor/components/CardTitle";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { variantDetailsChannelsAvailabilityCardMessages as messages } from "../messages";
+
+interface VariantDetailsChannelsAvailabilityCardContainerProps {
+  children: React.ReactNode;
+}
+
+const VariantDetailsChannelsAvailabilityCardContainer: React.FC<VariantDetailsChannelsAvailabilityCardContainerProps> = ({
+  children
+}) => (
+  <>
+    <Card>
+      <CardTitle title={<FormattedMessage {...messages.title} />} />
+      {children}
+    </Card>
+    <CardSpacer />
+  </>
+);
+
+export default VariantDetailsChannelsAvailabilityCardContainer;

--- a/src/products/components/ProductVariantPage/VariantDetailsChannelsAvailabilityCard/index.tsx
+++ b/src/products/components/ProductVariantPage/VariantDetailsChannelsAvailabilityCard/index.tsx
@@ -142,6 +142,7 @@ const VariantDetailsChannelsAvailabilityCard: React.FC<VariantDetailsChannelsAva
         <ExpansionPanelSummary
           expandIcon={<IconChevronDown />}
           classes={summaryClasses}
+          data-test-id="channels-variant-availability-summary"
         >
           <>
             <Typography variant="caption">
@@ -157,8 +158,15 @@ const VariantDetailsChannelsAvailabilityCard: React.FC<VariantDetailsChannelsAva
           <>
             <Divider />
             <CardContent>
-              <Typography>{channel.name}</Typography>
-              <Typography variant="caption">
+              <Typography
+                data-test-id={`channels-variant-availability-item-title-${channel.id}`}
+              >
+                {channel.name}
+              </Typography>
+              <Typography
+                variant="caption"
+                data-test-id={`channels-variant-availability-item-subtitle-${channel.id}`}
+              >
                 {getItemSubtitle(channel.id)}
               </Typography>
             </CardContent>

--- a/src/products/components/ProductVariantPage/VariantDetailsChannelsAvailabilityCard/index.tsx
+++ b/src/products/components/ProductVariantPage/VariantDetailsChannelsAvailabilityCard/index.tsx
@@ -1,0 +1,172 @@
+import {
+  CardContent,
+  Divider,
+  ExpansionPanel,
+  ExpansionPanelSummary,
+  makeStyles,
+  Typography
+} from "@material-ui/core";
+import Skeleton from "@saleor/components/Skeleton";
+import { ProductVariant } from "@saleor/fragments/types/ProductVariant";
+import useDateLocalize from "@saleor/hooks/useDateLocalize";
+import IconChevronDown from "@saleor/icons/ChevronDown";
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { variantDetailsChannelsAvailabilityCardMessages as messages } from "../messages";
+import CardContainer from "./VariantDetailsChannelsAvailabilityCardContainer";
+
+const useExpanderStyles = makeStyles(
+  () => ({
+    expanded: {},
+    root: {
+      boxShadow: "none",
+      margin: 0,
+      padding: 0,
+
+      "&:before": {
+        content: "none"
+      },
+
+      "&$expanded": {
+        margin: 0,
+        border: "none"
+      }
+    }
+  }),
+  { name: "VariantDetailsChannelsAvailabilityCardExpander" }
+);
+
+const useSummaryStyles = makeStyles(
+  theme => ({
+    expanded: {},
+    root: {
+      width: "100%",
+      border: "none",
+      margin: 0,
+      padding: 0,
+      minHeight: 0,
+      paddingTop: theme.spacing(2),
+      paddingLeft: theme.spacing(3),
+      paddingRight: theme.spacing(5.5),
+      paddingBottom: theme.spacing(2),
+
+      "&$expanded": {
+        minHeight: 0
+      }
+    },
+    content: {
+      margin: 0,
+
+      "&$expanded": {
+        margin: 0
+      }
+    }
+  }),
+  { name: "VariantDetailsChannelsAvailabilityCardExpanderSummary" }
+);
+
+interface VariantDetailsChannelsAvailabilityCardProps {
+  variant: ProductVariant;
+}
+
+const VariantDetailsChannelsAvailabilityCard: React.FC<VariantDetailsChannelsAvailabilityCardProps> = ({
+  variant
+}) => {
+  const expanderClasses = useExpanderStyles({});
+  const summaryClasses = useSummaryStyles({});
+  const localizeDate = useDateLocalize();
+  const intl = useIntl();
+
+  const getProductChannelListingByChannelId = (channelId: string) =>
+    variant?.product.channelListings.find(
+      ({ channel }) => channel.id === channelId
+    );
+
+  const getItemSubtitle = (channelId: string) => {
+    const {
+      isPublished,
+      publicationDate
+    } = getProductChannelListingByChannelId(channelId);
+
+    if (!isPublished) {
+      return intl.formatMessage(messages.itemSubtitleHidden);
+    }
+
+    return intl.formatMessage(messages.itemSubtitlePublished, {
+      publicationDate: localizeDate(publicationDate)
+    });
+  };
+
+  if (!variant) {
+    return (
+      <CardContainer>
+        <CardContent>
+          <Skeleton />
+        </CardContent>
+      </CardContainer>
+    );
+  }
+
+  const { channelListings } = variant;
+
+  const isAvailableInAnyChannels = !!channelListings.length;
+
+  const variantChannelListingsChannelsIds = channelListings.map(
+    ({ channel: { id } }) => id
+  );
+
+  const allAvailableChannelsListings = variant.product.channelListings.filter(
+    ({ channel }) => variantChannelListingsChannelsIds.includes(channel.id)
+  );
+
+  const publishedInChannelsListings = allAvailableChannelsListings.filter(
+    ({ isPublished }) => isPublished
+  );
+
+  if (!isAvailableInAnyChannels) {
+    return (
+      <CardContainer>
+        <CardContent>
+          <Typography variant="caption">
+            {intl.formatMessage(messages.noItemsAvailable)}
+          </Typography>
+        </CardContent>
+      </CardContainer>
+    );
+  }
+
+  return (
+    <CardContainer>
+      <ExpansionPanel classes={expanderClasses}>
+        <ExpansionPanelSummary
+          expandIcon={<IconChevronDown />}
+          classes={summaryClasses}
+        >
+          <>
+            <Typography variant="caption">
+              {intl.formatMessage(messages.subtitle, {
+                publishedInChannelsCount: publishedInChannelsListings.length,
+                availableChannelsCount: allAvailableChannelsListings.length
+              })}
+            </Typography>
+          </>
+        </ExpansionPanelSummary>
+
+        {channelListings.map(({ channel }) => (
+          <>
+            <Divider />
+            <CardContent>
+              <Typography>{channel.name}</Typography>
+              <Typography variant="caption">
+                {getItemSubtitle(channel.id)}
+              </Typography>
+            </CardContent>
+          </>
+        ))}
+      </ExpansionPanel>
+    </CardContainer>
+  );
+};
+
+export default VariantDetailsChannelsAvailabilityCard;

--- a/src/products/components/ProductVariantPage/messages.ts
+++ b/src/products/components/ProductVariantPage/messages.ts
@@ -1,0 +1,26 @@
+import { defineMessages } from "react-intl";
+
+export const variantDetailsChannelsAvailabilityCardMessages = defineMessages({
+  title: {
+    defaultMessage: "Availability",
+    description: "VariantDetailsChannelsAvailabilityCard title"
+  },
+  subtitle: {
+    defaultMessage:
+      "Available in {publishedInChannelsCount} out of {availableChannelsCount}",
+    description: "VariantDetailsChannelsAvailabilityCard subtitle"
+  },
+  itemSubtitlePublished: {
+    defaultMessage: "Published since {publicationDate}",
+    description:
+      "VariantDetailsChannelsAvailabilityCard item subtitle published"
+  },
+  itemSubtitleHidden: {
+    defaultMessage: "Hidden",
+    description: "VariantDetailsChannelsAvailabilityCard item subtitle hidden"
+  },
+  noItemsAvailable: {
+    defaultMessage: "This variant is not available at any of the channels",
+    description: "VariantDetailsChannelsAvailabilityCard no items available"
+  }
+});

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -21,7 +21,7 @@ import {
 } from "@saleor/utils/errors";
 import getProductErrorMessage from "@saleor/utils/errors/product";
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage, MessageDescriptor, useIntl } from "react-intl";
 
 const useStyles = makeStyles(
   theme => ({
@@ -67,6 +67,7 @@ interface ProductVariantPriceProps {
   loading?: boolean;
   disabled?: boolean;
   onChange?: (id: string, data: ChannelPriceArgs) => void;
+  disabledMessage?: MessageDescriptor;
 }
 
 const numberOfColumns = 2;
@@ -77,7 +78,8 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
     errors = [],
     ProductVariantChannelListings = [],
     loading,
-    onChange
+    onChange,
+    disabledMessage
   } = props;
   const classes = useStyles(props);
   const intl = useIntl();
@@ -94,10 +96,13 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
         />
         <CardContent>
           <Typography variant="caption">
-            {intl.formatMessage({
-              defaultMessage: "There is no channel to define prices for",
-              description: "variant pricing section subtitle"
-            })}
+            {intl.formatMessage(
+              disabledMessage || {
+                defaultMessage: "There is no channel to define prices for",
+                description: "variant pricing section subtitle",
+                id: "product variant pricing card disabled subtitle"
+              }
+            )}
           </Typography>
         </CardContent>
       </Card>

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -1,4 +1,5 @@
 import {
+  Divider,
   TableBody,
   TableCell,
   TableHead,
@@ -13,6 +14,7 @@ import PriceField from "@saleor/components/PriceField";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
 import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
+import { ProductVariant } from "@saleor/fragments/types/ProductVariant";
 import { renderCollection } from "@saleor/misc";
 import { makeStyles } from "@saleor/theme";
 import {
@@ -64,6 +66,7 @@ const useStyles = makeStyles(
 interface ProductVariantPriceProps {
   ProductVariantChannelListings: ChannelData[];
   errors: ProductChannelListingErrorFragment[];
+  variant: ProductVariant;
   loading?: boolean;
   onChange: (id: string, data: ChannelPriceArgs) => void;
 }
@@ -72,6 +75,7 @@ const numberOfColumns = 2;
 
 const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
   const {
+    variant,
     errors = [],
     ProductVariantChannelListings,
     loading,
@@ -80,6 +84,27 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
   const classes = useStyles(props);
   const intl = useIntl();
   const formErrors = getFormChannelErrors(["price", "costPrice"], errors);
+
+  if (!variant?.id || !ProductVariantChannelListings.length) {
+    return (
+      <Card>
+        <CardTitle
+          title={intl.formatMessage({
+            defaultMessage: "Pricing",
+            description: "product pricing, section header"
+          })}
+        />
+        <CardContent>
+          <Typography variant="caption">
+            {intl.formatMessage({
+              defaultMessage: "There is no channel to define prices for",
+              description: "variant pricing section subtitle"
+            })}
+          </Typography>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card>

--- a/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
+++ b/src/products/components/ProductVariantPrice/ProductVariantPrice.tsx
@@ -1,5 +1,4 @@
 import {
-  Divider,
   TableBody,
   TableCell,
   TableHead,
@@ -14,7 +13,6 @@ import PriceField from "@saleor/components/PriceField";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
 import { ProductChannelListingErrorFragment } from "@saleor/fragments/types/ProductChannelListingErrorFragment";
-import { ProductVariant } from "@saleor/fragments/types/ProductVariant";
 import { renderCollection } from "@saleor/misc";
 import { makeStyles } from "@saleor/theme";
 import {
@@ -64,20 +62,20 @@ const useStyles = makeStyles(
 );
 
 interface ProductVariantPriceProps {
-  ProductVariantChannelListings: ChannelData[];
-  errors: ProductChannelListingErrorFragment[];
-  variant: ProductVariant;
+  ProductVariantChannelListings?: ChannelData[];
+  errors?: ProductChannelListingErrorFragment[];
   loading?: boolean;
-  onChange: (id: string, data: ChannelPriceArgs) => void;
+  disabled?: boolean;
+  onChange?: (id: string, data: ChannelPriceArgs) => void;
 }
 
 const numberOfColumns = 2;
 
 const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
   const {
-    variant,
+    disabled = false,
     errors = [],
-    ProductVariantChannelListings,
+    ProductVariantChannelListings = [],
     loading,
     onChange
   } = props;
@@ -85,7 +83,7 @@ const ProductVariantPrice: React.FC<ProductVariantPriceProps> = props => {
   const intl = useIntl();
   const formErrors = getFormChannelErrors(["price", "costPrice"], errors);
 
-  if (!variant?.id || !ProductVariantChannelListings.length) {
+  if (disabled || !ProductVariantChannelListings.length) {
     return (
       <Card>
         <CardTitle

--- a/src/products/fixtures.ts
+++ b/src/products/fixtures.ts
@@ -2817,6 +2817,8 @@ export const variant = (placeholderImage: string): ProductVariant => ({
     channelListings: [
       {
         __typename: "ProductChannelListing",
+        isPublished: false,
+        publicationDate: null,
         channel: {
           __typename: "Channel",
           currencyCode: "USD",
@@ -2848,6 +2850,8 @@ export const variant = (placeholderImage: string): ProductVariant => ({
       },
       {
         __typename: "ProductChannelListing",
+        isPublished: true,
+        publicationDate: "2022-01-21",
         channel: {
           __typename: "Channel",
           currencyCode: "USD",

--- a/src/products/types/ProductVariantChannelListingUpdate.ts
+++ b/src/products/types/ProductVariantChannelListingUpdate.ts
@@ -189,6 +189,8 @@ export interface ProductVariantChannelListingUpdate_productVariantChannelListing
 
 export interface ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_product_channelListings_channel;
   pricing: ProductVariantChannelListingUpdate_productVariantChannelListingUpdate_variant_product_channelListings_pricing | null;
 }

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -189,6 +189,8 @@ export interface ProductVariantDetails_productVariant_product_channelListings_pr
 
 export interface ProductVariantDetails_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: ProductVariantDetails_productVariant_product_channelListings_channel;
   pricing: ProductVariantDetails_productVariant_product_channelListings_pricing | null;
 }

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -480,6 +480,8 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_product
 
 export interface SimpleProductUpdate_productVariantUpdate_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: SimpleProductUpdate_productVariantUpdate_productVariant_product_channelListings_channel;
   pricing: SimpleProductUpdate_productVariantUpdate_productVariant_product_channelListings_pricing | null;
 }
@@ -767,6 +769,8 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_p
 
 export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_channelListings_channel;
   pricing: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_channelListings_pricing | null;
 }
@@ -1053,6 +1057,8 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_p
 
 export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_channelListings_channel;
   pricing: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_channelListings_pricing | null;
 }
@@ -1340,6 +1346,8 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_p
 
 export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_channelListings_channel;
   pricing: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_channelListings_pricing | null;
 }

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -196,6 +196,8 @@ export interface VariantCreate_productVariantCreate_productVariant_product_chann
 
 export interface VariantCreate_productVariantCreate_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: VariantCreate_productVariantCreate_productVariant_product_channelListings_channel;
   pricing: VariantCreate_productVariantCreate_productVariant_product_channelListings_pricing | null;
 }

--- a/src/products/types/VariantMediaAssign.ts
+++ b/src/products/types/VariantMediaAssign.ts
@@ -195,6 +195,8 @@ export interface VariantMediaAssign_variantMediaAssign_productVariant_product_ch
 
 export interface VariantMediaAssign_variantMediaAssign_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: VariantMediaAssign_variantMediaAssign_productVariant_product_channelListings_channel;
   pricing: VariantMediaAssign_variantMediaAssign_productVariant_product_channelListings_pricing | null;
 }

--- a/src/products/types/VariantMediaUnassign.ts
+++ b/src/products/types/VariantMediaUnassign.ts
@@ -195,6 +195,8 @@ export interface VariantMediaUnassign_variantMediaUnassign_productVariant_produc
 
 export interface VariantMediaUnassign_variantMediaUnassign_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: VariantMediaUnassign_variantMediaUnassign_productVariant_product_channelListings_channel;
   pricing: VariantMediaUnassign_variantMediaUnassign_productVariant_product_channelListings_pricing | null;
 }

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -196,6 +196,8 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product_chann
 
 export interface VariantUpdate_productVariantUpdate_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: VariantUpdate_productVariantUpdate_productVariant_product_channelListings_channel;
   pricing: VariantUpdate_productVariantUpdate_productVariant_product_channelListings_pricing | null;
 }
@@ -483,6 +485,8 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_product
 
 export interface VariantUpdate_productVariantStocksUpdate_productVariant_product_channelListings {
   __typename: "ProductChannelListing";
+  publicationDate: any | null;
+  isPublished: boolean;
   channel: VariantUpdate_productVariantStocksUpdate_productVariant_product_channelListings_channel;
   pricing: VariantUpdate_productVariantStocksUpdate_productVariant_product_channelListings_pricing | null;
 }

--- a/src/storybook/stories/products/ProductVariantCreatePage.tsx
+++ b/src/storybook/stories/products/ProductVariantCreatePage.tsx
@@ -22,7 +22,6 @@ storiesOf("Views / Products / Create product variant", module)
   .add("default", () => (
     <ProductVariantCreatePage
       channels={channels}
-      channelErrors={[]}
       weightUnit="kg"
       disabled={false}
       errors={[]}
@@ -44,7 +43,6 @@ storiesOf("Views / Products / Create product variant", module)
   .add("with errors", () => (
     <ProductVariantCreatePage
       channels={channels}
-      channelErrors={[]}
       weightUnit="kg"
       disabled={false}
       errors={[
@@ -85,7 +83,6 @@ storiesOf("Views / Products / Create product variant", module)
   .add("when loading data", () => (
     <ProductVariantCreatePage
       channels={channels}
-      channelErrors={[]}
       weightUnit="kg"
       disabled={true}
       errors={[]}
@@ -107,7 +104,6 @@ storiesOf("Views / Products / Create product variant", module)
   .add("add first variant", () => (
     <ProductVariantCreatePage
       channels={channels}
-      channelErrors={[]}
       weightUnit="kg"
       disabled={false}
       errors={[]}
@@ -132,7 +128,6 @@ storiesOf("Views / Products / Create product variant", module)
   .add("no warehouses", () => (
     <ProductVariantCreatePage
       channels={channels}
-      channelErrors={[]}
       weightUnit="kg"
       disabled={false}
       errors={[]}


### PR DESCRIPTION
I want to merge this change because it fixes / adds some stuff:
- [fetching correct, channel related products for order draft / unconfirmed](https://app.clickup.com/t/2549495/SALEOR-2547)
- [availability card showing up in variant details](https://app.clickup.com/t/2549495/SALEOR-2518)
- remove channel listings from variant creation form altogether, confirmed with @pwgryglak, only leave empty state in the card
<img width="553" alt="Screenshot 2021-04-16 at 10 14 38" src="https://user-images.githubusercontent.com/28022710/114993930-92ce1c00-9e9c-11eb-8db4-bfbcca882043.png">
- variant details pricing card in variant update having an empty state when no channels are selected for variant 
<img width="753" alt="Screenshot 2021-04-16 at 09 46 56" src="https://user-images.githubusercontent.com/28022710/114990461-ce66e700-9e98-11eb-917c-b0d194be65dc.png">


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/