### PR TITLE
Drop deprecated fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - rich text field updates, 
     - multiselect empty chip upon creation of a product/variant,
     - useFormset.setItemValue wrong updates,
+- Drop deprecated fields - #1071 by @jwm0
 
 # 2.11.1
 

--- a/cypress/apiRequests/HomePage.js
+++ b/cypress/apiRequests/HomePage.js
@@ -8,9 +8,9 @@ export function getSalesForChannel(channelSlug, period) {
   }`;
   return cy.sendRequestWithQuery(query);
 }
-export function getOrdersForChannel(channelSlug, created) {
+export function getOrdersForChannel(channelSlug, { gte, lte }) {
   const query = `query{
-    orders(created: ${created}, channel:"${channelSlug}"){
+    orders(filter: { created: { gte: "${gte}", lte: "${lte}" } }, channel:"${channelSlug}"){
       totalCount
     }
   }`;
@@ -18,7 +18,7 @@ export function getOrdersForChannel(channelSlug, created) {
 }
 export function getOrdersWithStatus(status, channelSlug) {
   const query = `query{
-    orders(status: ${status}, channel:"${channelSlug}"){
+    orders(filter: { status: ${status} }, channel:"${channelSlug}"){
       totalCount
     }
   }`;
@@ -26,7 +26,7 @@ export function getOrdersWithStatus(status, channelSlug) {
 }
 export function getProductsOutOfStock(channelSlug) {
   const query = `query{
-    products(stockAvailability: OUT_OF_STOCK, channel:"${channelSlug}"){
+    products(filter: { stockAvailability: OUT_OF_STOCK, channel:"${channelSlug}" }){
       totalCount
     }
   }`;

--- a/cypress/integration/products/productsList/sortingProducts.js
+++ b/cypress/integration/products/productsList/sortingProducts.js
@@ -10,13 +10,18 @@ describe("Sorting products", () => {
       cy.clearSessionData()
         .loginUserViaRequest()
         .visit(urlList.products);
+      cy.get(SHARED_ELEMENTS.header).should("be.visible");
       if (sortBy !== "name") {
         cy.get(PRODUCTS_LIST.tableHeaders[sortBy]).click();
         cy.get(SHARED_ELEMENTS.progressBar).should("not.exist");
       }
       expectProductsSortedBy(sortBy);
-      cy.get(PRODUCTS_LIST.tableHeaders[sortBy]).click();
-      cy.get(SHARED_ELEMENTS.progressBar).should("not.exist");
+      cy.addAliasToGraphRequest("ProductList")
+        .get(PRODUCTS_LIST.tableHeaders[sortBy])
+        .click()
+        .get(SHARED_ELEMENTS.progressBar)
+        .should("not.exist")
+        .wait("@ProductList");
       expectProductsSortedBy(sortBy, false);
     });
   });

--- a/cypress/utils/homePageUtils.js
+++ b/cypress/utils/homePageUtils.js
@@ -1,4 +1,5 @@
 import * as homePage from "../apiRequests/HomePage";
+import { getDatePeriod } from "./misc";
 
 export function getOrdersReadyToFulfill(channelSlug) {
   return homePage
@@ -21,7 +22,9 @@ export function getSalesAmount(channelSlug) {
     .its("body.data.ordersTotal.gross.amount");
 }
 export function getTodaysOrders(channelSlug) {
+  const today = getDatePeriod(1);
+
   return homePage
-    .getOrdersForChannel(channelSlug, "TODAY")
+    .getOrdersForChannel(channelSlug, today)
     .its("body.data.orders.totalCount");
 }

--- a/cypress/utils/misc.js
+++ b/cypress/utils/misc.js
@@ -1,0 +1,16 @@
+import moment from "moment-timezone";
+
+export function getDatePeriod(days) {
+  if (days < 1) {
+    return {};
+  }
+
+  const end = moment().startOf("day");
+  const start = end.subtract(days - 1);
+  const format = "YYYY-MM-DD";
+
+  return {
+    gte: start.format(format),
+    lte: end.format(format)
+  };
+}

--- a/cypress/utils/products/productsListUtils.js
+++ b/cypress/utils/products/productsListUtils.js
@@ -14,21 +14,31 @@ export function getDisplayedColumnArray(columnName) {
     .then(() => productsList);
 }
 export function expectProductsSortedBy(columnName, inAscOrder = true) {
-  getDisplayedColumnArray(columnName).then(productsArray => {
-    let sortedProductsArray = productsArray.slice();
-    if (columnName !== "price") {
-      sortedProductsArray.sort();
-      if (!inAscOrder) {
-        sortedProductsArray.reverse();
+  let sortedProductsArray;
+  let productsArray;
+  getDisplayedColumnArray(columnName)
+    .then(productsArrayResp => {
+      productsArray = productsArrayResp;
+      sortedProductsArray = productsArray.slice();
+      if (columnName !== "price") {
+        sortedProductsArray = sortedProductsArray.sort((a, b) =>
+          a.localeCompare(b, undefined, { ignorePunctuation: true })
+        );
+        if (!inAscOrder) {
+          sortedProductsArray.reverse();
+        }
+      } else {
+        sortedProductsArray = getSortedPriceColumn(
+          sortedProductsArray,
+          inAscOrder
+        );
       }
-    } else {
-      sortedProductsArray = getSortedPriceColumn(
-        sortedProductsArray,
-        inAscOrder
-      );
-    }
-    expect(productsArray).to.be.deep.eq(sortedProductsArray);
-  });
+    })
+    .then(() => {
+      expect(
+        JSON.stringify(productsArray) === JSON.stringify(sortedProductsArray)
+      ).to.be.eq(true);
+    });
 }
 function getSortedPriceColumn(productsArray, inAscOrder) {
   return inAscOrder

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -484,13 +484,13 @@
     "context": "dialog header",
     "string": "Activate App"
   },
+  "src_dot_apps_dot_components_dot_AppActivateDialog_dot_2449960665": {
+    "context": "activate app",
+    "string": "Are you sure you want to activate this app? Activating will start gathering events."
+  },
   "src_dot_apps_dot_components_dot_AppActivateDialog_dot_3356885734": {
     "context": "activate app",
     "string": "Are you sure you want to activate {name}? Activating will start gathering events."
-  },
-  "src_dot_apps_dot_components_dot_AppActivateDialog_dot_3761045983": {
-    "context": "activate app",
-    "string": "Are you sure you want to activate this app? Activating will start gathering events"
   },
   "src_dot_apps_dot_components_dot_AppActivateDialog_dot_3865193889": {
     "context": "button label",
@@ -504,12 +504,20 @@
     "context": "dialog header",
     "string": "Dectivate App"
   },
-  "src_dot_apps_dot_components_dot_AppDeactivateDialog_dot_2955925498": {
+  "src_dot_apps_dot_components_dot_AppDeactivateDialog_dot_deactivateApp": {
     "context": "deactivate app",
     "string": "Are you sure you want to disable this app? Your data will be kept until you reactivate the app. You will be still billed for the app."
   },
-  "src_dot_apps_dot_components_dot_AppDeactivateDialog_dot_329373780": {
-    "context": "deactivate app",
+  "src_dot_apps_dot_components_dot_AppDeactivateDialog_dot_deactivateLocalApp": {
+    "context": "deactivate local app",
+    "string": "Are you sure you want to disable this app? Your data will be kept until you reactivate the app."
+  },
+  "src_dot_apps_dot_components_dot_AppDeactivateDialog_dot_deactivateLocalNamedApp": {
+    "context": "deactivate local named app",
+    "string": "Are you sure you want to disable {name}? Your data will be kept until you reactivate the app."
+  },
+  "src_dot_apps_dot_components_dot_AppDeactivateDialog_dot_deactivateNamedApp": {
+    "context": "deactivate named app",
     "string": "Are you sure you want to disable {name}? Your data will be kept until you reactivate the app. You will be still billed for the app."
   },
   "src_dot_apps_dot_components_dot_AppDeleteDialog_dot_1347203024": {
@@ -656,10 +664,6 @@
     "context": "header",
     "string": "Create New App"
   },
-  "src_dot_apps_dot_components_dot_CustomAppCreatePage_dot_570656367": {
-    "context": "checkbox label",
-    "string": "App is active"
-  },
   "src_dot_apps_dot_components_dot_CustomAppDefaultToken_dot_1336855942": {
     "string": "Generated Token"
   },
@@ -681,13 +685,17 @@
     "context": "checkbox label",
     "string": "Grant this app full access to the store"
   },
+  "src_dot_apps_dot_components_dot_CustomAppDetailsPage_dot_1782042241": {
+    "context": "link",
+    "string": "Deactivate"
+  },
   "src_dot_apps_dot_components_dot_CustomAppDetailsPage_dot_3076071936": {
     "context": "card description",
     "string": "Expand or restrict app permissions to access certain part of Saleor system."
   },
-  "src_dot_apps_dot_components_dot_CustomAppDetailsPage_dot_570656367": {
-    "context": "checkbox label",
-    "string": "App is active"
+  "src_dot_apps_dot_components_dot_CustomAppDetailsPage_dot_3865193889": {
+    "context": "link",
+    "string": "Activate"
   },
   "src_dot_apps_dot_components_dot_CustomAppInformation_dot_2860466085": {
     "context": "header",
@@ -826,6 +834,14 @@
   "src_dot_apps_dot_views_dot_CustomAppCreate_dot_3230241731": {
     "context": "window title",
     "string": "Create App"
+  },
+  "src_dot_apps_dot_views_dot_CustomAppDetails_dot_2021043385": {
+    "context": "snackbar text",
+    "string": "App activated"
+  },
+  "src_dot_apps_dot_views_dot_CustomAppDetails_dot_3791371350": {
+    "context": "snackbar text",
+    "string": "App deactivated"
   },
   "src_dot_attributes": {
     "context": "attributes section name",
@@ -3877,6 +3893,10 @@
     "context": "vat included in order price",
     "string": "VAT included"
   },
+  "src_dot_orders_dot_components_dot_OrderPayment_dot_1934027242": {
+    "context": "voucher type order discount",
+    "string": "Voucher"
+  },
   "src_dot_orders_dot_components_dot_OrderPayment_dot_2183023165": {
     "context": "ordered products",
     "string": "{quantity} items"
@@ -3884,6 +3904,10 @@
   "src_dot_orders_dot_components_dot_OrderPayment_dot_2320183694": {
     "context": "order payment",
     "string": "Captured amount"
+  },
+  "src_dot_orders_dot_components_dot_OrderPayment_dot_2392156856": {
+    "context": "staff added type order discount",
+    "string": "Staff added"
   },
   "src_dot_orders_dot_components_dot_OrderPayment_dot_2444197639": {
     "context": "void payment, button",

--- a/recordings/User_3768991250/will-be-logged-in-if-has-valid-credentials_3587751314/recording.har
+++ b/recordings/User_3768991250/will-be-logged-in-if-has-valid-credentials_3587751314/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "a2b8a02f624e52cd2b73a831f65d9a52",
+        "_id": "4062f0ffdf1fab89a50cd1b667a889ef",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 598,
+          "bodySize": 583,
           "cookies": [],
           "headers": [
             {
@@ -28,7 +28,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "598"
+              "value": "583"
             },
             {
               "_fromType": "array",
@@ -50,13 +50,13 @@
               "value": "localhost:8000"
             }
           ],
-          "headersSize": 254,
+          "headersSize": 281,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "[{\"operationName\":\"TokenAuth\",\"variables\":{\"email\":\"admin@example.com\",\"password\":\"admin\"},\"query\":\"fragment User on User {\\n  id\\n  email\\n  firstName\\n  lastName\\n  isStaff\\n  userPermissions {\\n    code\\n    name\\n    __typename\\n  }\\n  avatar {\\n    url\\n    __typename\\n  }\\n  __typename\\n}\\n\\nmutation TokenAuth($email: String!, $password: String!) {\\n  tokenCreate(email: $email, password: $password) {\\n    errors: accountErrors {\\n      field\\n      message\\n      __typename\\n    }\\n    csrfToken\\n    token\\n    user {\\n      ...User\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+            "text": "[{\"operationName\":\"TokenAuth\",\"variables\":{\"email\":\"admin@example.com\",\"password\":\"admin\"},\"query\":\"fragment User on User {\\n  id\\n  email\\n  firstName\\n  lastName\\n  isStaff\\n  userPermissions {\\n    code\\n    name\\n    __typename\\n  }\\n  avatar {\\n    url\\n    __typename\\n  }\\n  __typename\\n}\\n\\nmutation TokenAuth($email: String!, $password: String!) {\\n  tokenCreate(email: $email, password: $password) {\\n    errors {\\n      field\\n      message\\n      __typename\\n    }\\n    csrfToken\\n    token\\n    user {\\n      ...User\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
           },
           "queryString": [],
           "url": "http://localhost:8000/graphql/"
@@ -113,8 +113,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-01-14T13:55:44.094Z",
-        "time": 392,
+        "startedDateTime": "2021-04-22T11:07:20.652Z",
+        "time": 758,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -122,7 +122,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 392
+          "wait": 758
         }
       }
     ],

--- a/recordings/User_3768991250/will-not-be-logged-in-if-doesn-t-have-valid-credentials_3719199657/recording.har
+++ b/recordings/User_3768991250/will-not-be-logged-in-if-doesn-t-have-valid-credentials_3719199657/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d94d7821dc951e48c410d691d7eccdef",
+        "_id": "6fed086670e88883223acb33bab4ff31",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 614,
+          "bodySize": 599,
           "cookies": [],
           "headers": [
             {
@@ -28,7 +28,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "614"
+              "value": "599"
             },
             {
               "_fromType": "array",
@@ -50,13 +50,13 @@
               "value": "localhost:8000"
             }
           ],
-          "headersSize": 254,
+          "headersSize": 281,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "[{\"operationName\":\"TokenAuth\",\"variables\":{\"email\":\"admin@example.com\",\"password\":\"NotAValidPassword123!\"},\"query\":\"fragment User on User {\\n  id\\n  email\\n  firstName\\n  lastName\\n  isStaff\\n  userPermissions {\\n    code\\n    name\\n    __typename\\n  }\\n  avatar {\\n    url\\n    __typename\\n  }\\n  __typename\\n}\\n\\nmutation TokenAuth($email: String!, $password: String!) {\\n  tokenCreate(email: $email, password: $password) {\\n    errors: accountErrors {\\n      field\\n      message\\n      __typename\\n    }\\n    csrfToken\\n    token\\n    user {\\n      ...User\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+            "text": "[{\"operationName\":\"TokenAuth\",\"variables\":{\"email\":\"admin@example.com\",\"password\":\"NotAValidPassword123!\"},\"query\":\"fragment User on User {\\n  id\\n  email\\n  firstName\\n  lastName\\n  isStaff\\n  userPermissions {\\n    code\\n    name\\n    __typename\\n  }\\n  avatar {\\n    url\\n    __typename\\n  }\\n  __typename\\n}\\n\\nmutation TokenAuth($email: String!, $password: String!) {\\n  tokenCreate(email: $email, password: $password) {\\n    errors {\\n      field\\n      message\\n      __typename\\n    }\\n    csrfToken\\n    token\\n    user {\\n      ...User\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
           },
           "queryString": [],
           "url": "http://localhost:8000/graphql/"
@@ -66,7 +66,7 @@
           "content": {
             "mimeType": "application/json",
             "size": 214,
-            "text": "[{\"data\": {\"tokenCreate\": {\"errors\": [{\"field\": \"email\", \"message\": \"Please, enter valid credentials\", \"__typename\": \"AccountError\"}], \"csrfToken\": null, \"token\": null, \"user\": null, \"__typename\": \"CreateToken\"}}}]"
+            "text": "[{\"data\": {\"tokenCreate\": {\"errors\": [{\"field\": \"email\", \"message\": \"Please, enter valid credentials\", \"__typename\": \"Error\"}], \"csrfToken\": null, \"token\": null, \"user\": null, \"__typename\": \"CreateToken\"}}}]"
           },
           "cookies": [],
           "headers": [
@@ -101,8 +101,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-01-14T13:55:44.521Z",
-        "time": 1183,
+        "startedDateTime": "2021-04-22T11:09:20.963Z",
+        "time": 555,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -110,7 +110,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1183
+          "wait": 555
         }
       }
     ],

--- a/recordings/User_3768991250/will-not-be-logged-in-if-is-non-staff_2544500193/recording.har
+++ b/recordings/User_3768991250/will-not-be-logged-in-if-is-non-staff_2544500193/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "0b09ec35ecae5b17a2ccda062b1d6ef5",
+        "_id": "8948f5cbe2259e56b6dd03f068fbfa4d",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 602,
+          "bodySize": 587,
           "cookies": [],
           "headers": [
             {
@@ -28,7 +28,7 @@
             {
               "_fromType": "array",
               "name": "content-length",
-              "value": "602"
+              "value": "587"
             },
             {
               "_fromType": "array",
@@ -50,13 +50,13 @@
               "value": "localhost:8000"
             }
           ],
-          "headersSize": 254,
+          "headersSize": 281,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "[{\"operationName\":\"TokenAuth\",\"variables\":{\"email\":\"client@example.com\",\"password\":\"password\"},\"query\":\"fragment User on User {\\n  id\\n  email\\n  firstName\\n  lastName\\n  isStaff\\n  userPermissions {\\n    code\\n    name\\n    __typename\\n  }\\n  avatar {\\n    url\\n    __typename\\n  }\\n  __typename\\n}\\n\\nmutation TokenAuth($email: String!, $password: String!) {\\n  tokenCreate(email: $email, password: $password) {\\n    errors: accountErrors {\\n      field\\n      message\\n      __typename\\n    }\\n    csrfToken\\n    token\\n    user {\\n      ...User\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
+            "text": "[{\"operationName\":\"TokenAuth\",\"variables\":{\"email\":\"client@example.com\",\"password\":\"password\"},\"query\":\"fragment User on User {\\n  id\\n  email\\n  firstName\\n  lastName\\n  isStaff\\n  userPermissions {\\n    code\\n    name\\n    __typename\\n  }\\n  avatar {\\n    url\\n    __typename\\n  }\\n  __typename\\n}\\n\\nmutation TokenAuth($email: String!, $password: String!) {\\n  tokenCreate(email: $email, password: $password) {\\n    errors {\\n      field\\n      message\\n      __typename\\n    }\\n    csrfToken\\n    token\\n    user {\\n      ...User\\n      __typename\\n    }\\n    __typename\\n  }\\n}\\n\"}]"
           },
           "queryString": [],
           "url": "http://localhost:8000/graphql/"
@@ -113,8 +113,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2021-01-19T14:28:37.164Z",
-        "time": 468,
+        "startedDateTime": "2021-04-22T11:09:21.540Z",
+        "time": 382,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -122,7 +122,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 468
+          "wait": 382
         }
       }
     ],

--- a/schema.graphql
+++ b/schema.graphql
@@ -4,29 +4,29 @@ schema {
 }
 
 type AccountAddressCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   address: Address
 }
 
 type AccountDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   user: User
 }
 
@@ -78,9 +78,9 @@ input AccountInput {
 }
 
 type AccountRegister {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   requiresConfirmation: Boolean
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   user: User
 }
 
@@ -89,22 +89,23 @@ input AccountRegisterInput {
   password: String!
   redirectUrl: String
   languageCode: LanguageCodeEnum
+  metadata: [MetadataInput!]
 }
 
 type AccountRequestDeletion {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type AccountSetDefaultAddress {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type AccountUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   user: User
 }
 
@@ -126,16 +127,16 @@ type Address implements Node {
 }
 
 type AddressCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   address: Address
 }
 
 type AddressDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   address: Address
 }
 
@@ -154,9 +155,9 @@ input AddressInput {
 }
 
 type AddressSetDefault {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 enum AddressTypeEnum {
@@ -165,9 +166,9 @@ enum AddressTypeEnum {
 }
 
 type AddressUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   address: Address
 }
 
@@ -220,8 +221,8 @@ type App implements Node & ObjectWithMetadata {
 }
 
 type AppActivate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   app: App
 }
 
@@ -237,27 +238,27 @@ type AppCountableEdge {
 }
 
 type AppCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   authToken: String
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   app: App
 }
 
 type AppDeactivate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   app: App
 }
 
 type AppDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   app: App
 }
 
 type AppDeleteFailedInstallation {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   appInstallation: AppInstallation
 }
 
@@ -285,9 +286,9 @@ enum AppErrorCode {
 }
 
 type AppFetchManifest {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   manifest: Manifest
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
 }
 
 input AppFilterInput {
@@ -298,13 +299,12 @@ input AppFilterInput {
 
 input AppInput {
   name: String
-  isActive: Boolean
   permissions: [PermissionEnum]
 }
 
 type AppInstall {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   appInstallation: AppInstallation
 }
 
@@ -326,8 +326,8 @@ type AppInstallation implements Node & Job {
 }
 
 type AppRetryInstall {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   appInstallation: AppInstallation
 }
 
@@ -348,15 +348,15 @@ type AppToken implements Node {
 }
 
 type AppTokenCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   authToken: String
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   appToken: AppToken
 }
 
 type AppTokenDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   appToken: AppToken
 }
 
@@ -366,9 +366,9 @@ input AppTokenInput {
 }
 
 type AppTokenVerify {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   valid: Boolean!
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
 }
 
 enum AppTypeEnum {
@@ -377,15 +377,15 @@ enum AppTypeEnum {
 }
 
 type AppUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  appErrors: [AppError!]!
+  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AppError!]!
   app: App
 }
 
 type AssignNavigation {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   menu: Menu
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
 }
 
 type Attribute implements Node & ObjectWithMetadata {
@@ -410,9 +410,9 @@ type Attribute implements Node & ObjectWithMetadata {
 }
 
 type AttributeBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
 }
 
 type AttributeCountableConnection {
@@ -427,9 +427,9 @@ type AttributeCountableEdge {
 }
 
 type AttributeCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
 }
 
 input AttributeCreateInput {
@@ -449,8 +449,8 @@ input AttributeCreateInput {
 }
 
 type AttributeDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
   attribute: Attribute
 }
 
@@ -492,7 +492,6 @@ input AttributeFilterInput {
 
 input AttributeInput {
   slug: String!
-  value: String
   values: [String]
 }
 
@@ -505,9 +504,9 @@ enum AttributeInputTypeEnum {
 }
 
 type AttributeReorderValues {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
 }
 
 enum AttributeSortField {
@@ -535,8 +534,8 @@ type AttributeTranslatableContent implements Node {
 }
 
 type AttributeTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   attribute: Attribute
 }
 
@@ -552,9 +551,9 @@ enum AttributeTypeEnum {
 }
 
 type AttributeUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
 }
 
 input AttributeUpdateInput {
@@ -584,15 +583,15 @@ type AttributeValue implements Node {
 }
 
 type AttributeValueBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
 }
 
 type AttributeValueCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
 
@@ -603,9 +602,9 @@ input AttributeValueCreateInput {
 }
 
 type AttributeValueDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
 
@@ -626,8 +625,8 @@ type AttributeValueTranslatableContent implements Node {
 }
 
 type AttributeValueTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   attributeValue: AttributeValue
 }
 
@@ -644,9 +643,9 @@ input AttributeValueTranslationInput {
 }
 
 type AttributeValueUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   attribute: Attribute
-  attributeErrors: [AttributeError!]!
+  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
 
@@ -695,16 +694,15 @@ type Category implements Node & ObjectWithMetadata {
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
-  url: String @deprecated(reason: "This field will be removed after 2020-07-31.")
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
 }
 
 type CategoryBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type CategoryCountableConnection {
@@ -719,14 +717,14 @@ type CategoryCountableEdge {
 }
 
 type CategoryCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   category: Category
 }
 
 type CategoryDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   category: Category
 }
 
@@ -769,8 +767,8 @@ type CategoryTranslatableContent implements Node {
 }
 
 type CategoryTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   category: Category
 }
 
@@ -785,8 +783,8 @@ type CategoryTranslation implements Node {
 }
 
 type CategoryUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   category: Category
 }
 
@@ -801,14 +799,14 @@ type Channel implements Node {
 }
 
 type ChannelActivate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   channel: Channel
-  channelErrors: [ChannelError!]!
+  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ChannelError!]!
 }
 
 type ChannelCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  channelErrors: [ChannelError!]!
+  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ChannelError!]!
   channel: Channel
 }
 
@@ -821,14 +819,14 @@ input ChannelCreateInput {
 }
 
 type ChannelDeactivate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   channel: Channel
-  channelErrors: [ChannelError!]!
+  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ChannelError!]!
 }
 
 type ChannelDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  channelErrors: [ChannelError!]!
+  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ChannelError!]!
   channel: Channel
 }
 
@@ -857,8 +855,8 @@ enum ChannelErrorCode {
 }
 
 type ChannelUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  channelErrors: [ChannelError!]!
+  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ChannelError!]!
   channel: Channel
 }
 
@@ -901,23 +899,23 @@ type Checkout implements Node & ObjectWithMetadata {
 }
 
 type CheckoutAddPromoCode {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutBillingAddressUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutComplete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
   confirmationNeeded: Boolean!
   confirmationData: JSONString
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutCountableConnection {
@@ -932,9 +930,9 @@ type CheckoutCountableEdge {
 }
 
 type CheckoutCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   created: Boolean
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
   checkout: Checkout
 }
 
@@ -948,21 +946,21 @@ input CheckoutCreateInput {
 }
 
 type CheckoutCustomerAttach {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutCustomerDetach {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutEmailUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutError {
@@ -999,9 +997,9 @@ enum CheckoutErrorCode {
 }
 
 type CheckoutLanguageCodeUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutLine implements Node {
@@ -1024,9 +1022,9 @@ type CheckoutLineCountableEdge {
 }
 
 type CheckoutLineDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 input CheckoutLineInput {
@@ -1035,40 +1033,40 @@ input CheckoutLineInput {
 }
 
 type CheckoutLinesAdd {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutLinesUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutPaymentCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
   payment: Payment
-  paymentErrors: [PaymentError!]!
+  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PaymentError!]!
 }
 
 type CheckoutRemovePromoCode {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutShippingAddressUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type CheckoutShippingMethodUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]!
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CheckoutError!]!
 }
 
 type ChoiceValue {
@@ -1093,15 +1091,15 @@ type Collection implements Node & ObjectWithMetadata {
 }
 
 type CollectionAddProducts {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   collection: Collection
-  collectionErrors: [CollectionError!]!
+  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CollectionError!]!
 }
 
 type CollectionBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  collectionErrors: [CollectionError!]!
+  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CollectionError!]!
 }
 
 type CollectionChannelListing implements Node {
@@ -1121,9 +1119,9 @@ type CollectionChannelListingError {
 }
 
 type CollectionChannelListingUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   collection: Collection
-  collectionChannelListingErrors: [CollectionChannelListingError!]!
+  collectionChannelListingErrors: [CollectionChannelListingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CollectionChannelListingError!]!
 }
 
 input CollectionChannelListingUpdateInput {
@@ -1143,8 +1141,8 @@ type CollectionCountableEdge {
 }
 
 type CollectionCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  collectionErrors: [CollectionError!]!
+  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CollectionError!]!
   collection: Collection
 }
 
@@ -1161,8 +1159,8 @@ input CollectionCreateInput {
 }
 
 type CollectionDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  collectionErrors: [CollectionError!]!
+  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CollectionError!]!
   collection: Collection
 }
 
@@ -1208,15 +1206,15 @@ enum CollectionPublished {
 }
 
 type CollectionRemoveProducts {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   collection: Collection
-  collectionErrors: [CollectionError!]!
+  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CollectionError!]!
 }
 
 type CollectionReorderProducts {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   collection: Collection
-  collectionErrors: [CollectionError!]!
+  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CollectionError!]!
 }
 
 enum CollectionSortField {
@@ -1244,8 +1242,8 @@ type CollectionTranslatableContent implements Node {
 }
 
 type CollectionTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   collection: Collection
 }
 
@@ -1260,8 +1258,8 @@ type CollectionTranslation implements Node {
 }
 
 type CollectionUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  collectionErrors: [CollectionError!]!
+  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [CollectionError!]!
   collection: Collection
 }
 
@@ -1288,15 +1286,15 @@ enum ConfigurationTypeFieldEnum {
 }
 
 type ConfirmAccount {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type ConfirmEmailChange {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 enum CountryCode {
@@ -1559,12 +1557,12 @@ type CountryDisplay {
 }
 
 type CreateToken {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   token: String
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type CreditCard {
@@ -1576,20 +1574,20 @@ type CreditCard {
 }
 
 type CustomerBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type CustomerCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   user: User
 }
 
 type CustomerDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   user: User
 }
 
@@ -1639,8 +1637,8 @@ input CustomerInput {
 }
 
 type CustomerUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
   user: User
 }
 
@@ -1659,19 +1657,19 @@ input DateTimeRangeInput {
 }
 
 type DeactivateAllUserTokens {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type DeleteMetadata {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  metadataErrors: [MetadataError!]!
+  metadataErrors: [MetadataError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type DeletePrivateMetadata {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  metadataErrors: [MetadataError!]!
+  metadataErrors: [MetadataError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
@@ -1700,16 +1698,16 @@ type DigitalContentCountableEdge {
 }
 
 type DigitalContentCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type DigitalContentDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   variant: ProductVariant
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 input DigitalContentInput {
@@ -1720,10 +1718,10 @@ input DigitalContentInput {
 }
 
 type DigitalContentUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 input DigitalContentUploadInput {
@@ -1744,8 +1742,8 @@ type DigitalContentUrl implements Node {
 }
 
 type DigitalContentUrlCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   digitalContentUrl: DigitalContentUrl
 }
 
@@ -1790,20 +1788,20 @@ type Domain {
 }
 
 type DraftOrderBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type DraftOrderComplete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type DraftOrderCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
   order: Order
 }
 
@@ -1822,8 +1820,8 @@ input DraftOrderCreateInput {
 }
 
 type DraftOrderDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
   order: Order
 }
 
@@ -1841,20 +1839,15 @@ input DraftOrderInput {
 }
 
 type DraftOrderLinesBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type DraftOrderUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
   order: Order
-}
-
-type Error {
-  field: String
-  message: String
 }
 
 type ExportError {
@@ -1937,9 +1930,9 @@ input ExportInfoInput {
 }
 
 type ExportProducts {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   exportFile: ExportFile
-  exportErrors: [ExportError!]!
+  exportErrors: [ExportError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ExportError!]!
 }
 
 input ExportProductsInput {
@@ -1962,41 +1955,41 @@ type ExternalAuthentication {
 }
 
 type ExternalAuthenticationUrl {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   authenticationData: JSONString
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type ExternalLogout {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   logoutData: JSONString
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type ExternalObtainAccessTokens {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   token: String
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type ExternalRefresh {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   token: String
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type ExternalVerify {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
   isValid: Boolean!
   verifyData: JSONString
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type File {
@@ -2010,9 +2003,9 @@ enum FileTypesEnum {
 }
 
 type FileUpload {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   uploadedFile: File
-  uploadErrors: [UploadError!]!
+  uploadErrors: [UploadError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [UploadError!]!
 }
 
 type Fulfillment implements Node & ObjectWithMetadata {
@@ -2029,10 +2022,10 @@ type Fulfillment implements Node & ObjectWithMetadata {
 }
 
 type FulfillmentCancel {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input FulfillmentCancelInput {
@@ -2046,19 +2039,19 @@ type FulfillmentLine implements Node {
 }
 
 type FulfillmentRefundProducts {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type FulfillmentReturnProducts {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   returnFulfillment: Fulfillment
   replaceFulfillment: Fulfillment
   order: Order
   replaceOrder: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 enum FulfillmentStatus {
@@ -2071,10 +2064,10 @@ enum FulfillmentStatus {
 }
 
 type FulfillmentUpdateTracking {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input FulfillmentUpdateTrackingInput {
@@ -2104,9 +2097,9 @@ type GiftCard implements Node {
 }
 
 type GiftCardActivate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]!
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [GiftCardError!]!
 }
 
 type GiftCardCountableConnection {
@@ -2121,8 +2114,8 @@ type GiftCardCountableEdge {
 }
 
 type GiftCardCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  giftCardErrors: [GiftCardError!]!
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [GiftCardError!]!
   giftCard: GiftCard
 }
 
@@ -2135,9 +2128,9 @@ input GiftCardCreateInput {
 }
 
 type GiftCardDeactivate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]!
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [GiftCardError!]!
 }
 
 type GiftCardError {
@@ -2156,8 +2149,8 @@ enum GiftCardErrorCode {
 }
 
 type GiftCardUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  giftCardErrors: [GiftCardError!]!
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [GiftCardError!]!
   giftCard: GiftCard
 }
 
@@ -2211,8 +2204,8 @@ type Invoice implements ObjectWithMetadata & Job & Node {
 }
 
 type InvoiceCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  invoiceErrors: [InvoiceError!]!
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [InvoiceError!]!
   invoice: Invoice
 }
 
@@ -2222,8 +2215,8 @@ input InvoiceCreateInput {
 }
 
 type InvoiceDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  invoiceErrors: [InvoiceError!]!
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [InvoiceError!]!
   invoice: Invoice
 }
 
@@ -2244,27 +2237,27 @@ enum InvoiceErrorCode {
 }
 
 type InvoiceRequest {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  invoiceErrors: [InvoiceError!]!
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceRequestDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  invoiceErrors: [InvoiceError!]!
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceSendNotification {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  invoiceErrors: [InvoiceError!]!
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  invoiceErrors: [InvoiceError!]!
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [InvoiceError!]!
   invoice: Invoice
 }
 
@@ -2384,9 +2377,9 @@ type Menu implements Node & ObjectWithMetadata {
 }
 
 type MenuBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
 }
 
 type MenuCountableConnection {
@@ -2401,8 +2394,8 @@ type MenuCountableEdge {
 }
 
 type MenuCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
   menu: Menu
 }
 
@@ -2413,8 +2406,8 @@ input MenuCreateInput {
 }
 
 type MenuDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
   menu: Menu
 }
 
@@ -2464,9 +2457,9 @@ type MenuItem implements Node & ObjectWithMetadata {
 }
 
 type MenuItemBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
 }
 
 type MenuItemCountableConnection {
@@ -2481,8 +2474,8 @@ type MenuItemCountableEdge {
 }
 
 type MenuItemCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
   menuItem: MenuItem
 }
 
@@ -2497,8 +2490,8 @@ input MenuItemCreateInput {
 }
 
 type MenuItemDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
   menuItem: MenuItem
 }
 
@@ -2516,9 +2509,9 @@ input MenuItemInput {
 }
 
 type MenuItemMove {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   menu: Menu
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
 }
 
 input MenuItemMoveInput {
@@ -2540,8 +2533,8 @@ type MenuItemTranslatableContent implements Node {
 }
 
 type MenuItemTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   menuItem: MenuItem
 }
 
@@ -2552,8 +2545,8 @@ type MenuItemTranslation implements Node {
 }
 
 type MenuItemUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
   menuItem: MenuItem
 }
 
@@ -2572,8 +2565,8 @@ input MenuSortingInput {
 }
 
 type MenuUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  menuErrors: [MenuError!]!
+  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MenuError!]!
   menu: Menu
 }
 
@@ -2603,7 +2596,6 @@ type MetadataItem {
 type Money {
   currency: String!
   amount: Float!
-  localized: String! @deprecated(reason: "Price formatting according to the current locale should be handled by the frontend client. This field will be removed after 2020-07-31.")
 }
 
 type MoneyRange {
@@ -2793,7 +2785,7 @@ type Mutation {
   checkoutBillingAddressUpdate(billingAddress: AddressInput!, checkoutId: ID!): CheckoutBillingAddressUpdate
   checkoutComplete(checkoutId: ID!, paymentData: JSONString, redirectUrl: String, storeSource: Boolean = false): CheckoutComplete
   checkoutCreate(input: CheckoutCreateInput!): CheckoutCreate
-  checkoutCustomerAttach(checkoutId: ID!, customerId: ID): CheckoutCustomerAttach
+  checkoutCustomerAttach(checkoutId: ID!): CheckoutCustomerAttach
   checkoutCustomerDetach(checkoutId: ID!): CheckoutCustomerDetach
   checkoutEmailUpdate(checkoutId: ID, email: String!): CheckoutEmailUpdate
   checkoutLineDelete(checkoutId: ID!, lineId: ID): CheckoutLineDelete
@@ -2879,11 +2871,6 @@ input NameTranslationInput {
   name: String
 }
 
-type Navigation {
-  main: Menu
-  secondary: Menu
-}
-
 enum NavigationType {
   MAIN
   SECONDARY
@@ -2957,10 +2944,10 @@ enum OrderAction {
 }
 
 type OrderAddNote {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
   event: OrderEvent
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input OrderAddNoteInput {
@@ -2968,27 +2955,27 @@ input OrderAddNoteInput {
 }
 
 type OrderBulkCancel {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type OrderCancel {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type OrderCapture {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type OrderConfirm {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type OrderCountableConnection {
@@ -3019,9 +3006,9 @@ type OrderDiscount implements Node {
 }
 
 type OrderDiscountAdd {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input OrderDiscountCommonInput {
@@ -3031,9 +3018,9 @@ input OrderDiscountCommonInput {
 }
 
 type OrderDiscountDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 enum OrderDiscountType {
@@ -3042,9 +3029,9 @@ enum OrderDiscountType {
 }
 
 type OrderDiscountUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input OrderDraftFilterInput {
@@ -3214,10 +3201,10 @@ input OrderFilterInput {
 }
 
 type OrderFulfill {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   fulfillments: [Fulfillment]
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input OrderFulfillInput {
@@ -3265,24 +3252,24 @@ input OrderLineCreateInput {
 }
 
 type OrderLineDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
   orderLine: OrderLine
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type OrderLineDiscountRemove {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   orderLine: OrderLine
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type OrderLineDiscountUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   orderLine: OrderLine
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input OrderLineInput {
@@ -3290,29 +3277,29 @@ input OrderLineInput {
 }
 
 type OrderLineUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
   orderLine: OrderLine
 }
 
 type OrderLinesCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
   orderLines: [OrderLine!]
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type OrderMarkAsPaid {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type OrderRefund {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input OrderRefundFulfillmentLineInput {
@@ -3367,9 +3354,9 @@ enum OrderSettingsErrorCode {
 }
 
 type OrderSettingsUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   orderSettings: OrderSettings
-  orderSettingsErrors: [OrderSettingsError!]!
+  orderSettingsErrors: [OrderSettingsError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderSettingsError!]!
 }
 
 input OrderSettingsUpdateInput {
@@ -3411,8 +3398,8 @@ enum OrderStatusFilter {
 }
 
 type OrderUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
   order: Order
 }
 
@@ -3423,9 +3410,9 @@ input OrderUpdateInput {
 }
 
 type OrderUpdateShipping {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 input OrderUpdateShippingInput {
@@ -3433,9 +3420,9 @@ input OrderUpdateShippingInput {
 }
 
 type OrderVoid {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   order: Order
-  orderErrors: [OrderError!]!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type Page implements Node & ObjectWithMetadata {
@@ -3457,27 +3444,27 @@ type Page implements Node & ObjectWithMetadata {
 }
 
 type PageAttributeAssign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   pageType: PageType
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
 }
 
 type PageAttributeUnassign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   pageType: PageType
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
 }
 
 type PageBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
 }
 
 type PageBulkPublish {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
 }
 
 type PageCountableConnection {
@@ -3492,8 +3479,8 @@ type PageCountableEdge {
 }
 
 type PageCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
   page: Page
 }
 
@@ -3509,8 +3496,8 @@ input PageCreateInput {
 }
 
 type PageDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
   page: Page
 }
 
@@ -3555,9 +3542,9 @@ input PageInput {
 }
 
 type PageReorderAttributeValues {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   page: Page
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
 }
 
 enum PageSortField {
@@ -3585,8 +3572,8 @@ type PageTranslatableContent implements Node {
 }
 
 type PageTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   page: PageTranslatableContent
 }
 
@@ -3619,9 +3606,9 @@ type PageType implements Node & ObjectWithMetadata {
 }
 
 type PageTypeBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
 }
 
 type PageTypeCountableConnection {
@@ -3636,8 +3623,8 @@ type PageTypeCountableEdge {
 }
 
 type PageTypeCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
   pageType: PageType
 }
 
@@ -3648,8 +3635,8 @@ input PageTypeCreateInput {
 }
 
 type PageTypeDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
   pageType: PageType
 }
 
@@ -3658,9 +3645,9 @@ input PageTypeFilterInput {
 }
 
 type PageTypeReorderAttributes {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   pageType: PageType
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
 }
 
 enum PageTypeSortField {
@@ -3674,8 +3661,8 @@ input PageTypeSortingInput {
 }
 
 type PageTypeUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
   pageType: PageType
 }
 
@@ -3687,15 +3674,15 @@ input PageTypeUpdateInput {
 }
 
 type PageUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  pageErrors: [PageError!]!
+  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PageError!]!
   page: Page
 }
 
 type PasswordChange {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type Payment implements Node {
@@ -3720,9 +3707,9 @@ type Payment implements Node {
 }
 
 type PaymentCapture {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   payment: Payment
-  paymentErrors: [PaymentError!]!
+  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PaymentError!]!
 }
 
 enum PaymentChargeStatusEnum {
@@ -3780,9 +3767,9 @@ type PaymentGateway {
 }
 
 type PaymentInitialize {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   initializedPayment: PaymentInitialized
-  paymentErrors: [PaymentError!]!
+  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PaymentError!]!
 }
 
 type PaymentInitialized {
@@ -3799,9 +3786,9 @@ input PaymentInput {
 }
 
 type PaymentRefund {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   payment: Payment
-  paymentErrors: [PaymentError!]!
+  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PaymentError!]!
 }
 
 type PaymentSource {
@@ -3810,9 +3797,9 @@ type PaymentSource {
 }
 
 type PaymentVoid {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   payment: Payment
-  paymentErrors: [PaymentError!]!
+  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PaymentError!]!
 }
 
 type Permission {
@@ -3841,8 +3828,8 @@ enum PermissionEnum {
 }
 
 type PermissionGroupCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  permissionGroupErrors: [PermissionGroupError!]!
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PermissionGroupError!]!
   group: Group
 }
 
@@ -3853,8 +3840,8 @@ input PermissionGroupCreateInput {
 }
 
 type PermissionGroupDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  permissionGroupErrors: [PermissionGroupError!]!
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PermissionGroupError!]!
   group: Group
 }
 
@@ -3891,8 +3878,8 @@ input PermissionGroupSortingInput {
 }
 
 type PermissionGroupUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  permissionGroupErrors: [PermissionGroupError!]!
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PermissionGroupError!]!
   group: Group
 }
 
@@ -3954,9 +3941,9 @@ input PluginSortingInput {
 }
 
 type PluginUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   plugin: Plugin
-  pluginsErrors: [PluginError!]!
+  pluginsErrors: [PluginError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [PluginError!]!
 }
 
 input PluginUpdateInput {
@@ -3993,7 +3980,6 @@ type Product implements Node & ObjectWithMetadata {
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
-  url: String! @deprecated(reason: "This field will be removed after 2020-07-31.")
   thumbnail(size: Int): Image
   pricing(address: AddressInput): ProductPricingInfo
   isAvailable(address: AddressInput): Boolean
@@ -4012,9 +3998,9 @@ type Product implements Node & ObjectWithMetadata {
 }
 
 type ProductAttributeAssign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productType: ProductType
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 input ProductAttributeAssignInput {
@@ -4028,15 +4014,15 @@ enum ProductAttributeType {
 }
 
 type ProductAttributeUnassign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productType: ProductType
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type ProductBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type ProductChannelListing implements Node {
@@ -4075,9 +4061,9 @@ type ProductChannelListingError {
 }
 
 type ProductChannelListingUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
-  productChannelListingErrors: [ProductChannelListingError!]!
+  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductChannelListingError!]!
 }
 
 input ProductChannelListingUpdateInput {
@@ -4097,8 +4083,8 @@ type ProductCountableEdge {
 }
 
 type ProductCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   product: Product
 }
 
@@ -4118,8 +4104,8 @@ input ProductCreateInput {
 }
 
 type ProductDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   product: Product
 }
 
@@ -4173,7 +4159,6 @@ input ProductFilterInput {
   hasCategory: Boolean
   attributes: [AttributeInput]
   stockAvailability: StockAvailability
-  productType: ID
   stocks: ProductStockFilterInput
   search: String
   metadata: [MetadataInput]
@@ -4215,16 +4200,16 @@ type ProductMedia implements Node {
 }
 
 type ProductMediaBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type ProductMediaCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 input ProductMediaCreateInput {
@@ -4235,17 +4220,17 @@ input ProductMediaCreateInput {
 }
 
 type ProductMediaDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type ProductMediaReorder {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
   media: [ProductMedia!]
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 enum ProductMediaType {
@@ -4254,10 +4239,10 @@ enum ProductMediaType {
 }
 
 type ProductMediaUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 input ProductMediaUpdateInput {
@@ -4294,9 +4279,9 @@ type ProductPricingInfo {
 }
 
 type ProductReorderAttributeValues {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 input ProductStockFilterInput {
@@ -4316,8 +4301,8 @@ type ProductTranslatableContent implements Node {
 }
 
 type ProductTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   product: Product
 }
 
@@ -4341,7 +4326,7 @@ type ProductType implements Node & ObjectWithMetadata {
   weight: Weight
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "Use the top-level `products` query with the `productTypes` filter.")
+  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "Will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.")
   taxType: TaxType
   variantAttributes(variantSelection: VariantAttributeScope): [Attribute]
   productAttributes: [Attribute]
@@ -4349,9 +4334,9 @@ type ProductType implements Node & ObjectWithMetadata {
 }
 
 type ProductTypeBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 enum ProductTypeConfigurable {
@@ -4371,14 +4356,14 @@ type ProductTypeCountableEdge {
 }
 
 type ProductTypeCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   productType: ProductType
 }
 
@@ -4408,9 +4393,9 @@ input ProductTypeInput {
 }
 
 type ProductTypeReorderAttributes {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productType: ProductType
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 enum ProductTypeSortField {
@@ -4425,14 +4410,14 @@ input ProductTypeSortingInput {
 }
 
 type ProductTypeUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   product: Product
 }
 
@@ -4461,10 +4446,10 @@ type ProductVariant implements Node & ObjectWithMetadata {
 }
 
 type ProductVariantBulkCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
   productVariants: [ProductVariant!]!
-  bulkProductErrors: [BulkProductError!]!
+  bulkProductErrors: [BulkProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [BulkProductError!]!
 }
 
 input ProductVariantBulkCreateInput {
@@ -4477,9 +4462,9 @@ input ProductVariantBulkCreateInput {
 }
 
 type ProductVariantBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type ProductVariantChannelListing implements Node {
@@ -4497,9 +4482,9 @@ input ProductVariantChannelListingAddInput {
 }
 
 type ProductVariantChannelListingUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   variant: ProductVariant
-  productChannelListingErrors: [ProductChannelListingError!]!
+  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductChannelListingError!]!
 }
 
 type ProductVariantCountableConnection {
@@ -4514,8 +4499,8 @@ type ProductVariantCountableEdge {
 }
 
 type ProductVariantCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   productVariant: ProductVariant
 }
 
@@ -4529,8 +4514,8 @@ input ProductVariantCreateInput {
 }
 
 type ProductVariantDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   productVariant: ProductVariant
 }
 
@@ -4548,39 +4533,39 @@ input ProductVariantInput {
 }
 
 type ProductVariantReorder {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type ProductVariantReorderAttributeValues {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productVariant: ProductVariant
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type ProductVariantSetDefault {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   product: Product
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type ProductVariantStocksCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productVariant: ProductVariant
-  bulkStockErrors: [BulkStockError!]!
+  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [BulkStockError!]!
 }
 
 type ProductVariantStocksDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productVariant: ProductVariant
-  stockErrors: [StockError!]!
+  stockErrors: [StockError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [StockError!]!
 }
 
 type ProductVariantStocksUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productVariant: ProductVariant
-  bulkStockErrors: [BulkStockError!]!
+  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [BulkStockError!]!
 }
 
 type ProductVariantTranslatableContent implements Node {
@@ -4591,8 +4576,8 @@ type ProductVariantTranslatableContent implements Node {
 }
 
 type ProductVariantTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   productVariant: ProductVariant
 }
 
@@ -4603,8 +4588,8 @@ type ProductVariantTranslation implements Node {
 }
 
 type ProductVariantUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
   productVariant: ProductVariant
 }
 
@@ -4635,7 +4620,7 @@ type Query {
   collection(id: ID, slug: String, channel: String): Collection
   collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, channel: String, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   product(id: ID, slug: String, channel: String): Product
-  products(filter: ProductFilterInput, sortBy: ProductOrder, stockAvailability: StockAvailability, channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(filter: ProductFilterInput, sortBy: ProductOrder, channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   productType(id: ID!): ProductType
   productTypes(filter: ProductTypeFilterInput, sortBy: ProductTypeSortingInput, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
   productVariant(id: ID, sku: String, channel: String): ProductVariant
@@ -4649,8 +4634,8 @@ type Query {
   pageTypes(sortBy: PageTypeSortingInput, filter: PageTypeFilterInput, before: String, after: String, first: Int, last: Int): PageTypeCountableConnection
   homepageEvents(before: String, after: String, first: Int, last: Int): OrderEventCountableConnection
   order(id: ID!): Order
-  orders(sortBy: OrderSortingInput, filter: OrderFilterInput, created: ReportingPeriod, status: OrderStatusFilter, channel: String, before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, created: ReportingPeriod, before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  orders(sortBy: OrderSortingInput, filter: OrderFilterInput, channel: String, before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, before: String, after: String, first: Int, last: Int): OrderCountableConnection
   ordersTotal(period: ReportingPeriod, channel: String): TaxedMoney
   orderByToken(token: UUID!): Order
   menu(channel: String, id: ID, name: String, slug: String): Menu
@@ -4697,10 +4682,10 @@ type ReducedRate {
 }
 
 type RefreshToken {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   token: String
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 input ReorderInput {
@@ -4714,14 +4699,14 @@ enum ReportingPeriod {
 }
 
 type RequestEmailChange {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type RequestPasswordReset {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type Sale implements Node {
@@ -4740,15 +4725,15 @@ type Sale implements Node {
 }
 
 type SaleAddCatalogues {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   sale: Sale
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
 }
 
 type SaleBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
 }
 
 type SaleChannelListing implements Node {
@@ -4769,9 +4754,9 @@ input SaleChannelListingInput {
 }
 
 type SaleChannelListingUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   sale: Sale
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
 }
 
 type SaleCountableConnection {
@@ -4786,14 +4771,14 @@ type SaleCountableEdge {
 }
 
 type SaleCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
   sale: Sale
 }
 
 type SaleDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
   sale: Sale
 }
 
@@ -4816,9 +4801,9 @@ input SaleInput {
 }
 
 type SaleRemoveCatalogues {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   sale: Sale
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
 }
 
 enum SaleSortField {
@@ -4843,8 +4828,8 @@ type SaleTranslatableContent implements Node {
 }
 
 type SaleTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   sale: Sale
 }
 
@@ -4860,8 +4845,8 @@ enum SaleType {
 }
 
 type SaleUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
   sale: Sale
 }
 
@@ -4876,12 +4861,12 @@ input SeoInput {
 }
 
 type SetPassword {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   token: String
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type ShippingError {
@@ -4944,9 +4929,9 @@ input ShippingMethodChannelListingInput {
 }
 
 type ShippingMethodChannelListingUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
 }
 
 type ShippingMethodPostalCodeRule implements Node {
@@ -4982,29 +4967,29 @@ input ShippingPostalCodeRulesCreateInputRange {
 }
 
 type ShippingPriceBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
 }
 
 type ShippingPriceCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shippingZone: ShippingZone
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
 }
 
 type ShippingPriceDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shippingMethod: ShippingMethod
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
 }
 
 type ShippingPriceExcludeProducts {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
 }
 
 input ShippingPriceExcludeProductsInput {
@@ -5026,14 +5011,14 @@ input ShippingPriceInput {
 }
 
 type ShippingPriceRemoveProductFromExclude {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
 }
 
 type ShippingPriceTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   shippingMethod: ShippingMethod
 }
 
@@ -5043,10 +5028,10 @@ input ShippingPriceTranslationInput {
 }
 
 type ShippingPriceUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shippingZone: ShippingZone
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
 }
 
 type ShippingZone implements Node & ObjectWithMetadata {
@@ -5064,9 +5049,9 @@ type ShippingZone implements Node & ObjectWithMetadata {
 }
 
 type ShippingZoneBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
 }
 
 type ShippingZoneCountableConnection {
@@ -5081,8 +5066,8 @@ type ShippingZoneCountableEdge {
 }
 
 type ShippingZoneCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
 
@@ -5096,8 +5081,8 @@ input ShippingZoneCreateInput {
 }
 
 type ShippingZoneDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
 
@@ -5106,8 +5091,8 @@ input ShippingZoneFilterInput {
 }
 
 type ShippingZoneUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shippingErrors: [ShippingError!]!
+  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
 
@@ -5134,7 +5119,6 @@ type Shop {
   domain: Domain!
   languages: [LanguageDisplay]!
   name: String!
-  navigation: Navigation @deprecated(reason: "Fetch menus using the `menu` query with `slug` parameter.")
   permissions: [Permission]!
   phonePrefixes: [String]!
   headerText: String
@@ -5155,15 +5139,15 @@ type Shop {
 }
 
 type ShopAddressUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shop: Shop
-  shopErrors: [ShopError!]!
+  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShopError!]!
 }
 
 type ShopDomainUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shop: Shop
-  shopErrors: [ShopError!]!
+  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShopError!]!
 }
 
 type ShopError {
@@ -5183,9 +5167,9 @@ enum ShopErrorCode {
 }
 
 type ShopFetchTaxRates {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shop: Shop
-  shopErrors: [ShopError!]!
+  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShopError!]!
 }
 
 input ShopSettingsInput {
@@ -5205,9 +5189,9 @@ input ShopSettingsInput {
 }
 
 type ShopSettingsTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shop: Shop
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
 }
 
 input ShopSettingsTranslationInput {
@@ -5216,9 +5200,9 @@ input ShopSettingsTranslationInput {
 }
 
 type ShopSettingsUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   shop: Shop
-  shopErrors: [ShopError!]!
+  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShopError!]!
 }
 
 type ShopTranslation implements Node {
@@ -5234,14 +5218,14 @@ input SiteDomainInput {
 }
 
 type StaffBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  staffErrors: [StaffError!]!
+  staffErrors: [StaffError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [StaffError!]!
 }
 
 type StaffCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  staffErrors: [StaffError!]!
+  staffErrors: [StaffError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [StaffError!]!
   user: User
 }
 
@@ -5256,8 +5240,8 @@ input StaffCreateInput {
 }
 
 type StaffDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  staffErrors: [StaffError!]!
+  staffErrors: [StaffError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [StaffError!]!
   user: User
 }
 
@@ -5283,14 +5267,14 @@ type StaffNotificationRecipient implements Node {
 }
 
 type StaffNotificationRecipientCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shopErrors: [ShopError!]!
+  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffNotificationRecipientDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shopErrors: [ShopError!]!
+  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
@@ -5301,14 +5285,14 @@ input StaffNotificationRecipientInput {
 }
 
 type StaffNotificationRecipientUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shopErrors: [ShopError!]!
+  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  staffErrors: [StaffError!]!
+  staffErrors: [StaffError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [StaffError!]!
   user: User
 }
 
@@ -5500,14 +5484,14 @@ input UpdateInvoiceInput {
 }
 
 type UpdateMetadata {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  metadataErrors: [MetadataError!]!
+  metadataErrors: [MetadataError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type UpdatePrivateMetadata {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  metadataErrors: [MetadataError!]!
+  metadataErrors: [MetadataError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
@@ -5538,11 +5522,10 @@ type User implements Node & ObjectWithMetadata {
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   addresses: [Address]
-  checkout: Checkout @deprecated(reason: "Use the `checkout_tokens` field to fetch the user checkouts.")
+  checkout: Checkout @deprecated(reason: "Will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts.")
   checkoutTokens(channel: String): [UUID!]
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  permissions: [Permission] @deprecated(reason: "Will be removed in Saleor 2.11.Use the `userPermissions` instead.")
   userPermissions: [UserPermission]
   permissionGroups: [Group]
   editableGroups: [Group]
@@ -5553,21 +5536,21 @@ type User implements Node & ObjectWithMetadata {
 }
 
 type UserAvatarDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type UserAvatarUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type UserBulkSetActive {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type UserCountableConnection {
@@ -5624,17 +5607,17 @@ enum VariantAttributeScope {
 }
 
 type VariantMediaAssign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productVariant: ProductVariant
   media: ProductMedia
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type VariantMediaUnassign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   productVariant: ProductVariant
   media: ProductMedia
-  productErrors: [ProductError!]!
+  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [ProductError!]!
 }
 
 type VariantPricingInfo {
@@ -5647,11 +5630,11 @@ type VariantPricingInfo {
 }
 
 type VerifyToken {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   user: User
   isValid: Boolean!
   payload: GenericScalar
-  accountErrors: [AccountError!]!
+  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [AccountError!]!
 }
 
 type Voucher implements Node {
@@ -5679,15 +5662,15 @@ type Voucher implements Node {
 }
 
 type VoucherAddCatalogues {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   voucher: Voucher
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
 }
 
 type VoucherBulkDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
 }
 
 type VoucherChannelListing implements Node {
@@ -5710,9 +5693,9 @@ input VoucherChannelListingInput {
 }
 
 type VoucherChannelListingUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   voucher: Voucher
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
 }
 
 type VoucherCountableConnection {
@@ -5727,14 +5710,14 @@ type VoucherCountableEdge {
 }
 
 type VoucherCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
   voucher: Voucher
 }
 
 type VoucherDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
   voucher: Voucher
 }
 
@@ -5770,9 +5753,9 @@ input VoucherInput {
 }
 
 type VoucherRemoveCatalogues {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   voucher: Voucher
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
 }
 
 enum VoucherSortField {
@@ -5799,8 +5782,8 @@ type VoucherTranslatableContent implements Node {
 }
 
 type VoucherTranslate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  translationErrors: [TranslationError!]!
+  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [TranslationError!]!
   voucher: Voucher
 }
 
@@ -5817,8 +5800,8 @@ enum VoucherTypeEnum {
 }
 
 type VoucherUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  discountErrors: [DiscountError!]!
+  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [DiscountError!]!
   voucher: Voucher
 }
 
@@ -5857,8 +5840,8 @@ type WarehouseCountableEdge {
 }
 
 type WarehouseCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  warehouseErrors: [WarehouseError!]!
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
@@ -5872,8 +5855,8 @@ input WarehouseCreateInput {
 }
 
 type WarehouseDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  warehouseErrors: [WarehouseError!]!
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
@@ -5898,14 +5881,14 @@ input WarehouseFilterInput {
 }
 
 type WarehouseShippingZoneAssign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  warehouseErrors: [WarehouseError!]!
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
 type WarehouseShippingZoneUnassign {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  warehouseErrors: [WarehouseError!]!
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
@@ -5919,8 +5902,8 @@ input WarehouseSortingInput {
 }
 
 type WarehouseUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  warehouseErrors: [WarehouseError!]!
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
@@ -5943,8 +5926,8 @@ type Webhook implements Node {
 }
 
 type WebhookCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  webhookErrors: [WebhookError!]!
+  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WebhookError!]!
   webhook: Webhook
 }
 
@@ -5958,8 +5941,8 @@ input WebhookCreateInput {
 }
 
 type WebhookDelete {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  webhookErrors: [WebhookError!]!
+  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WebhookError!]!
   webhook: Webhook
 }
 
@@ -6038,8 +6021,8 @@ enum WebhookSampleEventTypeEnum {
 }
 
 type WebhookUpdate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  webhookErrors: [WebhookError!]!
+  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [WebhookError!]!
   webhook: Webhook
 }
 

--- a/src/apps/components/AppActivateDialog/AppActivateDialog.tsx
+++ b/src/apps/components/AppActivateDialog/AppActivateDialog.tsx
@@ -41,7 +41,7 @@ const AppActivateDialog: React.FC<AppActivateDialogProps> = ({
       <DialogContentText>
         {["", null].includes(name) ? (
           <FormattedMessage
-            defaultMessage="Are you sure you want to activate this app? Activating will start gathering events"
+            defaultMessage="Are you sure you want to activate this app? Activating will start gathering events."
             description="activate app"
           />
         ) : (

--- a/src/apps/components/AppDeactivateDialog/AppDeactivateDialog.tsx
+++ b/src/apps/components/AppDeactivateDialog/AppDeactivateDialog.tsx
@@ -5,10 +5,13 @@ import { getStringOrPlaceholder } from "@saleor/misc";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import msgs from "./messages";
+
 export interface AppDeactivateDialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
   open: boolean;
   name: string;
+  thirdParty?: boolean;
   onClose: () => void;
   onConfirm: () => void;
 }
@@ -17,6 +20,7 @@ const AppDeactivateDialog: React.FC<AppDeactivateDialogProps> = ({
   confirmButtonState,
   open,
   name,
+  thirdParty = true,
   onClose,
   onConfirm
 }) => {
@@ -41,13 +45,13 @@ const AppDeactivateDialog: React.FC<AppDeactivateDialogProps> = ({
       <DialogContentText>
         {["", null].includes(name) ? (
           <FormattedMessage
-            defaultMessage="Are you sure you want to disable this app? Your data will be kept until you reactivate the app. You will be still billed for the app."
-            description="deactivate app"
+            {...(thirdParty ? msgs.deactivateApp : msgs.deactivateLocalApp)}
           />
         ) : (
           <FormattedMessage
-            defaultMessage="Are you sure you want to disable {name}? Your data will be kept until you reactivate the app. You will be still billed for the app."
-            description="deactivate app"
+            {...(thirdParty
+              ? msgs.deactivateNamedApp
+              : msgs.deactivateLocalNamedApp)}
             values={{
               name: <strong>{getStringOrPlaceholder(name)}</strong>
             }}

--- a/src/apps/components/AppDeactivateDialog/messages.ts
+++ b/src/apps/components/AppDeactivateDialog/messages.ts
@@ -1,0 +1,24 @@
+import { defineMessages } from "react-intl";
+
+export default defineMessages({
+  deactivateApp: {
+    defaultMessage:
+      "Are you sure you want to disable this app? Your data will be kept until you reactivate the app. You will be still billed for the app.",
+    description: "deactivate app"
+  },
+  deactivateNamedApp: {
+    defaultMessage:
+      "Are you sure you want to disable {name}? Your data will be kept until you reactivate the app. You will be still billed for the app.",
+    description: "deactivate named app"
+  },
+  deactivateLocalApp: {
+    defaultMessage:
+      "Are you sure you want to disable this app? Your data will be kept until you reactivate the app.",
+    description: "deactivate local app"
+  },
+  deactivateLocalNamedApp: {
+    defaultMessage:
+      "Are you sure you want to disable {name}? Your data will be kept until you reactivate the app.",
+    description: "deactivate local named app"
+  }
+});

--- a/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
+++ b/src/apps/components/CustomAppCreatePage/CustomAppCreatePage.tsx
@@ -1,7 +1,5 @@
 import AccountPermissions from "@saleor/components/AccountPermissions";
 import AppHeader from "@saleor/components/AppHeader";
-import AppStatus from "@saleor/components/AppStatus";
-import CardSpacer from "@saleor/components/CardSpacer";
 import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
 import Container from "@saleor/components/Container";
 import Form from "@saleor/components/Form";
@@ -21,7 +19,6 @@ import CustomAppInformation from "../CustomAppInformation";
 
 export interface CustomAppCreatePageFormData {
   hasFullAccess: boolean;
-  isActive: boolean;
   name: string;
   permissions: PermissionEnum[];
 }
@@ -47,7 +44,6 @@ const CustomAppCreatePage: React.FC<CustomAppCreatePageProps> = props => {
 
   const initialForm: CustomAppCreatePageFormData = {
     hasFullAccess: false,
-    isActive: false,
     name: "",
     permissions: []
   };
@@ -93,16 +89,6 @@ const CustomAppCreatePage: React.FC<CustomAppCreatePageProps> = props => {
                   "Expand or restrict app permissions to access certain part of Saleor system.",
                 description: "card description"
               })}
-            />
-            <CardSpacer />
-            <AppStatus
-              data={data}
-              disabled={disabled}
-              label={intl.formatMessage({
-                defaultMessage: "App is active",
-                description: "checkbox label"
-              })}
-              onChange={change}
             />
           </Grid>
           <SaveButtonBar

--- a/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
+++ b/src/apps/components/CustomAppDetailsPage/CustomAppDetailsPage.tsx
@@ -1,6 +1,6 @@
+import Button from "@material-ui/core/Button";
 import AccountPermissions from "@saleor/components/AccountPermissions";
 import AppHeader from "@saleor/components/AppHeader";
-import AppStatus from "@saleor/components/AppStatus";
 import CardSpacer from "@saleor/components/CardSpacer";
 import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
 import Container from "@saleor/components/Container";
@@ -17,8 +17,10 @@ import { getFormErrors } from "@saleor/utils/errors";
 import getAppErrorMessage from "@saleor/utils/errors/app";
 import WebhooksList from "@saleor/webhooks/components/WebhooksList";
 import React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
+import activateIcon from "../../../../assets/images/activate-icon.svg";
+import { useStyles } from "../../styles";
 import { AppUpdate_appUpdate_app } from "../../types/AppUpdate";
 import CustomAppDefaultToken from "../CustomAppDefaultToken";
 import CustomAppInformation from "../CustomAppInformation";
@@ -47,6 +49,8 @@ export interface CustomAppDetailsPageProps {
   onWebhookCreate: () => void;
   onWebhookRemove: (id: string) => void;
   navigateToWebhookDetails: (id: string) => () => void;
+  onAppActivateOpen: () => void;
+  onAppDeactivateOpen: () => void;
 }
 
 const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
@@ -66,9 +70,12 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
     onTokenDelete,
     onSubmit,
     onWebhookCreate,
-    onWebhookRemove
+    onWebhookRemove,
+    onAppActivateOpen,
+    onAppDeactivateOpen
   } = props;
   const intl = useIntl();
+  const classes = useStyles({});
 
   const webhooks = app?.webhooks;
 
@@ -94,7 +101,28 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
           <AppHeader onBack={onBack}>
             {intl.formatMessage(sectionNames.apps)}
           </AppHeader>
-          <PageHeader title={app?.name} />
+          <PageHeader title={app?.name}>
+            <Button
+              variant="text"
+              color="primary"
+              className={classes.activateButton}
+              disableFocusRipple
+              onClick={data.isActive ? onAppDeactivateOpen : onAppActivateOpen}
+            >
+              <img src={activateIcon} alt="" />
+              {data?.isActive ? (
+                <FormattedMessage
+                  defaultMessage="Deactivate"
+                  description="link"
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="Activate"
+                  description="link"
+                />
+              )}
+            </Button>
+          </PageHeader>
           <Grid>
             <div>
               {token && (
@@ -145,16 +173,6 @@ const CustomAppDetailsPage: React.FC<CustomAppDetailsPageProps> = props => {
                     "Expand or restrict app permissions to access certain part of Saleor system.",
                   description: "card description"
                 })}
-              />
-              <CardSpacer />
-              <AppStatus
-                data={data}
-                disabled={disabled}
-                label={intl.formatMessage({
-                  defaultMessage: "App is active",
-                  description: "checkbox label"
-                })}
-                onChange={change}
               />
             </div>
           </Grid>

--- a/src/apps/mutations.ts
+++ b/src/apps/mutations.ts
@@ -38,7 +38,7 @@ export const appCreateMutation = gql`
       app {
         ...AppFragment
       }
-      errors: appErrors {
+      errors {
         ...AppErrorFragment
       }
     }
@@ -54,7 +54,7 @@ export const appDeleteMutation = gql`
       app {
         ...AppFragment
       }
-      errors: appErrors {
+      errors {
         ...AppErrorFragment
       }
     }
@@ -71,7 +71,7 @@ export const appDeleteFailedInstallationMutation = gql`
         appName
         message
       }
-      errors: appErrors {
+      errors {
         ...AppErrorFragment
       }
     }
@@ -99,7 +99,7 @@ export const appFetchMutation = gql`
           name
         }
       }
-      errors: appErrors {
+      errors {
         ...AppErrorFragment
       }
     }
@@ -116,7 +116,7 @@ export const appInstallMutation = gql`
         appName
         manifestUrl
       }
-      errors: appErrors {
+      errors {
         ...AppErrorFragment
       }
     }
@@ -133,29 +133,7 @@ export const appRetryInstallMutation = gql`
         appName
         manifestUrl
       }
-      errors: appErrors {
-        ...AppErrorFragment
-      }
-    }
-  }
-`;
-
-export const appActivateMutation = gql`
-  ${appErrorFragment}
-  mutation AppActivate($id: ID!) {
-    appActivate(id: $id) {
-      errors: appErrors {
-        ...AppErrorFragment
-      }
-    }
-  }
-`;
-
-export const appDeactivateMutation = gql`
-  ${appErrorFragment}
-  mutation AppDeactivate($id: ID!) {
-    appDeactivate(id: $id) {
-      errors: appErrors {
+      errors {
         ...AppErrorFragment
       }
     }
@@ -175,7 +153,7 @@ export const appUpdateMutation = gql`
           name
         }
       }
-      errors: appErrors {
+      errors {
         ...AppErrorFragment
         message
         permissions
@@ -194,7 +172,7 @@ export const appTokenCreateMutation = gql`
         id
       }
       authToken
-      errors: appErrors {
+      errors {
         ...AppErrorFragment
       }
     }
@@ -210,7 +188,29 @@ export const appTokenDeleteMutation = gql`
         authToken
         id
       }
-      errors: appErrors {
+      errors {
+        ...AppErrorFragment
+      }
+    }
+  }
+`;
+
+export const appActivateMutation = gql`
+  ${appErrorFragment}
+  mutation AppActivate($id: ID!) {
+    appActivate(id: $id) {
+      errors {
+        ...AppErrorFragment
+      }
+    }
+  }
+`;
+
+export const appDeactivateMutation = gql`
+  ${appErrorFragment}
+  mutation AppDeactivate($id: ID!) {
+    appDeactivate(id: $id) {
+      errors {
         ...AppErrorFragment
       }
     }

--- a/src/apps/styles.ts
+++ b/src/apps/styles.ts
@@ -198,6 +198,11 @@ export const useStyles = makeStyles(
       flex: 1,
       fontWeight: 500,
       lineHeight: 1
+    },
+    activateButton: {
+      "& img": {
+        marginRight: theme.spacing(1)
+      }
     }
   }),
   { name: "AppList" }

--- a/src/apps/urls.ts
+++ b/src/apps/urls.ts
@@ -27,7 +27,9 @@ export enum AppListUrlSortField {
 export type CustomAppUrlDialog =
   | "create-token"
   | "remove-webhook"
-  | "remove-token";
+  | "remove-token"
+  | "app-activate"
+  | "app-deactivate";
 export type CustomAppUrlQueryParams = Dialog<CustomAppUrlDialog> & SingleAction;
 
 export const appsSection = "/apps/";

--- a/src/apps/views/CustomAppCreate/CustomAppCreate.tsx
+++ b/src/apps/views/CustomAppCreate/CustomAppCreate.tsx
@@ -45,7 +45,6 @@ export const CustomAppCreate: React.FC<CustomAppCreateProps> = ({
     createApp({
       variables: {
         input: {
-          isActive: data.isActive,
           name: data.name,
           permissions: data.hasFullAccess
             ? shop.permissions.map(permission => permission.code)

--- a/src/attributes/mutations.ts
+++ b/src/attributes/mutations.ts
@@ -40,7 +40,7 @@ const attributeBulkDelete = gql`
   ${attributeErrorFragment}
   mutation AttributeBulkDelete($ids: [ID!]!) {
     attributeBulkDelete(ids: $ids) {
-      errors: attributeErrors {
+      errors {
         ...AttributeErrorFragment
       }
     }
@@ -55,7 +55,7 @@ const attributeDelete = gql`
   ${attributeErrorFragment}
   mutation AttributeDelete($id: ID!) {
     attributeDelete(id: $id) {
-      errors: attributeErrors {
+      errors {
         ...AttributeErrorFragment
       }
     }
@@ -74,7 +74,7 @@ export const attributeUpdateMutation = gql`
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: attributeErrors {
+      errors {
         ...AttributeErrorFragment
       }
     }
@@ -93,7 +93,7 @@ const attributeValueDelete = gql`
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: attributeErrors {
+      errors {
         ...AttributeErrorFragment
       }
     }
@@ -112,7 +112,7 @@ export const attributeValueUpdateMutation = gql`
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: attributeErrors {
+      errors {
         ...AttributeErrorFragment
       }
     }
@@ -131,7 +131,7 @@ export const attributeValueCreateMutation = gql`
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: attributeErrors {
+      errors {
         ...AttributeErrorFragment
       }
     }
@@ -150,7 +150,7 @@ export const attributeCreateMutation = gql`
       attribute {
         ...AttributeDetailsFragment
       }
-      errors: attributeErrors {
+      errors {
         ...AttributeErrorFragment
       }
     }
@@ -171,7 +171,7 @@ const attributeValueReorderMutation = gql`
           id
         }
       }
-      errors: attributeErrors {
+      errors {
         ...AttributeErrorFragment
       }
     }

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -110,7 +110,7 @@ export const mergeFileUploadErrors = (
   uploadFilesResult: Array<MutationFetchResult<FileUpload>>
 ): UploadErrorFragment[] =>
   uploadFilesResult.reduce((errors, uploadFileResult) => {
-    const uploadErrors = uploadFileResult?.data?.fileUpload?.uploadErrors;
+    const uploadErrors = uploadFileResult?.data?.fileUpload?.errors;
     if (uploadErrors) {
       return [...errors, ...uploadErrors];
     }

--- a/src/auth/mutations.ts
+++ b/src/auth/mutations.ts
@@ -13,7 +13,7 @@ export const tokenAuthMutation = gql`
   ${fragmentUser}
   mutation TokenAuth($email: String!, $password: String!) {
     tokenCreate(email: $email, password: $password) {
-      errors: accountErrors {
+      errors {
         field
         message
       }
@@ -50,7 +50,7 @@ export const requestPasswordReset = gql`
   ${accountErrorFragment}
   mutation RequestPasswordReset($email: String!, $redirectUrl: String!) {
     requestPasswordReset(email: $email, redirectUrl: $redirectUrl) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
     }
@@ -66,7 +66,7 @@ export const setPassword = gql`
   ${fragmentUser}
   mutation SetPassword($email: String!, $password: String!, $token: String!) {
     setPassword(email: $email, password: $password, token: $token) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       csrfToken
@@ -88,7 +88,7 @@ export const externalAuthenticationUrlMutation = gql`
   mutation ExternalAuthenticationUrl($pluginId: String!, $input: JSONString!) {
     externalAuthenticationUrl(pluginId: $pluginId, input: $input) {
       authenticationData
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
     }
@@ -105,7 +105,7 @@ export const externalObtainAccessTokensMutation = gql`
       user {
         ...User
       }
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
     }

--- a/src/categories/mutations.ts
+++ b/src/categories/mutations.ts
@@ -24,7 +24,7 @@ export const categoryDeleteMutation = gql`
   ${productErrorFragment}
   mutation CategoryDelete($id: ID!) {
     categoryDelete(id: $id) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
     }
@@ -43,7 +43,7 @@ export const categoryCreateMutation = gql`
       category {
         ...CategoryDetailsFragment
       }
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
     }
@@ -62,7 +62,7 @@ export const categoryUpdateMutation = gql`
       category {
         ...CategoryDetailsFragment
       }
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
     }
@@ -77,7 +77,7 @@ export const categoryBulkDeleteMutation = gql`
   ${productErrorFragment}
   mutation CategoryBulkDelete($ids: [ID]!) {
     categoryBulkDelete(ids: $ids) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
     }

--- a/src/channels/mutations.ts
+++ b/src/channels/mutations.ts
@@ -25,7 +25,7 @@ export const channelCreateMutation = gql`
       channel {
         ...ChannelDetailsFragment
       }
-      errors: channelErrors {
+      errors {
         ...ChannelErrorFragment
       }
     }
@@ -40,7 +40,7 @@ export const channelUpdateMutation = gql`
       channel {
         ...ChannelDetailsFragment
       }
-      errors: channelErrors {
+      errors {
         ...ChannelErrorFragment
       }
     }
@@ -51,7 +51,7 @@ export const channelDeleteMutation = gql`
   ${channelErrorFragment}
   mutation ChannelDelete($id: ID!, $input: ChannelDeleteInput) {
     channelDelete(id: $id, input: $input) {
-      errors: channelErrors {
+      errors {
         ...ChannelErrorFragment
       }
     }
@@ -66,7 +66,7 @@ export const channelActivateMutation = gql`
       channel {
         ...ChannelDetailsFragment
       }
-      errors: channelErrors {
+      errors {
         ...ChannelErrorFragment
       }
     }
@@ -81,7 +81,7 @@ export const channelDeactivateMutation = gql`
       channel {
         ...ChannelDetailsFragment
       }
-      errors: channelErrors {
+      errors {
         ...ChannelErrorFragment
       }
     }

--- a/src/collections/mutations.ts
+++ b/src/collections/mutations.ts
@@ -46,7 +46,7 @@ const collectionUpdate = gql`
       collection {
         ...CollectionDetailsFragment
       }
-      errors: collectionErrors {
+      errors {
         ...CollectionErrorFragment
       }
     }
@@ -85,7 +85,7 @@ const assignCollectionProduct = gql`
           }
         }
       }
-      errors: collectionErrors {
+      errors {
         ...CollectionErrorFragment
       }
     }
@@ -104,7 +104,7 @@ const createCollection = gql`
       collection {
         ...CollectionDetailsFragment
       }
-      errors: collectionErrors {
+      errors {
         ...CollectionErrorFragment
       }
     }
@@ -119,7 +119,7 @@ const removeCollection = gql`
   ${collectionsErrorFragment}
   mutation RemoveCollection($id: ID!) {
     collectionDelete(id: $id) {
-      errors: collectionErrors {
+      errors {
         ...CollectionErrorFragment
       }
     }
@@ -168,7 +168,7 @@ const unassignCollectionProduct = gql`
           }
         }
       }
-      errors: collectionErrors {
+      errors {
         ...CollectionErrorFragment
       }
     }
@@ -183,7 +183,7 @@ const collectionBulkDelete = gql`
   ${collectionsErrorFragment}
   mutation CollectionBulkDelete($ids: [ID]!) {
     collectionBulkDelete(ids: $ids) {
-      errors: collectionErrors {
+      errors {
         ...CollectionErrorFragment
       }
     }
@@ -201,7 +201,7 @@ const collectionChannelListingUpdate = gql`
     $input: CollectionChannelListingUpdateInput!
   ) {
     collectionChannelListingUpdate(id: $id, input: $input) {
-      errors: collectionChannelListingErrors {
+      errors {
         ...CollectionChannelListingErrorFragment
       }
     }

--- a/src/customers/mutations.ts
+++ b/src/customers/mutations.ts
@@ -45,7 +45,7 @@ const updateCustomer = gql`
   ${customerDetailsFragment}
   mutation UpdateCustomer($id: ID!, $input: CustomerInput!) {
     customerUpdate(id: $id, input: $input) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       user {
@@ -63,7 +63,7 @@ const createCustomer = gql`
   ${accountErrorFragment}
   mutation CreateCustomer($input: UserCreateInput!) {
     customerCreate(input: $input) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       user {
@@ -81,7 +81,7 @@ const removeCustomer = gql`
   ${accountErrorFragment}
   mutation RemoveCustomer($id: ID!) {
     customerDelete(id: $id) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
     }
@@ -101,7 +101,7 @@ const setCustomerDefaultAddress = gql`
     $type: AddressTypeEnum!
   ) {
     addressSetDefault(addressId: $addressId, userId: $userId, type: $type) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       user {
@@ -121,7 +121,7 @@ const createCustomerAddress = gql`
   ${fragmentAddress}
   mutation CreateCustomerAddress($id: ID!, $input: AddressInput!) {
     addressCreate(userId: $id, input: $input) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       address {
@@ -143,7 +143,7 @@ const updateCustomerAddress = gql`
   ${fragmentAddress}
   mutation UpdateCustomerAddress($id: ID!, $input: AddressInput!) {
     addressUpdate(id: $id, input: $input) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       address {
@@ -162,7 +162,7 @@ const removeCustomerAddress = gql`
   ${customerAddressesFragment}
   mutation RemoveCustomerAddress($id: ID!) {
     addressDelete(id: $id) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       user {
@@ -180,7 +180,7 @@ export const bulkRemoveCustomers = gql`
   ${accountErrorFragment}
   mutation BulkRemoveCustomers($ids: [ID]!) {
     customerBulkDelete(ids: $ids) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
     }

--- a/src/discounts/mutations.ts
+++ b/src/discounts/mutations.ts
@@ -53,7 +53,7 @@ const saleUpdate = gql`
   ${saleFragment}
   mutation SaleUpdate($input: SaleInput!, $id: ID!) {
     saleUpdate(id: $id, input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       sale {
@@ -78,7 +78,7 @@ const saleCataloguesAdd = gql`
     $last: Int
   ) {
     saleCataloguesAdd(id: $id, input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       sale {
@@ -104,7 +104,7 @@ const saleCataloguesRemove = gql`
     $last: Int
   ) {
     saleCataloguesRemove(id: $id, input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       sale {
@@ -123,7 +123,7 @@ const saleCreate = gql`
   ${saleFragment}
   mutation SaleCreate($input: SaleInput!) {
     saleCreate(input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       sale {
@@ -140,7 +140,7 @@ const saleDelete = gql`
   ${discountErrorFragment}
   mutation SaleDelete($id: ID!) {
     saleDelete(id: $id) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
     }
@@ -173,7 +173,7 @@ const saleChannelListingUpdate = gql`
     $input: SaleChannelListingInput!
   ) {
     saleChannelListingUpdate(id: $id, input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       sale {
@@ -195,7 +195,7 @@ const voucherChannelListingUpdate = gql`
     $input: VoucherChannelListingInput!
   ) {
     voucherChannelListingUpdate(id: $id, input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       voucher {
@@ -214,7 +214,7 @@ const voucherUpdate = gql`
   ${voucherFragment}
   mutation VoucherUpdate($input: VoucherInput!, $id: ID!) {
     voucherUpdate(id: $id, input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       voucher {
@@ -240,7 +240,7 @@ const voucherCataloguesAdd = gql`
     $last: Int
   ) {
     voucherCataloguesAdd(id: $id, input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       voucher {
@@ -266,7 +266,7 @@ const voucherCataloguesRemove = gql`
     $last: Int
   ) {
     voucherCataloguesRemove(id: $id, input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       voucher {
@@ -285,7 +285,7 @@ const voucherCreate = gql`
   ${voucherFragment}
   mutation VoucherCreate($input: VoucherInput!) {
     voucherCreate(input: $input) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
       voucher {
@@ -303,7 +303,7 @@ const voucherDelete = gql`
   ${discountErrorFragment}
   mutation VoucherDelete($id: ID!) {
     voucherDelete(id: $id) {
-      errors: discountErrors {
+      errors {
         ...DiscountErrorFragment
       }
     }

--- a/src/discounts/types/SaleBulkDelete.ts
+++ b/src/discounts/types/SaleBulkDelete.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface SaleBulkDelete_saleBulkDelete_errors {
-  __typename: "Error";
+  __typename: "DiscountError";
   field: string | null;
   message: string | null;
 }

--- a/src/discounts/types/VoucherBulkDelete.ts
+++ b/src/discounts/types/VoucherBulkDelete.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface VoucherBulkDelete_voucherBulkDelete_errors {
-  __typename: "Error";
+  __typename: "DiscountError";
   field: string | null;
   message: string | null;
 }

--- a/src/files/mutations.ts
+++ b/src/files/mutations.ts
@@ -13,7 +13,7 @@ const fileUploadMutation = gql`
       uploadedFile {
         ...FileFragment
       }
-      uploadErrors {
+      errors {
         ...UploadErrorFragment
       }
     }

--- a/src/files/types/FileUpload.ts
+++ b/src/files/types/FileUpload.ts
@@ -15,7 +15,7 @@ export interface FileUpload_fileUpload_uploadedFile {
   contentType: string | null;
 }
 
-export interface FileUpload_fileUpload_uploadErrors {
+export interface FileUpload_fileUpload_errors {
   __typename: "UploadError";
   code: UploadErrorCode;
   field: string | null;
@@ -24,7 +24,7 @@ export interface FileUpload_fileUpload_uploadErrors {
 export interface FileUpload_fileUpload {
   __typename: "FileUpload";
   uploadedFile: FileUpload_fileUpload_uploadedFile | null;
-  uploadErrors: FileUpload_fileUpload_uploadErrors[];
+  errors: FileUpload_fileUpload_errors[];
 }
 
 export interface FileUpload {

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -261,9 +261,6 @@ export const fragmentOrderDetails = gql`
         ...Money
       }
     }
-    discount {
-      ...Money
-    }
     invoices {
       ...InvoiceFragment
     }

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -450,12 +450,6 @@ export interface OrderDetailsFragment_availableShippingMethods {
   price: OrderDetailsFragment_availableShippingMethods_price | null;
 }
 
-export interface OrderDetailsFragment_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderDetailsFragment_invoices {
   __typename: "Invoice";
   id: string;
@@ -504,7 +498,6 @@ export interface OrderDetailsFragment {
   user: OrderDetailsFragment_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderDetailsFragment_availableShippingMethods | null)[] | null;
-  discount: OrderDetailsFragment_discount | null;
   invoices: (OrderDetailsFragment_invoices | null)[] | null;
   channel: OrderDetailsFragment_channel;
   isPaid: boolean;

--- a/src/home/queries.ts
+++ b/src/home/queries.ts
@@ -6,6 +6,7 @@ import { Home, HomeVariables } from "./types/Home";
 const home = gql`
   query Home(
     $channel: String!
+    $datePeriod: DateRangeInput!
     $PERMISSION_MANAGE_PRODUCTS: Boolean!
     $PERMISSION_MANAGE_ORDERS: Boolean!
   ) {
@@ -16,21 +17,24 @@ const home = gql`
         currency
       }
     }
-    ordersToday: orders(created: TODAY, channel: $channel)
+    ordersToday: orders(filter: { created: $datePeriod }, channel: $channel)
       @include(if: $PERMISSION_MANAGE_ORDERS) {
       totalCount
     }
-    ordersToFulfill: orders(status: READY_TO_FULFILL, channel: $channel)
-      @include(if: $PERMISSION_MANAGE_ORDERS) {
+    ordersToFulfill: orders(
+      filter: { status: READY_TO_FULFILL }
+      channel: $channel
+    ) @include(if: $PERMISSION_MANAGE_ORDERS) {
       totalCount
     }
-    ordersToCapture: orders(status: READY_TO_CAPTURE, channel: $channel)
-      @include(if: $PERMISSION_MANAGE_ORDERS) {
+    ordersToCapture: orders(
+      filter: { status: READY_TO_CAPTURE }
+      channel: $channel
+    ) @include(if: $PERMISSION_MANAGE_ORDERS) {
       totalCount
     }
     productsOutOfStock: products(
-      stockAvailability: OUT_OF_STOCK
-      channel: $channel
+      filter: { stockAvailability: OUT_OF_STOCK, channel: $channel }
     ) {
       totalCount
     }

--- a/src/home/types/Home.ts
+++ b/src/home/types/Home.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderEventsEmailsEnum, OrderEventsEnum } from "./../../types/globalTypes";
+import { DateRangeInput, OrderEventsEmailsEnum, OrderEventsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: Home
@@ -137,6 +137,7 @@ export interface Home {
 
 export interface HomeVariables {
   channel: string;
+  datePeriod: DateRangeInput;
   PERMISSION_MANAGE_PRODUCTS: boolean;
   PERMISSION_MANAGE_ORDERS: boolean;
 }

--- a/src/home/views/index.tsx
+++ b/src/home/views/index.tsx
@@ -4,7 +4,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import useUser from "@saleor/hooks/useUser";
 import React from "react";
 
-import { getUserName } from "../../misc";
+import { getDatePeriod, getUserName } from "../../misc";
 import { orderListUrl } from "../../orders/urls";
 import { productListUrl, productVariantEditUrl } from "../../products/urls";
 import { OrderStatusFilter, StockAvailability } from "../../types/globalTypes";
@@ -21,7 +21,7 @@ const HomeSection = () => {
   const { data } = useHomePage({
     displayLoader: true,
     skip: noChannel,
-    variables: { channel: channel?.slug }
+    variables: { channel: channel?.slug, datePeriod: getDatePeriod(1) }
   });
 
   return (

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -15,6 +15,7 @@ import {
 import {
   AddressInput,
   CountryCode,
+  DateRangeInput,
   OrderStatus,
   PaymentChargeStatusEnum
 } from "./types/globalTypes";
@@ -421,3 +422,18 @@ export function transformFormToAddress<T>(
 export function getStringOrPlaceholder(s: string | undefined): string {
   return s || "...";
 }
+
+export const getDatePeriod = (days: number): DateRangeInput => {
+  if (days < 1) {
+    return {};
+  }
+
+  const end = moment().startOf("day");
+  const start = end.subtract(days - 1);
+  const format = "YYYY-MM-DD";
+
+  return {
+    gte: start.format(format),
+    lte: end.format(format)
+  };
+};

--- a/src/navigation/mutations.ts
+++ b/src/navigation/mutations.ts
@@ -26,7 +26,7 @@ const menuCreate = gql`
   ${menuErrorFragment}
   mutation MenuCreate($input: MenuCreateInput!) {
     menuCreate(input: $input) {
-      errors: menuErrors {
+      errors {
         ...MenuErrorFragment
       }
       menu {
@@ -44,7 +44,7 @@ const menuBulkDelete = gql`
   ${menuErrorFragment}
   mutation MenuBulkDelete($ids: [ID]!) {
     menuBulkDelete(ids: $ids) {
-      errors: menuErrors {
+      errors {
         ...MenuErrorFragment
       }
     }
@@ -59,7 +59,7 @@ const menuDelete = gql`
   ${menuErrorFragment}
   mutation MenuDelete($id: ID!) {
     menuDelete(id: $id) {
-      errors: menuErrors {
+      errors {
         ...MenuErrorFragment
       }
     }
@@ -75,7 +75,7 @@ const menuItemCreate = gql`
   ${menuItemNestedFragment}
   mutation MenuItemCreate($input: MenuItemCreateInput!) {
     menuItemCreate(input: $input) {
-      errors: menuErrors {
+      errors {
         ...MenuErrorFragment
       }
       menuItem {
@@ -103,19 +103,19 @@ const menuUpdate = gql`
     $removeIds: [ID]!
   ) {
     menuUpdate(id: $id, input: { name: $name }) {
-      errors: menuErrors {
+      errors {
         ...MenuErrorFragment
       }
     }
 
     menuItemMove(menu: $id, moves: $moves) {
-      errors: menuErrors {
+      errors {
         ...MenuErrorFragment
       }
     }
 
     menuItemBulkDelete(ids: $removeIds) {
-      errors: menuErrors {
+      errors {
         ...MenuErrorFragment
       }
     }
@@ -131,7 +131,7 @@ const menuItemUpdate = gql`
   ${menuItemFragment}
   mutation MenuItemUpdate($id: ID!, $input: MenuItemInput!) {
     menuItemUpdate(id: $id, input: $input) {
-      errors: menuErrors {
+      errors {
         ...MenuErrorFragment
       }
       menuItem {

--- a/src/orders/components/OrderPayment/OrderPayment.tsx
+++ b/src/orders/components/OrderPayment/OrderPayment.tsx
@@ -12,7 +12,11 @@ import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { maybe, transformPaymentStatus } from "../../../misc";
-import { OrderAction, OrderStatus } from "../../../types/globalTypes";
+import {
+  OrderAction,
+  OrderDiscountType,
+  OrderStatus
+} from "../../../types/globalTypes";
 import { OrderDetails_order } from "../../types/OrderDetails";
 
 const useStyles = makeStyles(
@@ -163,7 +167,7 @@ const OrderPayment: React.FC<OrderPaymentProps> = props => {
                 )}
               </td>
             </tr>
-            {order?.discount?.amount > 0 && (
+            {order?.discounts?.map(discount => (
               <tr>
                 <td>
                   <FormattedMessage
@@ -171,12 +175,24 @@ const OrderPayment: React.FC<OrderPaymentProps> = props => {
                     description="order discount"
                   />
                 </td>
-                <td />
+                <td>
+                  {discount.type === OrderDiscountType.MANUAL ? (
+                    <FormattedMessage
+                      defaultMessage="Staff added"
+                      description="staff added type order discount"
+                    />
+                  ) : (
+                    <FormattedMessage
+                      defaultMessage="Voucher"
+                      description="voucher type order discount"
+                    />
+                  )}
+                </td>
                 <td className={classes.textRight}>
-                  -<Money money={order.discount} />
+                  -<Money money={discount.amount} />
                 </td>
               </tr>
-            )}
+            ))}
             <tr className={classes.totalRow}>
               <td>
                 <FormattedMessage

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -822,7 +822,6 @@ export const order = (placeholder: string): OrderDetails_order => ({
   },
   created: "2018-09-11T09:37:28.185874+00:00",
   customerNote: "Lorem ipsum dolor sit amet",
-  discount: null,
   discounts: [],
   events: [
     {
@@ -1380,9 +1379,7 @@ export const draftOrder = (placeholder: string): OrderDetails_order => ({
   },
   created: "2018-09-20T23:23:39.811428+00:00",
   customerNote: "Lorem ipsum dolor sit",
-  discount: null,
   discounts: [],
-
   events: [],
   fulfillments: [],
   id: "T3JkZXI6MjQ=",

--- a/src/orders/mutations.ts
+++ b/src/orders/mutations.ts
@@ -113,7 +113,7 @@ const orderCancelMutation = gql`
   ${orderErrorFragment}
   mutation OrderCancel($id: ID!) {
     orderCancel(id: $id) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -133,7 +133,7 @@ const orderDiscountAddMutation = gql`
   ${fragmentOrderDetails}
   mutation OrderDiscountAdd($input: OrderDiscountCommonInput!, $orderId: ID!) {
     orderDiscountAdd(input: $input, orderId: $orderId) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -153,7 +153,7 @@ const orderDiscountDeleteMutation = gql`
   ${fragmentOrderDetails}
   mutation OrderDiscountDelete($discountId: ID!) {
     orderDiscountDelete(discountId: $discountId) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -173,7 +173,7 @@ const orderLineDiscountRemoveMutation = gql`
   ${fragmentOrderDetails}
   mutation OrderLineDiscountRemove($orderLineId: ID!) {
     orderLineDiscountRemove(orderLineId: $orderLineId) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -196,7 +196,7 @@ const orderLineDiscountUpdateMutation = gql`
     $orderLineId: ID!
   ) {
     orderLineDiscountUpdate(input: $input, orderLineId: $orderLineId) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -219,7 +219,7 @@ const orderDiscountUpdateMutation = gql`
     $discountId: ID!
   ) {
     orderDiscountUpdate(input: $input, discountId: $discountId) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -241,7 +241,7 @@ const orderDraftCancelMutation = gql`
   ${orderErrorFragment}
   mutation OrderDraftCancel($id: ID!) {
     draftOrderDelete(id: $id) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -259,7 +259,7 @@ const orderDraftBulkCancelMutation = gql`
   ${orderErrorFragment}
   mutation OrderDraftBulkCancel($ids: [ID]!) {
     draftOrderBulkDelete(ids: $ids) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
     }
@@ -271,7 +271,7 @@ export const orderConfirmMutation = gql`
   ${orderErrorFragment}
   mutation OrderConfirm($id: ID!) {
     orderConfirm(id: $id) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -296,7 +296,7 @@ const orderDraftFinalizeMutation = gql`
   ${orderErrorFragment}
   mutation OrderDraftFinalize($id: ID!) {
     draftOrderComplete(id: $id) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -313,7 +313,7 @@ const orderReturnCreateMutation = gql`
     $input: OrderReturnProductsInput!
   ) {
     orderFulfillmentReturnProducts(input: $input, order: $id) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -341,7 +341,7 @@ const orderRefundMutation = gql`
   ${orderErrorFragment}
   mutation OrderRefund($id: ID!, $amount: PositiveDecimal!) {
     orderRefund(id: $id, amount: $amount) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -365,7 +365,7 @@ const orderFulfillmentRefundProductsMutation = gql`
     $order: ID!
   ) {
     orderFulfillmentRefundProducts(input: $input, order: $order) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       fulfillment {
@@ -387,7 +387,7 @@ const orderVoidMutation = gql`
   ${orderErrorFragment}
   mutation OrderVoid($id: ID!) {
     orderVoid(id: $id) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -406,7 +406,7 @@ const orderMarkAsPaidMutation = gql`
   ${orderErrorFragment}
   mutation OrderMarkAsPaid($id: ID!, $transactionReference: String) {
     orderMarkAsPaid(id: $id, transactionReference: $transactionReference) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -425,7 +425,7 @@ const orderCaptureMutation = gql`
   ${orderErrorFragment}
   mutation OrderCapture($id: ID!, $amount: PositiveDecimal!) {
     orderCapture(id: $id, amount: $amount) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -447,7 +447,7 @@ const orderFulfillmentUpdateTrackingMutation = gql`
     $input: FulfillmentUpdateTrackingInput!
   ) {
     orderFulfillmentUpdateTracking(id: $id, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -466,7 +466,7 @@ const orderFulfillmentCancelMutation = gql`
   ${orderErrorFragment}
   mutation OrderFulfillmentCancel($id: ID!, $input: FulfillmentCancelInput!) {
     orderFulfillmentCancel(id: $id, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -485,7 +485,7 @@ const orderAddNoteMutation = gql`
   ${orderErrorFragment}
   mutation OrderAddNote($order: ID!, $input: OrderAddNoteInput!) {
     orderAddNote(order: $order, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -507,7 +507,7 @@ const orderUpdateMutation = gql`
   ${orderErrorFragment}
   mutation OrderUpdate($id: ID!, $input: OrderUpdateInput!) {
     orderUpdate(id: $id, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -526,7 +526,7 @@ const orderDraftUpdateMutation = gql`
   ${orderErrorFragment}
   mutation OrderDraftUpdate($id: ID!, $input: DraftOrderInput!) {
     draftOrderUpdate(id: $id, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -548,7 +548,7 @@ const orderShippingMethodUpdateMutation = gql`
     $input: OrderUpdateShippingInput!
   ) {
     orderUpdateShipping(order: $id, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -596,7 +596,7 @@ const orderDraftCreateMutation = gql`
   ${orderErrorFragment}
   mutation OrderDraftCreate($input: DraftOrderCreateInput!) {
     draftOrderCreate(input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -615,7 +615,7 @@ const orderLineDeleteMutation = gql`
   ${orderErrorFragment}
   mutation OrderLineDelete($id: ID!) {
     orderLineDelete(id: $id) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -634,7 +634,7 @@ const orderLinesAddMutation = gql`
   ${orderErrorFragment}
   mutation OrderLinesAdd($id: ID!, $input: [OrderLineCreateInput]!) {
     orderLinesCreate(id: $id, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -653,7 +653,7 @@ const orderLineUpdateMutation = gql`
   ${orderErrorFragment}
   mutation OrderLineUpdate($id: ID!, $input: OrderLineInput!) {
     orderLineUpdate(id: $id, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
       }
       order {
@@ -672,7 +672,7 @@ const fulfillOrder = gql`
   ${orderErrorFragment}
   mutation FulfillOrder($orderId: ID!, $input: OrderFulfillInput!) {
     orderFulfill(order: $orderId, input: $input) {
-      errors: orderErrors {
+      errors {
         ...OrderErrorFragment
         warehouse
         orderLine
@@ -693,7 +693,7 @@ const invoiceRequestMutation = gql`
   ${invoiceFragment}
   mutation InvoiceRequest($orderId: ID!) {
     invoiceRequest(orderId: $orderId) {
-      errors: invoiceErrors {
+      errors {
         ...InvoiceErrorFragment
       }
       invoice {
@@ -718,7 +718,7 @@ const invoiceEmailSendMutation = gql`
   ${invoiceFragment}
   mutation InvoiceEmailSend($id: ID!) {
     invoiceSendNotification(id: $id) {
-      errors: invoiceErrors {
+      errors {
         ...InvoiceErrorFragment
       }
       invoice {
@@ -737,7 +737,7 @@ const orderSettingsUpdateMutation = gql`
   ${orderSettingsErrorFragment}
   mutation OrderSettingsUpdate($input: OrderSettingsUpdateInput!) {
     orderSettingsUpdate(input: $input) {
-      errors: orderSettingsErrors {
+      errors {
         ...OrderSettingsErrorFragment
       }
       orderSettings {

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -458,12 +458,6 @@ export interface FulfillOrder_orderFulfill_order_availableShippingMethods {
   price: FulfillOrder_orderFulfill_order_availableShippingMethods_price | null;
 }
 
-export interface FulfillOrder_orderFulfill_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface FulfillOrder_orderFulfill_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -512,7 +506,6 @@ export interface FulfillOrder_orderFulfill_order {
   user: FulfillOrder_orderFulfill_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (FulfillOrder_orderFulfill_order_availableShippingMethods | null)[] | null;
-  discount: FulfillOrder_orderFulfill_order_discount | null;
   invoices: (FulfillOrder_orderFulfill_order_invoices | null)[] | null;
   channel: FulfillOrder_orderFulfill_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -456,12 +456,6 @@ export interface OrderCancel_orderCancel_order_availableShippingMethods {
   price: OrderCancel_orderCancel_order_availableShippingMethods_price | null;
 }
 
-export interface OrderCancel_orderCancel_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderCancel_orderCancel_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderCancel_orderCancel_order {
   user: OrderCancel_orderCancel_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderCancel_orderCancel_order_availableShippingMethods | null)[] | null;
-  discount: OrderCancel_orderCancel_order_discount | null;
   invoices: (OrderCancel_orderCancel_order_invoices | null)[] | null;
   channel: OrderCancel_orderCancel_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -456,12 +456,6 @@ export interface OrderCapture_orderCapture_order_availableShippingMethods {
   price: OrderCapture_orderCapture_order_availableShippingMethods_price | null;
 }
 
-export interface OrderCapture_orderCapture_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderCapture_orderCapture_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderCapture_orderCapture_order {
   user: OrderCapture_orderCapture_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderCapture_orderCapture_order_availableShippingMethods | null)[] | null;
-  discount: OrderCapture_orderCapture_order_discount | null;
   invoices: (OrderCapture_orderCapture_order_invoices | null)[] | null;
   channel: OrderCapture_orderCapture_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -456,12 +456,6 @@ export interface OrderConfirm_orderConfirm_order_availableShippingMethods {
   price: OrderConfirm_orderConfirm_order_availableShippingMethods_price | null;
 }
 
-export interface OrderConfirm_orderConfirm_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderConfirm_orderConfirm_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderConfirm_orderConfirm_order {
   user: OrderConfirm_orderConfirm_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderConfirm_orderConfirm_order_availableShippingMethods | null)[] | null;
-  discount: OrderConfirm_orderConfirm_order_discount | null;
   invoices: (OrderConfirm_orderConfirm_order_invoices | null)[] | null;
   channel: OrderConfirm_orderConfirm_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -450,12 +450,6 @@ export interface OrderDetails_order_availableShippingMethods {
   price: OrderDetails_order_availableShippingMethods_price | null;
 }
 
-export interface OrderDetails_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderDetails_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -504,7 +498,6 @@ export interface OrderDetails_order {
   user: OrderDetails_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderDetails_order_availableShippingMethods | null)[] | null;
-  discount: OrderDetails_order_discount | null;
   invoices: (OrderDetails_order_invoices | null)[] | null;
   channel: OrderDetails_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -456,12 +456,6 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_availableShippingMethod
   price: OrderDiscountAdd_orderDiscountAdd_order_availableShippingMethods_price | null;
 }
 
-export interface OrderDiscountAdd_orderDiscountAdd_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderDiscountAdd_orderDiscountAdd_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderDiscountAdd_orderDiscountAdd_order {
   user: OrderDiscountAdd_orderDiscountAdd_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderDiscountAdd_orderDiscountAdd_order_availableShippingMethods | null)[] | null;
-  discount: OrderDiscountAdd_orderDiscountAdd_order_discount | null;
   invoices: (OrderDiscountAdd_orderDiscountAdd_order_invoices | null)[] | null;
   channel: OrderDiscountAdd_orderDiscountAdd_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -456,12 +456,6 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_availableShipping
   price: OrderDiscountDelete_orderDiscountDelete_order_availableShippingMethods_price | null;
 }
 
-export interface OrderDiscountDelete_orderDiscountDelete_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderDiscountDelete_orderDiscountDelete_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderDiscountDelete_orderDiscountDelete_order {
   user: OrderDiscountDelete_orderDiscountDelete_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderDiscountDelete_orderDiscountDelete_order_availableShippingMethods | null)[] | null;
-  discount: OrderDiscountDelete_orderDiscountDelete_order_discount | null;
   invoices: (OrderDiscountDelete_orderDiscountDelete_order_invoices | null)[] | null;
   channel: OrderDiscountDelete_orderDiscountDelete_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -456,12 +456,6 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_availableShipping
   price: OrderDiscountUpdate_orderDiscountUpdate_order_availableShippingMethods_price | null;
 }
 
-export interface OrderDiscountUpdate_orderDiscountUpdate_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order {
   user: OrderDiscountUpdate_orderDiscountUpdate_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderDiscountUpdate_orderDiscountUpdate_order_availableShippingMethods | null)[] | null;
-  discount: OrderDiscountUpdate_orderDiscountUpdate_order_discount | null;
   invoices: (OrderDiscountUpdate_orderDiscountUpdate_order_invoices | null)[] | null;
   channel: OrderDiscountUpdate_orderDiscountUpdate_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -456,12 +456,6 @@ export interface OrderDraftCancel_draftOrderDelete_order_availableShippingMethod
   price: OrderDraftCancel_draftOrderDelete_order_availableShippingMethods_price | null;
 }
 
-export interface OrderDraftCancel_draftOrderDelete_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderDraftCancel_draftOrderDelete_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderDraftCancel_draftOrderDelete_order {
   user: OrderDraftCancel_draftOrderDelete_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderDraftCancel_draftOrderDelete_order_availableShippingMethods | null)[] | null;
-  discount: OrderDraftCancel_draftOrderDelete_order_discount | null;
   invoices: (OrderDraftCancel_draftOrderDelete_order_invoices | null)[] | null;
   channel: OrderDraftCancel_draftOrderDelete_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -456,12 +456,6 @@ export interface OrderDraftFinalize_draftOrderComplete_order_availableShippingMe
   price: OrderDraftFinalize_draftOrderComplete_order_availableShippingMethods_price | null;
 }
 
-export interface OrderDraftFinalize_draftOrderComplete_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderDraftFinalize_draftOrderComplete_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderDraftFinalize_draftOrderComplete_order {
   user: OrderDraftFinalize_draftOrderComplete_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderDraftFinalize_draftOrderComplete_order_availableShippingMethods | null)[] | null;
-  discount: OrderDraftFinalize_draftOrderComplete_order_discount | null;
   invoices: (OrderDraftFinalize_draftOrderComplete_order_invoices | null)[] | null;
   channel: OrderDraftFinalize_draftOrderComplete_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -456,12 +456,6 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_availableShippingMethod
   price: OrderDraftUpdate_draftOrderUpdate_order_availableShippingMethods_price | null;
 }
 
-export interface OrderDraftUpdate_draftOrderUpdate_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderDraftUpdate_draftOrderUpdate_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderDraftUpdate_draftOrderUpdate_order {
   user: OrderDraftUpdate_draftOrderUpdate_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderDraftUpdate_draftOrderUpdate_order_availableShippingMethods | null)[] | null;
-  discount: OrderDraftUpdate_draftOrderUpdate_order_discount | null;
   invoices: (OrderDraftUpdate_draftOrderUpdate_order_invoices | null)[] | null;
   channel: OrderDraftUpdate_draftOrderUpdate_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -456,12 +456,6 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_availableSh
   price: OrderFulfillmentCancel_orderFulfillmentCancel_order_availableShippingMethods_price | null;
 }
 
-export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order {
   user: OrderFulfillmentCancel_orderFulfillmentCancel_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderFulfillmentCancel_orderFulfillmentCancel_order_availableShippingMethods | null)[] | null;
-  discount: OrderFulfillmentCancel_orderFulfillmentCancel_order_discount | null;
   invoices: (OrderFulfillmentCancel_orderFulfillmentCancel_order_invoices | null)[] | null;
   channel: OrderFulfillmentCancel_orderFulfillmentCancel_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -551,12 +551,6 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   price: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_availableShippingMethods_price | null;
 }
 
-export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -605,7 +599,6 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   user: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_availableShippingMethods | null)[] | null;
-  discount: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_discount | null;
   invoices: (OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_invoices | null)[] | null;
   channel: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -456,12 +456,6 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   price: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_availableShippingMethods_price | null;
 }
 
-export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   user: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_availableShippingMethods | null)[] | null;
-  discount: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_discount | null;
   invoices: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_invoices | null)[] | null;
   channel: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -456,12 +456,6 @@ export interface OrderLineDelete_orderLineDelete_order_availableShippingMethods 
   price: OrderLineDelete_orderLineDelete_order_availableShippingMethods_price | null;
 }
 
-export interface OrderLineDelete_orderLineDelete_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderLineDelete_orderLineDelete_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderLineDelete_orderLineDelete_order {
   user: OrderLineDelete_orderLineDelete_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderLineDelete_orderLineDelete_order_availableShippingMethods | null)[] | null;
-  discount: OrderLineDelete_orderLineDelete_order_discount | null;
   invoices: (OrderLineDelete_orderLineDelete_order_invoices | null)[] | null;
   channel: OrderLineDelete_orderLineDelete_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -456,12 +456,6 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_available
   price: OrderLineDiscountRemove_orderLineDiscountRemove_order_availableShippingMethods_price | null;
 }
 
-export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order {
   user: OrderLineDiscountRemove_orderLineDiscountRemove_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderLineDiscountRemove_orderLineDiscountRemove_order_availableShippingMethods | null)[] | null;
-  discount: OrderLineDiscountRemove_orderLineDiscountRemove_order_discount | null;
   invoices: (OrderLineDiscountRemove_orderLineDiscountRemove_order_invoices | null)[] | null;
   channel: OrderLineDiscountRemove_orderLineDiscountRemove_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -456,12 +456,6 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_available
   price: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_availableShippingMethods_price | null;
 }
 
-export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order {
   user: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderLineDiscountUpdate_orderLineDiscountUpdate_order_availableShippingMethods | null)[] | null;
-  discount: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_discount | null;
   invoices: (OrderLineDiscountUpdate_orderLineDiscountUpdate_order_invoices | null)[] | null;
   channel: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -456,12 +456,6 @@ export interface OrderLineUpdate_orderLineUpdate_order_availableShippingMethods 
   price: OrderLineUpdate_orderLineUpdate_order_availableShippingMethods_price | null;
 }
 
-export interface OrderLineUpdate_orderLineUpdate_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderLineUpdate_orderLineUpdate_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderLineUpdate_orderLineUpdate_order {
   user: OrderLineUpdate_orderLineUpdate_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderLineUpdate_orderLineUpdate_order_availableShippingMethods | null)[] | null;
-  discount: OrderLineUpdate_orderLineUpdate_order_discount | null;
   invoices: (OrderLineUpdate_orderLineUpdate_order_invoices | null)[] | null;
   channel: OrderLineUpdate_orderLineUpdate_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -456,12 +456,6 @@ export interface OrderLinesAdd_orderLinesCreate_order_availableShippingMethods {
   price: OrderLinesAdd_orderLinesCreate_order_availableShippingMethods_price | null;
 }
 
-export interface OrderLinesAdd_orderLinesCreate_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderLinesAdd_orderLinesCreate_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderLinesAdd_orderLinesCreate_order {
   user: OrderLinesAdd_orderLinesCreate_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderLinesAdd_orderLinesCreate_order_availableShippingMethods | null)[] | null;
-  discount: OrderLinesAdd_orderLinesCreate_order_discount | null;
   invoices: (OrderLinesAdd_orderLinesCreate_order_invoices | null)[] | null;
   channel: OrderLinesAdd_orderLinesCreate_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -456,12 +456,6 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_availableShippingMethods 
   price: OrderMarkAsPaid_orderMarkAsPaid_order_availableShippingMethods_price | null;
 }
 
-export interface OrderMarkAsPaid_orderMarkAsPaid_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order {
   user: OrderMarkAsPaid_orderMarkAsPaid_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderMarkAsPaid_orderMarkAsPaid_order_availableShippingMethods | null)[] | null;
-  discount: OrderMarkAsPaid_orderMarkAsPaid_order_discount | null;
   invoices: (OrderMarkAsPaid_orderMarkAsPaid_order_invoices | null)[] | null;
   channel: OrderMarkAsPaid_orderMarkAsPaid_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -456,12 +456,6 @@ export interface OrderRefund_orderRefund_order_availableShippingMethods {
   price: OrderRefund_orderRefund_order_availableShippingMethods_price | null;
 }
 
-export interface OrderRefund_orderRefund_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderRefund_orderRefund_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderRefund_orderRefund_order {
   user: OrderRefund_orderRefund_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderRefund_orderRefund_order_availableShippingMethods | null)[] | null;
-  discount: OrderRefund_orderRefund_order_discount | null;
   invoices: (OrderRefund_orderRefund_order_invoices | null)[] | null;
   channel: OrderRefund_orderRefund_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -464,12 +464,6 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_user {
   email: string;
 }
 
-export interface OrderShippingMethodUpdate_orderUpdateShipping_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -518,7 +512,6 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order {
   undiscountedTotal: OrderShippingMethodUpdate_orderUpdateShipping_order_undiscountedTotal;
   user: OrderShippingMethodUpdate_orderUpdateShipping_order_user | null;
   userEmail: string | null;
-  discount: OrderShippingMethodUpdate_orderUpdateShipping_order_discount | null;
   invoices: (OrderShippingMethodUpdate_orderUpdateShipping_order_invoices | null)[] | null;
   channel: OrderShippingMethodUpdate_orderUpdateShipping_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -456,12 +456,6 @@ export interface OrderUpdate_orderUpdate_order_availableShippingMethods {
   price: OrderUpdate_orderUpdate_order_availableShippingMethods_price | null;
 }
 
-export interface OrderUpdate_orderUpdate_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderUpdate_orderUpdate_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderUpdate_orderUpdate_order {
   user: OrderUpdate_orderUpdate_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderUpdate_orderUpdate_order_availableShippingMethods | null)[] | null;
-  discount: OrderUpdate_orderUpdate_order_discount | null;
   invoices: (OrderUpdate_orderUpdate_order_invoices | null)[] | null;
   channel: OrderUpdate_orderUpdate_order_channel;
   isPaid: boolean;

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -456,12 +456,6 @@ export interface OrderVoid_orderVoid_order_availableShippingMethods {
   price: OrderVoid_orderVoid_order_availableShippingMethods_price | null;
 }
 
-export interface OrderVoid_orderVoid_order_discount {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
 export interface OrderVoid_orderVoid_order_invoices {
   __typename: "Invoice";
   id: string;
@@ -510,7 +504,6 @@ export interface OrderVoid_orderVoid_order {
   user: OrderVoid_orderVoid_order_user | null;
   userEmail: string | null;
   availableShippingMethods: (OrderVoid_orderVoid_order_availableShippingMethods | null)[] | null;
-  discount: OrderVoid_orderVoid_order_discount | null;
   invoices: (OrderVoid_orderVoid_order_invoices | null)[] | null;
   channel: OrderVoid_orderVoid_order_channel;
   isPaid: boolean;

--- a/src/pageTypes/mutations.ts
+++ b/src/pageTypes/mutations.ts
@@ -37,7 +37,7 @@ export const pageTypeUpdateMutation = gql`
   ${pageErrorFragment}
   mutation PageTypeUpdate($id: ID!, $input: PageTypeUpdateInput!) {
     pageTypeUpdate(id: $id, input: $input) {
-      errors: pageErrors {
+      errors {
         ...PageErrorFragment
       }
       pageType {
@@ -56,7 +56,7 @@ export const pageTypeCreateMutation = gql`
   ${pageErrorFragment}
   mutation PageTypeCreate($input: PageTypeCreateInput!) {
     pageTypeCreate(input: $input) {
-      errors: pageErrors {
+      errors {
         ...PageErrorFragment
       }
       pageType {
@@ -75,7 +75,7 @@ export const assignPageAttributeMutation = gql`
   ${pageErrorFragment}
   mutation AssignPageAttribute($id: ID!, $ids: [ID!]!) {
     pageAttributeAssign(pageTypeId: $id, attributeIds: $ids) {
-      errors: pageErrors {
+      errors {
         ...PageErrorFragment
       }
       pageType {
@@ -94,7 +94,7 @@ export const unassignPageAttributeMutation = gql`
   ${pageErrorFragment}
   mutation UnassignPageAttribute($id: ID!, $ids: [ID!]!) {
     pageAttributeUnassign(pageTypeId: $id, attributeIds: $ids) {
-      errors: pageErrors {
+      errors {
         ...PageErrorFragment
       }
       pageType {
@@ -111,7 +111,7 @@ export const useUnassignPageAttributeMutation = makeMutation<
 export const pageTypeDeleteMutation = gql`
   mutation PageTypeDelete($id: ID!) {
     pageTypeDelete(id: $id) {
-      errors: pageErrors {
+      errors {
         field
         message
       }
@@ -129,7 +129,7 @@ export const usePageTypeDeleteMutation = makeMutation<
 export const pageTypeBulkDeleteMutation = gql`
   mutation PageTypeBulkDelete($ids: [ID!]!) {
     pageTypeBulkDelete(ids: $ids) {
-      errors: pageErrors {
+      errors {
         field
         message
       }
@@ -146,7 +146,7 @@ export const pageTypeAttributeReorder = gql`
   ${pageErrorFragment}
   mutation PageTypeAttributeReorder($move: ReorderInput!, $pageTypeId: ID!) {
     pageTypeReorderAttributes(moves: [$move], pageTypeId: $pageTypeId) {
-      errors: pageErrors {
+      errors {
         ...PageErrorFragment
       }
       pageType {

--- a/src/pages/mutations.ts
+++ b/src/pages/mutations.ts
@@ -24,7 +24,7 @@ const pageCreate = gql`
   ${pageErrorWithAttributesFragment}
   mutation PageCreate($input: PageCreateInput!) {
     pageCreate(input: $input) {
-      errors: pageErrors {
+      errors {
         ...PageErrorWithAttributesFragment
         message
       }
@@ -43,7 +43,7 @@ const pageUpdate = gql`
   ${pageErrorWithAttributesFragment}
   mutation PageUpdate($id: ID!, $input: PageInput!) {
     pageUpdate(id: $id, input: $input) {
-      errors: pageErrors {
+      errors {
         ...PageErrorWithAttributesFragment
       }
       page {
@@ -61,7 +61,7 @@ const pageRemove = gql`
   ${pageErrorFragment}
   mutation PageRemove($id: ID!) {
     pageDelete(id: $id) {
-      errors: pageErrors {
+      errors {
         ...PageErrorFragment
       }
     }

--- a/src/pages/types/PageBulkPublish.ts
+++ b/src/pages/types/PageBulkPublish.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface PageBulkPublish_pageBulkPublish_errors {
-  __typename: "Error";
+  __typename: "PageError";
   field: string | null;
   message: string | null;
 }

--- a/src/pages/types/PageBulkRemove.ts
+++ b/src/pages/types/PageBulkRemove.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface PageBulkRemove_pageBulkDelete_errors {
-  __typename: "Error";
+  __typename: "PageError";
   field: string | null;
   message: string | null;
 }

--- a/src/permissionGroups/mutations.ts
+++ b/src/permissionGroups/mutations.ts
@@ -20,7 +20,7 @@ export const permissionGroupDelete = gql`
   ${permissionGroupErrorFragment}
   mutation PermissionGroupDelete($id: ID!) {
     permissionGroupDelete(id: $id) {
-      errors: permissionGroupErrors {
+      errors {
         ...PermissionGroupErrorFragment
       }
     }
@@ -37,7 +37,7 @@ export const permissionGroupCreate = gql`
 
   mutation PermissionGroupCreate($input: PermissionGroupCreateInput!) {
     permissionGroupCreate(input: $input) {
-      errors: permissionGroupErrors {
+      errors {
         ...PermissionGroupErrorFragment
       }
       group {
@@ -61,7 +61,7 @@ export const permissionGroupUpdate = gql`
     $input: PermissionGroupUpdateInput!
   ) {
     permissionGroupUpdate(id: $id, input: $input) {
-      errors: permissionGroupErrors {
+      errors {
         ...PermissionGroupErrorFragment
       }
       group {

--- a/src/plugins/mutations.ts
+++ b/src/plugins/mutations.ts
@@ -10,7 +10,7 @@ const pluginUpdate = gql`
   ${pluginErrorFragment}
   mutation PluginUpdate($id: ID!, $input: PluginUpdateInput!) {
     pluginUpdate(id: $id, input: $input) {
-      errors: pluginsErrors {
+      errors {
         ...PluginErrorFragment
       }
       plugin {

--- a/src/productTypes/mutations.ts
+++ b/src/productTypes/mutations.ts
@@ -91,7 +91,7 @@ export const assignProductAttributeMutation = gql`
     $operations: [ProductAttributeAssignInput!]!
   ) {
     productAttributeAssign(productTypeId: $id, operations: $operations) {
-      errors: productErrors {
+      errors {
         field
         message
       }
@@ -110,7 +110,7 @@ export const unassignProductAttributeMutation = gql`
   ${productTypeDetailsFragment}
   mutation UnassignProductAttribute($id: ID!, $ids: [ID]!) {
     productAttributeUnassign(productTypeId: $id, attributeIds: $ids) {
-      errors: productErrors {
+      errors {
         field
         message
       }

--- a/src/productTypes/types/ProductTypeAttributeReorder.ts
+++ b/src/productTypes/types/ProductTypeAttributeReorder.ts
@@ -10,7 +10,7 @@ import { ReorderInput, ProductAttributeType, AttributeTypeEnum, WeightUnitsEnum 
 // ====================================================
 
 export interface ProductTypeAttributeReorder_productTypeReorderAttributes_errors {
-  __typename: "Error";
+  __typename: "ProductError";
   field: string | null;
   message: string | null;
 }

--- a/src/productTypes/types/ProductTypeBulkDelete.ts
+++ b/src/productTypes/types/ProductTypeBulkDelete.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface ProductTypeBulkDelete_productTypeBulkDelete_errors {
-  __typename: "Error";
+  __typename: "ProductError";
   field: string | null;
   message: string | null;
 }

--- a/src/productTypes/types/ProductTypeCreate.ts
+++ b/src/productTypes/types/ProductTypeCreate.ts
@@ -10,7 +10,7 @@ import { ProductTypeInput, AttributeTypeEnum, WeightUnitsEnum } from "./../../ty
 // ====================================================
 
 export interface ProductTypeCreate_productTypeCreate_errors {
-  __typename: "Error";
+  __typename: "ProductError";
   field: string | null;
   message: string | null;
 }

--- a/src/productTypes/types/ProductTypeDelete.ts
+++ b/src/productTypes/types/ProductTypeDelete.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface ProductTypeDelete_productTypeDelete_errors {
-  __typename: "Error";
+  __typename: "ProductError";
   field: string | null;
   message: string | null;
 }

--- a/src/productTypes/types/ProductTypeUpdate.ts
+++ b/src/productTypes/types/ProductTypeUpdate.ts
@@ -10,7 +10,7 @@ import { ProductTypeInput, AttributeTypeEnum, WeightUnitsEnum } from "./../../ty
 // ====================================================
 
 export interface ProductTypeUpdate_productTypeUpdate_errors {
-  __typename: "Error";
+  __typename: "ProductError";
   field: string | null;
   message: string | null;
 }

--- a/src/products/components/ProductList/ProductList.tsx
+++ b/src/products/components/ProductList/ProductList.tsx
@@ -313,11 +313,10 @@ export const ProductList: React.FC<ProductListProps> = props => {
                   <TableCellAvatar
                     className={classes.colName}
                     thumbnail={maybe(() => product.thumbnail.url)}
-                    data-test="name"
                   >
                     {product?.productType ? (
                       <div className={classes.colNameWrapper}>
-                        <span>{product.name}</span>
+                        <span data-test="name">{product.name}</span>
                         {product?.productType && (
                           <Typography variant="caption">
                             {product.productType.hasVariants ? (

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -96,7 +96,7 @@ export const productMediaCreateMutation = gql`
         mediaUrl: $mediaUrl
       }
     ) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       product {
@@ -114,7 +114,7 @@ export const productDeleteMutation = gql`
   ${productErrorFragment}
   mutation ProductDelete($id: ID!) {
     productDelete(id: $id) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       product {
@@ -132,7 +132,7 @@ export const productMediaReorder = gql`
   ${productErrorFragment}
   mutation ProductMediaReorder($productId: ID!, $mediaIds: [ID]!) {
     productMediaReorder(productId: $productId, mediaIds: $mediaIds) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       product {
@@ -157,7 +157,7 @@ const productVariantSetDefault = gql`
   ${productFragmentDetails}
   mutation ProductVariantSetDefault($productId: ID!, $variantId: ID!) {
     productVariantSetDefault(productId: $productId, variantId: $variantId) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       product {
@@ -177,7 +177,7 @@ export const productUpdateMutation = gql`
   ${productFragmentDetails}
   mutation ProductUpdate($id: ID!, $input: ProductInput!) {
     productUpdate(id: $id, input: $input) {
-      errors: productErrors {
+      errors {
         ...ProductErrorWithAttributesFragment
       }
       product {
@@ -207,7 +207,7 @@ export const simpleProductUpdateMutation = gql`
     $updateStocks: [StockInput!]!
   ) {
     productUpdate(id: $id, input: $input) {
-      errors: productErrors {
+      errors {
         ...ProductErrorWithAttributesFragment
       }
       product {
@@ -215,7 +215,7 @@ export const simpleProductUpdateMutation = gql`
       }
     }
     productVariantUpdate(id: $productVariantId, input: $productVariantInput) {
-      errors: productErrors {
+      errors {
         ...ProductErrorWithAttributesFragment
       }
       productVariant {
@@ -226,7 +226,7 @@ export const simpleProductUpdateMutation = gql`
       stocks: $addStocks
       variantId: $productVariantId
     ) {
-      errors: bulkStockErrors {
+      errors {
         ...BulkStockErrorFragment
       }
       productVariant {
@@ -237,7 +237,7 @@ export const simpleProductUpdateMutation = gql`
       warehouseIds: $deleteStocks
       variantId: $productVariantId
     ) {
-      errors: stockErrors {
+      errors {
         ...StockErrorFragment
       }
       productVariant {
@@ -248,7 +248,7 @@ export const simpleProductUpdateMutation = gql`
       stocks: $updateStocks
       variantId: $productVariantId
     ) {
-      errors: bulkStockErrors {
+      errors {
         ...BulkStockErrorFragment
       }
       productVariant {
@@ -267,7 +267,7 @@ export const productCreateMutation = gql`
   ${productFragmentDetails}
   mutation ProductCreate($input: ProductCreateInput!) {
     productCreate(input: $input) {
-      errors: productErrors {
+      errors {
         ...ProductErrorWithAttributesFragment
       }
       product {
@@ -285,7 +285,7 @@ export const variantDeleteMutation = gql`
   ${productErrorFragment}
   mutation VariantDelete($id: ID!) {
     productVariantDelete(id: $id) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       productVariant {
@@ -322,7 +322,7 @@ export const variantUpdateMutation = gql`
         weight: $weight
       }
     ) {
-      errors: productErrors {
+      errors {
         ...ProductErrorWithAttributesFragment
       }
       productVariant {
@@ -330,7 +330,7 @@ export const variantUpdateMutation = gql`
       }
     }
     productVariantStocksUpdate(stocks: $stocks, variantId: $id) {
-      errors: bulkStockErrors {
+      errors {
         ...BulkStockErrorFragment
       }
       productVariant {
@@ -338,7 +338,7 @@ export const variantUpdateMutation = gql`
       }
     }
     productVariantStocksCreate(stocks: $addStocks, variantId: $id) {
-      errors: bulkStockErrors {
+      errors {
         ...BulkStockErrorFragment
       }
       productVariant {
@@ -349,7 +349,7 @@ export const variantUpdateMutation = gql`
       }
     }
     productVariantStocksDelete(warehouseIds: $removeStocks, variantId: $id) {
-      errors: stockErrors {
+      errors {
         code
         field
       }
@@ -372,7 +372,7 @@ export const variantCreateMutation = gql`
   ${productErrorWithAttributesFragment}
   mutation VariantCreate($input: ProductVariantCreateInput!) {
     productVariantCreate(input: $input) {
-      errors: productErrors {
+      errors {
         ...ProductErrorWithAttributesFragment
       }
       productVariant {
@@ -390,7 +390,7 @@ export const productMediaDeleteMutation = gql`
   ${productErrorFragment}
   mutation ProductMediaDelete($id: ID!) {
     productMediaDelete(id: $id) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       product {
@@ -412,7 +412,7 @@ export const productMediaUpdateMutation = gql`
   ${productFragmentDetails}
   mutation ProductMediaUpdate($id: ID!, $alt: String!) {
     productMediaUpdate(id: $id, input: { alt: $alt }) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       product {
@@ -431,7 +431,7 @@ export const variantMediaAssignMutation = gql`
   ${productErrorFragment}
   mutation VariantMediaAssign($variantId: ID!, $mediaId: ID!) {
     variantMediaAssign(variantId: $variantId, mediaId: $mediaId) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       productVariant {
@@ -450,7 +450,7 @@ export const variantMediaUnassignMutation = gql`
   ${productErrorFragment}
   mutation VariantMediaUnassign($variantId: ID!, $mediaId: ID!) {
     variantMediaUnassign(variantId: $variantId, mediaId: $mediaId) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       productVariant {
@@ -468,7 +468,7 @@ export const productBulkDeleteMutation = gql`
   ${productErrorFragment}
   mutation productBulkDelete($ids: [ID!]!) {
     productBulkDelete(ids: $ids) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
     }
@@ -486,7 +486,7 @@ export const ProductVariantBulkCreateMutation = gql`
     $inputs: [ProductVariantBulkCreateInput]!
   ) {
     productVariantBulkCreate(product: $id, variants: $inputs) {
-      errors: bulkProductErrors {
+      errors {
         ...BulkProductErrorFragment
       }
     }
@@ -501,7 +501,7 @@ export const ProductVariantBulkDeleteMutation = gql`
   ${productErrorFragment}
   mutation ProductVariantBulkDelete($ids: [ID!]!) {
     productVariantBulkDelete(ids: $ids) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
     }
@@ -520,7 +520,7 @@ export const productExportMutation = gql`
       exportFile {
         ...ExportFileFragment
       }
-      errors: exportErrors {
+      errors {
         ...ExportErrorFragment
       }
     }
@@ -542,7 +542,7 @@ export const ProductChannelListingUpdateMutation = gql`
       product {
         ...Product
       }
-      errors: productChannelListingErrors {
+      errors {
         ...ProductChannelListingErrorFragment
       }
     }
@@ -554,7 +554,7 @@ const productVariantReorder = gql`
   ${productFragmentDetails}
   mutation ProductVariantReorder($move: ReorderInput!, $productId: ID!) {
     productVariantReorder(moves: [$move], productId: $productId) {
-      errors: productErrors {
+      errors {
         ...ProductErrorFragment
       }
       product {
@@ -583,7 +583,7 @@ export const ProductVariantChannelListingUpdateMutation = gql`
       variant {
         ...ProductVariant
       }
-      errors: productChannelListingErrors {
+      errors {
         ...ProductChannelListingErrorFragment
       }
     }

--- a/src/shipping/mutations.ts
+++ b/src/shipping/mutations.ts
@@ -63,7 +63,7 @@ const deleteShippingZone = gql`
   ${shippingErrorFragment}
   mutation DeleteShippingZone($id: ID!) {
     shippingZoneDelete(id: $id) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
     }
@@ -78,7 +78,7 @@ const bulkDeleteShippingZone = gql`
   ${shippingErrorFragment}
   mutation BulkDeleteShippingZone($ids: [ID]!) {
     shippingZoneBulkDelete(ids: $ids) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
     }
@@ -112,7 +112,7 @@ const createShippingZone = gql`
   ${shippingErrorFragment}
   mutation CreateShippingZone($input: ShippingZoneCreateInput!) {
     shippingZoneCreate(input: $input) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
       shippingZone {
@@ -136,7 +136,7 @@ const updateShippingZone = gql`
   ${shippingErrorFragment}
   mutation UpdateShippingZone($id: ID!, $input: ShippingZoneUpdateInput!) {
     shippingZoneUpdate(id: $id, input: $input) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
       shippingZone {
@@ -160,7 +160,7 @@ const updateShippingRate = gql`
   ${shippingMethodFragment}
   mutation UpdateShippingRate($id: ID!, $input: ShippingPriceInput!) {
     shippingPriceUpdate(id: $id, input: $input) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
       shippingMethod {
@@ -180,7 +180,7 @@ const createShippingRate = gql`
   ${shippingZoneDetailsFragment}
   mutation CreateShippingRate($input: ShippingPriceInput!) {
     shippingPriceCreate(input: $input) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
       shippingZone {
@@ -202,7 +202,7 @@ const deleteShippingRate = gql`
   ${shippingZoneDetailsFragment}
   mutation DeleteShippingRate($id: ID!) {
     shippingPriceDelete(id: $id) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
       shippingZone {
@@ -220,7 +220,7 @@ const bulkDeleteShippingRate = gql`
   ${shippingErrorFragment}
   mutation BulkDeleteShippingRate($ids: [ID]!) {
     shippingPriceBulkDelete(ids: $ids) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
     }
@@ -242,7 +242,7 @@ export const shippingMethodChannelListingUpdate = gql`
       shippingMethod {
         ...ShippingMethodFragment
       }
-      errors: shippingErrors {
+      errors {
         ...ShippingChannelsErrorFragment
       }
     }
@@ -261,7 +261,7 @@ export const shippingPriceExcludeProducts = gql`
     $input: ShippingPriceExcludeProductsInput!
   ) {
     shippingPriceExcludeProducts(id: $id, input: $input) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
     }
@@ -277,7 +277,7 @@ export const shippingPriceRemoveProductsFromExclude = gql`
   ${shippingErrorFragment}
   mutation ShippingPriceRemoveProductFromExclude($id: ID!, $products: [ID]!) {
     shippingPriceRemoveProductFromExclude(id: $id, products: $products) {
-      errors: shippingErrors {
+      errors {
         ...ShippingErrorFragment
       }
     }

--- a/src/shipping/types/UpdateDefaultWeightUnit.ts
+++ b/src/shipping/types/UpdateDefaultWeightUnit.ts
@@ -10,7 +10,7 @@ import { WeightUnitsEnum } from "./../../types/globalTypes";
 // ====================================================
 
 export interface UpdateDefaultWeightUnit_shopSettingsUpdate_errors {
-  __typename: "Error";
+  __typename: "ShopError";
   field: string | null;
   message: string | null;
 }

--- a/src/siteSettings/mutations.ts
+++ b/src/siteSettings/mutations.ts
@@ -19,7 +19,7 @@ const shopSettingsUpdate = gql`
     $addressInput: AddressInput
   ) {
     shopSettingsUpdate(input: $shopSettingsInput) {
-      errors: shopErrors {
+      errors {
         ...ShopErrorFragment
       }
       shop {
@@ -27,7 +27,7 @@ const shopSettingsUpdate = gql`
       }
     }
     shopDomainUpdate(input: $shopDomainInput) {
-      errors: shopErrors {
+      errors {
         ...ShopErrorFragment
       }
       shop {
@@ -38,7 +38,7 @@ const shopSettingsUpdate = gql`
       }
     }
     shopAddressUpdate(input: $addressInput) {
-      errors: shopErrors {
+      errors {
         ...ShopErrorFragment
       }
       shop {

--- a/src/staff/mutations.ts
+++ b/src/staff/mutations.ts
@@ -34,7 +34,7 @@ const staffMemberAddMutation = gql`
   ${staffMemberDetailsFragment}
   mutation StaffMemberAdd($input: StaffCreateInput!) {
     staffCreate(input: $input) {
-      errors: staffErrors {
+      errors {
         ...StaffErrorFragment
       }
       user {
@@ -53,7 +53,7 @@ const staffMemberUpdateMutation = gql`
   ${staffMemberDetailsFragment}
   mutation StaffMemberUpdate($id: ID!, $input: StaffUpdateInput!) {
     staffUpdate(id: $id, input: $input) {
-      errors: staffErrors {
+      errors {
         ...StaffErrorFragment
       }
       user {
@@ -71,7 +71,7 @@ const staffMemberDeleteMutation = gql`
   ${staffErrorFragment}
   mutation StaffMemberDelete($id: ID!) {
     staffDelete(id: $id) {
-      errors: staffErrors {
+      errors {
         ...StaffErrorFragment
       }
     }
@@ -86,7 +86,7 @@ const staffAvatarUpdateMutation = gql`
   ${accountErrorFragment}
   mutation StaffAvatarUpdate($image: Upload!) {
     userAvatarUpdate(image: $image) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       user {
@@ -107,7 +107,7 @@ const staffAvatarDeleteMutation = gql`
   ${accountErrorFragment}
   mutation StaffAvatarDelete {
     userAvatarDelete {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
       user {
@@ -128,7 +128,7 @@ const changeStaffPassword = gql`
   ${accountErrorFragment}
   mutation ChangeStaffPassword($newPassword: String!, $oldPassword: String!) {
     passwordChange(newPassword: $newPassword, oldPassword: $oldPassword) {
-      errors: accountErrors {
+      errors {
         ...AccountErrorFragment
       }
     }

--- a/src/taxes/types/FetchTaxes.ts
+++ b/src/taxes/types/FetchTaxes.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface FetchTaxes_shopFetchTaxRates_errors {
-  __typename: "Error";
+  __typename: "ShopError";
   field: string | null;
   message: string | null;
 }

--- a/src/taxes/types/UpdateTaxSettings.ts
+++ b/src/taxes/types/UpdateTaxSettings.ts
@@ -10,7 +10,7 @@ import { ShopSettingsInput } from "./../../types/globalTypes";
 // ====================================================
 
 export interface UpdateTaxSettings_shopSettingsUpdate_errors {
-  __typename: "Error";
+  __typename: "ShopError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdateAttributeTranslations.ts
+++ b/src/translations/types/UpdateAttributeTranslations.ts
@@ -10,7 +10,7 @@ import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalType
 // ====================================================
 
 export interface UpdateAttributeTranslations_attributeTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdateAttributeValueTranslations.ts
+++ b/src/translations/types/UpdateAttributeValueTranslations.ts
@@ -10,7 +10,7 @@ import { AttributeValueTranslationInput, LanguageCodeEnum } from "./../../types/
 // ====================================================
 
 export interface UpdateAttributeValueTranslations_attributeValueTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdateCategoryTranslations.ts
+++ b/src/translations/types/UpdateCategoryTranslations.ts
@@ -10,7 +10,7 @@ import { TranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";
 // ====================================================
 
 export interface UpdateCategoryTranslations_categoryTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdateCollectionTranslations.ts
+++ b/src/translations/types/UpdateCollectionTranslations.ts
@@ -10,7 +10,7 @@ import { TranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";
 // ====================================================
 
 export interface UpdateCollectionTranslations_collectionTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdatePageTranslations.ts
+++ b/src/translations/types/UpdatePageTranslations.ts
@@ -10,7 +10,7 @@ import { PageTranslationInput, LanguageCodeEnum } from "./../../types/globalType
 // ====================================================
 
 export interface UpdatePageTranslations_pageTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdateProductTranslations.ts
+++ b/src/translations/types/UpdateProductTranslations.ts
@@ -10,7 +10,7 @@ import { TranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";
 // ====================================================
 
 export interface UpdateProductTranslations_productTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdateSaleTranslations.ts
+++ b/src/translations/types/UpdateSaleTranslations.ts
@@ -10,7 +10,7 @@ import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalType
 // ====================================================
 
 export interface UpdateSaleTranslations_saleTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdateShippingMethodTranslations.ts
+++ b/src/translations/types/UpdateShippingMethodTranslations.ts
@@ -10,7 +10,7 @@ import { ShippingPriceTranslationInput, LanguageCodeEnum } from "./../../types/g
 // ====================================================
 
 export interface UpdateShippingMethodTranslations_shippingPriceTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/translations/types/UpdateVoucherTranslations.ts
+++ b/src/translations/types/UpdateVoucherTranslations.ts
@@ -10,7 +10,7 @@ import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalType
 // ====================================================
 
 export interface UpdateVoucherTranslations_voucherTranslate_errors {
-  __typename: "Error";
+  __typename: "TranslationError";
   field: string | null;
   message: string | null;
 }

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1049,7 +1049,6 @@ export interface AppFilterInput {
 
 export interface AppInput {
   name?: string | null;
-  isActive?: boolean | null;
   permissions?: (PermissionEnum | null)[] | null;
 }
 
@@ -1104,7 +1103,6 @@ export interface AttributeFilterInput {
 
 export interface AttributeInput {
   slug: string;
-  value?: string | null;
   values?: (string | null)[] | null;
 }
 
@@ -1623,7 +1621,6 @@ export interface ProductFilterInput {
   hasCategory?: boolean | null;
   attributes?: (AttributeInput | null)[] | null;
   stockAvailability?: StockAvailability | null;
-  productType?: string | null;
   stocks?: ProductStockFilterInput | null;
   search?: string | null;
   metadata?: (MetadataInput | null)[] | null;

--- a/src/utils/metadata/updateMetadata.ts
+++ b/src/utils/metadata/updateMetadata.ts
@@ -21,12 +21,12 @@ const updateMetadata = gql`
     $keysToDelete: [String!]!
   ) {
     updateMetadata(id: $id, input: $input) {
-      errors: metadataErrors {
+      errors {
         ...MetadataErrorFragment
       }
     }
     deleteMetadata(id: $id, keys: $keysToDelete) {
-      errors: metadataErrors {
+      errors {
         ...MetadataErrorFragment
       }
       item {
@@ -52,12 +52,12 @@ const updatePrivateMetadata = gql`
     $keysToDelete: [String!]!
   ) {
     updatePrivateMetadata(id: $id, input: $input) {
-      errors: metadataErrors {
+      errors {
         ...MetadataErrorFragment
       }
     }
     deletePrivateMetadata(id: $id, keys: $keysToDelete) {
-      errors: metadataErrors {
+      errors {
         ...MetadataErrorFragment
       }
       item {

--- a/src/warehouses/mutations.ts
+++ b/src/warehouses/mutations.ts
@@ -20,7 +20,7 @@ const deleteWarehouse = gql`
   ${warehouseErrorFragment}
   mutation WarehouseDelete($id: ID!) {
     deleteWarehouse(id: $id) {
-      errors: warehouseErrors {
+      errors {
         ...WarehouseErrorFragment
       }
     }
@@ -36,7 +36,7 @@ const createWarehouse = gql`
   ${warehouseErrorFragment}
   mutation WarehouseCreate($input: WarehouseCreateInput!) {
     createWarehouse(input: $input) {
-      errors: warehouseErrors {
+      errors {
         ...WarehouseErrorFragment
       }
       warehouse {
@@ -55,7 +55,7 @@ const updateWarehouse = gql`
   ${warehouseErrorFragment}
   mutation WarehouseUpdate($id: ID!, $input: WarehouseUpdateInput!) {
     updateWarehouse(id: $id, input: $input) {
-      errors: warehouseErrors {
+      errors {
         ...WarehouseErrorFragment
       }
       warehouse {

--- a/src/webhooks/mutations.ts
+++ b/src/webhooks/mutations.ts
@@ -12,7 +12,7 @@ const webhookCreate = gql`
   ${webhookErrorFragment}
   mutation WebhookCreate($input: WebhookCreateInput!) {
     webhookCreate(input: $input) {
-      errors: webhookErrors {
+      errors {
         ...WebhookErrorFragment
       }
       webhook {
@@ -27,7 +27,7 @@ const webhookUpdate = gql`
   ${webhookErrorFragment}
   mutation WebhookUpdate($id: ID!, $input: WebhookUpdateInput!) {
     webhookUpdate(id: $id, input: $input) {
-      errors: webhookErrors {
+      errors {
         ...WebhookErrorFragment
       }
       webhook {
@@ -41,7 +41,7 @@ const webhookDelete = gql`
   ${webhookErrorFragment}
   mutation WebhookDelete($id: ID!) {
     webhookDelete(id: $id) {
-      errors: webhookErrors {
+      errors {
         ...WebhookErrorFragment
       }
     }


### PR DESCRIPTION
I want to merge this change because it drops all deprecated fields.

Additionally, following views were changed/altered to fit the current schema:
1. Local apps now have an "Activate"/"Deactivate" button instead of a checkbox:
![image](https://user-images.githubusercontent.com/28310983/115542441-913b9400-a2a0-11eb-9ecc-79ebfe85d658.png)
<!-- Please mention all relevant issue numbers. -->
2. Order view now shows all applied discounts:
![image](https://user-images.githubusercontent.com/28310983/115543032-39515d00-a2a1-11eb-964c-858015c6e163.png)


**PR intended to be tested with API branch:** https://github.com/mirumee/saleor/pull/7199

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://saleor-1083-drop-deprecated-queries-and-mutations.api.saleor.rocks/graphql/