### PR TITLE
Rich text, multiselect, useFormset fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add shipping method description - #1058 by @jwm0
 - Fix voucher and sales sorting errors - #1063 by @orzechdev
 - Fix custom currency formatting - #1067 by @orzechdev
+- Fixes - #1077 by @piotrgrundas:
+    - rich text field updates, 
+    - multiselect empty chip upon creation of a product/variant,
+    - useFormset.setItemValue wrong updates,
 
 # 2.11.1
 

--- a/src/attributes/utils/data.ts
+++ b/src/attributes/utils/data.ts
@@ -80,6 +80,9 @@ export function getSelectedAttributeValues(
   if (attribute.attribute.inputType === AttributeInputTypeEnum.REFERENCE) {
     return attribute.values.map(value => value.reference);
   }
+  if (attribute.attribute.inputType === AttributeInputTypeEnum.RICH_TEXT) {
+    return [attribute.values[0]?.richText];
+  }
   return attribute.values.map(value => value.slug);
 }
 

--- a/src/components/Attributes/AttributeRow.tsx
+++ b/src/components/Attributes/AttributeRow.tsx
@@ -153,7 +153,10 @@ const AttributeRow: React.FC<AttributeRowProps> = ({
             error={!!error}
             label={intl.formatMessage(messages.valueLabel)}
             helperText={getErrorMessage(error, intl)}
-            onChange={data => onChange(attribute.id, JSON.stringify(data))}
+            onChange={data => {
+              console.log({ data });
+              onChange(attribute.id, JSON.stringify(data));
+            }}
             data={getRichTextData(attribute)}
           />
         </BasicAttributeRow>

--- a/src/components/Attributes/AttributeRow.tsx
+++ b/src/components/Attributes/AttributeRow.tsx
@@ -153,10 +153,7 @@ const AttributeRow: React.FC<AttributeRowProps> = ({
             error={!!error}
             label={intl.formatMessage(messages.valueLabel)}
             helperText={getErrorMessage(error, intl)}
-            onChange={data => {
-              console.log({ data });
-              onChange(attribute.id, JSON.stringify(data));
-            }}
+            onChange={data => onChange(attribute.id, JSON.stringify(data))}
             data={getRichTextData(attribute)}
           />
         </BasicAttributeRow>

--- a/src/hooks/useFormset.ts
+++ b/src/hooks/useFormset.ts
@@ -1,5 +1,4 @@
 import { removeAtIndex } from "@saleor/utils/lists";
-import { useEffect } from "react";
 
 import useStateFromProps from "./useStateFromProps";
 
@@ -47,20 +46,19 @@ function useFormset<TData = {}, TValue = any>(
   }
 
   function setItemValue(id: string, value: TValue) {
-    const itemIndex = data.findIndex(item => item.id === id);
-    setData([
-      ...data.slice(0, itemIndex),
-      {
-        ...data[itemIndex],
-        value
-      },
-      ...data.slice(itemIndex + 1)
-    ]);
+    setData(data => {
+      const itemIndex = data.findIndex(item => item.id === id);
+      return [
+        ...data.slice(0, itemIndex),
+        {
+          ...data[itemIndex],
+          value
+        },
+        ...data.slice(itemIndex + 1)
+      ];
+    });
   }
 
-  useEffect(() => {
-    console.log(data);
-  }, [data]);
   return {
     add: addItem,
     change: setItemValue,

--- a/src/hooks/useFormset.ts
+++ b/src/hooks/useFormset.ts
@@ -1,4 +1,5 @@
 import { removeAtIndex } from "@saleor/utils/lists";
+import { useEffect } from "react";
 
 import useStateFromProps from "./useStateFromProps";
 
@@ -57,6 +58,9 @@ function useFormset<TData = {}, TValue = any>(
     ]);
   }
 
+  useEffect(() => {
+    console.log(data);
+  }, [data]);
   return {
     add: addItem,
     change: setItemValue,

--- a/src/products/components/ProductVariantPage/form.tsx
+++ b/src/products/components/ProductVariantPage/form.tsx
@@ -135,8 +135,6 @@ function useProductVariantUpdateForm(
     makeChangeHandler: makeMetadataChangeHandler
   } = useMetadataChangeTrigger();
 
-  // console.log({ attributes, initial });
-
   const handleChange: FormChange = (event, cb) => {
     form.change(event, cb);
     triggerChange();

--- a/src/products/utils/data.ts
+++ b/src/products/utils/data.ts
@@ -92,7 +92,7 @@ export function getAttributeInputFromAttributes(
     },
     id: attribute.id,
     label: attribute.name,
-    value: [""]
+    value: []
   }));
 }
 


### PR DESCRIPTION
I want to merge this change because it:
- fixes rich text attribute update,
- creation or products with multuple attribute which was rendering empty chip and breaking further process,
- fix incorrect, fast updates using `useFormset.setItemValue`

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/