### PR TITLE
Saleor 2798 user addresses selection for draft order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - useFormset.setItemValue wrong updates,
 - Drop deprecated fields - #1071 by @jwm0
 - Add service worker - #1073 by @dominik-zeglen
+- Choosing user shipping and billing addresses for draft order - #1082 by @orzechdev
 
 # 2.11.1
 

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3323,7 +3323,7 @@
   },
   "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_billingAddressDescription": {
     "context": "dialog content",
-    "string": "Select one of customer addresses or add a new address:"
+    "string": "Add a new address:"
   },
   "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_billingSameAsShipping": {
     "context": "checkbox label",
@@ -3333,13 +3333,21 @@
     "context": "address type",
     "string": "Use one of customer addresses"
   },
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_customerBillingAddressDescription": {
+    "context": "dialog content",
+    "string": "Select one of customer addresses or add a new address:"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_customerShippingAddressDescription": {
+    "context": "dialog content",
+    "string": "Which address would you like to use as shipping address for selected customer:"
+  },
   "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_newAddress": {
     "context": "address type",
     "string": "Add new address"
   },
   "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_shippingAddressDescription": {
     "context": "dialog content",
-    "string": "Which address would you like to use as shipping address for selected customer:"
+    "string": "This customer doesn’t have any shipping addresses. Provide address for order:"
   },
   "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_title": {
     "context": "dialog header",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2404,6 +2404,10 @@
     "context": "button",
     "string": "Refresh"
   },
+  "src_dot_continue": {
+    "context": "button",
+    "string": "Continue"
+  },
   "src_dot_create": {
     "context": "button",
     "string": "Create"
@@ -3320,6 +3324,46 @@
   "src_dot_orders_dot_components_dot_OrderChannelSectionCard_dot_1243773440": {
     "context": "section header",
     "string": "Sales channel"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_billingAddressDescription": {
+    "context": "dialog content",
+    "string": "Select one of customer addresses or add a new address:"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_billingSameAsShipping": {
+    "context": "checkbox label",
+    "string": "Billing address same as shipping address"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_customerAddress": {
+    "context": "address type",
+    "string": "Use one of customer addresses"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_newAddress": {
+    "context": "address type",
+    "string": "Add new address"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_shippingAddressDescription": {
+    "context": "dialog content",
+    "string": "Which address would you like to use as shipping address for selected customer:"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerAddressesEditDialog_dot_title": {
+    "context": "dialog header",
+    "string": "Shipping address for order"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerChangeDialog_dot_changeAddress": {
+    "context": "option label",
+    "string": "Change address"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerChangeDialog_dot_description": {
+    "context": "dialog description",
+    "string": "You have changed customer assigned to this order. What would you like to do with the shipping address?"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerChangeDialog_dot_keepAddress": {
+    "context": "option label",
+    "string": "Keep address"
+  },
+  "src_dot_orders_dot_components_dot_OrderCustomerChangeDialog_dot_title": {
+    "context": "dialog header",
+    "string": "Changed Customer"
   },
   "src_dot_orders_dot_components_dot_OrderCustomerNote_dot_1505053535": {
     "string": "No notes from customer"
@@ -5745,6 +5789,10 @@
   },
   "src_dot_savedChanges": {
     "string": "Saved changes"
+  },
+  "src_dot_select": {
+    "context": "select option, button",
+    "string": "Select"
   },
   "src_dot_selectAll": {
     "context": "select all options, button",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -370,10 +370,6 @@
     "context": "product field",
     "string": "Export Variant Weight"
   },
-  "productExportFieldVisibility": {
-    "context": "product field",
-    "string": "Visibility"
-  },
   "productStockHeader": {
     "context": "product stock, section header",
     "string": "Inventory"

--- a/schema.graphql
+++ b/schema.graphql
@@ -34,6 +34,7 @@ type AccountError {
   field: String
   message: String
   code: AccountErrorCode!
+  addressType: AddressTypeEnum
 }
 
 enum AccountErrorCode {
@@ -968,6 +969,7 @@ type CheckoutError {
   message: String
   code: CheckoutErrorCode!
   variants: [ID!]
+  addressType: AddressTypeEnum
 }
 
 enum CheckoutErrorCode {
@@ -3049,6 +3051,7 @@ type OrderError {
   warehouse: ID
   orderLine: ID
   variants: [ID!]
+  addressType: AddressTypeEnum
 }
 
 enum OrderErrorCode {
@@ -4142,7 +4145,6 @@ enum ProductFieldEnum {
   DESCRIPTION
   PRODUCT_TYPE
   CATEGORY
-  VISIBLE
   PRODUCT_WEIGHT
   COLLECTIONS
   CHARGE_TAXES
@@ -5249,6 +5251,7 @@ type StaffError {
   field: String
   message: String
   code: AccountErrorCode!
+  addressType: AddressTypeEnum
   permissions: [PermissionEnum!]
   groups: [ID!]
   users: [ID!]

--- a/src/auth/components/NewPasswordPage/NewPasswordPage.stories.tsx
+++ b/src/auth/components/NewPasswordPage/NewPasswordPage.stories.tsx
@@ -20,7 +20,8 @@ storiesOf("Views / Authentication / Set up a new password", module)
       errors={["password"].map(field => ({
         __typename: "AccountError",
         code: AccountErrorCode.PASSWORD_TOO_SHORT,
-        field
+        field,
+        addressType: null
       }))}
       disabled={false}
       onSubmit={() => undefined}

--- a/src/auth/types/ExternalAuthenticationUrl.ts
+++ b/src/auth/types/ExternalAuthenticationUrl.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ExternalAuthenticationUrl
@@ -13,6 +13,7 @@ export interface ExternalAuthenticationUrl_externalAuthenticationUrl_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface ExternalAuthenticationUrl_externalAuthenticationUrl {

--- a/src/auth/types/ExternalObtainAccessTokens.ts
+++ b/src/auth/types/ExternalObtainAccessTokens.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PermissionEnum, AccountErrorCode } from "./../../types/globalTypes";
+import { PermissionEnum, AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ExternalObtainAccessTokens
@@ -35,6 +35,7 @@ export interface ExternalObtainAccessTokens_externalObtainAccessTokens_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface ExternalObtainAccessTokens_externalObtainAccessTokens {

--- a/src/auth/types/RequestPasswordReset.ts
+++ b/src/auth/types/RequestPasswordReset.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: RequestPasswordReset
@@ -13,6 +13,7 @@ export interface RequestPasswordReset_requestPasswordReset_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface RequestPasswordReset_requestPasswordReset {

--- a/src/auth/types/SetPassword.ts
+++ b/src/auth/types/SetPassword.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode, PermissionEnum } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum, PermissionEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: SetPassword
@@ -13,6 +13,7 @@ export interface SetPassword_setPassword_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface SetPassword_setPassword_user_userPermissions {

--- a/src/components/AddressEdit/AddressEdit.tsx
+++ b/src/components/AddressEdit/AddressEdit.tsx
@@ -75,13 +75,6 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
     "streetAddress2"
   ];
 
-  const getPrefixedField = (fieldName: keyof AddressTypeInput) => {
-    // if (fieldsPrefix) {
-    //   return `${fieldsPrefix}_${fieldName}`;
-    // }
-    return fieldName;
-  };
-
   const formErrors = getFormErrors<
     keyof AddressTypeInput,
     AccountErrorFragment | OrderErrorFragment
@@ -96,7 +89,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             error={!!formErrors.firstName}
             helperText={getErrorMessage(formErrors.firstName, intl)}
             label={intl.formatMessage(commonMessages.firstName)}
-            name={getPrefixedField("firstName")}
+            name="firstName"
             onChange={onChange}
             value={data.firstName}
             fullWidth
@@ -108,7 +101,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             error={!!formErrors.lastName}
             helperText={getErrorMessage(formErrors.lastName, intl)}
             label={intl.formatMessage(commonMessages.lastName)}
-            name={getPrefixedField("lastName")}
+            name="lastName"
             onChange={onChange}
             value={data.lastName}
             fullWidth
@@ -125,7 +118,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "Company"
             })}
-            name={getPrefixedField("companyName")}
+            name="companyName"
             onChange={onChange}
             value={data.companyName}
             fullWidth
@@ -140,7 +133,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "Phone"
             })}
-            name={getPrefixedField("phone")}
+            name="phone"
             value={data.phone}
             onChange={onChange}
           />
@@ -154,7 +147,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
         label={intl.formatMessage({
           defaultMessage: "Address line 1"
         })}
-        name={getPrefixedField("streetAddress1")}
+        name="streetAddress1"
         onChange={onChange}
         value={data.streetAddress1}
         fullWidth
@@ -167,7 +160,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
         label={intl.formatMessage({
           defaultMessage: "Address line 2"
         })}
-        name={getPrefixedField("streetAddress2")}
+        name="streetAddress2"
         onChange={onChange}
         value={data.streetAddress2}
         fullWidth
@@ -182,7 +175,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "City"
             })}
-            name={getPrefixedField("city")}
+            name="city"
             onChange={onChange}
             value={data.city}
             fullWidth
@@ -196,7 +189,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "ZIP / Postal code"
             })}
-            name={getPrefixedField("postalCode")}
+            name="postalCode"
             onChange={onChange}
             value={data.postalCode}
             fullWidth
@@ -215,7 +208,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "Country"
             })}
-            name={getPrefixedField("country")}
+            name="country"
             onChange={onCountryChange}
             value={data.country}
             choices={countries}
@@ -232,7 +225,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "Country area"
             })}
-            name={getPrefixedField("countryArea")}
+            name="countryArea"
             onChange={onChange}
             value={data.countryArea}
             fullWidth

--- a/src/components/AddressEdit/AddressEdit.tsx
+++ b/src/components/AddressEdit/AddressEdit.tsx
@@ -74,6 +74,14 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
     "streetAddress1",
     "streetAddress2"
   ];
+
+  const getPrefixedField = (fieldName: keyof AddressTypeInput) => {
+    // if (fieldsPrefix) {
+    //   return `${fieldsPrefix}_${fieldName}`;
+    // }
+    return fieldName;
+  };
+
   const formErrors = getFormErrors<
     keyof AddressTypeInput,
     AccountErrorFragment | OrderErrorFragment
@@ -88,7 +96,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             error={!!formErrors.firstName}
             helperText={getErrorMessage(formErrors.firstName, intl)}
             label={intl.formatMessage(commonMessages.firstName)}
-            name="firstName"
+            name={getPrefixedField("firstName")}
             onChange={onChange}
             value={data.firstName}
             fullWidth
@@ -100,7 +108,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             error={!!formErrors.lastName}
             helperText={getErrorMessage(formErrors.lastName, intl)}
             label={intl.formatMessage(commonMessages.lastName)}
-            name="lastName"
+            name={getPrefixedField("lastName")}
             onChange={onChange}
             value={data.lastName}
             fullWidth
@@ -117,7 +125,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "Company"
             })}
-            name="companyName"
+            name={getPrefixedField("companyName")}
             onChange={onChange}
             value={data.companyName}
             fullWidth
@@ -132,7 +140,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "Phone"
             })}
-            name="phone"
+            name={getPrefixedField("phone")}
             value={data.phone}
             onChange={onChange}
           />
@@ -146,7 +154,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
         label={intl.formatMessage({
           defaultMessage: "Address line 1"
         })}
-        name="streetAddress1"
+        name={getPrefixedField("streetAddress1")}
         onChange={onChange}
         value={data.streetAddress1}
         fullWidth
@@ -159,7 +167,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
         label={intl.formatMessage({
           defaultMessage: "Address line 2"
         })}
-        name="streetAddress2"
+        name={getPrefixedField("streetAddress2")}
         onChange={onChange}
         value={data.streetAddress2}
         fullWidth
@@ -174,7 +182,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "City"
             })}
-            name="city"
+            name={getPrefixedField("city")}
             onChange={onChange}
             value={data.city}
             fullWidth
@@ -188,7 +196,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "ZIP / Postal code"
             })}
-            name="postalCode"
+            name={getPrefixedField("postalCode")}
             onChange={onChange}
             value={data.postalCode}
             fullWidth
@@ -207,7 +215,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "Country"
             })}
-            name="country"
+            name={getPrefixedField("country")}
             onChange={onCountryChange}
             value={data.country}
             choices={countries}
@@ -224,7 +232,7 @@ const AddressEdit: React.FC<AddressEditProps> = props => {
             label={intl.formatMessage({
               defaultMessage: "Country area"
             })}
-            name="countryArea"
+            name={getPrefixedField("countryArea")}
             onChange={onChange}
             value={data.countryArea}
             fullWidth

--- a/src/customers/components/CustomerAddressChoice/CustomerAddressChoice.tsx
+++ b/src/customers/components/CustomerAddressChoice/CustomerAddressChoice.tsx
@@ -1,0 +1,53 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import AddressFormatter from "@saleor/components/AddressFormatter";
+import useTheme from "@saleor/hooks/useTheme";
+import { makeStyles } from "@saleor/theme";
+import classNames from "classnames";
+import React from "react";
+
+import { CustomerAddresses_user_addresses } from "../../types/CustomerAddresses";
+
+export interface CustomerAddressChoiceProps {
+  address: CustomerAddresses_user_addresses;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    card: {
+      cursor: "pointer"
+    },
+    cardSelectedLight: {
+      borderColor: theme.palette.primary.light,
+      borderWidth: "2px"
+    },
+    cardSelectedDark: {
+      borderColor: theme.palette.primary.dark,
+      borderWidth: "2px"
+    }
+  }),
+  { name: "CustomerAddressChoice" }
+);
+const CustomerAddressChoice: React.FC<CustomerAddressChoiceProps> = props => {
+  const { address, selected, onSelect } = props;
+  const { isDark } = useTheme();
+  const classes = useStyles(props);
+
+  return (
+    <Card
+      className={classNames(classes.card, {
+        [classes.cardSelectedLight]: selected && !isDark,
+        [classes.cardSelectedDark]: selected && isDark
+      })}
+      onClick={onSelect}
+    >
+      <CardContent>
+        <AddressFormatter address={address} />
+      </CardContent>
+    </Card>
+  );
+};
+CustomerAddressChoice.displayName = "CustomerAddressChoice";
+export default CustomerAddressChoice;

--- a/src/customers/components/CustomerAddressChoice/CustomerAddressChoice.tsx
+++ b/src/customers/components/CustomerAddressChoice/CustomerAddressChoice.tsx
@@ -1,7 +1,6 @@
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import AddressFormatter from "@saleor/components/AddressFormatter";
-import useTheme from "@saleor/hooks/useTheme";
 import { makeStyles } from "@saleor/theme";
 import classNames from "classnames";
 import React from "react";
@@ -17,29 +16,25 @@ export interface CustomerAddressChoiceProps {
 const useStyles = makeStyles(
   theme => ({
     card: {
-      cursor: "pointer"
+      cursor: "pointer",
+      padding: "1px"
     },
-    cardSelectedLight: {
-      borderColor: theme.palette.primary.light,
-      borderWidth: "2px"
-    },
-    cardSelectedDark: {
-      borderColor: theme.palette.primary.dark,
-      borderWidth: "2px"
+    cardSelected: {
+      borderColor: theme.palette.primary.main,
+      borderWidth: "2px",
+      padding: "0"
     }
   }),
   { name: "CustomerAddressChoice" }
 );
 const CustomerAddressChoice: React.FC<CustomerAddressChoiceProps> = props => {
   const { address, selected, onSelect } = props;
-  const { isDark } = useTheme();
   const classes = useStyles(props);
 
   return (
     <Card
       className={classNames(classes.card, {
-        [classes.cardSelectedLight]: selected && !isDark,
-        [classes.cardSelectedDark]: selected && isDark
+        [classes.cardSelected]: selected
       })}
       onClick={onSelect}
     >

--- a/src/customers/components/CustomerAddressChoice/CustomerAddressChoice.tsx
+++ b/src/customers/components/CustomerAddressChoice/CustomerAddressChoice.tsx
@@ -1,11 +1,11 @@
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import AddressFormatter from "@saleor/components/AddressFormatter";
-import { makeStyles } from "@saleor/theme";
 import classNames from "classnames";
 import React from "react";
 
 import { CustomerAddresses_user_addresses } from "../../types/CustomerAddresses";
+import { useStyles } from "./styles";
 
 export interface CustomerAddressChoiceProps {
   address: CustomerAddresses_user_addresses;
@@ -13,20 +13,6 @@ export interface CustomerAddressChoiceProps {
   onSelect: () => void;
 }
 
-const useStyles = makeStyles(
-  theme => ({
-    card: {
-      cursor: "pointer",
-      padding: "1px"
-    },
-    cardSelected: {
-      borderColor: theme.palette.primary.main,
-      borderWidth: "2px",
-      padding: "0"
-    }
-  }),
-  { name: "CustomerAddressChoice" }
-);
 const CustomerAddressChoice: React.FC<CustomerAddressChoiceProps> = props => {
   const { address, selected, onSelect } = props;
   const classes = useStyles(props);

--- a/src/customers/components/CustomerAddressChoice/index.ts
+++ b/src/customers/components/CustomerAddressChoice/index.ts
@@ -1,2 +1,0 @@
-export { default } from "./CustomerAddressChoice";
-export * from "./CustomerAddressChoice";

--- a/src/customers/components/CustomerAddressChoice/index.ts
+++ b/src/customers/components/CustomerAddressChoice/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./CustomerAddressChoice";
+export * from "./CustomerAddressChoice";

--- a/src/customers/components/CustomerAddressChoice/styles.ts
+++ b/src/customers/components/CustomerAddressChoice/styles.ts
@@ -1,0 +1,16 @@
+import { makeStyles } from "@saleor/theme";
+
+export const useStyles = makeStyles(
+  theme => ({
+    card: {
+      cursor: "pointer",
+      padding: "1px"
+    },
+    cardSelected: {
+      borderColor: theme.palette.primary.main,
+      borderWidth: "2px",
+      padding: "0"
+    }
+  }),
+  { name: "CustomerAddressChoice" }
+);

--- a/src/customers/components/CustomerAddressChoiceCard/CustomerAddressChoiceCard.tsx
+++ b/src/customers/components/CustomerAddressChoiceCard/CustomerAddressChoiceCard.tsx
@@ -7,13 +7,13 @@ import React from "react";
 import { CustomerAddresses_user_addresses } from "../../types/CustomerAddresses";
 import { useStyles } from "./styles";
 
-export interface CustomerAddressChoiceProps {
+export interface CustomerAddressChoiceCardProps {
   address: CustomerAddresses_user_addresses;
   selected: boolean;
   onSelect: () => void;
 }
 
-const CustomerAddressChoice: React.FC<CustomerAddressChoiceProps> = props => {
+const CustomerAddressChoiceCard: React.FC<CustomerAddressChoiceCardProps> = props => {
   const { address, selected, onSelect } = props;
   const classes = useStyles(props);
 
@@ -30,5 +30,5 @@ const CustomerAddressChoice: React.FC<CustomerAddressChoiceProps> = props => {
     </Card>
   );
 };
-CustomerAddressChoice.displayName = "CustomerAddressChoice";
-export default CustomerAddressChoice;
+CustomerAddressChoiceCard.displayName = "CustomerAddressChoiceCard";
+export default CustomerAddressChoiceCard;

--- a/src/customers/components/CustomerAddressChoiceCard/index.ts
+++ b/src/customers/components/CustomerAddressChoiceCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./CustomerAddressChoiceCard";
+export * from "./CustomerAddressChoiceCard";

--- a/src/customers/components/CustomerAddressChoiceCard/styles.ts
+++ b/src/customers/components/CustomerAddressChoiceCard/styles.ts
@@ -12,5 +12,5 @@ export const useStyles = makeStyles(
       padding: "0"
     }
   }),
-  { name: "CustomerAddressChoice" }
+  { name: "CustomerAddressChoiceCard" }
 );

--- a/src/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
+++ b/src/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
@@ -8,6 +8,7 @@ import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
 import Form from "@saleor/components/Form";
+import { ShopInfo_shop_countries } from "@saleor/components/Shop/types/ShopInfo";
 import { AccountErrorFragment } from "@saleor/fragments/types/AccountErrorFragment";
 import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
@@ -16,6 +17,7 @@ import { buttonMessages } from "@saleor/intl";
 import { createStyles, WithStyles, withStyles } from "@saleor/theme";
 import { AddressInput } from "@saleor/types/globalTypes";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
+import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -25,10 +27,7 @@ import { CustomerAddresses_user_addresses } from "../../types/CustomerAddresses"
 export interface CustomerAddressDialogProps {
   address: CustomerAddresses_user_addresses;
   confirmButtonState: ConfirmButtonTransitionState;
-  countries: Array<{
-    code: string;
-    label: string;
-  }>;
+  countries: ShopInfo_shop_countries[];
   errors: AccountErrorFragment[];
   open: boolean;
   variant: "create" | "edit";
@@ -83,11 +82,7 @@ const CustomerAddressDialog = withStyles(
       streetAddress2: address?.streetAddress2 || ""
     };
 
-    const countryChoices =
-      countries?.map(country => ({
-        label: country.label,
-        value: country.code
-      })) || [];
+    const countryChoices = mapCountriesToChoices(countries || []);
 
     return (
       <Dialog

--- a/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
+++ b/src/customers/components/CustomerCreatePage/CustomerCreatePage.tsx
@@ -11,6 +11,7 @@ import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import { sectionNames } from "@saleor/intl";
 import { AddressInput } from "@saleor/types/globalTypes";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
+import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -69,10 +70,7 @@ const CustomerCreatePage: React.FC<CustomerCreatePageProps> = ({
   const intl = useIntl();
 
   const [countryDisplayName, setCountryDisplayName] = React.useState("");
-  const countryChoices = countries.map(country => ({
-    label: country.country,
-    value: country.code
-  }));
+  const countryChoices = mapCountriesToChoices(countries);
   const {
     errors: validationErrors,
     submit: handleSubmitWithAddress

--- a/src/customers/queries.ts
+++ b/src/customers/queries.ts
@@ -107,6 +107,10 @@ export const TypedCustomerAddressesQuery = TypedQuery<
   CustomerAddresses,
   CustomerAddressesVariables
 >(customerAddresses);
+export const useCustomerAddressesQuery = makeQuery<
+  CustomerAddresses,
+  CustomerAddressesVariables
+>(customerAddresses);
 
 const customerCreateData = gql`
   query CustomerCreateData {

--- a/src/customers/types.ts
+++ b/src/customers/types.ts
@@ -11,12 +11,6 @@ export interface AddressTypeInput {
   streetAddress1: string;
   streetAddress2?: string;
 }
-export type ShippingAddressTypeInput = {
-    [K in keyof AddressTypeInput as `shipping_${K}`]: AddressTypeInput[K]
-}
-export type BillingAddressTypeInput = {
-    [K in keyof AddressTypeInput as `billing_${K}`]: AddressTypeInput[K]
-}
 
 export interface AddressType {
   id: string;
@@ -34,10 +28,4 @@ export interface AddressType {
   postalCode: string;
   streetAddress1: string;
   streetAddress2?: string;
-}
-export type ShippingAddressType = {
-  [K in keyof AddressType as `shipping_${K}`]: AddressType[K]
-}
-export type BillingAddressType = {
-  [K in keyof AddressType as `billing_${K}`]: AddressType[K]
 }

--- a/src/customers/types.ts
+++ b/src/customers/types.ts
@@ -11,6 +11,13 @@ export interface AddressTypeInput {
   streetAddress1: string;
   streetAddress2?: string;
 }
+export type ShippingAddressTypeInput = {
+    [K in keyof AddressTypeInput as `shipping_${K}`]: AddressTypeInput[K]
+}
+export type BillingAddressTypeInput = {
+    [K in keyof AddressTypeInput as `billing_${K}`]: AddressTypeInput[K]
+}
+
 export interface AddressType {
   id: string;
   city: string;
@@ -27,4 +34,10 @@ export interface AddressType {
   postalCode: string;
   streetAddress1: string;
   streetAddress2?: string;
+}
+export type ShippingAddressType = {
+  [K in keyof AddressType as `shipping_${K}`]: AddressType[K]
+}
+export type BillingAddressType = {
+  [K in keyof AddressType as `billing_${K}`]: AddressType[K]
 }

--- a/src/customers/types/BulkRemoveCustomers.ts
+++ b/src/customers/types/BulkRemoveCustomers.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: BulkRemoveCustomers
@@ -13,6 +13,7 @@ export interface BulkRemoveCustomers_customerBulkDelete_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface BulkRemoveCustomers_customerBulkDelete {

--- a/src/customers/types/CreateCustomer.ts
+++ b/src/customers/types/CreateCustomer.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { UserCreateInput, AccountErrorCode } from "./../../types/globalTypes";
+import { UserCreateInput, AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CreateCustomer
@@ -13,6 +13,7 @@ export interface CreateCustomer_customerCreate_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface CreateCustomer_customerCreate_user {

--- a/src/customers/types/CreateCustomerAddress.ts
+++ b/src/customers/types/CreateCustomerAddress.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AddressInput, AccountErrorCode } from "./../../types/globalTypes";
+import { AddressInput, AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: CreateCustomerAddress
@@ -13,6 +13,7 @@ export interface CreateCustomerAddress_addressCreate_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface CreateCustomerAddress_addressCreate_address_country {

--- a/src/customers/types/RemoveCustomer.ts
+++ b/src/customers/types/RemoveCustomer.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: RemoveCustomer
@@ -13,6 +13,7 @@ export interface RemoveCustomer_customerDelete_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface RemoveCustomer_customerDelete {

--- a/src/customers/types/RemoveCustomerAddress.ts
+++ b/src/customers/types/RemoveCustomerAddress.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: RemoveCustomerAddress
@@ -13,6 +13,7 @@ export interface RemoveCustomerAddress_addressDelete_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface RemoveCustomerAddress_addressDelete_user_addresses_country {

--- a/src/customers/types/SetCustomerDefaultAddress.ts
+++ b/src/customers/types/SetCustomerDefaultAddress.ts
@@ -13,6 +13,7 @@ export interface SetCustomerDefaultAddress_addressSetDefault_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface SetCustomerDefaultAddress_addressSetDefault_user_addresses_country {

--- a/src/customers/types/UpdateCustomer.ts
+++ b/src/customers/types/UpdateCustomer.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { CustomerInput, AccountErrorCode } from "./../../types/globalTypes";
+import { CustomerInput, AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateCustomer
@@ -13,6 +13,7 @@ export interface UpdateCustomer_customerUpdate_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface UpdateCustomer_customerUpdate_user_metadata {

--- a/src/customers/types/UpdateCustomerAddress.ts
+++ b/src/customers/types/UpdateCustomerAddress.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AddressInput, AccountErrorCode } from "./../../types/globalTypes";
+import { AddressInput, AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: UpdateCustomerAddress
@@ -13,6 +13,7 @@ export interface UpdateCustomerAddress_addressUpdate_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface UpdateCustomerAddress_addressUpdate_address_country {

--- a/src/customers/views/CustomerAddresses.tsx
+++ b/src/customers/views/CustomerAddresses.tsx
@@ -101,11 +101,7 @@ const CustomerAddresses: React.FC<CustomerAddressesProps> = ({
                   {(removeCustomerAddress, removeCustomerAddressOpts) => (
                     <TypedCustomerAddressesQuery variables={{ id }}>
                       {customerData => {
-                        const countryChoices =
-                          shop?.countries?.map(country => ({
-                            code: country.code,
-                            label: country.country
-                          })) || [];
+                        const countryChoices = shop?.countries || [];
 
                         return (
                           <>

--- a/src/fragments/errors.ts
+++ b/src/fragments/errors.ts
@@ -44,6 +44,7 @@ export const accountErrorFragment = gql`
   fragment AccountErrorFragment on AccountError {
     code
     field
+    addressType
   }
 `;
 
@@ -66,6 +67,7 @@ export const orderErrorFragment = gql`
   fragment OrderErrorFragment on OrderError {
     code
     field
+    addressType
   }
 `;
 

--- a/src/fragments/types/AccountErrorFragment.ts
+++ b/src/fragments/types/AccountErrorFragment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: AccountErrorFragment
@@ -13,4 +13,5 @@ export interface AccountErrorFragment {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }

--- a/src/fragments/types/OrderErrorFragment.ts
+++ b/src/fragments/types/OrderErrorFragment.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: OrderErrorFragment
@@ -13,4 +13,5 @@ export interface OrderErrorFragment {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }

--- a/src/hooks/useAddressValidation.ts
+++ b/src/hooks/useAddressValidation.ts
@@ -1,7 +1,11 @@
 import { AddressTypeInput } from "@saleor/customers/types";
 import { AccountErrorFragment } from "@saleor/fragments/types/AccountErrorFragment";
 import { transformFormToAddress } from "@saleor/misc";
-import { AccountErrorCode, AddressInput } from "@saleor/types/globalTypes";
+import {
+  AccountErrorCode,
+  AddressInput,
+  AddressTypeEnum
+} from "@saleor/types/globalTypes";
 import { add, remove } from "@saleor/utils/lists";
 import { useState } from "react";
 
@@ -11,7 +15,8 @@ interface UseAddressValidation<TInput, TOutput> {
 }
 
 function useAddressValidation<TInput, TOutput>(
-  onSubmit: (address: TInput & AddressInput) => TOutput
+  onSubmit: (address: TInput & AddressInput) => TOutput,
+  addressType?: AddressTypeEnum
 ): UseAddressValidation<TInput, TOutput> {
   const [validationErrors, setValidationErrors] = useState<
     AccountErrorFragment[]
@@ -20,7 +25,8 @@ function useAddressValidation<TInput, TOutput>(
   const countryRequiredError: AccountErrorFragment = {
     __typename: "AccountError",
     code: AccountErrorCode.REQUIRED,
-    field: "country"
+    field: "country",
+    addressType
   };
 
   return {

--- a/src/hooks/useAddressValidation.ts
+++ b/src/hooks/useAddressValidation.ts
@@ -1,6 +1,6 @@
 import { AddressTypeInput } from "@saleor/customers/types";
 import { AccountErrorFragment } from "@saleor/fragments/types/AccountErrorFragment";
-import { transformFormToAddress } from "@saleor/misc";
+import { transformFormToAddressInput } from "@saleor/misc";
 import {
   AccountErrorCode,
   AddressInput,
@@ -40,7 +40,7 @@ function useAddressValidation<TInput, TOutput>(
             (a, b) => a.field === b.field
           )
         );
-        return onSubmit(transformFormToAddress(data));
+        return onSubmit(transformFormToAddressInput(data));
       } catch {
         setValidationErrors(add(countryRequiredError, validationErrors));
       }

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -164,6 +164,10 @@ export const buttonMessages = defineMessages({
     defaultMessage: "Save",
     description: "button"
   },
+  select: {
+    defaultMessage: "Select",
+    description: "select option, button"
+  },
   selectAll: {
     defaultMessage: "Select All",
     description: "select all options, button"

--- a/src/intl.ts
+++ b/src/intl.ts
@@ -128,6 +128,10 @@ export const buttonMessages = defineMessages({
     defaultMessage: "Confirm",
     description: "button"
   },
+  continue: {
+    defaultMessage: "Continue",
+    description: "button"
+  },
   create: {
     defaultMessage: "Create",
     description: "button"

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -410,7 +410,7 @@ export function capitalize(s: string) {
   return s.charAt(0).toLocaleUpperCase() + s.slice(1);
 }
 
-export function transformFormToAddress<T>(
+export function transformFormToAddressInput<T>(
   address: T & AddressTypeInput
 ): T & AddressInput {
   return {
@@ -437,3 +437,17 @@ export const getDatePeriod = (days: number): DateRangeInput => {
     lte: end.format(format)
   };
 };
+
+export const transformAddressToAddressInput = (data: AddressType) => ({
+  city: data?.city || "",
+  cityArea: data?.cityArea || "",
+  companyName: data?.companyName || "",
+  country: findInEnum(data?.country?.code || "", CountryCode),
+  countryArea: data?.countryArea || "",
+  firstName: data?.firstName || "",
+  lastName: data?.lastName || "",
+  phone: data?.phone || "",
+  postalCode: data?.postalCode || "",
+  streetAddress1: data?.streetAddress1 || "",
+  streetAddress2: data?.streetAddress2 || ""
+});

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -215,7 +215,7 @@ export const transformOrderStatus = (
   };
 };
 
-export const transformAddressToForm = (data: AddressType) => ({
+export const transformAddressToForm = (data?: AddressType) => ({
   city: data?.city || "",
   cityArea: data?.cityArea || "",
   companyName: data?.companyName || "",
@@ -438,7 +438,7 @@ export const getDatePeriod = (days: number): DateRangeInput => {
   };
 };
 
-export const transformAddressToAddressInput = (data: AddressType) => ({
+export const transformAddressToAddressInput = (data?: AddressType) => ({
   city: data?.city || "",
   cityArea: data?.cityArea || "",
   companyName: data?.companyName || "",

--- a/src/orders/components/OrderAddressEditDialog/OrderAddressEditDialog.tsx
+++ b/src/orders/components/OrderAddressEditDialog/OrderAddressEditDialog.tsx
@@ -8,16 +8,17 @@ import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
 import Form from "@saleor/components/Form";
+import { ShopInfo_shop_countries } from "@saleor/components/Shop/types/ShopInfo";
 import { AddressTypeInput } from "@saleor/customers/types";
 import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
 import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { buttonMessages } from "@saleor/intl";
-import { maybe } from "@saleor/misc";
 import { makeStyles } from "@saleor/theme";
 import { AddressInput } from "@saleor/types/globalTypes";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
+import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -36,10 +37,7 @@ interface OrderAddressEditDialogProps {
   open: boolean;
   errors: OrderErrorFragment[];
   variant: "billing" | "shipping" | string;
-  countries?: Array<{
-    code: string;
-    label: string;
-  }>;
+  countries?: ShopInfo_shop_countries[];
   onClose();
   onConfirm(data: AddressInput);
 }
@@ -59,9 +57,7 @@ const OrderAddressEditDialog: React.FC<OrderAddressEditDialogProps> = props => {
   const classes = useStyles(props);
   const intl = useIntl();
   const [countryDisplayName, setCountryDisplayName] = useStateFromProps(
-    maybe(
-      () => countries.find(country => address.country === country.code).label
-    )
+    countries.find(country => address?.country === country.code)?.country
   );
   const {
     errors: validationErrors,
@@ -72,10 +68,7 @@ const OrderAddressEditDialog: React.FC<OrderAddressEditDialogProps> = props => {
     open
   );
 
-  const countryChoices = countries.map(country => ({
-    label: country.label,
-    value: country.code
-  }));
+  const countryChoices = mapCountriesToChoices(countries);
 
   return (
     <Dialog onClose={onClose} open={open} classes={{ paper: classes.overflow }}>

--- a/src/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/src/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -57,7 +57,11 @@ export interface OrderCustomerProps
   canEditAddresses: boolean;
   canEditCustomer: boolean;
   fetchUsers?: (query: string) => void;
-  onCustomerEdit?: (data: { user?: string; userEmail?: string }) => void;
+  onCustomerEdit?: (data: {
+    user?: string;
+    userEmail?: string;
+    prevUser?: string;
+  }) => void;
   onProfileView: () => void;
   onBillingAddressEdit?: () => void;
   onShippingAddressEdit?: () => void;
@@ -132,6 +136,7 @@ const OrderCustomer: React.FC<OrderCustomerProps> = props => {
                 const value = event.target.value;
 
                 onCustomerEdit({
+                  prevUser: user?.id,
                   [value.includes("@") ? "userEmail" : "user"]: value
                 });
                 toggleEditMode();

--- a/src/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/src/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -48,6 +48,13 @@ const useStyles = makeStyles(
   { name: "OrderCustomer" }
 );
 
+export interface CustomerEditData {
+  user?: string;
+  userEmail?: string;
+  prevUser?: string;
+  prevUserEmail?: string;
+}
+
 export interface OrderCustomerProps
   extends Partial<FetchMoreProps>,
     UserPermissionProps {
@@ -57,11 +64,7 @@ export interface OrderCustomerProps
   canEditAddresses: boolean;
   canEditCustomer: boolean;
   fetchUsers?: (query: string) => void;
-  onCustomerEdit?: (data: {
-    user?: string;
-    userEmail?: string;
-    prevUser?: string;
-  }) => void;
+  onCustomerEdit?: (data: CustomerEditData) => void;
   onProfileView: () => void;
   onBillingAddressEdit?: () => void;
   onShippingAddressEdit?: () => void;
@@ -137,6 +140,7 @@ const OrderCustomer: React.FC<OrderCustomerProps> = props => {
 
                 onCustomerEdit({
                   prevUser: user?.id,
+                  prevUserEmail: userEmail,
                   [value.includes("@") ? "userEmail" : "user"]: value
                 });
                 toggleEditMode();

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
@@ -1,0 +1,121 @@
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Radio from "@material-ui/core/Radio";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import AddressEdit from "@saleor/components/AddressEdit";
+import CardSpacer from "@saleor/components/CardSpacer";
+import FormSpacer from "@saleor/components/FormSpacer";
+import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
+import CustomerAddressChoiceCard from "@saleor/customers/components/CustomerAddressChoiceCard";
+import { AddressTypeInput } from "@saleor/customers/types";
+import { CustomerAddresses_user_addresses } from "@saleor/customers/types/CustomerAddresses";
+import { AccountErrorFragment } from "@saleor/fragments/types/AccountErrorFragment";
+import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
+import { FormChange } from "@saleor/hooks/useForm";
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { AddressInputOptionEnum } from "./form";
+import { addressEditMessages } from "./messages";
+import { useStyles } from "./styles";
+
+export interface OrderCustomerAddressEditProps {
+  customerAddresses: CustomerAddresses_user_addresses[];
+  countryChoices: SingleAutocompleteChoiceType[];
+  addressInputOption: AddressInputOptionEnum;
+  addressInputName: string;
+  onChangeAddressInputOption: FormChange;
+  customerAddressId: string;
+  formAddress: AddressTypeInput;
+  formAddressCountryDisplayName: string;
+  formErrors: Array<AccountErrorFragment | OrderErrorFragment>;
+  onChangeCustomerAddress: (
+    customerAddress: CustomerAddresses_user_addresses
+  ) => void;
+  onChangeFormAddress: (event: React.ChangeEvent<any>) => void;
+  onChangeFormAddressCountry: (event: React.ChangeEvent<any>) => void;
+}
+
+const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props => {
+  const {
+    customerAddresses,
+    countryChoices,
+    addressInputOption,
+    addressInputName,
+    onChangeAddressInputOption,
+    customerAddressId,
+    formAddress,
+    formAddressCountryDisplayName,
+    formErrors,
+    onChangeCustomerAddress,
+    onChangeFormAddress,
+    onChangeFormAddressCountry
+  } = props;
+
+  const classes = useStyles(props);
+  const intl = useIntl();
+
+  return (
+    <RadioGroup
+      className={classes.container}
+      value={addressInputOption}
+      name={addressInputName}
+      onChange={event => onChangeAddressInputOption(event)}
+    >
+      <FormControlLabel
+        value={AddressInputOptionEnum.CUSTOMER_ADDRESS}
+        control={
+          <Radio
+            color="primary"
+            data-test="addressInputOption"
+            data-test-id={AddressInputOptionEnum.CUSTOMER_ADDRESS}
+          />
+        }
+        label={intl.formatMessage(addressEditMessages.customerAddress)}
+        className={classes.optionLabel}
+      />
+      {addressInputOption === AddressInputOptionEnum.CUSTOMER_ADDRESS && (
+        <>
+          {customerAddresses.map(customerAddress => (
+            <React.Fragment key={customerAddress.id}>
+              <CardSpacer />
+              <CustomerAddressChoiceCard
+                address={customerAddress}
+                selected={customerAddress.id === customerAddressId}
+                onSelect={() => onChangeCustomerAddress(customerAddress)}
+              />
+            </React.Fragment>
+          ))}
+          <FormSpacer />
+        </>
+      )}
+      <FormControlLabel
+        value={AddressInputOptionEnum.NEW_ADDRESS}
+        control={
+          <Radio
+            color="primary"
+            data-test={addressInputOption}
+            data-test-id={AddressInputOptionEnum.NEW_ADDRESS}
+          />
+        }
+        label={intl.formatMessage(addressEditMessages.newAddress)}
+        className={classes.optionLabel}
+      />
+      {addressInputOption === AddressInputOptionEnum.NEW_ADDRESS && (
+        <>
+          <FormSpacer />
+          <AddressEdit
+            countries={countryChoices}
+            countryDisplayValue={formAddressCountryDisplayName}
+            data={formAddress}
+            errors={formErrors}
+            onChange={onChangeFormAddress}
+            onCountryChange={onChangeFormAddressCountry}
+          />
+        </>
+      )}
+    </RadioGroup>
+  );
+};
+
+OrderCustomerAddressEdit.displayName = "OrderCustomerAddressEdit";
+export default OrderCustomerAddressEdit;

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
@@ -5,6 +5,7 @@ import AddressEdit from "@saleor/components/AddressEdit";
 import CardSpacer from "@saleor/components/CardSpacer";
 import FormSpacer from "@saleor/components/FormSpacer";
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
+import Skeleton from "@saleor/components/Skeleton";
 import CustomerAddressChoiceCard from "@saleor/customers/components/CustomerAddressChoiceCard";
 import { AddressTypeInput } from "@saleor/customers/types";
 import { CustomerAddresses_user_addresses } from "@saleor/customers/types/CustomerAddresses";
@@ -19,6 +20,7 @@ import { addressEditMessages } from "./messages";
 import { useStyles } from "./styles";
 
 export interface OrderCustomerAddressEditProps {
+  loading: boolean;
   customerAddresses: CustomerAddresses_user_addresses[];
   countryChoices: SingleAutocompleteChoiceType[];
   addressInputOption: AddressInputOptionEnum;
@@ -37,6 +39,7 @@ export interface OrderCustomerAddressEditProps {
 
 const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props => {
   const {
+    loading,
     customerAddresses,
     countryChoices,
     addressInputOption,
@@ -53,6 +56,23 @@ const OrderCustomerAddressEdit: React.FC<OrderCustomerAddressEditProps> = props 
 
   const classes = useStyles(props);
   const intl = useIntl();
+
+  if (loading) {
+    return <Skeleton />;
+  }
+
+  if (!customerAddresses.length) {
+    return (
+      <AddressEdit
+        countries={countryChoices}
+        countryDisplayValue={formAddressCountryDisplayName}
+        data={formAddress}
+        errors={formErrors}
+        onChange={onChangeFormAddress}
+        onCountryChange={onChangeFormAddressCountry}
+      />
+    );
+  }
 
   return (
     <RadioGroup

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
@@ -1,26 +1,13 @@
-import { transformAddressToForm } from "@saleor/misc";
 import Decorator from "@saleor/storybook/Decorator";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import { countries, order as orderFixture } from "../../fixtures";
 import OrderCustomerAddressesEditDialog, {
-  AddressInputOptionEnum,
-  OrderCustomerAddressesEditDialogData,
   OrderCustomerAddressesEditDialogProps
 } from "./OrderCustomerAddressesEditDialog";
 
 const order = orderFixture("");
-
-const data: OrderCustomerAddressesEditDialogData = {
-  billingSameAsShipping: false,
-  shippingAddressInputOption: AddressInputOptionEnum.CUSTOMER_ADDRESS,
-  billingAddressInputOption: AddressInputOptionEnum.NEW_ADDRESS,
-  shippingAddress: transformAddressToForm(order.shippingAddress),
-  billingAddress: transformAddressToForm(order.billingAddress),
-  customerShippingAddress: order.shippingAddress,
-  customerBillingAddress: order.billingAddress
-};
 
 const props: OrderCustomerAddressesEditDialogProps = {
   confirmButtonState: "default",

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 import { countries, order as orderFixture } from "../../fixtures";
 import OrderCustomerAddressesEditDialog, {
+  AddressInputOptionEnum,
   OrderCustomerAddressesEditDialogData,
   OrderCustomerAddressesEditDialogProps
 } from "./OrderCustomerAddressesEditDialog";
@@ -12,9 +13,13 @@ import OrderCustomerAddressesEditDialog, {
 const order = orderFixture("");
 
 const data: OrderCustomerAddressesEditDialogData = {
+  billingSameAsShipping: false,
+  shippingAddressInputOption: AddressInputOptionEnum.CUSTOMER_ADDRESS,
+  billingAddressInputOption: AddressInputOptionEnum.NEW_ADDRESS,
   shippingAddress: transformAddressToForm(order.shippingAddress),
   billingAddress: transformAddressToForm(order.billingAddress),
-  userAddresses: [order.shippingAddress, order.billingAddress]
+  userShippingAddress: order.shippingAddress,
+  userBillingAddress: order.billingAddress
 };
 
 const props: OrderCustomerAddressesEditDialogProps = {
@@ -34,6 +39,10 @@ storiesOf("Orders / OrderCustomerAddressesEditDialog", module)
       confirmButtonState="default"
       data={data}
       countries={countries}
+      userAddresses={[
+        order.shippingAddress,
+        { ...order.billingAddress, id: "asdfghjfuunie" }
+      ]}
       errors={[]}
       onClose={() => undefined}
       onConfirm={() => undefined}

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
@@ -11,6 +11,7 @@ const order = orderFixture("");
 
 const props: OrderCustomerAddressesEditDialogProps = {
   confirmButtonState: "default",
+  loading: false,
   onClose: () => undefined,
   onConfirm: () => undefined,
   open: true,
@@ -22,15 +23,24 @@ storiesOf("Orders / OrderCustomerAddressesEditDialog", module)
   .add("default", () => (
     <OrderCustomerAddressesEditDialog
       {...props}
-      confirmButtonState="default"
       countries={countries}
       customerAddresses={[
         order.shippingAddress,
         { ...order.billingAddress, id: "asdfghjfuunie" }
       ]}
-      errors={[]}
-      onClose={() => undefined}
-      onConfirm={() => undefined}
-      open={true}
+    />
+  ))
+  .add("no customer addresses", () => (
+    <OrderCustomerAddressesEditDialog
+      {...props}
+      countries={countries}
+      customerAddresses={[]}
+    />
+  ))
+  .add("loading", () => (
+    <OrderCustomerAddressesEditDialog
+      {...props}
+      loading={true}
+      confirmButtonState="loading"
     />
   ));

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
@@ -1,0 +1,42 @@
+import { transformAddressToForm } from "@saleor/misc";
+import Decorator from "@saleor/storybook/Decorator";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { countries, order as orderFixture } from "../../fixtures";
+import OrderCustomerAddressesEditDialog, {
+  OrderCustomerAddressesEditDialogData,
+  OrderCustomerAddressesEditDialogProps
+} from "./OrderCustomerAddressesEditDialog";
+
+const order = orderFixture("");
+
+const data: OrderCustomerAddressesEditDialogData = {
+  shippingAddress: transformAddressToForm(order.shippingAddress),
+  billingAddress: transformAddressToForm(order.billingAddress),
+  userAddresses: [order.shippingAddress, order.billingAddress]
+};
+
+const props: OrderCustomerAddressesEditDialogProps = {
+  confirmButtonState: "default",
+  onClose: () => undefined,
+  onConfirm: () => undefined,
+  open: true,
+  data,
+  errors: undefined
+};
+
+storiesOf("Orders / OrderCustomerAddressesEditDialog", module)
+  .addDecorator(Decorator)
+  .add("default", () => (
+    <OrderCustomerAddressesEditDialog
+      {...props}
+      confirmButtonState="default"
+      data={data}
+      countries={countries}
+      errors={[]}
+      onClose={() => undefined}
+      onConfirm={() => undefined}
+      open={true}
+    />
+  ));

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.stories.tsx
@@ -18,8 +18,8 @@ const data: OrderCustomerAddressesEditDialogData = {
   billingAddressInputOption: AddressInputOptionEnum.NEW_ADDRESS,
   shippingAddress: transformAddressToForm(order.shippingAddress),
   billingAddress: transformAddressToForm(order.billingAddress),
-  userShippingAddress: order.shippingAddress,
-  userBillingAddress: order.billingAddress
+  customerShippingAddress: order.shippingAddress,
+  customerBillingAddress: order.billingAddress
 };
 
 const props: OrderCustomerAddressesEditDialogProps = {
@@ -27,7 +27,6 @@ const props: OrderCustomerAddressesEditDialogProps = {
   onClose: () => undefined,
   onConfirm: () => undefined,
   open: true,
-  data,
   errors: undefined
 };
 
@@ -37,9 +36,8 @@ storiesOf("Orders / OrderCustomerAddressesEditDialog", module)
     <OrderCustomerAddressesEditDialog
       {...props}
       confirmButtonState="default"
-      data={data}
       countries={countries}
-      userAddresses={[
+      customerAddresses={[
         order.shippingAddress,
         { ...order.billingAddress, id: "asdfghjfuunie" }
       ]}

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -63,6 +63,9 @@ const useStyles = makeStyles(
     container: {
       display: "block"
     },
+    optionLabel: {
+      display: "block"
+    },
     overflow: {
       overflowY: "visible"
     }
@@ -70,15 +73,19 @@ const useStyles = makeStyles(
   { name: "OrderCustomerAddressesEditDialog" }
 );
 
-enum AddressInputTypeEnum {
-  CUSTOMER_ADDRESS,
-  NEW_ADDRESS
+export enum AddressInputOptionEnum {
+  CUSTOMER_ADDRESS = "customerAddress",
+  NEW_ADDRESS = "newAddress"
 }
 
 export interface OrderCustomerAddressesEditDialogData {
+  billingSameAsShipping: boolean;
+  shippingAddressInputOption: AddressInputOptionEnum;
+  billingAddressInputOption: AddressInputOptionEnum;
+  userShippingAddress: CustomerAddresses_user_addresses;
+  userBillingAddress: CustomerAddresses_user_addresses;
   shippingAddress: AddressTypeInput;
   billingAddress: AddressTypeInput;
-  userAddresses: CustomerAddresses_user_addresses[];
 }
 
 export interface OrderCustomerAddressesEditDialogProps {
@@ -90,6 +97,7 @@ export interface OrderCustomerAddressesEditDialogProps {
     code: string;
     label: string;
   }>;
+  userAddresses?: CustomerAddresses_user_addresses[];
   onClose();
   onConfirm(data: AddressInput);
 }
@@ -101,6 +109,7 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
     open,
     errors = [],
     countries = [],
+    userAddresses = [],
     onClose,
     onConfirm
   } = props;
@@ -148,88 +157,142 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                   <FormattedMessage {...messages.shippingAddressDescription} />
                 </Typography>
                 <FormSpacer />
-                <RadioGroup className={classes.container} value={undefined}>
+                <RadioGroup
+                  className={classes.container}
+                  value={data.shippingAddressInputOption}
+                  name="shippingAddressInputOption"
+                  onChange={event => change(event)}
+                >
                   <FormControlLabel
-                    value={AddressInputTypeEnum.CUSTOMER_ADDRESS}
+                    value={AddressInputOptionEnum.CUSTOMER_ADDRESS}
                     control={<Radio color="primary" />}
                     label={intl.formatMessage(messages.customerAddress)}
-                    onChange={() => null}
+                    className={classes.optionLabel}
                   />
-                  {data.userAddresses.map(userAddress => (
+                  {data.shippingAddressInputOption ===
+                    AddressInputOptionEnum.CUSTOMER_ADDRESS && (
                     <>
-                      <CardSpacer />
-                      <CustomerAddressChoice
-                        address={userAddress}
-                        selected={false}
-                        onSelect={() => null}
-                      />
+                      {userAddresses.map(userAddress => (
+                        <>
+                          <CardSpacer />
+                          <CustomerAddressChoice
+                            address={userAddress}
+                            selected={
+                              userAddress.id === data.userShippingAddress.id
+                            }
+                            onSelect={() =>
+                              change({
+                                target: {
+                                  name: "userShippingAddress",
+                                  value: userAddress
+                                }
+                              })
+                            }
+                          />
+                        </>
+                      ))}
+                      <FormSpacer />
                     </>
-                  ))}
-                  <FormSpacer />
+                  )}
                   <FormControlLabel
-                    value={AddressInputTypeEnum.NEW_ADDRESS}
+                    value={AddressInputOptionEnum.NEW_ADDRESS}
                     control={<Radio color="primary" />}
                     label={intl.formatMessage(messages.newAddress)}
-                    onChange={() => null}
+                    className={classes.optionLabel}
                   />
-                  <FormSpacer />
-                  <AddressEdit
-                    countries={countryChoices}
-                    countryDisplayValue={countryDisplayName}
-                    data={data.shippingAddress}
-                    errors={dialogErrors}
-                    onChange={change}
-                    onCountryChange={handleCountrySelect}
-                  />
+                  {data.shippingAddressInputOption ===
+                    AddressInputOptionEnum.NEW_ADDRESS && (
+                    <>
+                      <FormSpacer />
+                      <AddressEdit
+                        countries={countryChoices}
+                        countryDisplayValue={countryDisplayName}
+                        data={data.shippingAddress}
+                        errors={dialogErrors}
+                        onChange={change}
+                        onCountryChange={handleCountrySelect}
+                      />
+                    </>
+                  )}
                 </RadioGroup>
                 <FormSpacer />
                 <Divider />
                 <FormSpacer />
                 <ControlledCheckbox
-                  checked={false}
-                  name="sameAsShipping"
+                  checked={data.billingSameAsShipping}
+                  name="billingSameAsShipping"
                   label={intl.formatMessage(messages.billingSameAsShipping)}
-                  onChange={() => null}
+                  onChange={change}
                 />
-                <FormSpacer />
-                <Typography>
-                  <FormattedMessage {...messages.billingAddressDescription} />
-                </Typography>
-                <FormSpacer />
-                <RadioGroup className={classes.container} value={undefined}>
-                  <FormControlLabel
-                    value={AddressInputTypeEnum.CUSTOMER_ADDRESS}
-                    control={<Radio color="primary" />}
-                    label={intl.formatMessage(messages.customerAddress)}
-                    onChange={() => null}
-                  />
-                  {data.userAddresses.map(userAddress => (
-                    <>
-                      <CardSpacer />
-                      <CustomerAddressChoice
-                        address={userAddress}
-                        selected={false}
-                        onSelect={() => null}
+                {!data.billingSameAsShipping && (
+                  <>
+                    <FormSpacer />
+                    <Typography>
+                      <FormattedMessage
+                        {...messages.billingAddressDescription}
                       />
-                    </>
-                  ))}
-                  <FormSpacer />
-                  <FormControlLabel
-                    value={AddressInputTypeEnum.NEW_ADDRESS}
-                    control={<Radio color="primary" />}
-                    label={intl.formatMessage(messages.newAddress)}
-                    onChange={() => null}
-                  />
-                  <FormSpacer />
-                  <AddressEdit
-                    countries={countryChoices}
-                    countryDisplayValue={countryDisplayName}
-                    data={data.billingAddress}
-                    errors={dialogErrors}
-                    onChange={change}
-                    onCountryChange={handleCountrySelect}
-                  />
-                </RadioGroup>
+                    </Typography>
+                    <FormSpacer />
+                    <RadioGroup
+                      className={classes.container}
+                      value={data.billingAddressInputOption}
+                      name="billingAddressInputOption"
+                      onChange={event => change(event)}
+                    >
+                      <FormControlLabel
+                        value={AddressInputOptionEnum.CUSTOMER_ADDRESS}
+                        control={<Radio color="primary" />}
+                        label={intl.formatMessage(messages.customerAddress)}
+                        className={classes.optionLabel}
+                      />
+                      {data.billingAddressInputOption ===
+                        AddressInputOptionEnum.CUSTOMER_ADDRESS && (
+                        <>
+                          {userAddresses.map(userAddress => (
+                            <>
+                              <CardSpacer />
+                              <CustomerAddressChoice
+                                address={userAddress}
+                                selected={
+                                  userAddress.id === data.userBillingAddress.id
+                                }
+                                onSelect={() =>
+                                  change({
+                                    target: {
+                                      name: "userBillingAddress",
+                                      value: userAddress
+                                    }
+                                  })
+                                }
+                              />
+                            </>
+                          ))}
+                          <FormSpacer />
+                        </>
+                      )}
+                      <FormControlLabel
+                        value={AddressInputOptionEnum.NEW_ADDRESS}
+                        control={<Radio color="primary" />}
+                        label={intl.formatMessage(messages.newAddress)}
+                        className={classes.optionLabel}
+                      />
+                      {data.billingAddressInputOption ===
+                        AddressInputOptionEnum.NEW_ADDRESS && (
+                        <>
+                          <FormSpacer />
+                          <AddressEdit
+                            countries={countryChoices}
+                            countryDisplayValue={countryDisplayName}
+                            data={data.billingAddress}
+                            errors={dialogErrors}
+                            onChange={change}
+                            onCountryChange={handleCountrySelect}
+                          />
+                        </>
+                      )}
+                    </RadioGroup>
+                  </>
+                )}
               </DialogContent>
               <DialogActions>
                 <ConfirmButton

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -14,7 +14,8 @@ import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
 import FormSpacer from "@saleor/components/FormSpacer";
-import CustomerAddressChoice from "@saleor/customers/components/CustomerAddressChoice";
+import { ShopInfo_shop_countries } from "@saleor/components/Shop/types/ShopInfo";
+import CustomerAddressChoiceCard from "@saleor/customers/components/CustomerAddressChoiceCard";
 import {
   CustomerAddresses_user_addresses,
   CustomerAddresses_user_defaultBillingAddress,
@@ -27,9 +28,11 @@ import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 import { buttonMessages } from "@saleor/intl";
 import { transformAddressToAddressInput } from "@saleor/misc";
 import { AddressInput, AddressTypeEnum } from "@saleor/types/globalTypes";
+import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import { getById } from "../OrderReturnPage/utils";
 import OrderCustomerAddressesEditForm, {
   AddressInputOptionEnum,
   OrderCustomerAddressesEditFormData
@@ -46,10 +49,7 @@ export interface OrderCustomerAddressesEditDialogProps {
   open: boolean;
   confirmButtonState: ConfirmButtonTransitionState;
   errors: OrderErrorFragment[];
-  countries?: Array<{
-    code: string;
-    label: string;
-  }>;
+  countries?: ShopInfo_shop_countries[];
   customerAddresses?: CustomerAddresses_user_addresses[];
   defaultShippingAddress?: CustomerAddresses_user_defaultShippingAddress;
   defaultBillingAddress?: CustomerAddresses_user_defaultBillingAddress;
@@ -87,9 +87,7 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
 
   const getCustomerAddress = (customerAddressId: string): AddressInput =>
     transformAddressToAddressInput(
-      customerAddresses.find(
-        customerAddress => customerAddress.id === customerAddressId
-      )
+      customerAddresses.find(getById(customerAddressId))
     );
 
   const handleAddressesSubmit = (data: OrderCustomerAddressesEditFormData) => {
@@ -125,10 +123,7 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
     }
   };
 
-  const countryChoices = countries.map(country => ({
-    label: country.label,
-    value: country.code
-  }));
+  const countryChoices = mapCountriesToChoices(countries);
 
   return (
     <Dialog onClose={onClose} open={open}>
@@ -172,7 +167,7 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                     {customerAddresses.map(customerAddress => (
                       <React.Fragment key={customerAddress.id}>
                         <CardSpacer />
-                        <CustomerAddressChoice
+                        <CustomerAddressChoiceCard
                           address={customerAddress}
                           selected={
                             customerAddress.id ===
@@ -283,7 +278,7 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                         {customerAddresses.map(customerAddress => (
                           <React.Fragment key={customerAddress.id}>
                             <CardSpacer />
-                            <CustomerAddressChoice
+                            <CustomerAddressChoiceCard
                               address={customerAddress}
                               selected={
                                 customerAddress.id ===

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -26,7 +26,6 @@ import { SubmitPromise } from "@saleor/hooks/useForm";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 import { buttonMessages } from "@saleor/intl";
 import { transformAddressToAddressInput } from "@saleor/misc";
-import { makeStyles } from "@saleor/theme";
 import { AddressInput, AddressTypeEnum } from "@saleor/types/globalTypes";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -36,21 +35,7 @@ import OrderCustomerAddressesEditForm, {
   OrderCustomerAddressesEditFormData
 } from "./form";
 import messages from "./messages";
-
-const useStyles = makeStyles(
-  {
-    container: {
-      display: "block"
-    },
-    optionLabel: {
-      display: "block"
-    },
-    overflow: {
-      overflowY: "visible"
-    }
-  },
-  { name: "OrderCustomerAddressesEditDialog" }
-);
+import { useStyles } from "./styles";
 
 export interface OrderCustomerAddressesEditDialogOutput {
   shippingAddress: AddressInput;

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -4,18 +4,13 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import Divider from "@material-ui/core/Divider";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
-import Radio from "@material-ui/core/Radio";
-import RadioGroup from "@material-ui/core/RadioGroup";
 import Typography from "@material-ui/core/Typography";
-import AddressEdit from "@saleor/components/AddressEdit";
-import CardSpacer from "@saleor/components/CardSpacer";
 import Checkbox from "@saleor/components/Checkbox";
 import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
 import FormSpacer from "@saleor/components/FormSpacer";
 import { ShopInfo_shop_countries } from "@saleor/components/Shop/types/ShopInfo";
-import CustomerAddressChoiceCard from "@saleor/customers/components/CustomerAddressChoiceCard";
 import {
   CustomerAddresses_user_addresses,
   CustomerAddresses_user_defaultBillingAddress,
@@ -37,7 +32,8 @@ import OrderCustomerAddressesEditForm, {
   AddressInputOptionEnum,
   OrderCustomerAddressesEditFormData
 } from "./form";
-import messages from "./messages";
+import { dialogMessages } from "./messages";
+import OrderCustomerAddressEdit from "./OrderCustomerAddressEdit";
 import { useStyles } from "./styles";
 
 export interface OrderCustomerAddressesEditDialogOutput {
@@ -136,96 +132,38 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
         {({ change, data, handlers }) => (
           <>
             <DialogTitle>
-              <FormattedMessage {...messages.title} />
+              <FormattedMessage {...dialogMessages.title} />
             </DialogTitle>
             <DialogContent className={classes.overflow}>
               <Typography>
-                <FormattedMessage {...messages.shippingAddressDescription} />
+                <FormattedMessage
+                  {...dialogMessages.shippingAddressDescription}
+                />
               </Typography>
               <FormSpacer />
-              <RadioGroup
-                className={classes.container}
-                value={data.shippingAddressInputOption}
-                name="shippingAddressInputOption"
-                onChange={event => change(event)}
-              >
-                <FormControlLabel
-                  value={AddressInputOptionEnum.CUSTOMER_ADDRESS}
-                  control={
-                    <Radio
-                      color="primary"
-                      data-test="shippingAddressInputOption"
-                      data-test-id={AddressInputOptionEnum.CUSTOMER_ADDRESS}
-                    />
-                  }
-                  label={intl.formatMessage(messages.customerAddress)}
-                  className={classes.optionLabel}
-                />
-                {data.shippingAddressInputOption ===
-                  AddressInputOptionEnum.CUSTOMER_ADDRESS && (
-                  <>
-                    {customerAddresses.map(customerAddress => (
-                      <React.Fragment key={customerAddress.id}>
-                        <CardSpacer />
-                        <CustomerAddressChoiceCard
-                          address={customerAddress}
-                          selected={
-                            customerAddress.id ===
-                            data.customerShippingAddress?.id
-                          }
-                          onSelect={() =>
-                            change({
-                              target: {
-                                name: "customerShippingAddress",
-                                value: customerAddress
-                              }
-                            })
-                          }
-                        />
-                      </React.Fragment>
-                    ))}
-                    <FormSpacer />
-                  </>
+              <OrderCustomerAddressEdit
+                countryChoices={countryChoices}
+                addressInputOption={data.shippingAddressInputOption}
+                addressInputName="shippingAddressInputOption"
+                onChangeAddressInputOption={change}
+                customerAddresses={customerAddresses}
+                customerAddressId={data.customerShippingAddress?.id}
+                formAddress={data.shippingAddress}
+                formAddressCountryDisplayName={data.shippingCountryDisplayName}
+                formErrors={dialogErrors.filter(
+                  error => error.addressType === AddressTypeEnum.SHIPPING
                 )}
-                <FormControlLabel
-                  value={AddressInputOptionEnum.NEW_ADDRESS}
-                  control={
-                    <Radio
-                      color="primary"
-                      data-test="shippingAddressInputOption"
-                      data-test-id={AddressInputOptionEnum.NEW_ADDRESS}
-                    />
-                  }
-                  label={intl.formatMessage(messages.newAddress)}
-                  className={classes.optionLabel}
-                />
-                {data.shippingAddressInputOption ===
-                  AddressInputOptionEnum.NEW_ADDRESS && (
-                  <>
-                    <FormSpacer />
-                    <AddressEdit
-                      countries={countryChoices}
-                      countryDisplayValue={data.shippingCountryDisplayName}
-                      data={data.shippingAddress}
-                      errors={dialogErrors.filter(
-                        error => error.addressType === AddressTypeEnum.SHIPPING
-                      )}
-                      onChange={event =>
-                        change({
-                          target: {
-                            name: "shippingAddress",
-                            value: {
-                              ...data.shippingAddress,
-                              [event.target.name]: event.target.value
-                            }
-                          }
-                        })
-                      }
-                      onCountryChange={handlers.selectShippingCountry}
-                    />
-                  </>
-                )}
-              </RadioGroup>
+                onChangeCustomerAddress={customerAddress =>
+                  handlers.changeCustomerAddress(
+                    customerAddress,
+                    "customerShippingAddress"
+                  )
+                }
+                onChangeFormAddress={event =>
+                  handlers.changeFormAddress(event, "shippingAddress")
+                }
+                onChangeFormAddressCountry={handlers.selectShippingCountry}
+              />
               <FormSpacer />
               <Divider />
               <FormSpacer />
@@ -245,99 +183,42 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                     data-test="billingSameAsShipping"
                   />
                 }
-                label={intl.formatMessage(messages.billingSameAsShipping)}
+                label={intl.formatMessage(dialogMessages.billingSameAsShipping)}
               />
               {!data.billingSameAsShipping && (
                 <>
                   <FormSpacer />
                   <Typography>
-                    <FormattedMessage {...messages.billingAddressDescription} />
+                    <FormattedMessage
+                      {...dialogMessages.billingAddressDescription}
+                    />
                   </Typography>
                   <FormSpacer />
-                  <RadioGroup
-                    className={classes.container}
-                    value={data.billingAddressInputOption}
-                    name="billingAddressInputOption"
-                    onChange={event => change(event)}
-                  >
-                    <FormControlLabel
-                      value={AddressInputOptionEnum.CUSTOMER_ADDRESS}
-                      control={
-                        <Radio
-                          color="primary"
-                          data-test="billingAddressInputOption"
-                          data-test-id={AddressInputOptionEnum.CUSTOMER_ADDRESS}
-                        />
-                      }
-                      label={intl.formatMessage(messages.customerAddress)}
-                      className={classes.optionLabel}
-                    />
-                    {data.billingAddressInputOption ===
-                      AddressInputOptionEnum.CUSTOMER_ADDRESS && (
-                      <>
-                        {customerAddresses.map(customerAddress => (
-                          <React.Fragment key={customerAddress.id}>
-                            <CardSpacer />
-                            <CustomerAddressChoiceCard
-                              address={customerAddress}
-                              selected={
-                                customerAddress.id ===
-                                data.customerBillingAddress?.id
-                              }
-                              onSelect={() =>
-                                change({
-                                  target: {
-                                    name: "customerBillingAddress",
-                                    value: customerAddress
-                                  }
-                                })
-                              }
-                            />
-                          </React.Fragment>
-                        ))}
-                        <FormSpacer />
-                      </>
+                  <OrderCustomerAddressEdit
+                    countryChoices={countryChoices}
+                    addressInputOption={data.billingAddressInputOption}
+                    addressInputName="billingAddressInputOption"
+                    onChangeAddressInputOption={change}
+                    customerAddresses={customerAddresses}
+                    customerAddressId={data.customerBillingAddress?.id}
+                    formAddress={data.billingAddress}
+                    formAddressCountryDisplayName={
+                      data.billingCountryDisplayName
+                    }
+                    formErrors={dialogErrors.filter(
+                      error => error.addressType === AddressTypeEnum.BILLING
                     )}
-                    <FormControlLabel
-                      value={AddressInputOptionEnum.NEW_ADDRESS}
-                      control={
-                        <Radio
-                          color="primary"
-                          data-test="billingAddressInputOption"
-                          data-test-id={AddressInputOptionEnum.NEW_ADDRESS}
-                        />
-                      }
-                      label={intl.formatMessage(messages.newAddress)}
-                      className={classes.optionLabel}
-                    />
-                    {data.billingAddressInputOption ===
-                      AddressInputOptionEnum.NEW_ADDRESS && (
-                      <>
-                        <FormSpacer />
-                        <AddressEdit
-                          countries={countryChoices}
-                          countryDisplayValue={data.billingCountryDisplayName}
-                          data={data.billingAddress}
-                          errors={dialogErrors.filter(
-                            error =>
-                              error.addressType === AddressTypeEnum.BILLING
-                          )}
-                          onChange={event =>
-                            change({
-                              target: {
-                                name: "billingAddress",
-                                value: {
-                                  ...data.billingAddress,
-                                  [event.target.name]: event.target.value
-                                }
-                              }
-                            })
-                          }
-                          onCountryChange={handlers.selectBillingCountry}
-                        />
-                      </>
-                    )}
-                  </RadioGroup>
+                    onChangeCustomerAddress={customerAddress =>
+                      handlers.changeCustomerAddress(
+                        customerAddress,
+                        "customerBillingAddress"
+                      )
+                    }
+                    onChangeFormAddress={event =>
+                      handlers.changeFormAddress(event, "billingAddress")
+                    }
+                    onChangeFormAddressCountry={handlers.selectBillingCountry}
+                  />
                 </>
               )}
             </DialogContent>

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -43,6 +43,7 @@ export interface OrderCustomerAddressesEditDialogOutput {
 
 export interface OrderCustomerAddressesEditDialogProps {
   open: boolean;
+  loading: boolean;
   confirmButtonState: ConfirmButtonTransitionState;
   errors: OrderErrorFragment[];
   countries?: ShopInfo_shop_countries[];
@@ -56,6 +57,7 @@ export interface OrderCustomerAddressesEditDialogProps {
 const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialogProps> = props => {
   const {
     open,
+    loading,
     confirmButtonState,
     errors = [],
     countries = [],
@@ -88,8 +90,9 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
 
   const handleAddressesSubmit = (data: OrderCustomerAddressesEditFormData) => {
     const shippingAddress =
+      customerAddresses.length > 0 &&
       data.shippingAddressInputOption ===
-      AddressInputOptionEnum.CUSTOMER_ADDRESS
+        AddressInputOptionEnum.CUSTOMER_ADDRESS
         ? getCustomerAddress(data.customerShippingAddress.id)
         : handleShippingSubmit(data.shippingAddress);
 
@@ -101,6 +104,7 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
     }
 
     const billingAddress =
+      customerAddresses.length > 0 &&
       data.billingAddressInputOption === AddressInputOptionEnum.CUSTOMER_ADDRESS
         ? getCustomerAddress(data.customerBillingAddress.id)
         : handleBillingSubmit(data.billingAddress);
@@ -136,12 +140,19 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
             </DialogTitle>
             <DialogContent className={classes.overflow}>
               <Typography>
-                <FormattedMessage
-                  {...dialogMessages.shippingAddressDescription}
-                />
+                {customerAddresses.length > 0 ? (
+                  <FormattedMessage
+                    {...dialogMessages.customerShippingAddressDescription}
+                  />
+                ) : (
+                  <FormattedMessage
+                    {...dialogMessages.shippingAddressDescription}
+                  />
+                )}
               </Typography>
               <FormSpacer />
               <OrderCustomerAddressEdit
+                loading={loading}
                 countryChoices={countryChoices}
                 addressInputOption={data.shippingAddressInputOption}
                 addressInputName="shippingAddressInputOption"
@@ -189,12 +200,19 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                 <>
                   <FormSpacer />
                   <Typography>
-                    <FormattedMessage
-                      {...dialogMessages.billingAddressDescription}
-                    />
+                    {customerAddresses.length > 0 ? (
+                      <FormattedMessage
+                        {...dialogMessages.customerBillingAddressDescription}
+                      />
+                    ) : (
+                      <FormattedMessage
+                        {...dialogMessages.billingAddressDescription}
+                      />
+                    )}
                   </Typography>
                   <FormSpacer />
                   <OrderCustomerAddressEdit
+                    loading={loading}
                     countryChoices={countryChoices}
                     addressInputOption={data.billingAddressInputOption}
                     addressInputName="billingAddressInputOption"

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -1,0 +1,254 @@
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import Divider from "@material-ui/core/Divider";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Radio from "@material-ui/core/Radio";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import Typography from "@material-ui/core/Typography";
+import AddressEdit from "@saleor/components/AddressEdit";
+import CardSpacer from "@saleor/components/CardSpacer";
+import ConfirmButton, {
+  ConfirmButtonTransitionState
+} from "@saleor/components/ConfirmButton";
+import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
+import Form from "@saleor/components/Form";
+import FormSpacer from "@saleor/components/FormSpacer";
+import CustomerAddressChoice from "@saleor/customers/components/CustomerAddressChoice";
+import { AddressTypeInput } from "@saleor/customers/types";
+import { CustomerAddresses_user_addresses } from "@saleor/customers/types/CustomerAddresses";
+import { OrderErrorFragment } from "@saleor/fragments/types/OrderErrorFragment";
+import useAddressValidation from "@saleor/hooks/useAddressValidation";
+import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
+import useStateFromProps from "@saleor/hooks/useStateFromProps";
+import { buttonMessages } from "@saleor/intl";
+import { maybe } from "@saleor/misc";
+import { makeStyles } from "@saleor/theme";
+import { AddressInput } from "@saleor/types/globalTypes";
+import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
+import React from "react";
+import { defineMessages, FormattedMessage, useIntl } from "react-intl";
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: "Shipping address for order",
+    description: "dialog header"
+  },
+  customerAddress: {
+    defaultMessage: "Use one of customer addresses",
+    description: "address type"
+  },
+  newAddress: {
+    defaultMessage: "Add new address",
+    description: "address type"
+  },
+  billingSameAsShipping: {
+    defaultMessage: "Billing address same as shipping address",
+    description: "checkbox label"
+  },
+  shippingAddressDescription: {
+    defaultMessage:
+      "Which address would you like to use as shipping address for selected customer:",
+    description: "dialog content"
+  },
+  billingAddressDescription: {
+    defaultMessage: "Select one of customer addresses or add a new address:",
+    description: "dialog content"
+  }
+});
+
+const useStyles = makeStyles(
+  {
+    container: {
+      display: "block"
+    },
+    overflow: {
+      overflowY: "visible"
+    }
+  },
+  { name: "OrderCustomerAddressesEditDialog" }
+);
+
+enum AddressInputTypeEnum {
+  CUSTOMER_ADDRESS,
+  NEW_ADDRESS
+}
+
+export interface OrderCustomerAddressesEditDialogData {
+  shippingAddress: AddressTypeInput;
+  billingAddress: AddressTypeInput;
+  userAddresses: CustomerAddresses_user_addresses[];
+}
+
+export interface OrderCustomerAddressesEditDialogProps {
+  confirmButtonState: ConfirmButtonTransitionState;
+  data: OrderCustomerAddressesEditDialogData;
+  open: boolean;
+  errors: OrderErrorFragment[];
+  countries?: Array<{
+    code: string;
+    label: string;
+  }>;
+  onClose();
+  onConfirm(data: AddressInput);
+}
+
+const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialogProps> = props => {
+  const {
+    data,
+    confirmButtonState,
+    open,
+    errors = [],
+    countries = [],
+    onClose,
+    onConfirm
+  } = props;
+
+  const classes = useStyles(props);
+  const intl = useIntl();
+  const [countryDisplayName, setCountryDisplayName] = useStateFromProps(
+    maybe(
+      () =>
+        countries.find(country => data.shippingAddress.country === country.code)
+          .label
+    )
+  );
+  const {
+    errors: validationErrors,
+    submit: handleSubmit
+  } = useAddressValidation(onConfirm);
+  const dialogErrors = useModalDialogErrors(
+    [...errors, ...validationErrors],
+    open
+  );
+
+  const countryChoices = countries.map(country => ({
+    label: country.label,
+    value: country.code
+  }));
+
+  return (
+    <Dialog onClose={onClose} open={open}>
+      <Form initial={data} onSubmit={handleSubmit}>
+        {({ change, data }) => {
+          const handleCountrySelect = createSingleAutocompleteSelectHandler(
+            change,
+            setCountryDisplayName,
+            countryChoices
+          );
+
+          return (
+            <>
+              <DialogTitle>
+                <FormattedMessage {...messages.title} />
+              </DialogTitle>
+              <DialogContent className={classes.overflow}>
+                <Typography>
+                  <FormattedMessage {...messages.shippingAddressDescription} />
+                </Typography>
+                <FormSpacer />
+                <RadioGroup className={classes.container} value={undefined}>
+                  <FormControlLabel
+                    value={AddressInputTypeEnum.CUSTOMER_ADDRESS}
+                    control={<Radio color="primary" />}
+                    label={intl.formatMessage(messages.customerAddress)}
+                    onChange={() => null}
+                  />
+                  {data.userAddresses.map(userAddress => (
+                    <>
+                      <CardSpacer />
+                      <CustomerAddressChoice
+                        address={userAddress}
+                        selected={false}
+                        onSelect={() => null}
+                      />
+                    </>
+                  ))}
+                  <FormSpacer />
+                  <FormControlLabel
+                    value={AddressInputTypeEnum.NEW_ADDRESS}
+                    control={<Radio color="primary" />}
+                    label={intl.formatMessage(messages.newAddress)}
+                    onChange={() => null}
+                  />
+                  <FormSpacer />
+                  <AddressEdit
+                    countries={countryChoices}
+                    countryDisplayValue={countryDisplayName}
+                    data={data.shippingAddress}
+                    errors={dialogErrors}
+                    onChange={change}
+                    onCountryChange={handleCountrySelect}
+                  />
+                </RadioGroup>
+                <FormSpacer />
+                <Divider />
+                <FormSpacer />
+                <ControlledCheckbox
+                  checked={false}
+                  name="sameAsShipping"
+                  label={intl.formatMessage(messages.billingSameAsShipping)}
+                  onChange={() => null}
+                />
+                <FormSpacer />
+                <Typography>
+                  <FormattedMessage {...messages.billingAddressDescription} />
+                </Typography>
+                <FormSpacer />
+                <RadioGroup className={classes.container} value={undefined}>
+                  <FormControlLabel
+                    value={AddressInputTypeEnum.CUSTOMER_ADDRESS}
+                    control={<Radio color="primary" />}
+                    label={intl.formatMessage(messages.customerAddress)}
+                    onChange={() => null}
+                  />
+                  {data.userAddresses.map(userAddress => (
+                    <>
+                      <CardSpacer />
+                      <CustomerAddressChoice
+                        address={userAddress}
+                        selected={false}
+                        onSelect={() => null}
+                      />
+                    </>
+                  ))}
+                  <FormSpacer />
+                  <FormControlLabel
+                    value={AddressInputTypeEnum.NEW_ADDRESS}
+                    control={<Radio color="primary" />}
+                    label={intl.formatMessage(messages.newAddress)}
+                    onChange={() => null}
+                  />
+                  <FormSpacer />
+                  <AddressEdit
+                    countries={countryChoices}
+                    countryDisplayValue={countryDisplayName}
+                    data={data.billingAddress}
+                    errors={dialogErrors}
+                    onChange={change}
+                    onCountryChange={handleCountrySelect}
+                  />
+                </RadioGroup>
+              </DialogContent>
+              <DialogActions>
+                <ConfirmButton
+                  transitionState={confirmButtonState}
+                  color="primary"
+                  variant="contained"
+                  type="submit"
+                >
+                  <FormattedMessage {...buttonMessages.select} />
+                </ConfirmButton>
+              </DialogActions>
+            </>
+          );
+        }}
+      </Form>
+    </Dialog>
+  );
+};
+
+OrderCustomerAddressesEditDialog.displayName =
+  "OrderCustomerAddressesEditDialog";
+export default OrderCustomerAddressesEditDialog;

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -28,8 +28,10 @@ import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 import { buttonMessages } from "@saleor/intl";
 import { transformAddressToForm } from "@saleor/misc";
 import { makeStyles } from "@saleor/theme";
+import { AddressTypeEnum } from "@saleor/types/globalTypes";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
+
 import OrderCustomerAddressesEditForm, {
   AddressInputOptionEnum,
   OrderCustomerAddressesEditFormData
@@ -89,11 +91,11 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
   const {
     errors: shippingValidationErrors,
     submit: handleShippingSubmit
-  } = useAddressValidation(address => address);
+  } = useAddressValidation(address => address, AddressTypeEnum.SHIPPING);
   const {
     errors: billingValidationErrors,
     submit: handleBillingSubmit
-  } = useAddressValidation(address => address);
+  } = useAddressValidation(address => address, AddressTypeEnum.BILLING);
   const dialogErrors = useModalDialogErrors(
     [...errors, ...shippingValidationErrors, ...billingValidationErrors],
     open
@@ -213,7 +215,9 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                       countries={countryChoices}
                       countryDisplayValue={data.shippingCountryDisplayName}
                       data={data.shippingAddress}
-                      errors={dialogErrors}
+                      errors={dialogErrors.filter(
+                        error => error.addressType === AddressTypeEnum.SHIPPING
+                      )}
                       onChange={event =>
                         change({
                           target: {
@@ -298,7 +302,10 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                           countries={countryChoices}
                           countryDisplayValue={data.billingCountryDisplayName}
                           data={data.billingAddress}
-                          errors={dialogErrors}
+                          errors={dialogErrors.filter(
+                            error =>
+                              error.addressType === AddressTypeEnum.BILLING
+                          )}
                           onChange={event =>
                             change({
                               target: {

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -9,10 +9,10 @@ import RadioGroup from "@material-ui/core/RadioGroup";
 import Typography from "@material-ui/core/Typography";
 import AddressEdit from "@saleor/components/AddressEdit";
 import CardSpacer from "@saleor/components/CardSpacer";
+import Checkbox from "@saleor/components/Checkbox";
 import ConfirmButton, {
   ConfirmButtonTransitionState
 } from "@saleor/components/ConfirmButton";
-import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import FormSpacer from "@saleor/components/FormSpacer";
 import CustomerAddressChoice from "@saleor/customers/components/CustomerAddressChoice";
 import {
@@ -171,7 +171,13 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
               >
                 <FormControlLabel
                   value={AddressInputOptionEnum.CUSTOMER_ADDRESS}
-                  control={<Radio color="primary" />}
+                  control={
+                    <Radio
+                      color="primary"
+                      data-test="shippingAddressInputOption"
+                      data-test-id={AddressInputOptionEnum.CUSTOMER_ADDRESS}
+                    />
+                  }
                   label={intl.formatMessage(messages.customerAddress)}
                   className={classes.optionLabel}
                 />
@@ -203,7 +209,13 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                 )}
                 <FormControlLabel
                   value={AddressInputOptionEnum.NEW_ADDRESS}
-                  control={<Radio color="primary" />}
+                  control={
+                    <Radio
+                      color="primary"
+                      data-test="shippingAddressInputOption"
+                      data-test-id={AddressInputOptionEnum.NEW_ADDRESS}
+                    />
+                  }
                   label={intl.formatMessage(messages.newAddress)}
                   className={classes.optionLabel}
                 />
@@ -237,11 +249,23 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
               <FormSpacer />
               <Divider />
               <FormSpacer />
-              <ControlledCheckbox
-                checked={data.billingSameAsShipping}
-                name="billingSameAsShipping"
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={data.billingSameAsShipping}
+                    name="billingSameAsShipping"
+                    onChange={() =>
+                      change({
+                        target: {
+                          name: "billingSameAsShipping",
+                          value: !data.billingSameAsShipping
+                        }
+                      })
+                    }
+                    data-test="billingSameAsShipping"
+                  />
+                }
                 label={intl.formatMessage(messages.billingSameAsShipping)}
-                onChange={change}
               />
               {!data.billingSameAsShipping && (
                 <>
@@ -258,7 +282,13 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                   >
                     <FormControlLabel
                       value={AddressInputOptionEnum.CUSTOMER_ADDRESS}
-                      control={<Radio color="primary" />}
+                      control={
+                        <Radio
+                          color="primary"
+                          data-test="billingAddressInputOption"
+                          data-test-id={AddressInputOptionEnum.CUSTOMER_ADDRESS}
+                        />
+                      }
                       label={intl.formatMessage(messages.customerAddress)}
                       className={classes.optionLabel}
                     />
@@ -290,7 +320,13 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
                     )}
                     <FormControlLabel
                       value={AddressInputOptionEnum.NEW_ADDRESS}
-                      control={<Radio color="primary" />}
+                      control={
+                        <Radio
+                          color="primary"
+                          data-test="billingAddressInputOption"
+                          data-test-id={AddressInputOptionEnum.NEW_ADDRESS}
+                        />
+                      }
                       label={intl.formatMessage(messages.newAddress)}
                       className={classes.optionLabel}
                     />

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -25,7 +25,7 @@ import useAddressValidation from "@saleor/hooks/useAddressValidation";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import useModalDialogErrors from "@saleor/hooks/useModalDialogErrors";
 import { buttonMessages } from "@saleor/intl";
-import { transformAddressToForm, transformFormToAddress } from "@saleor/misc";
+import { transformAddressToAddressInput } from "@saleor/misc";
 import { makeStyles } from "@saleor/theme";
 import { AddressInput, AddressTypeEnum } from "@saleor/types/globalTypes";
 import React from "react";
@@ -101,11 +101,9 @@ const OrderCustomerAddressesEditDialog: React.FC<OrderCustomerAddressesEditDialo
   );
 
   const getCustomerAddress = (customerAddressId: string): AddressInput =>
-    transformFormToAddress(
-      transformAddressToForm(
-        customerAddresses.find(
-          customerAddress => customerAddress.id === customerAddressId
-        )
+    transformAddressToAddressInput(
+      customerAddresses.find(
+        customerAddress => customerAddress.id === customerAddressId
       )
     );
 

--- a/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
@@ -1,6 +1,7 @@
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
 import { AddressTypeInput } from "@saleor/customers/types";
 import {
+  CustomerAddresses_user_addresses,
   CustomerAddresses_user_defaultBillingAddress,
   CustomerAddresses_user_defaultShippingAddress
 } from "@saleor/customers/types/CustomerAddresses";
@@ -23,13 +24,21 @@ export interface OrderCustomerAddressesEditFormData {
   billingAddress: AddressTypeInput;
 }
 
-interface OrderCustomerAddressesEditData
+export interface OrderCustomerAddressesEditData
   extends OrderCustomerAddressesEditFormData {
   shippingCountryDisplayName: string;
   billingCountryDisplayName: string;
 }
 
-interface OrderCustomerAddressesEditHandlers {
+export interface OrderCustomerAddressesEditHandlers {
+  changeFormAddress: (
+    event: React.ChangeEvent<any>,
+    addressType: "shippingAddress" | "billingAddress"
+  ) => void;
+  changeCustomerAddress: (
+    customerAddress: CustomerAddresses_user_addresses,
+    addressType: "customerShippingAddress" | "customerBillingAddress"
+  ) => void;
   selectShippingCountry: FormChange;
   selectBillingCountry: FormChange;
 }
@@ -96,6 +105,29 @@ function useOrderCustomerAddressesEditForm(
     form.change(event, cb);
     triggerChange();
   };
+  const handleFormAddressChange = (
+    event: React.ChangeEvent<any>,
+    addressType: "shippingAddress" | "billingAddress"
+  ) =>
+    form.change({
+      target: {
+        name: addressType,
+        value: {
+          ...form.data[addressType],
+          [event.target.name]: event.target.value
+        }
+      }
+    });
+  const handleCustomerAddressChange = (
+    customerAddress: CustomerAddresses_user_addresses,
+    addressType: "customerShippingAddress" | "customerBillingAddress"
+  ) =>
+    form.change({
+      target: {
+        name: addressType,
+        value: customerAddress
+      }
+    });
   const handleShippingCountrySelect = createSingleAutocompleteSelectHandler(
     event =>
       form.change({
@@ -143,6 +175,8 @@ function useOrderCustomerAddressesEditForm(
     hasChanged: changed,
     data,
     handlers: {
+      changeCustomerAddress: handleCustomerAddressChange,
+      changeFormAddress: handleFormAddressChange,
       selectShippingCountry: handleShippingCountrySelect,
       selectBillingCountry: handleBillingCountrySelect
     }

--- a/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
@@ -1,0 +1,168 @@
+import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
+import { AddressTypeInput } from "@saleor/customers/types";
+import {
+  CustomerAddresses_user_defaultBillingAddress,
+  CustomerAddresses_user_defaultShippingAddress
+} from "@saleor/customers/types/CustomerAddresses";
+import useForm, { FormChange } from "@saleor/hooks/useForm";
+import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
+import React, { useState } from "react";
+
+export enum AddressInputOptionEnum {
+  CUSTOMER_ADDRESS = "customerAddress",
+  NEW_ADDRESS = "newAddress"
+}
+
+export interface OrderCustomerAddressesEditFormData {
+  billingSameAsShipping: boolean;
+  shippingAddressInputOption: AddressInputOptionEnum;
+  billingAddressInputOption: AddressInputOptionEnum;
+  customerShippingAddress: CustomerAddresses_user_defaultShippingAddress;
+  customerBillingAddress: CustomerAddresses_user_defaultBillingAddress;
+  shippingAddress: AddressTypeInput;
+  billingAddress: AddressTypeInput;
+}
+
+interface OrderCustomerAddressesEditData
+  extends OrderCustomerAddressesEditFormData {
+  shippingCountryDisplayName: string;
+  billingCountryDisplayName: string;
+}
+
+interface OrderCustomerAddressesEditHandlers {
+  selectShippingCountry: FormChange;
+  selectBillingCountry: FormChange;
+}
+
+interface UseOrderCustomerAddressesEditFormResult {
+  submit: (event: React.FormEvent<any>) => Promise<boolean>;
+  change: FormChange;
+  hasChanged: boolean;
+  data: OrderCustomerAddressesEditData;
+  handlers: OrderCustomerAddressesEditHandlers;
+}
+
+interface UseOrderCustomerAddressesEditFormOpts {
+  countryChoices: SingleAutocompleteChoiceType[];
+  defaultShippingAddress: CustomerAddresses_user_defaultShippingAddress;
+  defaultBillingAddress: CustomerAddresses_user_defaultBillingAddress;
+}
+
+export interface OrderCustomerAddressesEditFormProps
+  extends UseOrderCustomerAddressesEditFormOpts {
+  children: (props: UseOrderCustomerAddressesEditFormResult) => React.ReactNode;
+  initial?: Partial<OrderCustomerAddressesEditFormData>;
+  onSubmit: (data: OrderCustomerAddressesEditData) => Promise<boolean>;
+}
+
+function useOrderCustomerAddressesEditForm(
+  initial: Partial<OrderCustomerAddressesEditFormData>,
+  onSubmit: (data: OrderCustomerAddressesEditData) => Promise<boolean>,
+  opts: UseOrderCustomerAddressesEditFormOpts
+): UseOrderCustomerAddressesEditFormResult {
+  const initialAddress: AddressTypeInput = {
+    city: "",
+    country: "",
+    phone: "",
+    postalCode: "",
+    streetAddress1: ""
+  };
+  const defaultInitialFormData: OrderCustomerAddressesEditFormData = {
+    billingSameAsShipping: true,
+    shippingAddressInputOption: AddressInputOptionEnum.CUSTOMER_ADDRESS,
+    billingAddressInputOption: AddressInputOptionEnum.CUSTOMER_ADDRESS,
+    customerShippingAddress: opts.defaultShippingAddress,
+    customerBillingAddress: opts.defaultBillingAddress,
+    shippingAddress: initialAddress,
+    billingAddress: initialAddress
+  };
+
+  const form = useForm({
+    ...initial,
+    ...defaultInitialFormData
+  });
+
+  const [changed, setChanged] = useState(false);
+  const triggerChange = () => setChanged(true);
+
+  const [shippingCountryDisplayName, setShippingCountryDisplayName] = useState(
+    ""
+  );
+  const [billingCountryDisplayName, setBillingCountryDisplayName] = useState(
+    ""
+  );
+
+  const handleChange: FormChange = (event, cb) => {
+    form.change(event, cb);
+    triggerChange();
+  };
+  const handleShippingCountrySelect = createSingleAutocompleteSelectHandler(
+    event =>
+      form.change({
+        target: {
+          name: "shippingAddress",
+          value: {
+            ...form.data.shippingAddress,
+            [event.target.name]: event.target.value
+          }
+        }
+      }),
+    setShippingCountryDisplayName,
+    opts.countryChoices
+  );
+  const handleBillingCountrySelect = createSingleAutocompleteSelectHandler(
+    event =>
+      form.change({
+        target: {
+          name: "billingAddress",
+          value: {
+            ...form.data.billingAddress,
+            [event.target.name]: event.target.value
+          }
+        }
+      }),
+    setBillingCountryDisplayName,
+    opts.countryChoices
+  );
+
+  const data = {
+    ...form.data,
+    shippingCountryDisplayName,
+    billingCountryDisplayName
+  };
+
+  const submit = (event: React.FormEvent<any>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    return onSubmit(data);
+  };
+
+  return {
+    change: handleChange,
+    submit,
+    hasChanged: changed,
+    data,
+    handlers: {
+      selectShippingCountry: handleShippingCountrySelect,
+      selectBillingCountry: handleBillingCountrySelect
+    }
+  };
+}
+
+const OrderCustomerAddressesEditForm: React.FC<OrderCustomerAddressesEditFormProps> = ({
+  children,
+  initial,
+  onSubmit,
+  ...rest
+}) => {
+  const props = useOrderCustomerAddressesEditForm(
+    initial || {},
+    onSubmit,
+    rest
+  );
+
+  return <form onSubmit={props.submit}>{children(props)}</form>;
+};
+
+OrderCustomerAddressesEditForm.displayName = "OrderCustomerAddressesEditForm";
+export default OrderCustomerAddressesEditForm;

--- a/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
@@ -35,7 +35,7 @@ interface OrderCustomerAddressesEditHandlers {
 }
 
 interface UseOrderCustomerAddressesEditFormResult {
-  submit: (event: React.FormEvent<any>) => Promise<boolean>;
+  submit: (event: React.FormEvent<any>) => void;
   change: FormChange;
   hasChanged: boolean;
   data: OrderCustomerAddressesEditData;
@@ -52,12 +52,12 @@ export interface OrderCustomerAddressesEditFormProps
   extends UseOrderCustomerAddressesEditFormOpts {
   children: (props: UseOrderCustomerAddressesEditFormResult) => React.ReactNode;
   initial?: Partial<OrderCustomerAddressesEditFormData>;
-  onSubmit: (data: OrderCustomerAddressesEditData) => Promise<boolean>;
+  onSubmit: (data: OrderCustomerAddressesEditData) => void;
 }
 
 function useOrderCustomerAddressesEditForm(
   initial: Partial<OrderCustomerAddressesEditFormData>,
-  onSubmit: (data: OrderCustomerAddressesEditData) => Promise<boolean>,
+  onSubmit: (data: OrderCustomerAddressesEditData) => void,
   opts: UseOrderCustomerAddressesEditFormOpts
 ): UseOrderCustomerAddressesEditFormResult {
   const initialAddress: AddressTypeInput = {

--- a/src/orders/components/OrderCustomerAddressesEditDialog/index.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./OrderCustomerAddressesEditDialog";
+export * from "./OrderCustomerAddressesEditDialog";

--- a/src/orders/components/OrderCustomerAddressesEditDialog/messages.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/messages.ts
@@ -1,0 +1,31 @@
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: "Shipping address for order",
+    description: "dialog header"
+  },
+  customerAddress: {
+    defaultMessage: "Use one of customer addresses",
+    description: "address type"
+  },
+  newAddress: {
+    defaultMessage: "Add new address",
+    description: "address type"
+  },
+  billingSameAsShipping: {
+    defaultMessage: "Billing address same as shipping address",
+    description: "checkbox label"
+  },
+  shippingAddressDescription: {
+    defaultMessage:
+      "Which address would you like to use as shipping address for selected customer:",
+    description: "dialog content"
+  },
+  billingAddressDescription: {
+    defaultMessage: "Select one of customer addresses or add a new address:",
+    description: "dialog content"
+  }
+});
+
+export default messages;

--- a/src/orders/components/OrderCustomerAddressesEditDialog/messages.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/messages.ts
@@ -1,17 +1,9 @@
 import { defineMessages } from "react-intl";
 
-const messages = defineMessages({
+export const dialogMessages = defineMessages({
   title: {
     defaultMessage: "Shipping address for order",
     description: "dialog header"
-  },
-  customerAddress: {
-    defaultMessage: "Use one of customer addresses",
-    description: "address type"
-  },
-  newAddress: {
-    defaultMessage: "Add new address",
-    description: "address type"
   },
   billingSameAsShipping: {
     defaultMessage: "Billing address same as shipping address",
@@ -28,4 +20,13 @@ const messages = defineMessages({
   }
 });
 
-export default messages;
+export const addressEditMessages = defineMessages({
+  customerAddress: {
+    defaultMessage: "Use one of customer addresses",
+    description: "address type"
+  },
+  newAddress: {
+    defaultMessage: "Add new address",
+    description: "address type"
+  }
+});

--- a/src/orders/components/OrderCustomerAddressesEditDialog/messages.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/messages.ts
@@ -11,10 +11,19 @@ export const dialogMessages = defineMessages({
   },
   shippingAddressDescription: {
     defaultMessage:
-      "Which address would you like to use as shipping address for selected customer:",
+      "This customer doesn’t have any shipping addresses. Provide address for order:",
     description: "dialog content"
   },
   billingAddressDescription: {
+    defaultMessage: "Add a new address:",
+    description: "dialog content"
+  },
+  customerShippingAddressDescription: {
+    defaultMessage:
+      "Which address would you like to use as shipping address for selected customer:",
+    description: "dialog content"
+  },
+  customerBillingAddressDescription: {
     defaultMessage: "Select one of customer addresses or add a new address:",
     description: "dialog content"
   }

--- a/src/orders/components/OrderCustomerAddressesEditDialog/styles.ts
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/styles.ts
@@ -1,0 +1,16 @@
+import { makeStyles } from "@saleor/theme";
+
+export const useStyles = makeStyles(
+  {
+    container: {
+      display: "block"
+    },
+    optionLabel: {
+      display: "block"
+    },
+    overflow: {
+      overflowY: "visible"
+    }
+  },
+  { name: "OrderCustomerAddressesEditDialog" }
+);

--- a/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.stories.tsx
+++ b/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.stories.tsx
@@ -1,0 +1,24 @@
+import Decorator from "@saleor/storybook/Decorator";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import OrderCustomerChangeDialog, {
+  OrderCustomerChangeDialogProps
+} from "./OrderCustomerChangeDialog";
+
+const props: OrderCustomerChangeDialogProps = {
+  onClose: () => undefined,
+  onConfirm: () => undefined,
+  open: true
+};
+
+storiesOf("Orders / OrderCustomerChangeDialog", module)
+  .addDecorator(Decorator)
+  .add("default", () => (
+    <OrderCustomerChangeDialog
+      {...props}
+      onClose={() => undefined}
+      onConfirm={() => undefined}
+      open={true}
+    />
+  ));

--- a/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.tsx
+++ b/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.tsx
@@ -9,7 +9,6 @@ import Typography from "@material-ui/core/Typography";
 import ConfirmButton from "@saleor/components/ConfirmButton";
 import FormSpacer from "@saleor/components/FormSpacer";
 import { buttonMessages } from "@saleor/intl";
-import { makeStyles } from "@saleor/theme";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -18,21 +17,7 @@ import OrderCustomerChangeForm, {
   OrderCustomerChangeData
 } from "./form";
 import messages from "./messages";
-
-const useStyles = makeStyles(
-  {
-    container: {
-      display: "block"
-    },
-    optionLabel: {
-      display: "block"
-    },
-    overflow: {
-      overflowY: "visible"
-    }
-  },
-  { name: "OrderCustomerChangeDialog" }
-);
+import { useStyles } from "./styles";
 
 export interface OrderCustomerChangeDialogProps {
   open: boolean;

--- a/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.tsx
+++ b/src/orders/components/OrderCustomerChangeDialog/OrderCustomerChangeDialog.tsx
@@ -1,0 +1,100 @@
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Radio from "@material-ui/core/Radio";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import Typography from "@material-ui/core/Typography";
+import ConfirmButton from "@saleor/components/ConfirmButton";
+import FormSpacer from "@saleor/components/FormSpacer";
+import { buttonMessages } from "@saleor/intl";
+import { makeStyles } from "@saleor/theme";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import OrderCustomerChangeForm, {
+  CustomerChangeActionEnum,
+  OrderCustomerChangeData
+} from "./form";
+import messages from "./messages";
+
+const useStyles = makeStyles(
+  {
+    container: {
+      display: "block"
+    },
+    optionLabel: {
+      display: "block"
+    },
+    overflow: {
+      overflowY: "visible"
+    }
+  },
+  { name: "OrderCustomerChangeDialog" }
+);
+
+export interface OrderCustomerChangeDialogProps {
+  open: boolean;
+  onClose();
+  onConfirm(data: OrderCustomerChangeData): void;
+}
+
+const OrderCustomerChangeDialog: React.FC<OrderCustomerChangeDialogProps> = props => {
+  const { open, onClose, onConfirm } = props;
+
+  const classes = useStyles(props);
+  const intl = useIntl();
+
+  return (
+    <Dialog onClose={onClose} open={open}>
+      <OrderCustomerChangeForm onSubmit={onConfirm}>
+        {({ change, data }) => (
+          <>
+            <DialogTitle>
+              <FormattedMessage {...messages.title} />
+            </DialogTitle>
+            <DialogContent className={classes.overflow}>
+              <Typography>
+                <FormattedMessage {...messages.description} />
+              </Typography>
+              <FormSpacer />
+              <RadioGroup
+                className={classes.container}
+                value={data.changeActionOption}
+                name="changeActionOption"
+                onChange={event => change(event)}
+              >
+                <FormControlLabel
+                  value={CustomerChangeActionEnum.KEEP_ADDRESS}
+                  control={<Radio color="primary" />}
+                  label={intl.formatMessage(messages.keepAddress)}
+                  className={classes.optionLabel}
+                />
+                <FormControlLabel
+                  value={CustomerChangeActionEnum.CHANGE_ADDRESS}
+                  control={<Radio color="primary" />}
+                  label={intl.formatMessage(messages.changeAddress)}
+                  className={classes.optionLabel}
+                />
+              </RadioGroup>
+            </DialogContent>
+            <DialogActions>
+              <ConfirmButton
+                transitionState="default"
+                color="primary"
+                variant="contained"
+                type="submit"
+              >
+                <FormattedMessage {...buttonMessages.continue} />
+              </ConfirmButton>
+            </DialogActions>
+          </>
+        )}
+      </OrderCustomerChangeForm>
+    </Dialog>
+  );
+};
+
+OrderCustomerChangeDialog.displayName = "OrderCustomerChangeDialog";
+export default OrderCustomerChangeDialog;

--- a/src/orders/components/OrderCustomerChangeDialog/form.tsx
+++ b/src/orders/components/OrderCustomerChangeDialog/form.tsx
@@ -1,0 +1,72 @@
+import useForm, { FormChange } from "@saleor/hooks/useForm";
+import React, { useState } from "react";
+
+export enum CustomerChangeActionEnum {
+  KEEP_ADDRESS = "keepAddress",
+  CHANGE_ADDRESS = "changeAddress"
+}
+
+export interface OrderCustomerChangeData {
+  changeActionOption: CustomerChangeActionEnum;
+}
+
+interface UseOrderCustomerChangeFormResult {
+  submit: (event: React.FormEvent<any>) => void;
+  change: FormChange;
+  hasChanged: boolean;
+  data: OrderCustomerChangeData;
+}
+
+export interface OrderCustomerChangeFormProps {
+  children: (props: UseOrderCustomerChangeFormResult) => React.ReactNode;
+  initial?: Partial<OrderCustomerChangeData>;
+  onSubmit: (data: OrderCustomerChangeData) => void;
+}
+
+function useOrderCustomerChangeForm(
+  initial: Partial<OrderCustomerChangeData>,
+  onSubmit: (data: OrderCustomerChangeData) => void
+): UseOrderCustomerChangeFormResult {
+  const defaultInitialFormData: OrderCustomerChangeData = {
+    changeActionOption: CustomerChangeActionEnum.KEEP_ADDRESS
+  };
+
+  const form = useForm({
+    ...initial,
+    ...defaultInitialFormData
+  });
+
+  const [changed, setChanged] = useState(false);
+  const triggerChange = () => setChanged(true);
+
+  const handleChange: FormChange = (event, cb) => {
+    form.change(event, cb);
+    triggerChange();
+  };
+
+  const submit = (event: React.FormEvent<any>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    return onSubmit(form.data);
+  };
+
+  return {
+    change: handleChange,
+    submit,
+    hasChanged: changed,
+    data: form.data
+  };
+}
+
+const OrderCustomerChangeForm: React.FC<OrderCustomerChangeFormProps> = ({
+  children,
+  initial,
+  onSubmit
+}) => {
+  const props = useOrderCustomerChangeForm(initial || {}, onSubmit);
+
+  return <form onSubmit={props.submit}>{children(props)}</form>;
+};
+
+OrderCustomerChangeForm.displayName = "OrderCustomerChangeForm";
+export default OrderCustomerChangeForm;

--- a/src/orders/components/OrderCustomerChangeDialog/messages.ts
+++ b/src/orders/components/OrderCustomerChangeDialog/messages.ts
@@ -1,0 +1,23 @@
+import { defineMessages } from "react-intl";
+
+const messages = defineMessages({
+  title: {
+    defaultMessage: "Changed Customer",
+    description: "dialog header"
+  },
+  description: {
+    defaultMessage:
+      "You have changed customer assigned to this order. What would you like to do with the shipping address?",
+    description: "dialog description"
+  },
+  keepAddress: {
+    defaultMessage: "Keep address",
+    description: "option label"
+  },
+  changeAddress: {
+    defaultMessage: "Change address",
+    description: "option label"
+  }
+});
+
+export default messages;

--- a/src/orders/components/OrderCustomerChangeDialog/styles.ts
+++ b/src/orders/components/OrderCustomerChangeDialog/styles.ts
@@ -1,0 +1,16 @@
+import { makeStyles } from "@saleor/theme";
+
+export const useStyles = makeStyles(
+  {
+    container: {
+      display: "block"
+    },
+    optionLabel: {
+      display: "block"
+    },
+    overflow: {
+      overflowY: "visible"
+    }
+  },
+  { name: "OrderCustomerChangeDialog" }
+);

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -58,10 +58,6 @@ export interface OrderDetailsPageProps extends UserPermissionProps {
     id: string;
     name: string;
   }>;
-  countries?: Array<{
-    code: string;
-    label: string;
-  }>;
   disabled: boolean;
   saveButtonBarState: ConfirmButtonTransitionState;
   onOrderLineAdd?: () => void;

--- a/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
@@ -18,7 +18,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { OrderDetails_order } from "../../types/OrderDetails";
-import OrderCustomer from "../OrderCustomer";
+import OrderCustomer, { CustomerEditData } from "../OrderCustomer";
 import OrderDraftDetails from "../OrderDraftDetails/OrderDraftDetails";
 import { FormData as OrderDraftDetailsProductsFormData } from "../OrderDraftDetailsProducts";
 import OrderHistory, { FormData as HistoryFormData } from "../OrderHistory";
@@ -47,11 +47,7 @@ export interface OrderDraftPageProps
   fetchUsers: (query: string) => void;
   onBack: () => void;
   onBillingAddressEdit: () => void;
-  onCustomerEdit: (data: {
-    user?: string;
-    userEmail?: string;
-    prevUser?: string;
-  }) => void;
+  onCustomerEdit: (data: CustomerEditData) => void;
   onDraftFinalize: () => void;
   onDraftRemove: () => void;
   onNoteAdd: (data: HistoryFormData) => void;

--- a/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
@@ -43,10 +43,6 @@ export interface OrderDraftPageProps
   order: OrderDetails_order;
   users: SearchCustomers_search_edges_node[];
   usersLoading: boolean;
-  countries: Array<{
-    code: string;
-    label: string;
-  }>;
   saveButtonBarState: ConfirmButtonTransitionState;
   fetchUsers: (query: string) => void;
   onBack: () => void;

--- a/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
@@ -51,7 +51,11 @@ export interface OrderDraftPageProps
   fetchUsers: (query: string) => void;
   onBack: () => void;
   onBillingAddressEdit: () => void;
-  onCustomerEdit: (data: { user?: string; userEmail?: string }) => void;
+  onCustomerEdit: (data: {
+    user?: string;
+    userEmail?: string;
+    prevUser?: string;
+  }) => void;
   onDraftFinalize: () => void;
   onDraftRemove: () => void;
   onNoteAdd: (data: HistoryFormData) => void;

--- a/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
@@ -52,7 +52,7 @@ export interface OrderDraftPageProps
   fetchUsers: (query: string) => void;
   onBack: () => void;
   onBillingAddressEdit: () => void;
-  onCustomerEdit: (data: DraftOrderInput) => void;
+  onCustomerEdit: (data: { user?: string; userEmail?: string }) => void;
   onDraftFinalize: () => void;
   onDraftRemove: () => void;
   onNoteAdd: (data: HistoryFormData) => void;

--- a/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
@@ -17,7 +17,6 @@ import { FetchMoreProps, UserPermissionProps } from "@saleor/types";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { DraftOrderInput } from "../../../types/globalTypes";
 import { OrderDetails_order } from "../../types/OrderDetails";
 import OrderCustomer from "../OrderCustomer";
 import OrderDraftDetails from "../OrderDraftDetails/OrderDraftDetails";

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.stories.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.stories.tsx
@@ -37,7 +37,8 @@ storiesOf("Views / Orders / Fulfill order", module)
           code: OrderErrorCode.INSUFFICIENT_STOCK,
           field: null,
           orderLine: orderToFulfill.lines[0].id,
-          warehouse: warehouseList[0].id
+          warehouse: warehouseList[0].id,
+          addressType: null
         }
       ]}
     />

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1,3 +1,4 @@
+import { ShopInfo_shop_countries } from "@saleor/components/Shop/types/ShopInfo";
 import { InvoiceFragment } from "@saleor/fragments/types/InvoiceFragment";
 import { OrderSettingsFragment } from "@saleor/fragments/types/OrderSettingsFragment";
 import { SearchCustomers_search_edges_node } from "@saleor/searches/types/SearchCustomers";
@@ -1587,12 +1588,12 @@ export const variants = [
   { id: "p7", name: "Product 5: variant 2", sku: "14345", stockQuantity: 11 }
 ];
 export const prefixes = ["01", "02", "41", "49"];
-export const countries = [
-  { code: "AF", label: "Afghanistan" },
-  { code: "AX", label: "Åland Islands" },
-  { code: "AL", label: "Albania" },
-  { code: "DZ", label: "Algeria" },
-  { code: "AS", label: "American Samoa" }
+export const countries: ShopInfo_shop_countries[] = [
+  { __typename: "CountryDisplay", code: "AF", country: "Afghanistan" },
+  { __typename: "CountryDisplay", code: "AX", country: "Åland Islands" },
+  { __typename: "CountryDisplay", code: "AL", country: "Albania" },
+  { __typename: "CountryDisplay", code: "DZ", country: "Algeria" },
+  { __typename: "CountryDisplay", code: "AS", country: "American Samoa" }
 ];
 export const shippingMethods = [
   { country: "whole world", id: "s1", name: "DHL", price: {} },

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderFulfillInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderFulfillInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: FulfillOrder
@@ -13,6 +13,7 @@ export interface FulfillOrder_orderFulfill_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
   warehouse: string | null;
   orderLine: string | null;
 }

--- a/src/orders/types/FulfillmentReturnProducts.ts
+++ b/src/orders/types/FulfillmentReturnProducts.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderReturnProductsInput, OrderErrorCode } from "./../../types/globalTypes";
+import { OrderReturnProductsInput, OrderErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: FulfillmentReturnProducts
@@ -13,6 +13,7 @@ export interface FulfillmentReturnProducts_orderFulfillmentReturnProducts_errors
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface FulfillmentReturnProducts_orderFulfillmentReturnProducts_order {

--- a/src/orders/types/OrderAddNote.ts
+++ b/src/orders/types/OrderAddNote.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderAddNoteInput, OrderErrorCode, OrderEventsEmailsEnum, DiscountValueTypeEnum, OrderEventsEnum } from "./../../types/globalTypes";
+import { OrderAddNoteInput, OrderErrorCode, AddressTypeEnum, OrderEventsEmailsEnum, DiscountValueTypeEnum, OrderEventsEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderAddNote
@@ -13,6 +13,7 @@ export interface OrderAddNote_orderAddNote_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderAddNote_orderAddNote_order_events_discount_amount {

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderCancel
@@ -13,6 +13,7 @@ export interface OrderCancel_orderCancel_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderCancel_orderCancel_order_metadata {

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderCapture
@@ -13,6 +13,7 @@ export interface OrderCapture_orderCapture_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderCapture_orderCapture_order_metadata {

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderConfirm
@@ -13,6 +13,7 @@ export interface OrderConfirm_orderConfirm_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderConfirm_orderConfirm_order_metadata {

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderDiscountCommonInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderDiscountCommonInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderDiscountAdd
@@ -13,6 +13,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderDiscountAdd_orderDiscountAdd_order_metadata {

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderDiscountDelete
@@ -13,6 +13,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderDiscountDelete_orderDiscountDelete_order_metadata {

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderDiscountCommonInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderDiscountCommonInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderDiscountUpdate
@@ -13,6 +13,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderDiscountUpdate_orderDiscountUpdate_order_metadata {

--- a/src/orders/types/OrderDraftBulkCancel.ts
+++ b/src/orders/types/OrderDraftBulkCancel.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderDraftBulkCancel
@@ -13,6 +13,7 @@ export interface OrderDraftBulkCancel_draftOrderBulkDelete_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderDraftBulkCancel_draftOrderBulkDelete {

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderDraftCancel
@@ -13,6 +13,7 @@ export interface OrderDraftCancel_draftOrderDelete_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order_metadata {

--- a/src/orders/types/OrderDraftCreate.ts
+++ b/src/orders/types/OrderDraftCreate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { DraftOrderCreateInput, OrderErrorCode } from "./../../types/globalTypes";
+import { DraftOrderCreateInput, OrderErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderDraftCreate
@@ -13,6 +13,7 @@ export interface OrderDraftCreate_draftOrderCreate_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderDraftCreate_draftOrderCreate_order {

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderDraftFinalize
@@ -13,6 +13,7 @@ export interface OrderDraftFinalize_draftOrderComplete_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order_metadata {

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { DraftOrderInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { DraftOrderInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderDraftUpdate
@@ -13,6 +13,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_metadata {

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { FulfillmentCancelInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { FulfillmentCancelInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderFulfillmentCancel
@@ -13,6 +13,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_metadata {

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderRefundProductsInput, OrderErrorCode, DiscountValueTypeEnum, FulfillmentStatus, OrderDiscountType, OrderEventsEmailsEnum, OrderEventsEnum, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderRefundProductsInput, OrderErrorCode, AddressTypeEnum, DiscountValueTypeEnum, FulfillmentStatus, OrderDiscountType, OrderEventsEmailsEnum, OrderEventsEnum, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderFulfillmentRefundProducts
@@ -13,6 +13,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_e
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant {

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { FulfillmentUpdateTrackingInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { FulfillmentUpdateTrackingInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderFulfillmentUpdateTracking
@@ -13,6 +13,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_e
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_metadata {

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderLineDelete
@@ -13,6 +13,7 @@ export interface OrderLineDelete_orderLineDelete_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderLineDelete_orderLineDelete_order_metadata {

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderLineDiscountRemove
@@ -13,6 +13,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_metadata {

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderDiscountCommonInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderDiscountCommonInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderLineDiscountUpdate
@@ -13,6 +13,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_metadata {

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderLineInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderLineInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderLineUpdate
@@ -13,6 +13,7 @@ export interface OrderLineUpdate_orderLineUpdate_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderLineUpdate_orderLineUpdate_order_metadata {

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderLineCreateInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderLineCreateInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderLinesAdd
@@ -13,6 +13,7 @@ export interface OrderLinesAdd_orderLinesCreate_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderLinesAdd_orderLinesCreate_order_metadata {

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderMarkAsPaid
@@ -13,6 +13,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_metadata {

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderRefund
@@ -13,6 +13,7 @@ export interface OrderRefund_orderRefund_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderRefund_orderRefund_order_metadata {

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderUpdateShippingInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderUpdateShippingInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderShippingMethodUpdate
@@ -13,6 +13,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderShippingMethodUpdate_orderUpdateShipping_order_availableShippingMethods_price {

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderUpdateInput, OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderUpdateInput, OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderUpdate
@@ -13,6 +13,7 @@ export interface OrderUpdate_orderUpdate_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderUpdate_orderUpdate_order_metadata {

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderErrorCode, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
+import { OrderErrorCode, AddressTypeEnum, OrderDiscountType, DiscountValueTypeEnum, OrderEventsEmailsEnum, OrderEventsEnum, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, JobStatusEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderVoid
@@ -13,6 +13,7 @@ export interface OrderVoid_orderVoid_errors {
   __typename: "OrderError";
   code: OrderErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface OrderVoid_orderVoid_order_metadata {

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -105,6 +105,7 @@ export type OrderUrlDialog =
   | "cancel"
   | "cancel-fulfillment"
   | "capture"
+  | "customer-change"
   | "edit-customer-addresses"
   | "edit-billing-address"
   | "edit-fulfillment"

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -105,6 +105,7 @@ export type OrderUrlDialog =
   | "cancel"
   | "cancel-fulfillment"
   | "capture"
+  | "edit-customer-addresses"
   | "edit-billing-address"
   | "edit-fulfillment"
   | "edit-shipping"

--- a/src/orders/views/OrderDetails/OrderAddressFields.tsx
+++ b/src/orders/views/OrderDetails/OrderAddressFields.tsx
@@ -57,10 +57,7 @@ const OrderAddressFields = ({
     confirmButtonState: isDraft
       ? orderDraftUpdate.opts.status
       : orderUpdate.opts.status,
-    countries: data?.shop?.countries.map(country => ({
-      code: country.code,
-      label: country.country
-    })),
+    countries: data?.shop?.countries,
     errors: isDraft
       ? orderDraftUpdate.opts.data?.draftOrderUpdate.errors
       : orderUpdate.opts.data?.orderUpdate.errors,

--- a/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
+++ b/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
@@ -159,8 +159,8 @@ export const OrderDetailsMessages: React.FC<OrderDetailsMessages> = ({
           defaultMessage: "Order successfully updated"
         })
       });
+      closeModal();
     }
-    closeModal();
   };
   const handleShippingMethodUpdate = (data: OrderShippingMethodUpdate) => {
     const errs = data.orderUpdateShipping?.errors;

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -79,7 +79,7 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
 
   const { data: customerAddresses } = useCustomerAddressesQuery({
     variables: {
-      id: order.user.id
+      id: order?.user?.id
     },
     skip: params.action !== "edit-customer-addresses"
   });

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -83,7 +83,10 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
     variables: DEFAULT_INITIAL_SEARCH_DATA
   });
 
-  const { data: customerAddresses } = useCustomerAddressesQuery({
+  const {
+    data: customerAddresses,
+    loading: customerAddressesLoading
+  } = useCustomerAddressesQuery({
     variables: {
       id: order?.user?.id
     },
@@ -252,6 +255,7 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
       />
       <OrderCustomerAddressesEditDialog
         open={params.action === "edit-customer-addresses"}
+        loading={customerAddressesLoading}
         confirmButtonState={orderDraftUpdate.opts.status}
         errors={orderDraftUpdate.opts.data?.draftOrderUpdate?.errors || []}
         countries={data?.shop?.countries}

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -129,10 +129,16 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
                   userEmail: data.userEmail
                 }
               });
-              if (!result?.data?.draftOrderUpdate?.errors?.length) {
+              if (
+                data.prevUser &&
+                !result?.data?.draftOrderUpdate?.errors?.length
+              ) {
                 openModal("customer-change");
-              } else {
-                closeModal();
+              } else if (
+                !data.prevUser &&
+                !result?.data?.draftOrderUpdate?.errors?.length
+              ) {
+                openModal("edit-customer-addresses");
               }
             }}
             onDraftFinalize={() => orderDraftFinalize.mutate({ id })}

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -14,10 +14,7 @@ import React from "react";
 import { useIntl } from "react-intl";
 
 import { customerUrl } from "../../../../customers/urls";
-import {
-  getStringOrPlaceholder,
-  transformFormToAddress
-} from "../../../../misc";
+import { getStringOrPlaceholder } from "../../../../misc";
 import { productUrl } from "../../../../products/urls";
 import OrderDraftCancelDialog from "../../../components/OrderDraftCancelDialog/OrderDraftCancelDialog";
 import OrderDraftPage from "../../../components/OrderDraftPage";
@@ -128,7 +125,8 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
               const result = await orderDraftUpdate.mutate({
                 id,
                 input: {
-                  user: data.user
+                  user: data.user,
+                  userEmail: data.userEmail
                 }
               });
               if (!result?.data?.draftOrderUpdate?.errors?.length) {
@@ -234,8 +232,8 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
           const result = await orderDraftUpdate.mutate({
             id,
             input: {
-              shippingAddress: transformFormToAddress(data.shippingAddress),
-              billingAddress: transformFormToAddress(data.billingAddress)
+              shippingAddress: data.shippingAddress,
+              billingAddress: data.billingAddress
             }
           });
           if (!result?.data?.draftOrderUpdate?.errors?.length) {

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -3,6 +3,7 @@ import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
 import { useCustomerAddressesQuery } from "@saleor/customers/queries";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useUser from "@saleor/hooks/useUser";
+import { CustomerEditData } from "@saleor/orders/components/OrderCustomer";
 import OrderCustomerAddressesEditDialog, {
   OrderCustomerAddressesEditDialogOutput
 } from "@saleor/orders/components/OrderCustomerAddressesEditDialog";
@@ -94,12 +95,15 @@ export const OrderDraftDetails: React.FC<OrderDraftDetailsProps> = ({
   const handleCustomerChange = async ({
     user,
     userEmail,
-    prevUser
-  }: {
-    user?: string;
-    userEmail?: string;
-    prevUser?: string;
-  }) => {
+    prevUser,
+    prevUserEmail
+  }: CustomerEditData) => {
+    const sameUser = user && user === prevUser;
+    const sameUserEmail = userEmail && userEmail === prevUserEmail;
+    if (sameUser || sameUserEmail) {
+      return;
+    }
+
     const result = await orderDraftUpdate.mutate({
       id,
       input: {

--- a/src/products/components/ProductExportDialog/messages.ts
+++ b/src/products/components/ProductExportDialog/messages.ts
@@ -59,11 +59,6 @@ function useProductExportFieldMessages() {
       defaultMessage: "Export Variant Weight",
       description: "product field",
       id: "productExportFieldVariantWeight"
-    }),
-    [ProductFieldEnum.VISIBLE]: intl.formatMessage({
-      defaultMessage: "Visibility",
-      description: "product field",
-      id: "productExportFieldVisibility"
     })
   };
 

--- a/src/shipping/components/ShippingZoneAddWarehouseDialog/ShippingZoneAddWarehouseDialog.tsx
+++ b/src/shipping/components/ShippingZoneAddWarehouseDialog/ShippingZoneAddWarehouseDialog.tsx
@@ -22,6 +22,7 @@ import { buttonMessages } from "@saleor/intl";
 import { makeStyles } from "@saleor/theme";
 import { DialogProps } from "@saleor/types";
 import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
+import { mapCountriesToChoices } from "@saleor/utils/maps";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -85,10 +86,7 @@ const ShippingZoneAddWarehouseDialog: React.FC<ShippingZoneAddWarehouseDialogPro
   useModalDialogOpen(open, {});
   const intl = useIntl();
 
-  const countryChoices = countries.map(country => ({
-    label: country.country,
-    value: country.code
-  }));
+  const countryChoices = mapCountriesToChoices(countries);
 
   return (
     <Dialog

--- a/src/staff/types/ChangeStaffPassword.ts
+++ b/src/staff/types/ChangeStaffPassword.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: ChangeStaffPassword
@@ -13,6 +13,7 @@ export interface ChangeStaffPassword_passwordChange_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface ChangeStaffPassword_passwordChange {

--- a/src/staff/types/StaffAvatarDelete.ts
+++ b/src/staff/types/StaffAvatarDelete.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: StaffAvatarDelete
@@ -13,6 +13,7 @@ export interface StaffAvatarDelete_userAvatarDelete_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface StaffAvatarDelete_userAvatarDelete_user_avatar {

--- a/src/staff/types/StaffAvatarUpdate.ts
+++ b/src/staff/types/StaffAvatarUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AccountErrorCode } from "./../../types/globalTypes";
+import { AccountErrorCode, AddressTypeEnum } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: StaffAvatarUpdate
@@ -13,6 +13,7 @@ export interface StaffAvatarUpdate_userAvatarUpdate_errors {
   __typename: "AccountError";
   code: AccountErrorCode;
   field: string | null;
+  addressType: AddressTypeEnum | null;
 }
 
 export interface StaffAvatarUpdate_userAvatarUpdate_user_avatar {

--- a/src/storybook/stories/components/AddressEdit.tsx
+++ b/src/storybook/stories/components/AddressEdit.tsx
@@ -1,6 +1,7 @@
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
 import AddressEdit from "@saleor/components/AddressEdit";
+import { mapCountriesToChoices } from "@saleor/utils/maps";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -22,10 +23,7 @@ storiesOf("Generics / AddressEdit", module)
         <AddressEdit
           errors={[]}
           data={transformAddressToForm(customer.defaultBillingAddress)}
-          countries={countries.map(c => ({
-            label: c.label,
-            value: c.code
-          }))}
+          countries={mapCountriesToChoices(countries)}
           countryDisplayValue={customer.defaultBillingAddress.country.country}
           onChange={undefined}
           onCountryChange={() => undefined}

--- a/src/storybook/stories/customers/CustomerAddressDialog.tsx
+++ b/src/storybook/stories/customers/CustomerAddressDialog.tsx
@@ -12,8 +12,9 @@ const props: CustomerAddressDialogProps = {
   address: customer.addresses[0],
   confirmButtonState: "default",
   countries: countries.map(c => ({
+    __typename: "CountryDisplay",
     code: c.code,
-    label: c.name
+    country: c.name
   })),
   errors: [],
   onClose: () => undefined,

--- a/src/storybook/stories/customers/CustomerCreatePage.tsx
+++ b/src/storybook/stories/customers/CustomerCreatePage.tsx
@@ -45,7 +45,8 @@ storiesOf("Views / Customers / Create customer", module)
       ] as Array<keyof CustomerCreatePageFormData>).map(field => ({
         __typename: "AccountError",
         code: AccountErrorCode.INVALID,
-        field
+        field,
+        addressType: null
       }))}
     />
   ));

--- a/src/storybook/stories/customers/CustomerDetailsPage.tsx
+++ b/src/storybook/stories/customers/CustomerDetailsPage.tsx
@@ -43,7 +43,8 @@ storiesOf("Views / Customers / Customer details", module)
       >).map(field => ({
         __typename: "AccountError",
         code: AccountErrorCode.INVALID,
-        field
+        field,
+        addressType: null
       }))}
     />
   ))

--- a/src/storybook/stories/orders/OrderCancelDialog.tsx
+++ b/src/storybook/stories/orders/OrderCancelDialog.tsx
@@ -35,7 +35,8 @@ storiesOf("Orders / OrderCancelDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.CANNOT_CANCEL_ORDER,
-          field: null
+          field: null,
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderDetailsPage.tsx
+++ b/src/storybook/stories/orders/OrderDetailsPage.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import OrderDetailsPage, {
   OrderDetailsPageProps
 } from "../../../orders/components/OrderDetailsPage";
-import { countries, order as orderFixture } from "../../../orders/fixtures";
+import { order as orderFixture } from "../../../orders/fixtures";
 import {
   FulfillmentStatus,
   OrderStatus,
@@ -18,7 +18,6 @@ import Decorator from "../../Decorator";
 const order = orderFixture(placeholderImage);
 
 const props: Omit<OrderDetailsPageProps, "classes"> = {
-  countries,
   disabled: false,
   onBack: () => undefined,
   onBillingAddressEdit: undefined,

--- a/src/storybook/stories/orders/OrderDraftCancelDialog.tsx
+++ b/src/storybook/stories/orders/OrderDraftCancelDialog.tsx
@@ -26,7 +26,8 @@ storiesOf("Orders / OrderDraftCancelDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.GRAPHQL_ERROR,
-          field: null
+          field: null,
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/storybook/stories/orders/OrderDraftPage/OrderDraftPage.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import OrderDraftPage, {
   OrderDraftPageProps
 } from "../../../../orders/components/OrderDraftPage";
-import { clients, countries, draftOrder } from "../../../../orders/fixtures";
+import { clients, draftOrder } from "../../../../orders/fixtures";
 import Decorator from "../../../Decorator";
 import { getDiscountsProvidersWrapper } from "./utils";
 
@@ -15,7 +15,6 @@ const order = draftOrder(placeholderImage);
 
 const props: Omit<OrderDraftPageProps, "classes"> = {
   ...fetchMoreProps,
-  countries,
   disabled: false,
   fetchUsers: () => undefined,
   onBack: () => undefined,

--- a/src/storybook/stories/orders/OrderFulfillmentCancelDialog.tsx
+++ b/src/storybook/stories/orders/OrderFulfillmentCancelDialog.tsx
@@ -27,7 +27,8 @@ storiesOf("Orders / OrderFulfillmentCancelDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.GRAPHQL_ERROR,
-          field: null
+          field: null,
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderFulfillmentDialog.tsx
+++ b/src/storybook/stories/orders/OrderFulfillmentDialog.tsx
@@ -31,12 +31,14 @@ storiesOf("Orders / OrderFulfillmentDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.FULFILL_ORDER_LINE,
-          field: null
+          field: null,
+          addressType: null
         },
         {
           __typename: "OrderError",
           code: OrderErrorCode.INVALID,
-          field: "trackingNumber"
+          field: "trackingNumber",
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderFulfillmentTrackingDialog.tsx
+++ b/src/storybook/stories/orders/OrderFulfillmentTrackingDialog.tsx
@@ -26,12 +26,14 @@ storiesOf("Orders / OrderFulfillmentTrackingDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.GRAPHQL_ERROR,
-          field: null
+          field: null,
+          addressType: null
         },
         {
           __typename: "OrderError",
           code: OrderErrorCode.INVALID,
-          field: "trackingNumber"
+          field: "trackingNumber",
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderMarkAsPaidDialog.tsx
+++ b/src/storybook/stories/orders/OrderMarkAsPaidDialog.tsx
@@ -27,7 +27,8 @@ storiesOf("Orders / OrderMarkAsPaidDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.GRAPHQL_ERROR,
-          field: null
+          field: null,
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderPaymentDialog.tsx
+++ b/src/storybook/stories/orders/OrderPaymentDialog.tsx
@@ -26,12 +26,14 @@ storiesOf("Orders / OrderPaymentDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.CAPTURE_INACTIVE_PAYMENT,
-          field: null
+          field: null,
+          addressType: null
         },
         {
           __typename: "OrderError",
           code: OrderErrorCode.INVALID,
-          field: "payment"
+          field: "payment",
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderPaymentVoidDialog.tsx
+++ b/src/storybook/stories/orders/OrderPaymentVoidDialog.tsx
@@ -25,7 +25,8 @@ storiesOf("Orders / OrderPaymentVoidDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.VOID_INACTIVE_PAYMENT,
-          field: null
+          field: null,
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderProductAddDialog.tsx
+++ b/src/storybook/stories/orders/OrderProductAddDialog.tsx
@@ -34,7 +34,8 @@ storiesOf("Orders / OrderProductAddDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.GRAPHQL_ERROR,
-          field: null
+          field: null,
+          addressType: null
         }
       ]}
     />

--- a/src/storybook/stories/orders/OrderShippingMethodEditDialog.tsx
+++ b/src/storybook/stories/orders/OrderShippingMethodEditDialog.tsx
@@ -29,12 +29,14 @@ storiesOf("Orders / OrderShippingMethodEditDialog", module)
         {
           __typename: "OrderError",
           code: OrderErrorCode.SHIPPING_METHOD_NOT_APPLICABLE,
-          field: "shippingMethod"
+          field: "shippingMethod",
+          addressType: null
         },
         {
           __typename: "OrderError",
           code: OrderErrorCode.GRAPHQL_ERROR,
-          field: null
+          field: null,
+          addressType: null
         }
       ]}
     />

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -815,7 +815,6 @@ export enum ProductFieldEnum {
   VARIANT_MEDIA = "VARIANT_MEDIA",
   VARIANT_SKU = "VARIANT_SKU",
   VARIANT_WEIGHT = "VARIANT_WEIGHT",
-  VISIBLE = "VISIBLE",
 }
 
 export enum ProductMediaType {

--- a/src/utils/errors/staff.ts
+++ b/src/utils/errors/staff.ts
@@ -10,7 +10,8 @@ function getStaffErrorMessage(
   return getAccountErrorMessage(
     err && {
       ...err,
-      __typename: "AccountError"
+      __typename: "AccountError",
+      addressType: null
     },
     intl
   );


### PR DESCRIPTION
I want to merge this change because... it adds user addresses selection in modal for draft order details view.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> SALEOR-1491-do-not-update-draft-order-addresses-when-user-is-changing
https://github.com/mirumee/saleor/pull/7088

### Screenshots

<img width="631" alt="Zrzut ekranu 2021-04-28 o 13 51 06" src="https://user-images.githubusercontent.com/9825562/116399163-e7708000-a828-11eb-9291-e8f564b33c64.png">
<img width="629" alt="Zrzut ekranu 2021-04-28 o 13 51 14" src="https://user-images.githubusercontent.com/9825562/116399170-e9d2da00-a828-11eb-9ab9-20b00655600e.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/