### PR TITLE
Saleor 2183 Fix sortable chip style

### DIFF
--- a/src/components/SortableChipsField/SortableChipsField.tsx
+++ b/src/components/SortableChipsField/SortableChipsField.tsx
@@ -11,7 +11,7 @@ import SortableContainer from "./SortableContainer";
 const useStyles = makeStyles(
   theme => ({
     chip: {
-      background: "#fff",
+      background: theme.palette.background.paper,
       color: theme.palette.primary.dark,
       marginBottom: theme.spacing(1)
     },


### PR DESCRIPTION
I want to merge this change because... it fixes sortable chip style in dark mode.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> master

### Screenshots

before:
<img width="626" alt="Zrzut ekranu 2021-04-29 o 13 22 57" src="https://user-images.githubusercontent.com/9825562/116543349-0edd5080-a8ee-11eb-9637-c268a645b155.png">

after:
<img width="609" alt="Zrzut ekranu 2021-04-29 o 13 14 28" src="https://user-images.githubusercontent.com/9825562/116542838-6c24d200-a8ed-11eb-9c57-6fc40dd1843d.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/