### PR TITLE
Add product / page delete warning

### DIFF
--- a/src/components/DeleteButton/DeleteButton.tsx
+++ b/src/components/DeleteButton/DeleteButton.tsx
@@ -1,0 +1,47 @@
+import Button from "@material-ui/core/Button";
+import { buttonMessages } from "@saleor/intl";
+import { makeStyles } from "@saleor/theme";
+import React from "react";
+import { useIntl } from "react-intl";
+
+const useStyles = makeStyles(
+  theme => ({
+    button: {
+      "&:hover": {
+        backgroundColor: theme.palette.error.dark
+      },
+      backgroundColor: theme.palette.error.main,
+      color: theme.palette.error.contrastText
+    }
+  }),
+  { name: "DeleteButton" }
+);
+
+interface DeleteButtonProps {
+  onClick: () => void;
+  label?: string | React.ReactNode;
+  disabled?: boolean;
+}
+
+const DeleteButton: React.FC<DeleteButtonProps> = ({
+  onClick,
+  label,
+  disabled = false
+}) => {
+  const classes = useStyles({});
+  const intl = useIntl();
+
+  return (
+    <Button
+      variant="contained"
+      onClick={onClick}
+      className={classes.button}
+      data-test="button-bar-delete"
+      disabled={disabled}
+    >
+      {label || intl.formatMessage(buttonMessages.delete)}
+    </Button>
+  );
+};
+
+export default DeleteButton;

--- a/src/components/DeleteButton/index.tsx
+++ b/src/components/DeleteButton/index.tsx
@@ -1,0 +1,2 @@
+export * from "./DeleteButton";
+export { default } from "./DeleteButton";

--- a/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialog.tsx
+++ b/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialog.tsx
@@ -1,0 +1,128 @@
+import { CardContent } from "@material-ui/core";
+import Card from "@material-ui/core/Card";
+import CircularProgress from "@material-ui/core/CircularProgress";
+import Modal from "@material-ui/core/Modal";
+import { ConfirmButtonTransitionState } from "@saleor/components/ConfirmButton";
+import ModalTitle from "@saleor/orders/components/OrderDiscountCommonModal/ModalTitle";
+import { getById } from "@saleor/orders/components/OrderReturnPage/utils";
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { useTypeDeleteWarningDialogStyles as useStyles } from "./styles";
+import ProductTypeDeleteWarningDialogContent from "./TypeDeleteWarningDialogContent";
+import {
+  CommonTypeDeleteWarningMessages,
+  TypeDeleteWarningMessages
+} from "./types";
+
+export interface BaseTypeDeleteWarningDialogProps {
+  isOpen: boolean;
+  deleteButtonState: ConfirmButtonTransitionState;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+interface TypeBaseData {
+  id: string;
+  name: string;
+}
+
+interface TypeDeleteWarningDialogProps<T extends TypeBaseData>
+  extends BaseTypeDeleteWarningDialogProps {
+  baseMessages: CommonTypeDeleteWarningMessages;
+  singleWithItemsMessages: TypeDeleteWarningMessages;
+  singleWithoutItemsMessages: TypeDeleteWarningMessages;
+  multipleWithItemsMessages: TypeDeleteWarningMessages;
+  multipleWithoutItemsMessages: TypeDeleteWarningMessages;
+  viewAssignedItemsUrl: string;
+  typesToDelete: string[];
+  assignedItemsCount: number | undefined;
+  isLoading: boolean;
+  typesData: T[];
+}
+
+function TypeDeleteWarningDialog<T extends TypeBaseData>({
+  isLoading,
+  isOpen,
+  baseMessages,
+  singleWithItemsMessages,
+  singleWithoutItemsMessages,
+  multipleWithItemsMessages,
+  multipleWithoutItemsMessages,
+  onClose,
+  onDelete,
+  assignedItemsCount,
+  viewAssignedItemsUrl,
+  typesToDelete,
+  typesData
+}: TypeDeleteWarningDialogProps<T>) {
+  const intl = useIntl();
+  const classes = useStyles({});
+
+  const showMultiple = typesToDelete.length > 1;
+
+  const hasAssignedItems = !!assignedItemsCount;
+
+  const selectMessages = () => {
+    if (showMultiple) {
+      const multipleMessages = hasAssignedItems
+        ? multipleWithItemsMessages
+        : multipleWithoutItemsMessages;
+
+      return {
+        title: baseMessages.multipleTitle,
+        ...multipleMessages
+      };
+    }
+
+    const singleMessages = hasAssignedItems
+      ? singleWithItemsMessages
+      : singleWithoutItemsMessages;
+
+    return {
+      title: baseMessages.singleTitle,
+      ...singleMessages
+    };
+  };
+
+  const { title, description, consentLabel } = selectMessages();
+
+  const singleItemSelectedId = typesToDelete[0];
+
+  const singleItemSelectedName = typesData.find(getById(singleItemSelectedId))
+    ?.name;
+
+  return (
+    <Modal open={isOpen}>
+      <div className={classes.centerContainer}>
+        <Card className={classes.content}>
+          <ModalTitle
+            title={intl.formatMessage(title)}
+            withBorder
+            onClose={onClose}
+          />
+          {isLoading ? (
+            <CardContent className={classes.centerContainer}>
+              <CircularProgress size={16} />
+            </CardContent>
+          ) : (
+            <ProductTypeDeleteWarningDialogContent
+              assignedItemsCount={assignedItemsCount}
+              hasAssignedItems={hasAssignedItems}
+              singleItemSelectedName={singleItemSelectedName}
+              viewAssignedItemsUrl={viewAssignedItemsUrl}
+              onDelete={onDelete}
+              description={description}
+              consentLabel={consentLabel}
+              viewAssignedItemsButtonLabel={
+                baseMessages.viewAssignedItemsButtonLabel
+              }
+            />
+          )}
+        </Card>
+      </div>
+    </Modal>
+  );
+}
+
+export default TypeDeleteWarningDialog;

--- a/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialogContent.tsx
+++ b/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialogContent.tsx
@@ -1,0 +1,88 @@
+import CardContent from "@material-ui/core/CardContent";
+import Typography from "@material-ui/core/Typography";
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
+import CardSpacer from "@saleor/components/CardSpacer";
+import ConfirmButton from "@saleor/components/ConfirmButton";
+import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
+import DeleteButton from "@saleor/components/DeleteButton";
+import useNavigator from "@saleor/hooks/useNavigator";
+import React, { ChangeEvent, useState } from "react";
+import { MessageDescriptor, useIntl } from "react-intl";
+
+import { useTypeDeleteWarningDialogStyles as useStyles } from "./styles";
+
+interface TypeDeleteWarningDialogContentProps {
+  singleItemSelectedName?: string;
+  viewAssignedItemsButtonLabel: MessageDescriptor;
+  description: MessageDescriptor;
+  consentLabel: MessageDescriptor;
+  viewAssignedItemsUrl: string;
+  hasAssignedItems: boolean;
+  assignedItemsCount: number | undefined;
+  onDelete: () => void;
+}
+
+const TypeDeleteWarningDialogContent: React.FC<TypeDeleteWarningDialogContentProps> = ({
+  description,
+  consentLabel,
+  viewAssignedItemsUrl,
+  viewAssignedItemsButtonLabel,
+  singleItemSelectedName,
+  hasAssignedItems,
+  assignedItemsCount,
+  onDelete
+}) => {
+  const classes = useStyles({});
+  const intl = useIntl();
+  const navigate = useNavigator();
+
+  const [isConsentChecked, setIsConsentChecked] = useState(false);
+
+  const handleConsentChange = ({ target }: ChangeEvent<any>) =>
+    setIsConsentChecked(target.value);
+
+  const handleViewAssignedItems = () => navigate(viewAssignedItemsUrl);
+
+  const isDisbled = hasAssignedItems ? !isConsentChecked : false;
+
+  return (
+    <CardContent>
+      <Typography>
+        {intl.formatMessage(description, {
+          typeName: singleItemSelectedName,
+          assignedItemsCount
+        })}
+      </Typography>
+      <CardSpacer />
+      {consentLabel && (
+        <ControlledCheckbox
+          name="delete-assigned-items-consent"
+          checked={isConsentChecked}
+          onChange={handleConsentChange}
+          label={
+            <Typography className={classes.consentLabel}>
+              {intl.formatMessage(consentLabel)}
+            </Typography>
+          }
+        />
+      )}
+      <CardSpacer />
+      <div className={classes.buttonsSection}>
+        {hasAssignedItems && (
+          <>
+            <ConfirmButton
+              onClick={handleViewAssignedItems}
+              transitionState="default"
+            >
+              {intl.formatMessage(viewAssignedItemsButtonLabel)}
+            </ConfirmButton>
+            <HorizontalSpacer spacing={3} />
+          </>
+        )}
+        <DeleteButton onClick={onDelete} disabled={isDisbled} />
+      </div>
+    </CardContent>
+  );
+};
+
+export default TypeDeleteWarningDialogContent;

--- a/src/components/TypeDeleteWarningDialog/index.tsx
+++ b/src/components/TypeDeleteWarningDialog/index.tsx
@@ -1,0 +1,2 @@
+export * from "./TypeDeleteWarningDialog";
+export { default } from "./TypeDeleteWarningDialog";

--- a/src/components/TypeDeleteWarningDialog/styles.ts
+++ b/src/components/TypeDeleteWarningDialog/styles.ts
@@ -1,0 +1,23 @@
+import { makeStyles } from "@saleor/theme";
+
+export const useTypeDeleteWarningDialogStyles = makeStyles(
+  theme => ({
+    centerContainer: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      height: "100%"
+    },
+    content: {
+      width: 600
+    },
+    consentLabel: {
+      color: theme.palette.primary.main
+    },
+    buttonsSection: {
+      display: "flex",
+      justifyContent: "flex-end"
+    }
+  }),
+  { name: "ProductTypeDeleteWarningDialog" }
+);

--- a/src/components/TypeDeleteWarningDialog/types.ts
+++ b/src/components/TypeDeleteWarningDialog/types.ts
@@ -1,0 +1,10 @@
+import { MessageDescriptor } from "react-intl";
+
+export type CommonTypeDeleteWarningMessages = Record<
+  "singleTitle" | "multipleTitle" | "viewAssignedItemsButtonLabel",
+  MessageDescriptor
+>;
+
+export type TypeDeleteWarningMessages = Partial<
+  Record<"description" | "consentLabel", MessageDescriptor>
+>;

--- a/src/orders/components/OrderDiscountCommonModal/ModalTitle.tsx
+++ b/src/orders/components/OrderDiscountCommonModal/ModalTitle.tsx
@@ -1,5 +1,7 @@
+import Divider from "@material-ui/core/Divider";
 import Typography from "@material-ui/core/Typography";
 import CloseIcon from "@material-ui/icons/Close";
+import CardSpacer from "@saleor/components/CardSpacer";
 import { makeStyles } from "@saleor/theme";
 import React from "react";
 
@@ -19,16 +21,29 @@ const useStyles = makeStyles(
 interface ModalTitleProps {
   title: string;
   onClose: () => void;
+  withBorder?: boolean;
 }
 
-const ModalTitle: React.FC<ModalTitleProps> = ({ title, onClose }) => {
+const ModalTitle: React.FC<ModalTitleProps> = ({
+  title,
+  onClose,
+  withBorder = false
+}) => {
   const classes = useStyles({});
 
   return (
-    <div className={classes.container}>
-      <Typography variant="h5">{title}</Typography>
-      <CloseIcon onClick={onClose} />
-    </div>
+    <>
+      <div className={classes.container}>
+        <Typography variant="h5">{title}</Typography>
+        <CloseIcon onClick={onClose} />
+      </div>
+      {withBorder && (
+        <>
+          <CardSpacer />
+          <Divider />
+        </>
+      )}
+    </>
   );
 };
 

--- a/src/productTypes/views/ProductTypeList/productTypeDeleteWarningDialogMessages.ts
+++ b/src/productTypes/views/ProductTypeList/productTypeDeleteWarningDialogMessages.ts
@@ -1,0 +1,63 @@
+import { defineMessages } from "react-intl";
+
+export const baseMessages = defineMessages({
+  singleTitle: {
+    defaultMessage: "Delete product type",
+    description: "ProductTypeDeleteWarningDialog single title"
+  },
+  multipleTitle: {
+    defaultMessage: "Delete product types",
+    description: "ProductTypeDeleteWarningDialog multiple title"
+  },
+  viewAssignedItemsButtonLabel: {
+    defaultMessage: "View products",
+    description:
+      "ProductTypeDeleteWarningDialog single assigned items button label"
+  }
+});
+
+export const singleWithItemsMessages = defineMessages({
+  description: {
+    defaultMessage:
+      "You are about to delete product type {typeName}. It is assigned to {assignedItemsCount} products. Deleting this product type will also delete those products. Are you sure you want to do this?",
+    description:
+      "ProductTypeDeleteWarningDialog single assigned items description"
+  },
+  consentLabel: {
+    defaultMessage:
+      "Yes, I want to delete this product type and assigned products",
+    description: "ProductTypeDeleteWarningDialog single consent label"
+  }
+});
+
+export const multipleWithItemsMessages = defineMessages({
+  description: {
+    defaultMessage:
+      "You are about to delete multiple product types. Some of them are assigned to products. Deleting those product types will also delete those products",
+    description:
+      "ProductTypeDeleteWarningDialog with items multiple description"
+  },
+  consentLabel: {
+    defaultMessage:
+      "Yes, I want to delete those products types and assigned products",
+    description: "ProductTypeDeleteWarningDialog multiple consent label"
+  }
+});
+
+export const singleWithoutItemsMessages = defineMessages({
+  description: {
+    defaultMessage:
+      "Are you sure you want to delete {typeName}? If you remove it you won’t be able to assign it to created products.",
+    description:
+      "ProductTypeDeleteWarningDialog single assigned items description"
+  }
+});
+
+export const multipleWithoutItemsMessages = defineMessages({
+  description: {
+    defaultMessage:
+      "Are you sure you want to delete selected product types? If you remove them you won’t be able to assign them to created products.",
+    description:
+      "ProductTypeDeleteWarningDialog single assigned items description"
+  }
+});

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -176,6 +176,19 @@ export const useProductListQuery = makeQuery<ProductList, ProductListVariables>(
   productListQuery
 );
 
+const productCountQuery = gql`
+  query ProductCount($filter: ProductFilterInput) {
+    products(filter: $filter) {
+      totalCount
+    }
+  }
+`;
+
+export const useProductCountQuery = makeQuery<
+  ProductCount,
+  ProductCountVariables
+>(productCountQuery);
+
 const countAllProductsQuery = gql`
   query CountAllProducts {
     products {

--- a/src/products/types/ProductCount.ts
+++ b/src/products/types/ProductCount.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ProductFilterInput } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: ProductCount
+// ====================================================
+
+export interface ProductCount_products {
+  __typename: "ProductCountableConnection";
+  totalCount: number | null;
+}
+
+export interface ProductCount {
+  products: ProductCount_products | null;
+}
+
+export interface ProductCountVariables {
+  filter?: ProductFilterInput | null;
+}


### PR DESCRIPTION
I want to merge this change because it adds new product type / page type delete warning. There are 4 versions to show for each list (page type list, product type list, etc)
 - no assigned items to selected single type
<img width="597" alt="Screenshot 2021-05-06 at 15 49 40" src="https://user-images.githubusercontent.com/28022710/117309455-b7f1f100-ae82-11eb-8f25-7b42d4ef165e.png">

 - some assigned items to selected single type 
<img width="575" alt="Screenshot 2021-05-06 at 15 50 54" src="https://user-images.githubusercontent.com/28022710/117309627-e374db80-ae82-11eb-9b18-d3c57a4e8de0.png">
<img width="588" alt="Screenshot 2021-05-06 at 15 50 58" src="https://user-images.githubusercontent.com/28022710/117309653-e96abc80-ae82-11eb-99d8-f243adb464ed.png">

 
 - no assigned items to selected multiple type
<img width="588" alt="Screenshot 2021-05-06 at 15 50 20" src="https://user-images.githubusercontent.com/28022710/117309524-c7713a00-ae82-11eb-9bb1-b3bffb2b09a8.png">
 

 - some assigned items to selected multiple type
<img width="598" alt="Screenshot 2021-05-06 at 15 51 51" src="https://user-images.githubusercontent.com/28022710/117309754-030c0400-ae83-11eb-8b58-7bbfddad9be4.png">

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/