### PR TITLE
SALEOR 3115 Fix EditorJS inline formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop deprecated fields - #1071 by @jwm0
 - Add service worker - #1073 by @dominik-zeglen
 - Choosing user shipping and billing addresses for draft order - #1082 by @orzechdev
+- Fix EditorJS inline formatting - #1096 by @orzechdev
 
 # 2.11.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1837,6 +1837,11 @@
       "resolved": "https://registry.npmjs.org/@editorjs/list/-/list-1.6.2.tgz",
       "integrity": "sha512-OxowV0yuE11G01czYM1dEQlz1F37ehX0ak5vAbZ9ncSXrPh0fDRw/fBxTY654FlmrsQ40UFom3owSG++tLvVGw=="
     },
+    "@editorjs/paragraph": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@editorjs/paragraph/-/paragraph-2.8.0.tgz",
+      "integrity": "sha512-z6w5ZR0ru3p/IjxJW/tb7OcSnVttkZukQMIsnBMX1FIKc1BNdr7NwM1YoCyTl4OnC90YfL0xgES6/20/W267pw=="
+    },
     "@editorjs/quote": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@editorjs/quote/-/quote-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@editorjs/header": "^2.6.1",
     "@editorjs/image": "^2.6.0",
     "@editorjs/list": "^1.6.1",
+    "@editorjs/paragraph": "^2.8.0",
     "@editorjs/quote": "^2.4.0",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",

--- a/src/components/RichTextEditor/RichTextEditorContent.tsx
+++ b/src/components/RichTextEditor/RichTextEditorContent.tsx
@@ -6,6 +6,7 @@ import EditorJS, {
 } from "@editorjs/editorjs";
 import Header from "@editorjs/header";
 import List from "@editorjs/list";
+import Paragraph from "@editorjs/paragraph";
 import Quote from "@editorjs/quote";
 import strikethroughIcon from "@saleor/icons/StrikethroughIcon";
 import classNames from "classnames";
@@ -20,16 +21,29 @@ export interface RichTextEditorContentProps {
   onReady?: () => void;
 }
 
+const inlineToolbar = ["link", "bold", "italic", "strikethrough"];
+
 export const tools: Record<string, ToolConstructable | ToolSettings> = {
   header: {
     class: Header,
     config: {
       defaultLevel: 1,
       levels: [1, 2, 3]
-    }
+    },
+    inlineToolbar
   },
-  list: List,
-  quote: Quote,
+  list: {
+    class: List,
+    inlineToolbar
+  },
+  quote: {
+    class: Quote,
+    inlineToolbar
+  },
+  paragraph: {
+    class: Paragraph,
+    inlineToolbar
+  },
   strikethrough: createGenericInlineTool({
     sanitize: {
       s: {}


### PR DESCRIPTION
I want to merge this change because... it fixes inline formatting in rich text editors - it was impossible to save bold, italic, link and strikethrough.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> master

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="541" alt="Zrzut ekranu 2021-05-6 o 18 28 59" src="https://user-images.githubusercontent.com/9825562/117333171-f5617900-ae98-11eb-9340-31d9d4de7510.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/