### PR TITLE
Saleor 3065/replace shipping zones from channel with separate mutation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -5146,7 +5146,7 @@ type ShippingZoneDelete {
 
 input ShippingZoneFilterInput {
   search: String
-  channel: ID
+  channels: [ID]
 }
 
 type ShippingZoneUpdate {

--- a/schema.graphql
+++ b/schema.graphql
@@ -5146,6 +5146,7 @@ type ShippingZoneDelete {
 
 input ShippingZoneFilterInput {
   search: String
+  channel: ID
 }
 
 type ShippingZoneUpdate {

--- a/src/channels/components/ShippingZonesCard/ShippingZoneItem.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZoneItem.tsx
@@ -1,6 +1,6 @@
 import { Divider, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { Channel_channel_shippingZones } from "@saleor/channels/types/Channel";
+import { ChannelShippingZone } from "@saleor/channels/pages/ChannelDetailsPage/types";
 import DeletableItem from "@saleor/components/DeletableItem";
 import React from "react";
 
@@ -18,7 +18,7 @@ const useStyles = makeStyles(
 );
 
 interface ShippingZoneItemProps {
-  zone: Channel_channel_shippingZones;
+  zone: ChannelShippingZone;
   onDelete: (id: string) => void;
 }
 

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCard.stories.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCard.stories.tsx
@@ -1,4 +1,4 @@
-import { Channel_channel_shippingZones } from "@saleor/channels/types/Channel";
+import { ChannelShippingZones } from "@saleor/channels/pages/ChannelDetailsPage/types";
 import CommonDecorator from "@saleor/storybook/Decorator";
 import { storiesOf } from "@storybook/react";
 import React from "react";
@@ -28,7 +28,7 @@ const baseProps = {
     onFetchMore: () => undefined
   },
   shippingZones: [],
-  shippingZonesChoices: shippingZones as Channel_channel_shippingZones[]
+  shippingZonesChoices: shippingZones as ChannelShippingZones
 };
 
 storiesOf("Shipping zones card", module)
@@ -37,6 +37,6 @@ storiesOf("Shipping zones card", module)
   .add("with options selected", () => (
     <ShippingZonesCard
       {...baseProps}
-      shippingZones={shippingZones as Channel_channel_shippingZones[]}
+      shippingZones={shippingZones as ChannelShippingZones}
     />
   ));

--- a/src/channels/components/ShippingZonesCard/ShippingZonesCardListFooter.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesCardListFooter.tsx
@@ -1,5 +1,5 @@
 import { ClickAwayListener } from "@material-ui/core";
-import { Channel_channel_shippingZones } from "@saleor/channels/types/Channel";
+import { ChannelShippingZones } from "@saleor/channels/pages/ChannelDetailsPage/types";
 import SingleAutocompleteSelectField from "@saleor/components/SingleAutocompleteSelectField";
 import CardAddItemsFooter from "@saleor/products/components/ProductStocks/CardAddItemsFooter";
 import { mapNodeToChoice } from "@saleor/utils/maps";
@@ -25,9 +25,7 @@ const ShippingZonesCardListFooter: React.FC<ShippingZonesCardListFooterProps> = 
   shippingZones
 }) => {
   const [isChoicesSelectShown, setIsChoicesSelectShown] = useState(false);
-  const shippingZonesRef = useRef<Channel_channel_shippingZones[]>(
-    shippingZones
-  );
+  const shippingZonesRef = useRef<ChannelShippingZones>(shippingZones);
 
   // select holds value and displays it so it needs remounting
   // to display empty input after adding new zone

--- a/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
+++ b/src/channels/components/ShippingZonesCard/ShippingZonesListHeader.tsx
@@ -1,7 +1,7 @@
 import { ExpansionPanelSummary, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
-import { Channel_channel_shippingZones } from "@saleor/channels/types/Channel";
+import { ChannelShippingZones } from "@saleor/channels/pages/ChannelDetailsPage/types";
 import IconChevronDown from "@saleor/icons/ChevronDown";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";
@@ -47,7 +47,7 @@ const messages = defineMessages({
 });
 
 interface ShippingZonesListHeaderProps {
-  shippingZones: Channel_channel_shippingZones[];
+  shippingZones: ChannelShippingZones;
 }
 
 const ShippingZonesListHeader: React.FC<ShippingZonesListHeaderProps> = ({

--- a/src/channels/components/ShippingZonesCard/types.ts
+++ b/src/channels/components/ShippingZonesCard/types.ts
@@ -1,4 +1,4 @@
-import { Channel_channel_shippingZones } from "@saleor/channels/types/Channel";
+import { ChannelShippingZones } from "@saleor/channels/pages/ChannelDetailsPage/types";
 import { SearchShippingZones_search_edges_node } from "@saleor/searches/types/SearchShippingZones";
 import { FetchMoreProps } from "@saleor/types";
 
@@ -7,6 +7,6 @@ export interface ShippingZonesProps {
   removeShippingZone: (id: string) => void;
   searchShippingZones: (searchPhrase: string) => void;
   fetchMoreShippingZones: FetchMoreProps;
-  shippingZones: Channel_channel_shippingZones[];
+  shippingZones: ChannelShippingZones;
   shippingZonesChoices: SearchShippingZones_search_edges_node[];
 }

--- a/src/channels/fixtures.ts
+++ b/src/channels/fixtures.ts
@@ -18,7 +18,6 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    shippingZones: [],
     hasOrders: false,
     id: "Q2hhbm5lcDoy",
     isActive: true,
@@ -28,7 +27,6 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    shippingZones: [],
     hasOrders: false,
     id: "Q2hhbm7lbDoy213",
     isActive: true,
@@ -39,7 +37,6 @@ export const channelsList: Channels_channels[] = [
     __typename: "Channel",
     currencyCode: "euro",
     hasOrders: false,
-    shippingZones: [],
     id: "Q2hhbn5lbDoytr",
     isActive: true,
     name: "Channel test",
@@ -48,7 +45,6 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    shippingZones: [],
     hasOrders: false,
     id: "Q2hhbm5lbDo5bot",
     isActive: true,
@@ -58,7 +54,6 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    shippingZones: [],
     hasOrders: false,
     id: "Q2hhbm7lbDoyr0tr",
     isActive: true,
@@ -68,7 +63,6 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    shippingZones: [],
     hasOrders: false,
     id: "Q2hhbn5lbDoyya",
     isActive: true,
@@ -78,7 +72,6 @@ export const channelsList: Channels_channels[] = [
   {
     __typename: "Channel",
     currencyCode: "euro",
-    shippingZones: [],
     hasOrders: false,
     id: "Q2hhbm5lbDo5w0z",
     isActive: true,
@@ -90,7 +83,6 @@ export const channelsList: Channels_channels[] = [
 export const channel: Channel_channel = {
   __typename: "Channel",
   currencyCode: "zl",
-  shippingZones: [],
   hasOrders: false,
   id: "Q2hhbm5lbDov78",
   isActive: true,

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.stories.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.stories.tsx
@@ -21,6 +21,18 @@ const props: ChannelDetailsPageProps = {
   updateChannelStatus: () => undefined,
   searchShippingZones: () => undefined,
   searchShippingZonesData: undefined,
+  channelShippingZones: [
+    {
+      __typename: "ShippingZone",
+      id: "zone-1",
+      name: "Europe"
+    },
+    {
+      __typename: "ShippingZone",
+      id: "zone-2",
+      name: "USA"
+    }
+  ],
   fetchMoreShippingZones: {
     loading: false,
     hasMore: false,

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
@@ -20,10 +20,8 @@ import React, { useState } from "react";
 
 import { ChannelForm, FormData } from "../../components/ChannelForm";
 import { ChannelStatus } from "../../components/ChannelStatus/ChannelStatus";
-import {
-  Channel_channel,
-  Channel_channel_shippingZones
-} from "../../types/Channel";
+import { Channel_channel } from "../../types/Channel";
+import { ChannelShippingZones } from "./types";
 import { getUpdatedIdsWithNewId, getUpdatedIdsWithoutNewId } from "./utils";
 
 export interface ChannelDetailsPageProps {
@@ -40,6 +38,7 @@ export interface ChannelDetailsPageProps {
   searchShippingZones: (query: string) => void;
   searchShippingZonesData?: SearchData;
   fetchMoreShippingZones: FetchMoreProps;
+  channelShippingZones: ChannelShippingZones;
 }
 
 export const ChannelDetailsPage: React.FC<ChannelDetailsPageProps> = ({
@@ -55,13 +54,14 @@ export const ChannelDetailsPage: React.FC<ChannelDetailsPageProps> = ({
   updateChannelStatus,
   searchShippingZones,
   searchShippingZonesData,
-  fetchMoreShippingZones
+  fetchMoreShippingZones,
+  channelShippingZones
 }) => {
   const [selectedCurrencyCode, setSelectedCurrencyCode] = useState("");
 
   const [shippingZonesToDisplay, setShippingZonesToDisplay] = useStateFromProps<
-    Channel_channel_shippingZones[]
-  >(channel?.shippingZones || []);
+    ChannelShippingZones
+  >(channelShippingZones || []);
 
   const initialData: FormData = {
     currencyCode: "",

--- a/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
+++ b/src/channels/pages/ChannelDetailsPage/ChannelDetailsPage.tsx
@@ -38,7 +38,7 @@ export interface ChannelDetailsPageProps {
   searchShippingZones: (query: string) => void;
   searchShippingZonesData?: SearchData;
   fetchMoreShippingZones: FetchMoreProps;
-  channelShippingZones: ChannelShippingZones;
+  channelShippingZones?: ChannelShippingZones;
 }
 
 export const ChannelDetailsPage: React.FC<ChannelDetailsPageProps> = ({
@@ -55,13 +55,13 @@ export const ChannelDetailsPage: React.FC<ChannelDetailsPageProps> = ({
   searchShippingZones,
   searchShippingZonesData,
   fetchMoreShippingZones,
-  channelShippingZones
+  channelShippingZones = []
 }) => {
   const [selectedCurrencyCode, setSelectedCurrencyCode] = useState("");
 
   const [shippingZonesToDisplay, setShippingZonesToDisplay] = useStateFromProps<
     ChannelShippingZones
-  >(channelShippingZones || []);
+  >(channelShippingZones);
 
   const initialData: FormData = {
     currencyCode: "",

--- a/src/channels/pages/ChannelDetailsPage/types.ts
+++ b/src/channels/pages/ChannelDetailsPage/types.ts
@@ -1,0 +1,3 @@
+import { ShippingZoneChannels_shippingZones_edges_node } from "@saleor/shipping/types/ShippingZoneChannels";
+
+export type ChannelShippingZones = ShippingZoneChannels_shippingZones_edges_node[];

--- a/src/channels/pages/ChannelDetailsPage/types.ts
+++ b/src/channels/pages/ChannelDetailsPage/types.ts
@@ -1,3 +1,5 @@
-import { ShippingZoneChannels_shippingZones_edges_node } from "@saleor/shipping/types/ShippingZoneChannels";
+import { ChannelShippingZones_shippingZones_edges_node } from "@saleor/shipping/types/ChannelShippingZones";
 
-export type ChannelShippingZones = ShippingZoneChannels_shippingZones_edges_node[];
+export type ChannelShippingZone = ChannelShippingZones_shippingZones_edges_node;
+
+export type ChannelShippingZones = ChannelShippingZone[];

--- a/src/channels/types/Channel.ts
+++ b/src/channels/types/Channel.ts
@@ -7,34 +7,6 @@
 // GraphQL query operation: Channel
 // ====================================================
 
-export interface Channel_channel_shippingZones_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface Channel_channel_shippingZones_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface Channel_channel_shippingZones_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
-export interface Channel_channel_shippingZones {
-  __typename: "ShippingZone";
-  metadata: (Channel_channel_shippingZones_metadata | null)[];
-  privateMetadata: (Channel_channel_shippingZones_privateMetadata | null)[];
-  id: string;
-  countries: (Channel_channel_shippingZones_countries | null)[] | null;
-  name: string;
-  description: string | null;
-}
-
 export interface Channel_channel {
   __typename: "Channel";
   id: string;
@@ -43,7 +15,6 @@ export interface Channel_channel {
   slug: string;
   currencyCode: string;
   hasOrders: boolean;
-  shippingZones: Channel_channel_shippingZones[];
 }
 
 export interface Channel {

--- a/src/channels/types/ChannelActivate.ts
+++ b/src/channels/types/ChannelActivate.ts
@@ -9,34 +9,6 @@ import { ChannelErrorCode } from "./../../types/globalTypes";
 // GraphQL mutation operation: ChannelActivate
 // ====================================================
 
-export interface ChannelActivate_channelActivate_channel_shippingZones_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelActivate_channelActivate_channel_shippingZones_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelActivate_channelActivate_channel_shippingZones_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
-export interface ChannelActivate_channelActivate_channel_shippingZones {
-  __typename: "ShippingZone";
-  metadata: (ChannelActivate_channelActivate_channel_shippingZones_metadata | null)[];
-  privateMetadata: (ChannelActivate_channelActivate_channel_shippingZones_privateMetadata | null)[];
-  id: string;
-  countries: (ChannelActivate_channelActivate_channel_shippingZones_countries | null)[] | null;
-  name: string;
-  description: string | null;
-}
-
 export interface ChannelActivate_channelActivate_channel {
   __typename: "Channel";
   id: string;
@@ -45,7 +17,6 @@ export interface ChannelActivate_channelActivate_channel {
   slug: string;
   currencyCode: string;
   hasOrders: boolean;
-  shippingZones: ChannelActivate_channelActivate_channel_shippingZones[];
 }
 
 export interface ChannelActivate_channelActivate_errors {

--- a/src/channels/types/ChannelCreate.ts
+++ b/src/channels/types/ChannelCreate.ts
@@ -9,34 +9,6 @@ import { ChannelCreateInput, ChannelErrorCode } from "./../../types/globalTypes"
 // GraphQL mutation operation: ChannelCreate
 // ====================================================
 
-export interface ChannelCreate_channelCreate_channel_shippingZones_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelCreate_channelCreate_channel_shippingZones_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelCreate_channelCreate_channel_shippingZones_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
-export interface ChannelCreate_channelCreate_channel_shippingZones {
-  __typename: "ShippingZone";
-  metadata: (ChannelCreate_channelCreate_channel_shippingZones_metadata | null)[];
-  privateMetadata: (ChannelCreate_channelCreate_channel_shippingZones_privateMetadata | null)[];
-  id: string;
-  countries: (ChannelCreate_channelCreate_channel_shippingZones_countries | null)[] | null;
-  name: string;
-  description: string | null;
-}
-
 export interface ChannelCreate_channelCreate_channel {
   __typename: "Channel";
   id: string;
@@ -45,7 +17,6 @@ export interface ChannelCreate_channelCreate_channel {
   slug: string;
   currencyCode: string;
   hasOrders: boolean;
-  shippingZones: ChannelCreate_channelCreate_channel_shippingZones[];
 }
 
 export interface ChannelCreate_channelCreate_errors {

--- a/src/channels/types/ChannelDeactivate.ts
+++ b/src/channels/types/ChannelDeactivate.ts
@@ -9,34 +9,6 @@ import { ChannelErrorCode } from "./../../types/globalTypes";
 // GraphQL mutation operation: ChannelDeactivate
 // ====================================================
 
-export interface ChannelDeactivate_channelDeactivate_channel_shippingZones_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelDeactivate_channelDeactivate_channel_shippingZones_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelDeactivate_channelDeactivate_channel_shippingZones_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
-export interface ChannelDeactivate_channelDeactivate_channel_shippingZones {
-  __typename: "ShippingZone";
-  metadata: (ChannelDeactivate_channelDeactivate_channel_shippingZones_metadata | null)[];
-  privateMetadata: (ChannelDeactivate_channelDeactivate_channel_shippingZones_privateMetadata | null)[];
-  id: string;
-  countries: (ChannelDeactivate_channelDeactivate_channel_shippingZones_countries | null)[] | null;
-  name: string;
-  description: string | null;
-}
-
 export interface ChannelDeactivate_channelDeactivate_channel {
   __typename: "Channel";
   id: string;
@@ -45,7 +17,6 @@ export interface ChannelDeactivate_channelDeactivate_channel {
   slug: string;
   currencyCode: string;
   hasOrders: boolean;
-  shippingZones: ChannelDeactivate_channelDeactivate_channel_shippingZones[];
 }
 
 export interface ChannelDeactivate_channelDeactivate_errors {

--- a/src/channels/types/ChannelUpdate.ts
+++ b/src/channels/types/ChannelUpdate.ts
@@ -9,34 +9,6 @@ import { ChannelUpdateInput, ChannelErrorCode } from "./../../types/globalTypes"
 // GraphQL mutation operation: ChannelUpdate
 // ====================================================
 
-export interface ChannelUpdate_channelUpdate_channel_shippingZones_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelUpdate_channelUpdate_channel_shippingZones_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelUpdate_channelUpdate_channel_shippingZones_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
-export interface ChannelUpdate_channelUpdate_channel_shippingZones {
-  __typename: "ShippingZone";
-  metadata: (ChannelUpdate_channelUpdate_channel_shippingZones_metadata | null)[];
-  privateMetadata: (ChannelUpdate_channelUpdate_channel_shippingZones_privateMetadata | null)[];
-  id: string;
-  countries: (ChannelUpdate_channelUpdate_channel_shippingZones_countries | null)[] | null;
-  name: string;
-  description: string | null;
-}
-
 export interface ChannelUpdate_channelUpdate_channel {
   __typename: "Channel";
   id: string;
@@ -45,7 +17,6 @@ export interface ChannelUpdate_channelUpdate_channel {
   slug: string;
   currencyCode: string;
   hasOrders: boolean;
-  shippingZones: ChannelUpdate_channelUpdate_channel_shippingZones[];
 }
 
 export interface ChannelUpdate_channelUpdate_errors {

--- a/src/channels/types/Channels.ts
+++ b/src/channels/types/Channels.ts
@@ -7,34 +7,6 @@
 // GraphQL query operation: Channels
 // ====================================================
 
-export interface Channels_channels_shippingZones_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface Channels_channels_shippingZones_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface Channels_channels_shippingZones_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
-export interface Channels_channels_shippingZones {
-  __typename: "ShippingZone";
-  metadata: (Channels_channels_shippingZones_metadata | null)[];
-  privateMetadata: (Channels_channels_shippingZones_privateMetadata | null)[];
-  id: string;
-  countries: (Channels_channels_shippingZones_countries | null)[] | null;
-  name: string;
-  description: string | null;
-}
-
 export interface Channels_channels {
   __typename: "Channel";
   id: string;
@@ -43,7 +15,6 @@ export interface Channels_channels {
   slug: string;
   currencyCode: string;
   hasOrders: boolean;
-  shippingZones: Channels_channels_shippingZones[];
 }
 
 export interface Channels {

--- a/src/channels/views/ChannelDetails/ChannelDetails.tsx
+++ b/src/channels/views/ChannelDetails/ChannelDetails.tsx
@@ -14,6 +14,7 @@ import useNotifier from "@saleor/hooks/useNotifier";
 import { getDefaultNotifierSuccessErrorData } from "@saleor/hooks/useNotifier/utils";
 import { sectionNames } from "@saleor/intl";
 import useShippingZonesSearch from "@saleor/searches/useShippingZonesSearch";
+import { useChannelShippingZones } from "@saleor/shipping/queries";
 import getChannelsErrorMessage from "@saleor/utils/errors/channels";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import React from "react";
@@ -152,6 +153,17 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
   };
 
   const {
+    data: channelShippingZonesData,
+    loading: channelsShippingZonesLoading
+  } = useChannelShippingZones({
+    variables: {
+      filter: {
+        channel: id
+      }
+    }
+  });
+
+  const {
     loadMore: fetchMoreShippingZones,
     search: searchShippingZones,
     result: searchShippingZonesResult
@@ -173,6 +185,7 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
         </AppHeader>
         <PageHeader title={data?.channel?.name} />
         <ChannelDetailsPage
+          channelShippingZones={channelShippingZonesData?.shippingZones?.edges}
           searchShippingZones={searchShippingZones}
           searchShippingZonesData={searchShippingZonesResult.data}
           fetchMoreShippingZones={getSearchFetchMoreProps(
@@ -180,7 +193,9 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
             fetchMoreShippingZones
           )}
           channel={data?.channel}
-          disabled={updateChannelOpts.loading || loading}
+          disabled={
+            updateChannelOpts.loading || loading || channelsShippingZonesLoading
+          }
           disabledStatus={
             activateChannelOpts.loading || deactivateChannelOpts.loading
           }

--- a/src/channels/views/ChannelDetails/ChannelDetails.tsx
+++ b/src/channels/views/ChannelDetails/ChannelDetails.tsx
@@ -158,7 +158,7 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
   } = useChannelShippingZones({
     variables: {
       filter: {
-        channel: id
+        channels: [id]
       }
     }
   });

--- a/src/channels/views/ChannelDetails/ChannelDetails.tsx
+++ b/src/channels/views/ChannelDetails/ChannelDetails.tsx
@@ -185,7 +185,9 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
         </AppHeader>
         <PageHeader title={data?.channel?.name} />
         <ChannelDetailsPage
-          channelShippingZones={channelShippingZonesData?.shippingZones?.edges}
+          channelShippingZones={channelShippingZonesData?.shippingZones?.edges?.map(
+            ({ node }) => node
+          )}
           searchShippingZones={searchShippingZones}
           searchShippingZonesData={searchShippingZonesResult.data}
           fetchMoreShippingZones={getSearchFetchMoreProps(

--- a/src/fragments/channels.ts
+++ b/src/fragments/channels.ts
@@ -1,7 +1,5 @@
 import gql from "graphql-tag";
 
-import { shippingZoneFragment } from "./shipping";
-
 export const channelErrorFragment = gql`
   fragment ChannelErrorFragment on ChannelError {
     code
@@ -22,12 +20,8 @@ export const channelFragment = gql`
 
 export const channelDetailsFragment = gql`
   ${channelFragment}
-  ${shippingZoneFragment}
   fragment ChannelDetailsFragment on Channel {
     ...ChannelFragment
     hasOrders
-    shippingZones {
-      ...ShippingZoneFragment
-    }
   }
 `;

--- a/src/fragments/types/ChannelDetailsFragment.ts
+++ b/src/fragments/types/ChannelDetailsFragment.ts
@@ -7,34 +7,6 @@
 // GraphQL fragment: ChannelDetailsFragment
 // ====================================================
 
-export interface ChannelDetailsFragment_shippingZones_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelDetailsFragment_shippingZones_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface ChannelDetailsFragment_shippingZones_countries {
-  __typename: "CountryDisplay";
-  code: string;
-  country: string;
-}
-
-export interface ChannelDetailsFragment_shippingZones {
-  __typename: "ShippingZone";
-  metadata: (ChannelDetailsFragment_shippingZones_metadata | null)[];
-  privateMetadata: (ChannelDetailsFragment_shippingZones_privateMetadata | null)[];
-  id: string;
-  countries: (ChannelDetailsFragment_shippingZones_countries | null)[] | null;
-  name: string;
-  description: string | null;
-}
-
 export interface ChannelDetailsFragment {
   __typename: "Channel";
   id: string;
@@ -43,5 +15,4 @@ export interface ChannelDetailsFragment {
   slug: string;
   currencyCode: string;
   hasOrders: boolean;
-  shippingZones: ChannelDetailsFragment_shippingZones[];
 }

--- a/src/shipping/queries.ts
+++ b/src/shipping/queries.ts
@@ -6,11 +6,11 @@ import {
 import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
 
-import { ShippingZone, ShippingZoneVariables } from "./types/ShippingZone";
 import {
-  ShippingZoneChannels,
-  ShippingZoneChannelsVariables
-} from "./types/ShippingZoneChannels";
+  ChannelShippingZones,
+  ChannelShippingZonesVariables
+} from "./types/ChannelShippingZones";
+import { ShippingZone, ShippingZoneVariables } from "./types/ShippingZone";
 import { ShippingZones, ShippingZonesVariables } from "./types/ShippingZones";
 
 const shippingZones = gql`
@@ -71,20 +71,20 @@ export const useShippingZone = makeQuery<ShippingZone, ShippingZoneVariables>(
   shippingZone
 );
 
-const shippingZoneChannels = gql`
-  query ShippingZoneChannels($id: ID!) {
-    shippingZone(id: $id) {
-      id
-      channels {
-        id
-        name
-        currencyCode
+const channelShippingZones = gql`
+  query ChannelShippingZones($filter: ShippingZoneFilterInput) {
+    shippingZones(filter: $filter) {
+      edges {
+        node {
+          id
+          name
+        }
       }
     }
   }
 `;
 
-export const useShippingZoneChannels = makeQuery<
-  ShippingZoneChannels,
-  ShippingZoneChannelsVariables
->(shippingZoneChannels);
+export const useChannelShippingZones = makeQuery<
+  ChannelShippingZones,
+  ChannelShippingZonesVariables
+>(channelShippingZones);

--- a/src/shipping/queries.ts
+++ b/src/shipping/queries.ts
@@ -93,9 +93,10 @@ export const useShippingZoneChannels = makeQuery<
   ShippingZoneChannelsVariables
 >(shippingZoneChannels);
 
+// first: 100 - to be removed when we implement pagintion in ui for this query
 const channelShippingZones = gql`
   query ChannelShippingZones($filter: ShippingZoneFilterInput) {
-    shippingZones(filter: $filter) {
+    shippingZones(filter: $filter, first: 100) {
       edges {
         node {
           id

--- a/src/shipping/queries.ts
+++ b/src/shipping/queries.ts
@@ -11,6 +11,10 @@ import {
   ChannelShippingZonesVariables
 } from "./types/ChannelShippingZones";
 import { ShippingZone, ShippingZoneVariables } from "./types/ShippingZone";
+import {
+  ShippingZoneChannels,
+  ShippingZoneChannelsVariables
+} from "./types/ShippingZoneChannels";
 import { ShippingZones, ShippingZonesVariables } from "./types/ShippingZones";
 
 const shippingZones = gql`
@@ -70,6 +74,24 @@ const shippingZone = gql`
 export const useShippingZone = makeQuery<ShippingZone, ShippingZoneVariables>(
   shippingZone
 );
+
+const shippingZoneChannels = gql`
+  query ShippingZoneChannels($id: ID!) {
+    shippingZone(id: $id) {
+      id
+      channels {
+        id
+        name
+        currencyCode
+      }
+    }
+  }
+`;
+
+export const useShippingZoneChannels = makeQuery<
+  ShippingZoneChannels,
+  ShippingZoneChannelsVariables
+>(shippingZoneChannels);
 
 const channelShippingZones = gql`
   query ChannelShippingZones($filter: ShippingZoneFilterInput) {

--- a/src/shipping/types/ChannelShippingZones.ts
+++ b/src/shipping/types/ChannelShippingZones.ts
@@ -6,29 +6,29 @@
 import { ShippingZoneFilterInput } from "./../../types/globalTypes";
 
 // ====================================================
-// GraphQL query operation: ShippingZoneChannels
+// GraphQL query operation: ChannelShippingZones
 // ====================================================
 
-export interface ShippingZoneChannels_shippingZones_edges_node {
+export interface ChannelShippingZones_shippingZones_edges_node {
   __typename: "ShippingZone";
   id: string;
   name: string;
 }
 
-export interface ShippingZoneChannels_shippingZones_edges {
+export interface ChannelShippingZones_shippingZones_edges {
   __typename: "ShippingZoneCountableEdge";
-  node: ShippingZoneChannels_shippingZones_edges_node;
+  node: ChannelShippingZones_shippingZones_edges_node;
 }
 
-export interface ShippingZoneChannels_shippingZones {
+export interface ChannelShippingZones_shippingZones {
   __typename: "ShippingZoneCountableConnection";
-  edges: ShippingZoneChannels_shippingZones_edges[];
+  edges: ChannelShippingZones_shippingZones_edges[];
 }
 
-export interface ShippingZoneChannels {
-  shippingZones: ShippingZoneChannels_shippingZones | null;
+export interface ChannelShippingZones {
+  shippingZones: ChannelShippingZones_shippingZones | null;
 }
 
-export interface ShippingZoneChannelsVariables {
+export interface ChannelShippingZonesVariables {
   filter?: ShippingZoneFilterInput | null;
 }

--- a/src/shipping/types/ShippingZoneChannels.ts
+++ b/src/shipping/types/ShippingZoneChannels.ts
@@ -3,32 +3,27 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ShippingZoneFilterInput } from "./../../types/globalTypes";
-
 // ====================================================
 // GraphQL query operation: ShippingZoneChannels
 // ====================================================
 
-export interface ShippingZoneChannels_shippingZones_edges_node {
-  __typename: "ShippingZone";
+export interface ShippingZoneChannels_shippingZone_channels {
+  __typename: "Channel";
   id: string;
   name: string;
+  currencyCode: string;
 }
 
-export interface ShippingZoneChannels_shippingZones_edges {
-  __typename: "ShippingZoneCountableEdge";
-  node: ShippingZoneChannels_shippingZones_edges_node;
-}
-
-export interface ShippingZoneChannels_shippingZones {
-  __typename: "ShippingZoneCountableConnection";
-  edges: ShippingZoneChannels_shippingZones_edges[];
+export interface ShippingZoneChannels_shippingZone {
+  __typename: "ShippingZone";
+  id: string;
+  channels: ShippingZoneChannels_shippingZone_channels[];
 }
 
 export interface ShippingZoneChannels {
-  shippingZones: ShippingZoneChannels_shippingZones | null;
+  shippingZone: ShippingZoneChannels_shippingZone | null;
 }
 
 export interface ShippingZoneChannelsVariables {
-  filter?: ShippingZoneFilterInput | null;
+  id: string;
 }

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1849,6 +1849,11 @@ export interface ShippingZoneCreateInput {
   addChannels?: string[] | null;
 }
 
+export interface ShippingZoneFilterInput {
+  search?: string | null;
+  channel?: string | null;
+}
+
 export interface ShippingZoneUpdateInput {
   name?: string | null;
   description?: string | null;

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1851,7 +1851,7 @@ export interface ShippingZoneCreateInput {
 
 export interface ShippingZoneFilterInput {
   search?: string | null;
-  channel?: string | null;
+  channels?: (string | null)[] | null;
 }
 
 export interface ShippingZoneUpdateInput {


### PR DESCRIPTION
I want to merge this change because it adds separate mutation for fetching channel shipping zones instead of using them directly from channel data. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.cloud/graphql/