### PR TITLE
Add new readonly plugin configuration field

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -68,6 +68,8 @@ enum AccountErrorCode {
   JWT_DECODE_ERROR
   JWT_MISSING_TOKEN
   JWT_INVALID_CSRF_TOKEN
+  CHANNEL_INACTIVE
+  MISSING_CHANNEL_SLUG
 }
 
 input AccountInput {
@@ -91,6 +93,7 @@ input AccountRegisterInput {
   redirectUrl: String
   languageCode: LanguageCodeEnum
   metadata: [MetadataInput!]
+  channel: String
 }
 
 type AccountRequestDeletion {
@@ -887,7 +890,6 @@ type Checkout implements Node & ObjectWithMetadata {
   created: DateTime!
   lastChange: DateTime!
   user: User
-  quantity: Int!
   channel: Channel!
   billingAddress: Address
   shippingAddress: Address
@@ -904,6 +906,7 @@ type Checkout implements Node & ObjectWithMetadata {
   availablePaymentGateways: [PaymentGateway!]!
   email: String!
   isShippingRequired: Boolean!
+  quantity: Int!
   lines: [CheckoutLine]
   shippingPrice: TaxedMoney
   shippingMethod: ShippingMethod
@@ -1299,6 +1302,7 @@ enum ConfigurationTypeFieldEnum {
   SECRET
   PASSWORD
   SECRETMULTILINE
+  OUTPUT
 }
 
 type ConfirmAccount {
@@ -2751,7 +2755,7 @@ type Mutation {
   paymentCapture(amount: PositiveDecimal, paymentId: ID!): PaymentCapture
   paymentRefund(amount: PositiveDecimal, paymentId: ID!): PaymentRefund
   paymentVoid(paymentId: ID!): PaymentVoid
-  paymentInitialize(gateway: String!, paymentData: JSONString): PaymentInitialize
+  paymentInitialize(channel: String, gateway: String!, paymentData: JSONString): PaymentInitialize
   pageCreate(input: PageCreateInput!): PageCreate
   pageDelete(id: ID!): PageDelete
   pageBulkDelete(ids: [ID]!): PageBulkDelete
@@ -2891,19 +2895,19 @@ type Mutation {
   externalRefresh(input: JSONString!, pluginId: String!): ExternalRefresh
   externalLogout(input: JSONString!, pluginId: String!): ExternalLogout
   externalVerify(input: JSONString!, pluginId: String!): ExternalVerify
-  requestPasswordReset(email: String!, redirectUrl: String!): RequestPasswordReset
+  requestPasswordReset(channel: String, email: String!, redirectUrl: String!): RequestPasswordReset
   confirmAccount(email: String!, token: String!): ConfirmAccount
   setPassword(email: String!, password: String!, token: String!): SetPassword
   passwordChange(newPassword: String!, oldPassword: String!): PasswordChange
-  requestEmailChange(newEmail: String!, password: String!, redirectUrl: String!): RequestEmailChange
-  confirmEmailChange(token: String!): ConfirmEmailChange
+  requestEmailChange(channel: String, newEmail: String!, password: String!, redirectUrl: String!): RequestEmailChange
+  confirmEmailChange(channel: String, token: String!): ConfirmEmailChange
   accountAddressCreate(input: AddressInput!, type: AddressTypeEnum): AccountAddressCreate
   accountAddressUpdate(id: ID!, input: AddressInput!): AccountAddressUpdate
   accountAddressDelete(id: ID!): AccountAddressDelete
   accountSetDefaultAddress(id: ID!, type: AddressTypeEnum!): AccountSetDefaultAddress
   accountRegister(input: AccountRegisterInput!): AccountRegister
   accountUpdate(input: AccountInput!): AccountUpdate
-  accountRequestDeletion(redirectUrl: String!): AccountRequestDeletion
+  accountRequestDeletion(channel: String, redirectUrl: String!): AccountRequestDeletion
   accountDelete(token: String!): AccountDelete
   addressCreate(input: AddressInput!, userId: ID!): AddressCreate
   addressUpdate(id: ID!, input: AddressInput!): AddressUpdate
@@ -3579,9 +3583,9 @@ enum PageErrorCode {
 }
 
 input PageFilterInput {
-  pageTypes: [ID!]
   search: String
   metadata: [MetadataInput]
+  pageTypes: [ID]
 }
 
 type PageInfo {
@@ -5185,7 +5189,7 @@ input ShippingZoneUpdateInput {
 }
 
 type Shop {
-  availablePaymentGateways(currency: String): [PaymentGateway!]!
+  availablePaymentGateways(currency: String, channel: String): [PaymentGateway!]!
   availableExternalAuthentications: [ExternalAuthentication!]!
   availableShippingMethods(channel: String!, address: AddressInput): [ShippingMethod]
   countries(languageCode: LanguageCodeEnum): [CountryDisplay!]!
@@ -5609,7 +5613,7 @@ type User implements Node & ObjectWithMetadata {
   editableGroups: [Group]
   avatar(size: Int): Image
   events: [CustomerEvent]
-  storedPaymentSources: [PaymentSource]
+  storedPaymentSources(channel: String): [PaymentSource]
   languageCode: LanguageCodeEnum!
 }
 
@@ -5652,6 +5656,7 @@ input UserCreateInput {
   note: String
   languageCode: LanguageCodeEnum
   redirectUrl: String
+  channel: String
 }
 
 type UserPermission {

--- a/src/plugins/components/PluginSettings/PluginSettings.tsx
+++ b/src/plugins/components/PluginSettings/PluginSettings.tsx
@@ -111,7 +111,14 @@ const PluginSettings: React.FC<PluginSettingsProps> = ({
                     fieldData.type === ConfigurationTypeFieldEnum.MULTILINE
                   }
                   InputProps={{
-                    rowsMax: 6
+                    rowsMax: 6,
+                    readOnly:
+                      fieldData.type === ConfigurationTypeFieldEnum.OUTPUT
+                  }}
+                  onFocus={event => {
+                    if (fieldData.type === ConfigurationTypeFieldEnum.OUTPUT) {
+                      event.target.select();
+                    }
                   }}
                   fullWidth
                   value={field.value}

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -10,6 +10,7 @@
 export enum AccountErrorCode {
   ACTIVATE_OWN_ACCOUNT = "ACTIVATE_OWN_ACCOUNT",
   ACTIVATE_SUPERUSER_ACCOUNT = "ACTIVATE_SUPERUSER_ACCOUNT",
+  CHANNEL_INACTIVE = "CHANNEL_INACTIVE",
   DEACTIVATE_OWN_ACCOUNT = "DEACTIVATE_OWN_ACCOUNT",
   DEACTIVATE_SUPERUSER_ACCOUNT = "DEACTIVATE_SUPERUSER_ACCOUNT",
   DELETE_NON_STAFF_USER = "DELETE_NON_STAFF_USER",
@@ -28,6 +29,7 @@ export enum AccountErrorCode {
   JWT_MISSING_TOKEN = "JWT_MISSING_TOKEN",
   JWT_SIGNATURE_EXPIRED = "JWT_SIGNATURE_EXPIRED",
   LEFT_NOT_MANAGEABLE_PERMISSION = "LEFT_NOT_MANAGEABLE_PERMISSION",
+  MISSING_CHANNEL_SLUG = "MISSING_CHANNEL_SLUG",
   NOT_FOUND = "NOT_FOUND",
   OUT_OF_SCOPE_GROUP = "OUT_OF_SCOPE_GROUP",
   OUT_OF_SCOPE_PERMISSION = "OUT_OF_SCOPE_PERMISSION",
@@ -155,6 +157,7 @@ export enum CollectionSortField {
 export enum ConfigurationTypeFieldEnum {
   BOOLEAN = "BOOLEAN",
   MULTILINE = "MULTILINE",
+  OUTPUT = "OUTPUT",
   PASSWORD = "PASSWORD",
   SECRET = "SECRET",
   SECRETMULTILINE = "SECRETMULTILINE",
@@ -1534,9 +1537,9 @@ export interface PageCreateInput {
 }
 
 export interface PageFilterInput {
-  pageTypes?: string[] | null;
   search?: string | null;
   metadata?: (MetadataInput | null)[] | null;
+  pageTypes?: (string | null)[] | null;
 }
 
 export interface PageInput {
@@ -1945,6 +1948,7 @@ export interface UserCreateInput {
   note?: string | null;
   languageCode?: LanguageCodeEnum | null;
   redirectUrl?: string | null;
+  channel?: string | null;
 }
 
 export interface UserSortingInput {


### PR DESCRIPTION
I want to merge this change because it adds a new plugin settings field of readonly type.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** fix/handle-plugin-webhook-per-plugin

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://fix-handle-plugin-webhook-per-plugin.api.saleor.rocks/graphql/