### PR TITLE
Add error for co category set for product

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -7005,6 +7005,10 @@
   "src_dot_utils_dot_errors_dot_nameAlreadyTaken": {
     "string": "This name is already taken. Please provide another."
   },
+  "src_dot_utils_dot_errors_dot_noCategorySet": {
+    "context": "no category set error",
+    "string": "Product category not set"
+  },
   "src_dot_utils_dot_errors_dot_noShippingAddress": {
     "context": "error message",
     "string": "Cannot choose a shipping method for an order without the shipping address"

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -300,7 +300,12 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
   const [updateChannels, updateChannelsOpts] = useProductChannelListingUpdate({
     onCompleted: data => {
       if (!!data.productChannelListingUpdate.errors.length) {
-        return;
+        data.productChannelListingUpdate.errors.map(error =>
+          notify({
+            status: "error",
+            text: getProductErrorMessage(error, intl)
+          })
+        );
       }
     }
   });

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -300,7 +300,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
   const [updateChannels, updateChannelsOpts] = useProductChannelListingUpdate({
     onCompleted: data => {
       if (!!data.productChannelListingUpdate.errors.length) {
-        data.productChannelListingUpdate.errors.map(error =>
+        data.productChannelListingUpdate.errors.forEach(error =>
           notify({
             status: "error",
             text: getProductErrorMessage(error, intl)

--- a/src/utils/errors/product.ts
+++ b/src/utils/errors/product.ts
@@ -50,6 +50,10 @@ const messages = defineMessages({
   variantUnique: {
     defaultMessage: "This variant already exists",
     description: "product attribute error"
+  },
+  noCategorySet: {
+    defaultMessage: "Product category not set",
+    description: "no category set error"
   }
 });
 
@@ -79,6 +83,8 @@ function getProductErrorMessage(
         return intl.formatMessage(messages.variantNoDigitalContent);
       case ProductErrorCode.UNSUPPORTED_MEDIA_PROVIDER:
         return intl.formatMessage(messages.unsupportedMediaProvider);
+      case ProductErrorCode.PRODUCT_WITHOUT_CATEGORY:
+        return intl.formatMessage(messages.noCategorySet);
       case ProductErrorCode.INVALID:
         if (err.field === "price") {
           return intl.formatMessage(messages.priceInvalid);


### PR DESCRIPTION
I want to merge this change because it adds missing error when updating product channel listing with no category set for product

<img width="345" alt="Screenshot 2021-05-13 at 11 21 51" src="https://user-images.githubusercontent.com/28022710/118106521-f7b65c80-b3dd-11eb-8d2c-9c4eb437ac19.png">


<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/