### PR TITLE
SALEOR-3345 Attribute values pagination on attribute details page

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -413,7 +413,7 @@ type Attribute implements Node & ObjectWithMetadata {
   slug: String
   type: AttributeTypeEnum
   unit: MeasurementUnitsEnum
-  values: [AttributeValue]
+  values(before: String, after: String, first: Int, last: Int): AttributeValueCountableConnection
   valueRequired: Boolean!
   visibleInStorefront: Boolean!
   filterableInStorefront: Boolean!
@@ -606,6 +606,17 @@ type AttributeValueBulkDelete {
   errors: [AttributeError!]!
 }
 
+type AttributeValueCountableConnection {
+  pageInfo: PageInfo!
+  edges: [AttributeValueCountableEdge!]!
+  totalCount: Int
+}
+
+type AttributeValueCountableEdge {
+  node: AttributeValue!
+  cursor: String!
+}
+
 type AttributeValueCreate {
   attribute: Attribute
   attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
@@ -699,9 +710,9 @@ input CatalogueInput {
 }
 
 type Category implements Node & ObjectWithMetadata {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   name: String!
   description: JSONString
   slug: String!
@@ -774,9 +785,9 @@ input CategorySortingInput {
 }
 
 type CategoryTranslatableContent implements Node {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   name: String!
   description: JSONString
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
@@ -791,9 +802,9 @@ type CategoryTranslate {
 }
 
 type CategoryTranslation implements Node {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   name: String!
   description: JSONString
   language: LanguageDisplay!
@@ -813,7 +824,6 @@ type Channel implements Node {
   slug: String!
   currencyCode: String!
   hasOrders: Boolean!
-  shippingZones: [ShippingZone!]!
 }
 
 type ChannelActivate {
@@ -1094,9 +1104,9 @@ type ChoiceValue {
 }
 
 type Collection implements Node & ObjectWithMetadata {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   name: String!
   description: JSONString
   slug: String!
@@ -1122,9 +1132,9 @@ type CollectionBulkDelete {
 }
 
 type CollectionChannelListing implements Node {
+  id: ID!
   publicationDate: Date
   isPublished: Boolean!
-  id: ID!
   channel: Channel!
 }
 
@@ -1250,9 +1260,9 @@ input CollectionSortingInput {
 }
 
 type CollectionTranslatableContent implements Node {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   name: String!
   description: JSONString
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
@@ -1267,9 +1277,9 @@ type CollectionTranslate {
 }
 
 type CollectionTranslation implements Node {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   name: String!
   description: JSONString
   language: LanguageDisplay!
@@ -1302,7 +1312,6 @@ enum ConfigurationTypeFieldEnum {
   SECRET
   PASSWORD
   SECRETMULTILINE
-  OUTPUT
 }
 
 type ConfirmAccount {
@@ -2975,6 +2984,8 @@ type Order implements Node & ObjectWithMetadata {
   availableShippingMethods: [ShippingMethod]
   invoices: [Invoice]
   number: String
+  original: ID
+  origin: OrderOriginEnum!
   isPaid: Boolean!
   paymentStatus: PaymentChargeStatusEnum!
   paymentStatusDisplay: String!
@@ -3359,6 +3370,12 @@ type OrderMarkAsPaid {
   errors: [OrderError!]!
 }
 
+enum OrderOriginEnum {
+  CHECKOUT
+  DRAFT
+  REISSUE
+}
+
 type OrderRefund {
   order: Order
   orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
@@ -3489,9 +3506,9 @@ type OrderVoid {
 }
 
 type Page implements Node & ObjectWithMetadata {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   title: String!
   content: JSONString
   publicationDate: Date
@@ -3625,9 +3642,9 @@ input PageSortingInput {
 }
 
 type PageTranslatableContent implements Node {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   title: String!
   content: JSONString
   contentJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
@@ -3642,9 +3659,9 @@ type PageTranslate {
 }
 
 type PageTranslation implements Node {
+  id: ID!
   seoTitle: String
   seoDescription: String
-  id: ID!
   title: String!
   content: JSONString
   language: LanguageDisplay!

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -23,7 +23,7 @@ import {
   AttributeTypeEnum,
   MeasurementUnitsEnum
 } from "@saleor/types/globalTypes";
-import { mapMetadataItemToInput } from "@saleor/utils/maps";
+import { mapEdgesToItems, mapMetadataItemToInput } from "@saleor/utils/maps";
 import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTrigger";
 import React from "react";
 import { useIntl } from "react-intl";
@@ -39,7 +39,7 @@ export interface AttributePageProps {
   disabled: boolean;
   errors: AttributeErrorFragment[];
   saveButtonBarState: ConfirmButtonTransitionState;
-  values: AttributeDetailsFragment_values[];
+  values: AttributeDetailsFragment_values;
   onBack: () => void;
   onDelete: () => void;
   onSubmit: (data: AttributePageFormData) => void;
@@ -47,6 +47,12 @@ export interface AttributePageProps {
   onValueDelete: (id: string) => void;
   onValueReorder: ReorderAction;
   onValueUpdate: (id: string) => void;
+  pageInfo: {
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
+  onNextPage: () => void;
+  onPreviousPage: () => void;
 }
 
 export interface AttributePageFormData extends MetadataFormData {
@@ -76,7 +82,10 @@ const AttributePage: React.FC<AttributePageProps> = ({
   onValueAdd,
   onValueDelete,
   onValueReorder,
-  onValueUpdate
+  onValueUpdate,
+  pageInfo,
+  onNextPage,
+  onPreviousPage
 }) => {
   const intl = useIntl();
   const {
@@ -190,11 +199,14 @@ const AttributePage: React.FC<AttributePageProps> = ({
                     <CardSpacer />
                     <AttributeValues
                       disabled={disabled}
-                      values={values}
+                      values={mapEdgesToItems(values)}
                       onValueAdd={onValueAdd}
                       onValueDelete={onValueDelete}
                       onValueReorder={onValueReorder}
                       onValueUpdate={onValueUpdate}
+                      pageInfo={pageInfo}
+                      onNextPage={onNextPage}
+                      onPreviousPage={onPreviousPage}
                     />
                   </>
                 )}

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -1,3 +1,4 @@
+import { AttributeDetails_attribute_values } from "@saleor/attributes/types/AttributeDetails";
 import { ATTRIBUTE_TYPES_WITH_DEDICATED_VALUES } from "@saleor/attributes/utils/data";
 import AppHeader from "@saleor/components/AppHeader";
 import CardSpacer from "@saleor/components/CardSpacer";
@@ -9,10 +10,7 @@ import Metadata from "@saleor/components/Metadata/Metadata";
 import { MetadataFormData } from "@saleor/components/Metadata/types";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
-import {
-  AttributeDetailsFragment,
-  AttributeDetailsFragment_values
-} from "@saleor/fragments/types/AttributeDetailsFragment";
+import { AttributeDetailsFragment } from "@saleor/fragments/types/AttributeDetailsFragment";
 import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import { sectionNames } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
@@ -39,7 +37,7 @@ export interface AttributePageProps {
   disabled: boolean;
   errors: AttributeErrorFragment[];
   saveButtonBarState: ConfirmButtonTransitionState;
-  values: AttributeDetailsFragment_values;
+  values: AttributeDetails_attribute_values;
   onBack: () => void;
   onDelete: () => void;
   onSubmit: (data: AttributePageFormData) => void;

--- a/src/attributes/components/AttributePage/AttributePage.tsx
+++ b/src/attributes/components/AttributePage/AttributePage.tsx
@@ -16,7 +16,7 @@ import {
 import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import { sectionNames } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
-import { ReorderAction } from "@saleor/types";
+import { ListSettings, ReorderAction } from "@saleor/types";
 import {
   AttributeEntityTypeEnum,
   AttributeInputTypeEnum,
@@ -47,6 +47,8 @@ export interface AttributePageProps {
   onValueDelete: (id: string) => void;
   onValueReorder: ReorderAction;
   onValueUpdate: (id: string) => void;
+  settings?: ListSettings;
+  onUpdateListSettings?: (key: keyof ListSettings, value: any) => void;
   pageInfo: {
     hasNextPage: boolean;
     hasPreviousPage: boolean;
@@ -83,6 +85,8 @@ const AttributePage: React.FC<AttributePageProps> = ({
   onValueDelete,
   onValueReorder,
   onValueUpdate,
+  settings,
+  onUpdateListSettings,
   pageInfo,
   onNextPage,
   onPreviousPage
@@ -204,6 +208,8 @@ const AttributePage: React.FC<AttributePageProps> = ({
                       onValueDelete={onValueDelete}
                       onValueReorder={onValueReorder}
                       onValueUpdate={onValueUpdate}
+                      settings={settings}
+                      onUpdateListSettings={onUpdateListSettings}
                       pageInfo={pageInfo}
                       onNextPage={onNextPage}
                       onPreviousPage={onPreviousPage}

--- a/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
+++ b/src/attributes/components/AttributeValueEditDialog/AttributeValueEditDialog.tsx
@@ -17,13 +17,13 @@ import { getFormErrors } from "@saleor/utils/errors";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { AttributeDetails_attribute_values } from "../../types/AttributeDetails";
+import { AttributeDetails_attribute_values_edges_node } from "../../types/AttributeDetails";
 
 export interface AttributeValueEditDialogFormData {
   name: string;
 }
 export interface AttributeValueEditDialogProps {
-  attributeValue: AttributeDetails_attribute_values | null;
+  attributeValue: AttributeDetails_attribute_values_edges_node | null;
   confirmButtonState: ConfirmButtonTransitionState;
   disabled: boolean;
   errors: AttributeErrorFragment[];

--- a/src/attributes/components/AttributeValues/AttributeValues.tsx
+++ b/src/attributes/components/AttributeValues/AttributeValues.tsx
@@ -67,6 +67,8 @@ const AttributeValues: React.FC<AttributeValuesProps> = ({
   onValueReorder,
   onValueUpdate,
   values,
+  settings,
+  onUpdateListSettings,
   pageInfo,
   onNextPage,
   onPreviousPage
@@ -119,6 +121,8 @@ const AttributeValues: React.FC<AttributeValuesProps> = ({
                 pageInfo && !disabled ? pageInfo.hasPreviousPage : false
               }
               onPreviousPage={onPreviousPage}
+              settings={settings}
+              onUpdateListSettings={onUpdateListSettings}
             />
           </TableRow>
         </TableFooter>

--- a/src/attributes/components/AttributeValues/AttributeValues.tsx
+++ b/src/attributes/components/AttributeValues/AttributeValues.tsx
@@ -2,6 +2,7 @@ import Button from "@material-ui/core/Button";
 import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
 import TableCell from "@material-ui/core/TableCell";
+import TableFooter from "@material-ui/core/TableFooter";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -12,16 +13,18 @@ import {
   SortableTableBody,
   SortableTableRow
 } from "@saleor/components/SortableTable";
-import { AttributeDetailsFragment_values } from "@saleor/fragments/types/AttributeDetailsFragment";
+import TablePagination from "@saleor/components/TablePagination";
+import { AttributeDetailsFragment_values_edges_node } from "@saleor/fragments/types/AttributeDetailsFragment";
 import { maybe, renderCollection, stopPropagation } from "@saleor/misc";
 import { makeStyles } from "@saleor/theme";
-import { ReorderAction } from "@saleor/types";
+import { ListProps, ReorderAction } from "@saleor/types";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-export interface AttributeValuesProps {
+export interface AttributeValuesProps
+  extends Pick<ListProps, Exclude<keyof ListProps, "onRowClick">> {
   disabled: boolean;
-  values: AttributeDetailsFragment_values[];
+  values: AttributeDetailsFragment_values_edges_node[];
   onValueAdd: () => void;
   onValueDelete: (id: string) => void;
   onValueReorder: ReorderAction;
@@ -55,13 +58,18 @@ const useStyles = makeStyles(
   { name: "AttributeValues" }
 );
 
+const numberOfColumns = 4;
+
 const AttributeValues: React.FC<AttributeValuesProps> = ({
   disabled,
   onValueAdd,
   onValueDelete,
   onValueReorder,
   onValueUpdate,
-  values
+  values,
+  pageInfo,
+  onNextPage,
+  onPreviousPage
 }) => {
   const classes = useStyles({});
   const intl = useIntl();
@@ -101,6 +109,19 @@ const AttributeValues: React.FC<AttributeValuesProps> = ({
             <TableCell className={classes.iconCell} />
           </TableRow>
         </TableHead>
+        <TableFooter>
+          <TableRow>
+            <TablePagination
+              colSpan={numberOfColumns}
+              hasNextPage={pageInfo && !disabled ? pageInfo.hasNextPage : false}
+              onNextPage={onNextPage}
+              hasPreviousPage={
+                pageInfo && !disabled ? pageInfo.hasPreviousPage : false
+              }
+              onPreviousPage={onPreviousPage}
+            />
+          </TableRow>
+        </TableFooter>
         <SortableTableBody onSortEnd={onValueReorder}>
           {renderCollection(
             values,

--- a/src/attributes/components/AttributeValues/AttributeValues.tsx
+++ b/src/attributes/components/AttributeValues/AttributeValues.tsx
@@ -14,7 +14,7 @@ import {
   SortableTableRow
 } from "@saleor/components/SortableTable";
 import TablePagination from "@saleor/components/TablePagination";
-import { AttributeDetailsFragment_values_edges_node } from "@saleor/fragments/types/AttributeDetailsFragment";
+import { AttributeValueListFragment_edges_node } from "@saleor/fragments/types/AttributeValueListFragment";
 import { maybe, renderCollection, stopPropagation } from "@saleor/misc";
 import { makeStyles } from "@saleor/theme";
 import { ListProps, ReorderAction } from "@saleor/types";
@@ -24,7 +24,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 export interface AttributeValuesProps
   extends Pick<ListProps, Exclude<keyof ListProps, "onRowClick">> {
   disabled: boolean;
-  values: AttributeDetailsFragment_values_edges_node[];
+  values: AttributeValueListFragment_edges_node[];
   onValueAdd: () => void;
   onValueDelete: (id: string) => void;
   onValueReorder: ReorderAction;

--- a/src/attributes/fixtures.ts
+++ b/src/attributes/fixtures.ts
@@ -1,13 +1,13 @@
-import { AttributeDetailsFragment } from "@saleor/fragments/types/AttributeDetailsFragment";
 import { ProductDetails_product_productType_variantAttributes } from "@saleor/products/types/ProductDetails";
 import {
   AttributeInputTypeEnum,
   AttributeTypeEnum
 } from "@saleor/types/globalTypes";
 
+import { AttributeDetails_attribute } from "./types/AttributeDetails";
 import { AttributeList_attributes_edges_node } from "./types/AttributeList";
 
-export const attribute: AttributeDetailsFragment = {
+export const attribute: AttributeDetails_attribute = {
   __typename: "Attribute" as "Attribute",
   availableInGrid: true,
   entityType: null,

--- a/src/attributes/fixtures.ts
+++ b/src/attributes/fixtures.ts
@@ -29,26 +29,44 @@ export const attribute: AttributeDetailsFragment = {
   type: AttributeTypeEnum.PRODUCT_TYPE,
   valueRequired: true,
   unit: null,
-  values: [
-    {
-      __typename: "AttributeValue" as "AttributeValue",
-      file: null,
-      id: "UHJvZHVjdEF0dHJpYnV0ZVZhbHVlOjI0",
-      name: "John Doe",
-      reference: null,
-      slug: "john-doe",
-      richText: null
+  values: {
+    __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
+    pageInfo: {
+      __typename: "PageInfo" as "PageInfo",
+      endCursor: "",
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: ""
     },
-    {
-      __typename: "AttributeValue" as "AttributeValue",
-      file: null,
-      id: "UHJvZHVjdEF0dHJpYnV0ZVZhbHVlOjI1",
-      name: "Milionare Pirate",
-      reference: null,
-      slug: "milionare-pirate",
-      richText: null
-    }
-  ],
+    edges: [
+      {
+        __typename: "AttributeValueCountableEdge" as "AttributeValueCountableEdge",
+        cursor: "1",
+        node: {
+          __typename: "AttributeValue" as "AttributeValue",
+          file: null,
+          id: "UHJvZHVjdEF0dHJpYnV0ZVZhbHVlOjI0",
+          name: "John Doe",
+          reference: null,
+          slug: "john-doe",
+          richText: null
+        }
+      },
+      {
+        __typename: "AttributeValueCountableEdge" as "AttributeValueCountableEdge",
+        cursor: "2",
+        node: {
+          __typename: "AttributeValue" as "AttributeValue",
+          file: null,
+          id: "UHJvZHVjdEF0dHJpYnV0ZVZhbHVlOjI1",
+          name: "Milionare Pirate",
+          reference: null,
+          slug: "milionare-pirate",
+          richText: null
+        }
+      }
+    ]
+  },
   visibleInStorefront: true
 };
 

--- a/src/attributes/mutations.ts
+++ b/src/attributes/mutations.ts
@@ -1,4 +1,7 @@
-import { attributeDetailsFragment } from "@saleor/fragments/attributes";
+import {
+  attributeDetailsFragment,
+  attributeValueListFragment
+} from "@saleor/fragments/attributes";
 import { attributeErrorFragment } from "@saleor/fragments/errors";
 import { pageInfoFragment } from "@saleor/fragments/pageInfo";
 import makeMutation from "@saleor/hooks/makeMutation";
@@ -70,14 +73,7 @@ export const useAttributeDeleteMutation = makeMutation<
 export const attributeUpdateMutation = gql`
   ${attributeDetailsFragment}
   ${attributeErrorFragment}
-  mutation AttributeUpdate(
-    $id: ID!
-    $input: AttributeUpdateInput!
-    $firstValues: Int
-    $afterValues: String
-    $lastValues: Int
-    $beforeValues: String
-  ) {
+  mutation AttributeUpdate($id: ID!, $input: AttributeUpdateInput!) {
     attributeUpdate(id: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
@@ -95,6 +91,7 @@ export const useAttributeUpdateMutation = makeMutation<
 
 const attributeValueDelete = gql`
   ${attributeDetailsFragment}
+  ${attributeValueListFragment}
   ${attributeErrorFragment}
   mutation AttributeValueDelete(
     $id: ID!
@@ -106,6 +103,14 @@ const attributeValueDelete = gql`
     attributeValueDelete(id: $id) {
       attribute {
         ...AttributeDetailsFragment
+        values(
+          first: $firstValues
+          after: $afterValues
+          last: $lastValues
+          before: $beforeValues
+        ) {
+          ...AttributeValueListFragment
+        }
       }
       errors {
         ...AttributeErrorFragment
@@ -120,6 +125,7 @@ export const useAttributeValueDeleteMutation = makeMutation<
 
 export const attributeValueUpdateMutation = gql`
   ${attributeDetailsFragment}
+  ${attributeValueListFragment}
   ${attributeErrorFragment}
   mutation AttributeValueUpdate(
     $id: ID!
@@ -132,6 +138,14 @@ export const attributeValueUpdateMutation = gql`
     attributeValueUpdate(id: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
+        values(
+          first: $firstValues
+          after: $afterValues
+          last: $lastValues
+          before: $beforeValues
+        ) {
+          ...AttributeValueListFragment
+        }
       }
       errors {
         ...AttributeErrorFragment
@@ -146,6 +160,7 @@ export const useAttributeValueUpdateMutation = makeMutation<
 
 export const attributeValueCreateMutation = gql`
   ${attributeDetailsFragment}
+  ${attributeValueListFragment}
   ${attributeErrorFragment}
   mutation AttributeValueCreate(
     $id: ID!
@@ -158,6 +173,14 @@ export const attributeValueCreateMutation = gql`
     attributeValueCreate(attribute: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
+        values(
+          first: $firstValues
+          after: $afterValues
+          last: $lastValues
+          before: $beforeValues
+        ) {
+          ...AttributeValueListFragment
+        }
       }
       errors {
         ...AttributeErrorFragment
@@ -171,18 +194,11 @@ export const useAttributeValueCreateMutation = makeMutation<
 >(attributeValueCreateMutation);
 
 export const attributeCreateMutation = gql`
-  ${attributeDetailsFragment}
   ${attributeErrorFragment}
-  mutation AttributeCreate(
-    $input: AttributeCreateInput!
-    $firstValues: Int
-    $afterValues: String
-    $lastValues: Int
-    $beforeValues: String
-  ) {
+  mutation AttributeCreate($input: AttributeCreateInput!) {
     attributeCreate(input: $input) {
       attribute {
-        ...AttributeDetailsFragment
+        id
       }
       errors {
         ...AttributeErrorFragment

--- a/src/attributes/mutations.ts
+++ b/src/attributes/mutations.ts
@@ -1,5 +1,6 @@
 import { attributeDetailsFragment } from "@saleor/fragments/attributes";
 import { attributeErrorFragment } from "@saleor/fragments/errors";
+import { pageInfoFragment } from "@saleor/fragments/pageInfo";
 import makeMutation from "@saleor/hooks/makeMutation";
 import gql from "graphql-tag";
 
@@ -69,7 +70,14 @@ export const useAttributeDeleteMutation = makeMutation<
 export const attributeUpdateMutation = gql`
   ${attributeDetailsFragment}
   ${attributeErrorFragment}
-  mutation AttributeUpdate($id: ID!, $input: AttributeUpdateInput!) {
+  mutation AttributeUpdate(
+    $id: ID!
+    $input: AttributeUpdateInput!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     attributeUpdate(id: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
@@ -88,7 +96,13 @@ export const useAttributeUpdateMutation = makeMutation<
 const attributeValueDelete = gql`
   ${attributeDetailsFragment}
   ${attributeErrorFragment}
-  mutation AttributeValueDelete($id: ID!) {
+  mutation AttributeValueDelete(
+    $id: ID!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     attributeValueDelete(id: $id) {
       attribute {
         ...AttributeDetailsFragment
@@ -107,7 +121,14 @@ export const useAttributeValueDeleteMutation = makeMutation<
 export const attributeValueUpdateMutation = gql`
   ${attributeDetailsFragment}
   ${attributeErrorFragment}
-  mutation AttributeValueUpdate($id: ID!, $input: AttributeValueCreateInput!) {
+  mutation AttributeValueUpdate(
+    $id: ID!
+    $input: AttributeValueCreateInput!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     attributeValueUpdate(id: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
@@ -126,7 +147,14 @@ export const useAttributeValueUpdateMutation = makeMutation<
 export const attributeValueCreateMutation = gql`
   ${attributeDetailsFragment}
   ${attributeErrorFragment}
-  mutation AttributeValueCreate($id: ID!, $input: AttributeValueCreateInput!) {
+  mutation AttributeValueCreate(
+    $id: ID!
+    $input: AttributeValueCreateInput!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     attributeValueCreate(attribute: $id, input: $input) {
       attribute {
         ...AttributeDetailsFragment
@@ -145,7 +173,13 @@ export const useAttributeValueCreateMutation = makeMutation<
 export const attributeCreateMutation = gql`
   ${attributeDetailsFragment}
   ${attributeErrorFragment}
-  mutation AttributeCreate($input: AttributeCreateInput!) {
+  mutation AttributeCreate(
+    $input: AttributeCreateInput!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     attributeCreate(input: $input) {
       attribute {
         ...AttributeDetailsFragment
@@ -163,12 +197,33 @@ export const useAttributeCreateMutation = makeMutation<
 
 const attributeValueReorderMutation = gql`
   ${attributeErrorFragment}
-  mutation AttributeValueReorder($id: ID!, $move: ReorderInput!) {
+  ${pageInfoFragment}
+  mutation AttributeValueReorder(
+    $id: ID!
+    $move: ReorderInput!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     attributeReorderValues(attributeId: $id, moves: [$move]) {
       attribute {
         id
-        values {
-          id
+        values(
+          first: $firstValues
+          after: $afterValues
+          last: $lastValues
+          before: $beforeValues
+        ) {
+          pageInfo {
+            ...PageInfoFragment
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
         }
       }
       errors {

--- a/src/attributes/mutations.ts
+++ b/src/attributes/mutations.ts
@@ -90,7 +90,6 @@ export const useAttributeUpdateMutation = makeMutation<
 >(attributeUpdateMutation);
 
 const attributeValueDelete = gql`
-  ${attributeDetailsFragment}
   ${attributeValueListFragment}
   ${attributeErrorFragment}
   mutation AttributeValueDelete(
@@ -102,7 +101,7 @@ const attributeValueDelete = gql`
   ) {
     attributeValueDelete(id: $id) {
       attribute {
-        ...AttributeDetailsFragment
+        id
         values(
           first: $firstValues
           after: $afterValues
@@ -124,7 +123,6 @@ export const useAttributeValueDeleteMutation = makeMutation<
 >(attributeValueDelete);
 
 export const attributeValueUpdateMutation = gql`
-  ${attributeDetailsFragment}
   ${attributeValueListFragment}
   ${attributeErrorFragment}
   mutation AttributeValueUpdate(
@@ -137,7 +135,7 @@ export const attributeValueUpdateMutation = gql`
   ) {
     attributeValueUpdate(id: $id, input: $input) {
       attribute {
-        ...AttributeDetailsFragment
+        id
         values(
           first: $firstValues
           after: $afterValues
@@ -159,7 +157,6 @@ export const useAttributeValueUpdateMutation = makeMutation<
 >(attributeValueUpdateMutation);
 
 export const attributeValueCreateMutation = gql`
-  ${attributeDetailsFragment}
   ${attributeValueListFragment}
   ${attributeErrorFragment}
   mutation AttributeValueCreate(
@@ -172,7 +169,7 @@ export const attributeValueCreateMutation = gql`
   ) {
     attributeValueCreate(attribute: $id, input: $input) {
       attribute {
-        ...AttributeDetailsFragment
+        id
         values(
           first: $firstValues
           after: $afterValues

--- a/src/attributes/queries.ts
+++ b/src/attributes/queries.ts
@@ -1,6 +1,7 @@
 import {
   attributeDetailsFragment,
-  attributeFragment
+  attributeFragment,
+  attributeValueListFragment
 } from "@saleor/fragments/attributes";
 import { pageInfoFragment } from "@saleor/fragments/pageInfo";
 import makeQuery from "@saleor/hooks/makeQuery";
@@ -14,6 +15,7 @@ import { AttributeList, AttributeListVariables } from "./types/AttributeList";
 
 const attributeDetails = gql`
   ${attributeDetailsFragment}
+  ${attributeValueListFragment}
   query AttributeDetails(
     $id: ID!
     $firstValues: Int
@@ -23,6 +25,14 @@ const attributeDetails = gql`
   ) {
     attribute(id: $id) {
       ...AttributeDetailsFragment
+      values(
+        first: $firstValues
+        after: $afterValues
+        last: $lastValues
+        before: $beforeValues
+      ) {
+        ...AttributeValueListFragment
+      }
     }
   }
 `;

--- a/src/attributes/queries.ts
+++ b/src/attributes/queries.ts
@@ -14,7 +14,13 @@ import { AttributeList, AttributeListVariables } from "./types/AttributeList";
 
 const attributeDetails = gql`
   ${attributeDetailsFragment}
-  query AttributeDetails($id: ID!) {
+  query AttributeDetails(
+    $id: ID!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     attribute(id: $id) {
       ...AttributeDetailsFragment
     }

--- a/src/attributes/types/AttributeCreate.ts
+++ b/src/attributes/types/AttributeCreate.ts
@@ -3,78 +3,15 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AttributeCreateInput, AttributeTypeEnum, MeasurementUnitsEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeCreateInput, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeCreate
 // ====================================================
 
-export interface AttributeCreate_attributeCreate_attribute_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface AttributeCreate_attributeCreate_attribute_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface AttributeCreate_attributeCreate_attribute_values_pageInfo {
-  __typename: "PageInfo";
-  endCursor: string | null;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-  startCursor: string | null;
-}
-
-export interface AttributeCreate_attributeCreate_attribute_values_edges_node_file {
-  __typename: "File";
-  url: string;
-  contentType: string | null;
-}
-
-export interface AttributeCreate_attributeCreate_attribute_values_edges_node {
-  __typename: "AttributeValue";
-  id: string;
-  name: string | null;
-  slug: string | null;
-  file: AttributeCreate_attributeCreate_attribute_values_edges_node_file | null;
-  reference: string | null;
-  richText: any | null;
-}
-
-export interface AttributeCreate_attributeCreate_attribute_values_edges {
-  __typename: "AttributeValueCountableEdge";
-  cursor: string;
-  node: AttributeCreate_attributeCreate_attribute_values_edges_node;
-}
-
-export interface AttributeCreate_attributeCreate_attribute_values {
-  __typename: "AttributeValueCountableConnection";
-  pageInfo: AttributeCreate_attributeCreate_attribute_values_pageInfo;
-  edges: AttributeCreate_attributeCreate_attribute_values_edges[];
-}
-
 export interface AttributeCreate_attributeCreate_attribute {
   __typename: "Attribute";
   id: string;
-  name: string | null;
-  slug: string | null;
-  type: AttributeTypeEnum | null;
-  visibleInStorefront: boolean;
-  filterableInDashboard: boolean;
-  filterableInStorefront: boolean;
-  unit: MeasurementUnitsEnum | null;
-  metadata: (AttributeCreate_attributeCreate_attribute_metadata | null)[];
-  privateMetadata: (AttributeCreate_attributeCreate_attribute_privateMetadata | null)[];
-  availableInGrid: boolean;
-  inputType: AttributeInputTypeEnum | null;
-  entityType: AttributeEntityTypeEnum | null;
-  storefrontSearchPosition: number;
-  valueRequired: boolean;
-  values: AttributeCreate_attributeCreate_attribute_values | null;
 }
 
 export interface AttributeCreate_attributeCreate_errors {
@@ -95,8 +32,4 @@ export interface AttributeCreate {
 
 export interface AttributeCreateVariables {
   input: AttributeCreateInput;
-  firstValues?: number | null;
-  afterValues?: string | null;
-  lastValues?: number | null;
-  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeCreate.ts
+++ b/src/attributes/types/AttributeCreate.ts
@@ -21,20 +21,40 @@ export interface AttributeCreate_attributeCreate_attribute_privateMetadata {
   value: string;
 }
 
-export interface AttributeCreate_attributeCreate_attribute_values_file {
+export interface AttributeCreate_attributeCreate_attribute_values_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeCreate_attributeCreate_attribute_values_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface AttributeCreate_attributeCreate_attribute_values {
+export interface AttributeCreate_attributeCreate_attribute_values_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: AttributeCreate_attributeCreate_attribute_values_file | null;
+  file: AttributeCreate_attributeCreate_attribute_values_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface AttributeCreate_attributeCreate_attribute_values_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeCreate_attributeCreate_attribute_values_edges_node;
+}
+
+export interface AttributeCreate_attributeCreate_attribute_values {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeCreate_attributeCreate_attribute_values_pageInfo;
+  edges: AttributeCreate_attributeCreate_attribute_values_edges[];
 }
 
 export interface AttributeCreate_attributeCreate_attribute {
@@ -54,7 +74,7 @@ export interface AttributeCreate_attributeCreate_attribute {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: (AttributeCreate_attributeCreate_attribute_values | null)[] | null;
+  values: AttributeCreate_attributeCreate_attribute_values | null;
 }
 
 export interface AttributeCreate_attributeCreate_errors {
@@ -75,4 +95,8 @@ export interface AttributeCreate {
 
 export interface AttributeCreateVariables {
   input: AttributeCreateInput;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeDetails.ts
+++ b/src/attributes/types/AttributeDetails.ts
@@ -21,20 +21,40 @@ export interface AttributeDetails_attribute_privateMetadata {
   value: string;
 }
 
-export interface AttributeDetails_attribute_values_file {
+export interface AttributeDetails_attribute_values_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeDetails_attribute_values_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface AttributeDetails_attribute_values {
+export interface AttributeDetails_attribute_values_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: AttributeDetails_attribute_values_file | null;
+  file: AttributeDetails_attribute_values_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface AttributeDetails_attribute_values_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeDetails_attribute_values_edges_node;
+}
+
+export interface AttributeDetails_attribute_values {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeDetails_attribute_values_pageInfo;
+  edges: AttributeDetails_attribute_values_edges[];
 }
 
 export interface AttributeDetails_attribute {
@@ -54,7 +74,7 @@ export interface AttributeDetails_attribute {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: (AttributeDetails_attribute_values | null)[] | null;
+  values: AttributeDetails_attribute_values | null;
 }
 
 export interface AttributeDetails {
@@ -63,4 +83,8 @@ export interface AttributeDetails {
 
 export interface AttributeDetailsVariables {
   id: string;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeUpdate.ts
+++ b/src/attributes/types/AttributeUpdate.ts
@@ -21,42 +21,6 @@ export interface AttributeUpdate_attributeUpdate_attribute_privateMetadata {
   value: string;
 }
 
-export interface AttributeUpdate_attributeUpdate_attribute_values_pageInfo {
-  __typename: "PageInfo";
-  endCursor: string | null;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-  startCursor: string | null;
-}
-
-export interface AttributeUpdate_attributeUpdate_attribute_values_edges_node_file {
-  __typename: "File";
-  url: string;
-  contentType: string | null;
-}
-
-export interface AttributeUpdate_attributeUpdate_attribute_values_edges_node {
-  __typename: "AttributeValue";
-  id: string;
-  name: string | null;
-  slug: string | null;
-  file: AttributeUpdate_attributeUpdate_attribute_values_edges_node_file | null;
-  reference: string | null;
-  richText: any | null;
-}
-
-export interface AttributeUpdate_attributeUpdate_attribute_values_edges {
-  __typename: "AttributeValueCountableEdge";
-  cursor: string;
-  node: AttributeUpdate_attributeUpdate_attribute_values_edges_node;
-}
-
-export interface AttributeUpdate_attributeUpdate_attribute_values {
-  __typename: "AttributeValueCountableConnection";
-  pageInfo: AttributeUpdate_attributeUpdate_attribute_values_pageInfo;
-  edges: AttributeUpdate_attributeUpdate_attribute_values_edges[];
-}
-
 export interface AttributeUpdate_attributeUpdate_attribute {
   __typename: "Attribute";
   id: string;
@@ -74,7 +38,6 @@ export interface AttributeUpdate_attributeUpdate_attribute {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: AttributeUpdate_attributeUpdate_attribute_values | null;
 }
 
 export interface AttributeUpdate_attributeUpdate_errors {
@@ -96,8 +59,4 @@ export interface AttributeUpdate {
 export interface AttributeUpdateVariables {
   id: string;
   input: AttributeUpdateInput;
-  firstValues?: number | null;
-  afterValues?: string | null;
-  lastValues?: number | null;
-  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeUpdate.ts
+++ b/src/attributes/types/AttributeUpdate.ts
@@ -21,20 +21,40 @@ export interface AttributeUpdate_attributeUpdate_attribute_privateMetadata {
   value: string;
 }
 
-export interface AttributeUpdate_attributeUpdate_attribute_values_file {
+export interface AttributeUpdate_attributeUpdate_attribute_values_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeUpdate_attributeUpdate_attribute_values_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface AttributeUpdate_attributeUpdate_attribute_values {
+export interface AttributeUpdate_attributeUpdate_attribute_values_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: AttributeUpdate_attributeUpdate_attribute_values_file | null;
+  file: AttributeUpdate_attributeUpdate_attribute_values_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface AttributeUpdate_attributeUpdate_attribute_values_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeUpdate_attributeUpdate_attribute_values_edges_node;
+}
+
+export interface AttributeUpdate_attributeUpdate_attribute_values {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeUpdate_attributeUpdate_attribute_values_pageInfo;
+  edges: AttributeUpdate_attributeUpdate_attribute_values_edges[];
 }
 
 export interface AttributeUpdate_attributeUpdate_attribute {
@@ -54,7 +74,7 @@ export interface AttributeUpdate_attributeUpdate_attribute {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: (AttributeUpdate_attributeUpdate_attribute_values | null)[] | null;
+  values: AttributeUpdate_attributeUpdate_attribute_values | null;
 }
 
 export interface AttributeUpdate_attributeUpdate_errors {
@@ -76,4 +96,8 @@ export interface AttributeUpdate {
 export interface AttributeUpdateVariables {
   id: string;
   input: AttributeUpdateInput;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeValueCreate.ts
+++ b/src/attributes/types/AttributeValueCreate.ts
@@ -21,20 +21,40 @@ export interface AttributeValueCreate_attributeValueCreate_attribute_privateMeta
   value: string;
 }
 
-export interface AttributeValueCreate_attributeValueCreate_attribute_values_file {
+export interface AttributeValueCreate_attributeValueCreate_attribute_values_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeValueCreate_attributeValueCreate_attribute_values_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface AttributeValueCreate_attributeValueCreate_attribute_values {
+export interface AttributeValueCreate_attributeValueCreate_attribute_values_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: AttributeValueCreate_attributeValueCreate_attribute_values_file | null;
+  file: AttributeValueCreate_attributeValueCreate_attribute_values_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface AttributeValueCreate_attributeValueCreate_attribute_values_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeValueCreate_attributeValueCreate_attribute_values_edges_node;
+}
+
+export interface AttributeValueCreate_attributeValueCreate_attribute_values {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeValueCreate_attributeValueCreate_attribute_values_pageInfo;
+  edges: AttributeValueCreate_attributeValueCreate_attribute_values_edges[];
 }
 
 export interface AttributeValueCreate_attributeValueCreate_attribute {
@@ -54,7 +74,7 @@ export interface AttributeValueCreate_attributeValueCreate_attribute {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: (AttributeValueCreate_attributeValueCreate_attribute_values | null)[] | null;
+  values: AttributeValueCreate_attributeValueCreate_attribute_values | null;
 }
 
 export interface AttributeValueCreate_attributeValueCreate_errors {
@@ -76,4 +96,8 @@ export interface AttributeValueCreate {
 export interface AttributeValueCreateVariables {
   id: string;
   input: AttributeValueCreateInput;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeValueCreate.ts
+++ b/src/attributes/types/AttributeValueCreate.ts
@@ -3,23 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AttributeValueCreateInput, AttributeTypeEnum, MeasurementUnitsEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeValueCreateInput, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueCreate
 // ====================================================
-
-export interface AttributeValueCreate_attributeValueCreate_attribute_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface AttributeValueCreate_attributeValueCreate_attribute_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
 
 export interface AttributeValueCreate_attributeValueCreate_attribute_values_pageInfo {
   __typename: "PageInfo";
@@ -60,20 +48,6 @@ export interface AttributeValueCreate_attributeValueCreate_attribute_values {
 export interface AttributeValueCreate_attributeValueCreate_attribute {
   __typename: "Attribute";
   id: string;
-  name: string | null;
-  slug: string | null;
-  type: AttributeTypeEnum | null;
-  visibleInStorefront: boolean;
-  filterableInDashboard: boolean;
-  filterableInStorefront: boolean;
-  unit: MeasurementUnitsEnum | null;
-  metadata: (AttributeValueCreate_attributeValueCreate_attribute_metadata | null)[];
-  privateMetadata: (AttributeValueCreate_attributeValueCreate_attribute_privateMetadata | null)[];
-  availableInGrid: boolean;
-  inputType: AttributeInputTypeEnum | null;
-  entityType: AttributeEntityTypeEnum | null;
-  storefrontSearchPosition: number;
-  valueRequired: boolean;
   values: AttributeValueCreate_attributeValueCreate_attribute_values | null;
 }
 

--- a/src/attributes/types/AttributeValueDelete.ts
+++ b/src/attributes/types/AttributeValueDelete.ts
@@ -3,23 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AttributeTypeEnum, MeasurementUnitsEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueDelete
 // ====================================================
-
-export interface AttributeValueDelete_attributeValueDelete_attribute_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface AttributeValueDelete_attributeValueDelete_attribute_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
 
 export interface AttributeValueDelete_attributeValueDelete_attribute_values_pageInfo {
   __typename: "PageInfo";
@@ -60,20 +48,6 @@ export interface AttributeValueDelete_attributeValueDelete_attribute_values {
 export interface AttributeValueDelete_attributeValueDelete_attribute {
   __typename: "Attribute";
   id: string;
-  name: string | null;
-  slug: string | null;
-  type: AttributeTypeEnum | null;
-  visibleInStorefront: boolean;
-  filterableInDashboard: boolean;
-  filterableInStorefront: boolean;
-  unit: MeasurementUnitsEnum | null;
-  metadata: (AttributeValueDelete_attributeValueDelete_attribute_metadata | null)[];
-  privateMetadata: (AttributeValueDelete_attributeValueDelete_attribute_privateMetadata | null)[];
-  availableInGrid: boolean;
-  inputType: AttributeInputTypeEnum | null;
-  entityType: AttributeEntityTypeEnum | null;
-  storefrontSearchPosition: number;
-  valueRequired: boolean;
   values: AttributeValueDelete_attributeValueDelete_attribute_values | null;
 }
 

--- a/src/attributes/types/AttributeValueDelete.ts
+++ b/src/attributes/types/AttributeValueDelete.ts
@@ -21,20 +21,40 @@ export interface AttributeValueDelete_attributeValueDelete_attribute_privateMeta
   value: string;
 }
 
-export interface AttributeValueDelete_attributeValueDelete_attribute_values_file {
+export interface AttributeValueDelete_attributeValueDelete_attribute_values_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeValueDelete_attributeValueDelete_attribute_values_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface AttributeValueDelete_attributeValueDelete_attribute_values {
+export interface AttributeValueDelete_attributeValueDelete_attribute_values_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: AttributeValueDelete_attributeValueDelete_attribute_values_file | null;
+  file: AttributeValueDelete_attributeValueDelete_attribute_values_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface AttributeValueDelete_attributeValueDelete_attribute_values_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeValueDelete_attributeValueDelete_attribute_values_edges_node;
+}
+
+export interface AttributeValueDelete_attributeValueDelete_attribute_values {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeValueDelete_attributeValueDelete_attribute_values_pageInfo;
+  edges: AttributeValueDelete_attributeValueDelete_attribute_values_edges[];
 }
 
 export interface AttributeValueDelete_attributeValueDelete_attribute {
@@ -54,7 +74,7 @@ export interface AttributeValueDelete_attributeValueDelete_attribute {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: (AttributeValueDelete_attributeValueDelete_attribute_values | null)[] | null;
+  values: AttributeValueDelete_attributeValueDelete_attribute_values | null;
 }
 
 export interface AttributeValueDelete_attributeValueDelete_errors {
@@ -75,4 +95,8 @@ export interface AttributeValueDelete {
 
 export interface AttributeValueDeleteVariables {
   id: string;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeValueReorder.ts
+++ b/src/attributes/types/AttributeValueReorder.ts
@@ -9,15 +9,35 @@ import { ReorderInput, AttributeErrorCode } from "./../../types/globalTypes";
 // GraphQL mutation operation: AttributeValueReorder
 // ====================================================
 
-export interface AttributeValueReorder_attributeReorderValues_attribute_values {
+export interface AttributeValueReorder_attributeReorderValues_attribute_values_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeValueReorder_attributeReorderValues_attribute_values_edges_node {
   __typename: "AttributeValue";
   id: string;
+}
+
+export interface AttributeValueReorder_attributeReorderValues_attribute_values_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeValueReorder_attributeReorderValues_attribute_values_edges_node;
+}
+
+export interface AttributeValueReorder_attributeReorderValues_attribute_values {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeValueReorder_attributeReorderValues_attribute_values_pageInfo;
+  edges: AttributeValueReorder_attributeReorderValues_attribute_values_edges[];
 }
 
 export interface AttributeValueReorder_attributeReorderValues_attribute {
   __typename: "Attribute";
   id: string;
-  values: (AttributeValueReorder_attributeReorderValues_attribute_values | null)[] | null;
+  values: AttributeValueReorder_attributeReorderValues_attribute_values | null;
 }
 
 export interface AttributeValueReorder_attributeReorderValues_errors {
@@ -39,4 +59,8 @@ export interface AttributeValueReorder {
 export interface AttributeValueReorderVariables {
   id: string;
   move: ReorderInput;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeValueUpdate.ts
+++ b/src/attributes/types/AttributeValueUpdate.ts
@@ -21,20 +21,40 @@ export interface AttributeValueUpdate_attributeValueUpdate_attribute_privateMeta
   value: string;
 }
 
-export interface AttributeValueUpdate_attributeValueUpdate_attribute_values_file {
+export interface AttributeValueUpdate_attributeValueUpdate_attribute_values_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeValueUpdate_attributeValueUpdate_attribute_values_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface AttributeValueUpdate_attributeValueUpdate_attribute_values {
+export interface AttributeValueUpdate_attributeValueUpdate_attribute_values_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: AttributeValueUpdate_attributeValueUpdate_attribute_values_file | null;
+  file: AttributeValueUpdate_attributeValueUpdate_attribute_values_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface AttributeValueUpdate_attributeValueUpdate_attribute_values_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeValueUpdate_attributeValueUpdate_attribute_values_edges_node;
+}
+
+export interface AttributeValueUpdate_attributeValueUpdate_attribute_values {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeValueUpdate_attributeValueUpdate_attribute_values_pageInfo;
+  edges: AttributeValueUpdate_attributeValueUpdate_attribute_values_edges[];
 }
 
 export interface AttributeValueUpdate_attributeValueUpdate_attribute {
@@ -54,7 +74,7 @@ export interface AttributeValueUpdate_attributeValueUpdate_attribute {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: (AttributeValueUpdate_attributeValueUpdate_attribute_values | null)[] | null;
+  values: AttributeValueUpdate_attributeValueUpdate_attribute_values | null;
 }
 
 export interface AttributeValueUpdate_attributeValueUpdate_errors {
@@ -76,4 +96,8 @@ export interface AttributeValueUpdate {
 export interface AttributeValueUpdateVariables {
   id: string;
   input: AttributeValueCreateInput;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/attributes/types/AttributeValueUpdate.ts
+++ b/src/attributes/types/AttributeValueUpdate.ts
@@ -3,23 +3,11 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AttributeValueCreateInput, AttributeTypeEnum, MeasurementUnitsEnum, AttributeInputTypeEnum, AttributeEntityTypeEnum, AttributeErrorCode } from "./../../types/globalTypes";
+import { AttributeValueCreateInput, AttributeErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: AttributeValueUpdate
 // ====================================================
-
-export interface AttributeValueUpdate_attributeValueUpdate_attribute_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface AttributeValueUpdate_attributeValueUpdate_attribute_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
 
 export interface AttributeValueUpdate_attributeValueUpdate_attribute_values_pageInfo {
   __typename: "PageInfo";
@@ -60,20 +48,6 @@ export interface AttributeValueUpdate_attributeValueUpdate_attribute_values {
 export interface AttributeValueUpdate_attributeValueUpdate_attribute {
   __typename: "Attribute";
   id: string;
-  name: string | null;
-  slug: string | null;
-  type: AttributeTypeEnum | null;
-  visibleInStorefront: boolean;
-  filterableInDashboard: boolean;
-  filterableInStorefront: boolean;
-  unit: MeasurementUnitsEnum | null;
-  metadata: (AttributeValueUpdate_attributeValueUpdate_attribute_metadata | null)[];
-  privateMetadata: (AttributeValueUpdate_attributeValueUpdate_attribute_privateMetadata | null)[];
-  availableInGrid: boolean;
-  inputType: AttributeInputTypeEnum | null;
-  entityType: AttributeEntityTypeEnum | null;
-  storefrontSearchPosition: number;
-  valueRequired: boolean;
   values: AttributeValueUpdate_attributeValueUpdate_attribute_values | null;
 }
 

--- a/src/attributes/urls.ts
+++ b/src/attributes/urls.ts
@@ -48,7 +48,8 @@ export type AttributeAddUrlDialog =
   | "edit-value"
   | "remove-value"
   | "remove-values";
-export type AttributeAddUrlQueryParams = Dialog<AttributeAddUrlDialog> &
+export type AttributeAddUrlQueryParams = Pagination &
+  Dialog<AttributeAddUrlDialog> &
   SingleAction;
 export const attributeAddPath = urlJoin(attributeSection, "add");
 export const attributeAddUrl = (params?: AttributeAddUrlQueryParams) =>
@@ -60,7 +61,8 @@ export type AttributeUrlDialog =
   | "remove"
   | "remove-value"
   | "remove-values";
-export type AttributeUrlQueryParams = BulkAction &
+export type AttributeUrlQueryParams = Pagination &
+  BulkAction &
   Dialog<AttributeUrlDialog> &
   SingleAction;
 export const attributePath = (id: string) => urlJoin(attributeSection, id);

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -1,13 +1,13 @@
 import { getAttributeData } from "@saleor/attributes/utils/data";
-import { PAGINATE_BY } from "@saleor/config";
 import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
+import useListSettings from "@saleor/hooks/useListSettings";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import usePaginator, {
   createPaginationState
 } from "@saleor/hooks/usePaginator";
 import { getStringOrPlaceholder } from "@saleor/misc";
-import { ReorderEvent } from "@saleor/types";
+import { ListViews, ReorderEvent } from "@saleor/types";
 import { AttributeErrorCode } from "@saleor/types/globalTypes";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataCreateHandler from "@saleor/utils/handlers/metadataCreateHandler";
@@ -72,7 +72,10 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
     AttributeErrorFragment[]
   >([]);
 
-  const paginationState = createPaginationState(PAGINATE_BY, params);
+  const { updateListSettings, settings } = useListSettings(
+    ListViews.ATTRIBUTE_VALUE_LIST
+  );
+  const paginationState = createPaginationState(settings?.rowNumber, params);
   const { loadNextPage, loadPreviousPage, pageInfo } = paginate(
     {
       endCursor: "",
@@ -138,7 +141,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
     const result = await attributeCreate({
       variables: {
         input,
-        firstValues: PAGINATE_BY,
+        firstValues: settings.rowNumber,
         afterValues: params.after
       }
     });
@@ -198,6 +201,8 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
             }
           }))
         }}
+        settings={settings}
+        onUpdateListSettings={updateListSettings}
         pageInfo={pageInfo}
         onNextPage={loadNextPage}
         onPreviousPage={loadPreviousPage}

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -137,7 +137,9 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
 
     const result = await attributeCreate({
       variables: {
-        input
+        input,
+        firstValues: PAGINATE_BY,
+        afterValues: params.after
       }
     });
 

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -140,9 +140,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
 
     const result = await attributeCreate({
       variables: {
-        input,
-        firstValues: settings.rowNumber,
-        afterValues: params.after
+        input
       }
     });
 

--- a/src/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/src/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -1,7 +1,11 @@
 import { getAttributeData } from "@saleor/attributes/utils/data";
+import { PAGINATE_BY } from "@saleor/config";
 import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import { getStringOrPlaceholder } from "@saleor/misc";
 import { ReorderEvent } from "@saleor/types";
 import { AttributeErrorCode } from "@saleor/types/globalTypes";
@@ -57,6 +61,7 @@ function areValuesEqual(
 
 const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
   const navigate = useNavigator();
+  const paginate = usePaginator();
   const notify = useNotifier();
   const intl = useIntl();
 
@@ -66,6 +71,18 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
   const [valueErrors, setValueErrors] = React.useState<
     AttributeErrorFragment[]
   >([]);
+
+  const paginationState = createPaginationState(PAGINATE_BY, params);
+  const { loadNextPage, loadPreviousPage, pageInfo } = paginate(
+    {
+      endCursor: "",
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: ""
+    },
+    paginationState,
+    params
+  );
 
   const [attributeCreate, attributeCreateOpts] = useAttributeCreateMutation({
     onCompleted: data => {
@@ -154,17 +171,34 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
           })
         }
         saveButtonBarState={attributeCreateOpts.status}
-        values={values.map((value, valueIndex) => ({
-          __typename: "AttributeValue" as "AttributeValue",
-          file: null,
-          id: valueIndex.toString(),
-          reference: null,
-          slug: slugify(value.name).toLowerCase(),
-          sortOrder: valueIndex,
-          value: null,
-          richText: null,
-          ...value
-        }))}
+        values={{
+          __typename: "AttributeValueCountableConnection" as "AttributeValueCountableConnection",
+          pageInfo: {
+            __typename: "PageInfo" as "PageInfo",
+            endCursor: "",
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: ""
+          },
+          edges: values.map((value, valueIndex) => ({
+            __typename: "AttributeValueCountableEdge" as "AttributeValueCountableEdge",
+            cursor: "1",
+            node: {
+              __typename: "AttributeValue" as "AttributeValue",
+              file: null,
+              id: valueIndex.toString(),
+              reference: null,
+              slug: slugify(value.name).toLowerCase(),
+              sortOrder: valueIndex,
+              value: null,
+              richText: null,
+              ...value
+            }
+          }))
+        }}
+        pageInfo={pageInfo}
+        onNextPage={loadNextPage}
+        onPreviousPage={loadPreviousPage}
       />
       <AttributeValueEditDialog
         attributeValue={null}

--- a/src/attributes/views/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/views/AttributeDetails/AttributeDetails.tsx
@@ -1,4 +1,4 @@
-import { PAGINATE_BY } from "@saleor/config";
+import useListSettings from "@saleor/hooks/useListSettings";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import usePaginator, {
@@ -6,7 +6,7 @@ import usePaginator, {
 } from "@saleor/hooks/usePaginator";
 import { commonMessages } from "@saleor/intl";
 import { maybe } from "@saleor/misc";
-import { ReorderEvent } from "@saleor/types";
+import { ListViews, ReorderEvent } from "@saleor/types";
 import getAttributeErrorMessage from "@saleor/utils/errors/attribute";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
@@ -58,15 +58,20 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
     AttributeUrlQueryParams
   >(navigate, params => attributeUrl(id, params), params);
 
+  const { updateListSettings, settings } = useListSettings(
+    ListViews.ATTRIBUTE_VALUE_LIST
+  );
+
   const { data, loading } = useAttributeDetailsQuery({
     variables: {
       id,
-      firstValues: PAGINATE_BY,
+      firstValues: settings?.rowNumber,
       afterValues: params.after
-    }
+    },
+    skip: !settings
   });
 
-  const paginationState = createPaginationState(PAGINATE_BY, params);
+  const paginationState = createPaginationState(settings?.rowNumber, params);
   const { loadNextPage, loadPreviousPage, pageInfo } = paginate(
     data?.attribute?.values?.pageInfo,
     paginationState,
@@ -192,7 +197,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
           id: data.attribute.values.edges[oldIndex].node.id,
           sortOrder: newIndex - oldIndex
         },
-        firstValues: PAGINATE_BY,
+        firstValues: settings.rowNumber,
         afterValues: params.after
       }
     });
@@ -211,7 +216,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
       variables: {
         id,
         input,
-        firstValues: PAGINATE_BY,
+        firstValues: settings.rowNumber,
         afterValues: params.after
       }
     });
@@ -249,6 +254,8 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
         }
         saveButtonBarState={attributeUpdateOpts.status}
         values={maybe(() => data.attribute.values)}
+        settings={settings}
+        onUpdateListSettings={updateListSettings}
         pageInfo={pageInfo}
         onNextPage={loadNextPage}
         onPreviousPage={loadPreviousPage}
@@ -283,7 +290,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
           attributeValueDelete({
             variables: {
               id: params.id,
-              firstValues: PAGINATE_BY,
+              firstValues: settings.rowNumber,
               afterValues: params.after
             }
           })
@@ -303,7 +310,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
             variables: {
               id,
               input,
-              firstValues: PAGINATE_BY,
+              firstValues: settings.rowNumber,
               afterValues: params.after
             }
           })
@@ -330,7 +337,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
                 value => params.id === value.node.id
               ).node.id,
               input,
-              firstValues: PAGINATE_BY,
+              firstValues: settings.rowNumber,
               afterValues: params.after
             }
           })

--- a/src/attributes/views/AttributeDetails/AttributeDetails.tsx
+++ b/src/attributes/views/AttributeDetails/AttributeDetails.tsx
@@ -215,9 +215,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
     const result = await attributeUpdate({
       variables: {
         id,
-        input,
-        firstValues: settings.rowNumber,
-        afterValues: params.after
+        input
       }
     });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ export const defaultListSettings: AppListViewSettings = {
     rowNumber: 10
   },
   [ListViews.ATTRIBUTE_VALUE_LIST]: {
-    rowNumber: PAGINATE_BY
+    rowNumber: 10
   },
   [ListViews.CATEGORY_LIST]: {
     rowNumber: PAGINATE_BY

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export const PAGINATE_BY = 20;
 export type ProductListColumns = "productType" | "availability" | "price";
 export interface AppListViewSettings {
   [ListViews.APPS_LIST]: ListSettings;
+  [ListViews.ATTRIBUTE_VALUE_LIST]: ListSettings;
   [ListViews.CATEGORY_LIST]: ListSettings;
   [ListViews.COLLECTION_LIST]: ListSettings;
   [ListViews.CUSTOMER_LIST]: ListSettings;
@@ -43,6 +44,9 @@ export interface AppListViewSettings {
 export const defaultListSettings: AppListViewSettings = {
   [ListViews.APPS_LIST]: {
     rowNumber: 10
+  },
+  [ListViews.ATTRIBUTE_VALUE_LIST]: {
+    rowNumber: PAGINATE_BY
   },
   [ListViews.CATEGORY_LIST]: {
     rowNumber: PAGINATE_BY

--- a/src/fragments/attributes.ts
+++ b/src/fragments/attributes.ts
@@ -2,6 +2,7 @@ import gql from "graphql-tag";
 
 import { fileFragment } from "./file";
 import { metadataFragment } from "./metadata";
+import { pageInfoFragment } from "./pageInfo";
 
 export const attributeValueFragment = gql`
   ${fileFragment}
@@ -34,6 +35,7 @@ export const attributeDetailsFragment = gql`
   ${attributeFragment}
   ${metadataFragment}
   ${attributeValueFragment}
+  ${pageInfoFragment}
   fragment AttributeDetailsFragment on Attribute {
     ...AttributeFragment
     ...MetadataFragment
@@ -43,8 +45,21 @@ export const attributeDetailsFragment = gql`
     unit
     storefrontSearchPosition
     valueRequired
-    values {
-      ...AttributeValueFragment
+    values(
+      first: $firstValues
+      after: $afterValues
+      last: $lastValues
+      before: $beforeValues
+    ) {
+      pageInfo {
+        ...PageInfoFragment
+      }
+      edges {
+        cursor
+        node {
+          ...AttributeValueFragment
+        }
+      }
     }
   }
 `;

--- a/src/fragments/attributes.ts
+++ b/src/fragments/attributes.ts
@@ -34,8 +34,6 @@ export const attributeFragment = gql`
 export const attributeDetailsFragment = gql`
   ${attributeFragment}
   ${metadataFragment}
-  ${attributeValueFragment}
-  ${pageInfoFragment}
   fragment AttributeDetailsFragment on Attribute {
     ...AttributeFragment
     ...MetadataFragment
@@ -45,20 +43,20 @@ export const attributeDetailsFragment = gql`
     unit
     storefrontSearchPosition
     valueRequired
-    values(
-      first: $firstValues
-      after: $afterValues
-      last: $lastValues
-      before: $beforeValues
-    ) {
-      pageInfo {
-        ...PageInfoFragment
-      }
-      edges {
-        cursor
-        node {
-          ...AttributeValueFragment
-        }
+  }
+`;
+
+export const attributeValueListFragment = gql`
+  ${attributeValueFragment}
+  ${pageInfoFragment}
+  fragment AttributeValueListFragment on AttributeValueCountableConnection {
+    pageInfo {
+      ...PageInfoFragment
+    }
+    edges {
+      cursor
+      node {
+        ...AttributeValueFragment
       }
     }
   }

--- a/src/fragments/pages.ts
+++ b/src/fragments/pages.ts
@@ -24,9 +24,9 @@ export const pageAttributesFragment = gql`
         entityType
         valueRequired
         unit
-        values {
-          ...AttributeValueFragment
-        }
+        # values {
+        #   ...AttributeValueFragment
+        # }
       }
       values {
         ...AttributeValueFragment
@@ -41,9 +41,9 @@ export const pageAttributesFragment = gql`
         inputType
         entityType
         valueRequired
-        values {
-          ...AttributeValueFragment
-        }
+        # values {
+        #   ...AttributeValueFragment
+        # }
       }
     }
   }

--- a/src/fragments/products.ts
+++ b/src/fragments/products.ts
@@ -117,6 +117,7 @@ export const productFragment = gql`
 export const productVariantAttributesFragment = gql`
   ${priceRangeFragment}
   ${attributeValueFragment}
+
   fragment ProductVariantAttributesFragment on Product {
     id
     attributes {
@@ -128,9 +129,9 @@ export const productVariantAttributesFragment = gql`
         entityType
         valueRequired
         unit
-        values {
-          ...AttributeValueFragment
-        }
+        # values {
+        #   ...AttributeValueFragment
+        # }
       }
       values {
         ...AttributeValueFragment
@@ -141,9 +142,9 @@ export const productVariantAttributesFragment = gql`
       variantAttributes(variantSelection: VARIANT_SELECTION) {
         id
         name
-        values {
-          ...AttributeValueFragment
-        }
+        # values {
+        #   ...AttributeValueFragment
+        # }
       }
     }
     channelListings {
@@ -241,9 +242,9 @@ export const variantAttributeFragment = gql`
     entityType
     valueRequired
     unit
-    values {
-      ...AttributeValueFragment
-    }
+    # values {
+    #   ...AttributeValueFragment
+    # }
   }
 `;
 

--- a/src/fragments/translations.ts
+++ b/src/fragments/translations.ts
@@ -171,17 +171,17 @@ export const attributeTranslationFragment = gql`
       id
       name
       inputType
-      values {
-        id
-        name
-        richText
-        inputType
-        translation(languageCode: $language) {
-          id
-          name
-          richText
-        }
-      }
+      # values {
+      #   id
+      #   name
+      #   richText
+      #   inputType
+      #   translation(languageCode: $language) {
+      #     id
+      #     name
+      #     richText
+      #   }
+      # }
     }
   }
 `;

--- a/src/fragments/types/AttributeDetailsFragment.ts
+++ b/src/fragments/types/AttributeDetailsFragment.ts
@@ -21,20 +21,40 @@ export interface AttributeDetailsFragment_privateMetadata {
   value: string;
 }
 
-export interface AttributeDetailsFragment_values_file {
+export interface AttributeDetailsFragment_values_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeDetailsFragment_values_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface AttributeDetailsFragment_values {
+export interface AttributeDetailsFragment_values_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: AttributeDetailsFragment_values_file | null;
+  file: AttributeDetailsFragment_values_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface AttributeDetailsFragment_values_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeDetailsFragment_values_edges_node;
+}
+
+export interface AttributeDetailsFragment_values {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeDetailsFragment_values_pageInfo;
+  edges: AttributeDetailsFragment_values_edges[];
 }
 
 export interface AttributeDetailsFragment {
@@ -54,5 +74,5 @@ export interface AttributeDetailsFragment {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: (AttributeDetailsFragment_values | null)[] | null;
+  values: AttributeDetailsFragment_values | null;
 }

--- a/src/fragments/types/AttributeDetailsFragment.ts
+++ b/src/fragments/types/AttributeDetailsFragment.ts
@@ -21,42 +21,6 @@ export interface AttributeDetailsFragment_privateMetadata {
   value: string;
 }
 
-export interface AttributeDetailsFragment_values_pageInfo {
-  __typename: "PageInfo";
-  endCursor: string | null;
-  hasNextPage: boolean;
-  hasPreviousPage: boolean;
-  startCursor: string | null;
-}
-
-export interface AttributeDetailsFragment_values_edges_node_file {
-  __typename: "File";
-  url: string;
-  contentType: string | null;
-}
-
-export interface AttributeDetailsFragment_values_edges_node {
-  __typename: "AttributeValue";
-  id: string;
-  name: string | null;
-  slug: string | null;
-  file: AttributeDetailsFragment_values_edges_node_file | null;
-  reference: string | null;
-  richText: any | null;
-}
-
-export interface AttributeDetailsFragment_values_edges {
-  __typename: "AttributeValueCountableEdge";
-  cursor: string;
-  node: AttributeDetailsFragment_values_edges_node;
-}
-
-export interface AttributeDetailsFragment_values {
-  __typename: "AttributeValueCountableConnection";
-  pageInfo: AttributeDetailsFragment_values_pageInfo;
-  edges: AttributeDetailsFragment_values_edges[];
-}
-
 export interface AttributeDetailsFragment {
   __typename: "Attribute";
   id: string;
@@ -74,5 +38,4 @@ export interface AttributeDetailsFragment {
   entityType: AttributeEntityTypeEnum | null;
   storefrontSearchPosition: number;
   valueRequired: boolean;
-  values: AttributeDetailsFragment_values | null;
 }

--- a/src/fragments/types/AttributeValueListFragment.ts
+++ b/src/fragments/types/AttributeValueListFragment.ts
@@ -1,0 +1,44 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: AttributeValueListFragment
+// ====================================================
+
+export interface AttributeValueListFragment_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface AttributeValueListFragment_edges_node_file {
+  __typename: "File";
+  url: string;
+  contentType: string | null;
+}
+
+export interface AttributeValueListFragment_edges_node {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+  file: AttributeValueListFragment_edges_node_file | null;
+  reference: string | null;
+  richText: any | null;
+}
+
+export interface AttributeValueListFragment_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: AttributeValueListFragment_edges_node;
+}
+
+export interface AttributeValueListFragment {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: AttributeValueListFragment_pageInfo;
+  edges: AttributeValueListFragment_edges[];
+}

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -64,11 +64,11 @@ const initialProductFilterAttributesQuery = gql`
           id
           name
           slug
-          values {
-            id
-            name
-            slug
-          }
+          # values {
+          #   id
+          #   name
+          #   slug
+          # }
         }
       }
     }
@@ -222,9 +222,9 @@ const productTypeQuery = gql`
         name
         valueRequired
         unit
-        values {
-          ...AttributeValueFragment
-        }
+        # values {
+        #   ...AttributeValueFragment
+        # }
       }
       taxType {
         ...TaxTypeFragment

--- a/src/searches/usePageTypeSearch.ts
+++ b/src/searches/usePageTypeSearch.ts
@@ -28,9 +28,9 @@ export const searchPageTypes = gql`
             slug
             name
             valueRequired
-            values {
-              ...AttributeValueFragment
-            }
+            # values {
+            #   ...AttributeValueFragment
+            # }
           }
         }
       }

--- a/src/storybook/stories/attributes/AttributePage.tsx
+++ b/src/storybook/stories/attributes/AttributePage.tsx
@@ -23,7 +23,13 @@ const props: AttributePageProps = {
   onValueReorder: () => undefined,
   onValueUpdate: () => undefined,
   saveButtonBarState: "default",
-  values: attribute.values
+  values: attribute.values,
+  pageInfo: {
+    hasNextPage: false,
+    hasPreviousPage: false
+  },
+  onNextPage: () => undefined,
+  onPreviousPage: () => undefined
 };
 
 storiesOf("Views / Attributes / Attribute details", module)

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface ListSettings<TColumn extends string = string> {
 export enum ListViews {
   APPS_LIST = "APPS_LIST",
   ATTRIBUTE_LIST = "ATTRIBUTE_LIST",
+  ATTRIBUTE_VALUE_LIST = "ATTRIBUTE_VALUE_LIST",
   CATEGORY_LIST = "CATEGORY_LIST",
   COLLECTION_LIST = "COLLECTION_LIST",
   CUSTOMER_LIST = "CUSTOMER_LIST",


### PR DESCRIPTION
I want to merge this change because... it adds support for attribute values pagination on attribute details page.

:information_source: Temporary some values fields in queries are commented out to make apollo codegen working, pagination support for them will be added in other pull requests.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> SALEOR-3071-paginate-attributes
https://github.com/mirumee/saleor/pull/7341

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="693" alt="Zrzut ekranu 2021-05-14 o 17 23 59" src="https://user-images.githubusercontent.com/9825562/118292833-56143580-b4d9-11eb-9940-22401551edb9.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://saleor-3071-paginate-attributes.api.saleor.rocks/graphql/