### PR TITLE
Fix logo appearing too high on screen when loading login

### DIFF
--- a/src/auth/components/LoginPage/LoginPage.tsx
+++ b/src/auth/components/LoginPage/LoginPage.tsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles(
     loading: {
       alignItems: "center",
       display: "flex",
-      height: "100vh",
+      minHeight: "80vh",
       justifyContent: "center"
     },
     loginButton: {


### PR DESCRIPTION
I want to merge this change because it fixes saleor logo appearing too high on the screen when logging in

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/