### PR TITLE
Unify channel ID param in graphql

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -848,7 +848,7 @@ type ChannelDelete {
 }
 
 input ChannelDeleteInput {
-  targetChannel: ID!
+  channelId: ID!
 }
 
 type ChannelError {
@@ -865,7 +865,6 @@ enum ChannelErrorCode {
   NOT_FOUND
   REQUIRED
   UNIQUE
-  CHANNEL_TARGET_ID_MUST_BE_DIFFERENT
   CHANNELS_CURRENCY_MUST_BE_THE_SAME
   CHANNEL_WITH_ORDERS
   DUPLICATED_INPUT_ITEM
@@ -1842,7 +1841,7 @@ input DraftOrderCreateInput {
   shippingMethod: ID
   voucher: ID
   customerNote: String
-  channel: ID
+  channelId: ID
   redirectUrl: String
   lines: [OrderLineCreateInput]
 }
@@ -1862,7 +1861,7 @@ input DraftOrderInput {
   shippingMethod: ID
   voucher: ID
   customerNote: String
-  channel: ID
+  channelId: ID
   redirectUrl: String
 }
 
@@ -2823,7 +2822,7 @@ type Mutation {
   giftCardCreate(input: GiftCardCreateInput!): GiftCardCreate
   giftCardDeactivate(id: ID!): GiftCardDeactivate
   giftCardUpdate(id: ID!, input: GiftCardUpdateInput!): GiftCardUpdate
-  pluginUpdate(channel: ID, id: ID!, input: PluginUpdateInput!): PluginUpdate
+  pluginUpdate(channelId: ID, id: ID!, input: PluginUpdateInput!): PluginUpdate
   saleCreate(input: SaleInput!): SaleCreate
   saleDelete(id: ID!): SaleDelete
   saleBulkDelete(ids: [ID]!): SaleBulkDelete

--- a/src/channels/views/ChannelDetails/ChannelDetails.tsx
+++ b/src/channels/views/ChannelDetails/ChannelDetails.tsx
@@ -145,10 +145,8 @@ export const ChannelDetails: React.FC<ChannelDetailsProps> = ({
     channelsListData?.data?.channels
   );
 
-  const handleRemoveConfirm = (targetChannelId?: string) => {
-    const data = targetChannelId
-      ? { id, input: { targetChannel: targetChannelId } }
-      : { id };
+  const handleRemoveConfirm = (channelId?: string) => {
+    const data = channelId ? { id, input: { channelId } } : { id };
     deleteChannel({ variables: data });
   };
 

--- a/src/channels/views/ChannelsList/ChannelsList.tsx
+++ b/src/channels/views/ChannelsList/ChannelsList.tsx
@@ -80,16 +80,15 @@ export const ChannelsList: React.FC<ChannelsListProps> = ({ params }) => {
 
   const navigateToChannelCreate = () => navigate(channelAddUrl);
 
-  const handleRemoveConfirm = (targetChannelId?: string) => {
-    if (targetChannelId) {
-      deleteChannel({
-        variables: { id: params.id, input: { targetChannel: targetChannelId } }
-      });
-    } else {
-      deleteChannel({
-        variables: { id: params.id }
-      });
-    }
+  const handleRemoveConfirm = (channelId?: string) => {
+    const inputVariables = channelId ? { input: { channelId } } : {};
+
+    deleteChannel({
+      variables: {
+        id: params.id,
+        ...inputVariables
+      }
+    });
   };
 
   return (

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -262,10 +262,10 @@ export const OrderDraftList: React.FC<OrderDraftListProps> = ({ params }) => {
                 defaultChoice={channel?.id}
                 open={params.action === "create-order"}
                 onClose={closeModal}
-                onConfirm={channel =>
+                onConfirm={channelId =>
                   createOrder({
                     variables: {
-                      input: { channel }
+                      input: { channelId }
                     }
                   })
                 }

--- a/src/orders/views/OrderList/OrderList.tsx
+++ b/src/orders/views/OrderList/OrderList.tsx
@@ -196,10 +196,10 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
           defaultChoice={channel.id}
           open={params.action === "create-order"}
           onClose={closeModal}
-          onConfirm={channel =>
+          onConfirm={channelId =>
             createOrder({
               variables: {
-                input: { channel }
+                input: { channelId }
               }
             })
           }

--- a/src/plugins/mutations.ts
+++ b/src/plugins/mutations.ts
@@ -8,8 +8,8 @@ import { PluginUpdate, PluginUpdateVariables } from "./types/PluginUpdate";
 const pluginUpdate = gql`
   ${pluginsDetailsFragment}
   ${pluginErrorFragment}
-  mutation PluginUpdate($channel: ID, $id: ID!, $input: PluginUpdateInput!) {
-    pluginUpdate(channel: $channel, id: $id, input: $input) {
+  mutation PluginUpdate($channelId: ID, $id: ID!, $input: PluginUpdateInput!) {
+    pluginUpdate(channelId: $channelId, id: $id, input: $input) {
       errors {
         ...PluginErrorFragment
       }

--- a/src/plugins/types/PluginUpdate.ts
+++ b/src/plugins/types/PluginUpdate.ts
@@ -81,7 +81,7 @@ export interface PluginUpdate {
 }
 
 export interface PluginUpdateVariables {
-  channel?: string | null;
+  channelId?: string | null;
   id: string;
   input: PluginUpdateInput;
 }

--- a/src/plugins/views/PluginsDetails.tsx
+++ b/src/plugins/views/PluginsDetails.tsx
@@ -102,7 +102,7 @@ export const PluginsDetails: React.FC<PluginsDetailsProps> = ({
         const handleFieldUpdate = (value: string) =>
           pluginUpdate({
             variables: {
-              channel: selectedChannelId,
+              channelId: selectedChannelId,
               id,
               input: {
                 configuration: [
@@ -118,7 +118,7 @@ export const PluginsDetails: React.FC<PluginsDetailsProps> = ({
         const handleSubmit = async (formData: PluginDetailsPageFormData) => {
           const result = await pluginUpdate({
             variables: {
-              channel: selectedChannelId,
+              channelId: selectedChannelId,
               id,
               input: {
                 active: formData.active,

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -122,7 +122,6 @@ export enum CategorySortField {
 export enum ChannelErrorCode {
   ALREADY_EXISTS = "ALREADY_EXISTS",
   CHANNELS_CURRENCY_MUST_BE_THE_SAME = "CHANNELS_CURRENCY_MUST_BE_THE_SAME",
-  CHANNEL_TARGET_ID_MUST_BE_DIFFERENT = "CHANNEL_TARGET_ID_MUST_BE_DIFFERENT",
   CHANNEL_WITH_ORDERS = "CHANNEL_WITH_ORDERS",
   DUPLICATED_INPUT_ITEM = "DUPLICATED_INPUT_ITEM",
   GRAPHQL_ERROR = "GRAPHQL_ERROR",
@@ -1203,7 +1202,7 @@ export interface ChannelCreateInput {
 }
 
 export interface ChannelDeleteInput {
-  targetChannel: string;
+  channelId: string;
 }
 
 export interface ChannelUpdateInput {
@@ -1298,7 +1297,7 @@ export interface DraftOrderCreateInput {
   shippingMethod?: string | null;
   voucher?: string | null;
   customerNote?: string | null;
-  channel?: string | null;
+  channelId?: string | null;
   redirectUrl?: string | null;
   lines?: (OrderLineCreateInput | null)[] | null;
 }
@@ -1312,7 +1311,7 @@ export interface DraftOrderInput {
   shippingMethod?: string | null;
   voucher?: string | null;
   customerNote?: string | null;
-  channel?: string | null;
+  channelId?: string | null;
   redirectUrl?: string | null;
 }
 


### PR DESCRIPTION
I want to merge this change because it unified uses of channel id as param in graphql mutations. Mostly it changes channel -> channelId

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://saleor-3437-unify-channel-id-params.api.saleor.rocks/graphql/