### PR TITLE
Implement attribute values pagination for pages

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export const DEFAULT_INITIAL_PAGINATION_DATA: Pagination = {
 };
 
 export const PAGINATE_BY = 20;
+export const VALUES_PAGINATE_BY = 10;
 
 export type ProductListColumns = "productType" | "availability" | "price";
 export interface AppListViewSettings {

--- a/src/fragments/pages.ts
+++ b/src/fragments/pages.ts
@@ -1,6 +1,9 @@
 import gql from "graphql-tag";
 
-import { attributeValueFragment } from "./attributes";
+import {
+  attributeValueFragment,
+  attributeValueListFragment
+} from "./attributes";
 import { metadataFragment } from "./metadata";
 
 export const pageFragment = gql`
@@ -14,6 +17,7 @@ export const pageFragment = gql`
 
 export const pageAttributesFragment = gql`
   ${attributeValueFragment}
+  ${attributeValueListFragment}
   fragment PageAttributesFragment on Page {
     attributes {
       attribute {
@@ -24,9 +28,14 @@ export const pageAttributesFragment = gql`
         entityType
         valueRequired
         unit
-        # values {
-        #   ...AttributeValueFragment
-        # }
+        choices(
+          first: $firstValues
+          after: $afterValues
+          last: $lastValues
+          before: $beforeValues
+        ) {
+          ...AttributeValueListFragment
+        }
       }
       values {
         ...AttributeValueFragment
@@ -41,9 +50,14 @@ export const pageAttributesFragment = gql`
         inputType
         entityType
         valueRequired
-        # values {
-        #   ...AttributeValueFragment
-        # }
+        choices(
+          first: $firstValues
+          after: $afterValues
+          last: $lastValues
+          before: $beforeValues
+        ) {
+          ...AttributeValueListFragment
+        }
       }
     }
   }

--- a/src/fragments/types/PageAttributesFragment.ts
+++ b/src/fragments/types/PageAttributesFragment.ts
@@ -9,20 +9,40 @@ import { AttributeInputTypeEnum, AttributeEntityTypeEnum, MeasurementUnitsEnum }
 // GraphQL fragment: PageAttributesFragment
 // ====================================================
 
-export interface PageAttributesFragment_attributes_attribute_values_file {
+export interface PageAttributesFragment_attributes_attribute_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageAttributesFragment_attributes_attribute_choices_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface PageAttributesFragment_attributes_attribute_values {
+export interface PageAttributesFragment_attributes_attribute_choices_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: PageAttributesFragment_attributes_attribute_values_file | null;
+  file: PageAttributesFragment_attributes_attribute_choices_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface PageAttributesFragment_attributes_attribute_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageAttributesFragment_attributes_attribute_choices_edges_node;
+}
+
+export interface PageAttributesFragment_attributes_attribute_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageAttributesFragment_attributes_attribute_choices_pageInfo;
+  edges: PageAttributesFragment_attributes_attribute_choices_edges[];
 }
 
 export interface PageAttributesFragment_attributes_attribute {
@@ -34,7 +54,7 @@ export interface PageAttributesFragment_attributes_attribute {
   entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
-  values: (PageAttributesFragment_attributes_attribute_values | null)[] | null;
+  choices: PageAttributesFragment_attributes_attribute_choices | null;
 }
 
 export interface PageAttributesFragment_attributes_values_file {
@@ -59,20 +79,40 @@ export interface PageAttributesFragment_attributes {
   values: (PageAttributesFragment_attributes_values | null)[];
 }
 
-export interface PageAttributesFragment_pageType_attributes_values_file {
+export interface PageAttributesFragment_pageType_attributes_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageAttributesFragment_pageType_attributes_choices_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface PageAttributesFragment_pageType_attributes_values {
+export interface PageAttributesFragment_pageType_attributes_choices_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: PageAttributesFragment_pageType_attributes_values_file | null;
+  file: PageAttributesFragment_pageType_attributes_choices_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface PageAttributesFragment_pageType_attributes_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageAttributesFragment_pageType_attributes_choices_edges_node;
+}
+
+export interface PageAttributesFragment_pageType_attributes_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageAttributesFragment_pageType_attributes_choices_pageInfo;
+  edges: PageAttributesFragment_pageType_attributes_choices_edges[];
 }
 
 export interface PageAttributesFragment_pageType_attributes {
@@ -82,7 +122,7 @@ export interface PageAttributesFragment_pageType_attributes {
   inputType: AttributeInputTypeEnum | null;
   entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
-  values: (PageAttributesFragment_pageType_attributes_values | null)[] | null;
+  choices: PageAttributesFragment_pageType_attributes_choices | null;
 }
 
 export interface PageAttributesFragment_pageType {

--- a/src/fragments/types/PageDetailsFragment.ts
+++ b/src/fragments/types/PageDetailsFragment.ts
@@ -9,20 +9,40 @@ import { AttributeInputTypeEnum, AttributeEntityTypeEnum, MeasurementUnitsEnum }
 // GraphQL fragment: PageDetailsFragment
 // ====================================================
 
-export interface PageDetailsFragment_attributes_attribute_values_file {
+export interface PageDetailsFragment_attributes_attribute_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageDetailsFragment_attributes_attribute_choices_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface PageDetailsFragment_attributes_attribute_values {
+export interface PageDetailsFragment_attributes_attribute_choices_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: PageDetailsFragment_attributes_attribute_values_file | null;
+  file: PageDetailsFragment_attributes_attribute_choices_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface PageDetailsFragment_attributes_attribute_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageDetailsFragment_attributes_attribute_choices_edges_node;
+}
+
+export interface PageDetailsFragment_attributes_attribute_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageDetailsFragment_attributes_attribute_choices_pageInfo;
+  edges: PageDetailsFragment_attributes_attribute_choices_edges[];
 }
 
 export interface PageDetailsFragment_attributes_attribute {
@@ -34,7 +54,7 @@ export interface PageDetailsFragment_attributes_attribute {
   entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
-  values: (PageDetailsFragment_attributes_attribute_values | null)[] | null;
+  choices: PageDetailsFragment_attributes_attribute_choices | null;
 }
 
 export interface PageDetailsFragment_attributes_values_file {
@@ -59,20 +79,40 @@ export interface PageDetailsFragment_attributes {
   values: (PageDetailsFragment_attributes_values | null)[];
 }
 
-export interface PageDetailsFragment_pageType_attributes_values_file {
+export interface PageDetailsFragment_pageType_attributes_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageDetailsFragment_pageType_attributes_choices_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface PageDetailsFragment_pageType_attributes_values {
+export interface PageDetailsFragment_pageType_attributes_choices_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: PageDetailsFragment_pageType_attributes_values_file | null;
+  file: PageDetailsFragment_pageType_attributes_choices_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface PageDetailsFragment_pageType_attributes_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageDetailsFragment_pageType_attributes_choices_edges_node;
+}
+
+export interface PageDetailsFragment_pageType_attributes_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageDetailsFragment_pageType_attributes_choices_pageInfo;
+  edges: PageDetailsFragment_pageType_attributes_choices_edges[];
 }
 
 export interface PageDetailsFragment_pageType_attributes {
@@ -82,7 +122,7 @@ export interface PageDetailsFragment_pageType_attributes {
   inputType: AttributeInputTypeEnum | null;
   entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
-  values: (PageDetailsFragment_pageType_attributes_values | null)[] | null;
+  choices: PageDetailsFragment_pageType_attributes_choices | null;
 }
 
 export interface PageDetailsFragment_pageType {

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -18,10 +18,13 @@ import { PageErrorWithAttributesFragment } from "@saleor/fragments/types/PageErr
 import useDateLocalize from "@saleor/hooks/useDateLocalize";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
+import { PageType_pageType } from "@saleor/pages/types/PageType";
+import { SearchAttributeValues_attribute_choices_edges_node } from "@saleor/searches/types/SearchAttributeValues";
 import { SearchPages_search_edges_node } from "@saleor/searches/types/SearchPages";
 import { SearchPageTypes_search_edges_node } from "@saleor/searches/types/SearchPageTypes";
 import { SearchProducts_search_edges_node } from "@saleor/searches/types/SearchProducts";
 import { FetchMoreProps } from "@saleor/types";
+import { mapNodeToChoice } from "@saleor/utils/maps";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -39,6 +42,8 @@ export interface PageDetailsPageProps {
   referenceProducts?: SearchProducts_search_edges_node[];
   allowEmptySlug?: boolean;
   saveButtonBarState: ConfirmButtonTransitionState;
+  selectedPageType?: PageType_pageType;
+  attributeValues: SearchAttributeValues_attribute_choices_edges_node[];
   onBack: () => void;
   onRemove: () => void;
   onSubmit: (data: PageData) => SubmitPromise;
@@ -50,17 +55,23 @@ export interface PageDetailsPageProps {
   fetchMoreReferencePages?: FetchMoreProps;
   fetchReferenceProducts?: (data: string) => void;
   fetchMoreReferenceProducts?: FetchMoreProps;
+  fetchAttributeValues: (query: string) => void;
+  fetchMoreAttributeValues?: FetchMoreProps;
   onCloseDialog: () => void;
+  onSelectPageType?: (pageTypeId: string) => void;
+  onAttributeSelect: (id: string) => void;
 }
 
 const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
   loading,
   errors,
   page,
-  pageTypes,
+  pageTypes: pageTypeChoiceList,
   referencePages = [],
   referenceProducts = [],
   saveButtonBarState,
+  selectedPageType,
+  attributeValues,
   onBack,
   onRemove,
   onSubmit,
@@ -72,7 +83,11 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
   fetchMoreReferencePages,
   fetchReferenceProducts,
   fetchMoreReferenceProducts,
-  onCloseDialog
+  fetchAttributeValues,
+  fetchMoreAttributeValues,
+  onCloseDialog,
+  onSelectPageType,
+  onAttributeSelect
 }) => {
   const intl = useIntl();
   const localizeDate = useDateLocalize();
@@ -80,6 +95,10 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
   const pageExists = page !== null;
 
   const canOpenAssignReferencesAttributeDialog = !!assignReferencesAttributeId;
+
+  const pageTypes = pageTypeChoiceList
+    ? mapNodeToChoice(pageTypeChoiceList)
+    : [];
 
   const handleAssignReferenceAttribute = (
     attributeValues: string[],
@@ -97,10 +116,15 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
     onCloseDialog();
   };
 
+  const handleSelectPageType = (pageTypeId: string) =>
+    onSelectPageType && onSelectPageType(pageTypeId);
+
   return (
     <PageForm
       page={page}
-      pageTypes={pageTypes}
+      pageTypes={pageTypeChoiceList}
+      selectedPageType={selectedPageType}
+      onSelectPageType={handleSelectPageType}
       referencePages={referencePages}
       referenceProducts={referenceProducts}
       fetchReferencePages={fetchReferencePages}
@@ -110,7 +134,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
       assignReferencesAttributeId={assignReferencesAttributeId}
       onSubmit={onSubmit}
     >
-      {({ change, data, pageType, handlers, hasChanged, submit }) => (
+      {({ change, data, handlers, hasChanged, submit }) => (
         <Container>
           <AppHeader onBack={onBack}>
             {intl.formatMessage(sectionNames.pages)}
@@ -155,7 +179,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
               {data.attributes.length > 0 && (
                 <Attributes
                   attributes={data.attributes}
-                  attributeValues={[]}
+                  attributeValues={attributeValues}
                   disabled={loading}
                   loading={loading}
                   errors={errors}
@@ -165,9 +189,9 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
                   onReferencesRemove={handlers.selectAttributeReference}
                   onReferencesAddClick={onAssignReferencesClick}
                   onReferencesReorder={handlers.reorderAttributeValue}
-                  fetchAttributeValues={() => undefined}
-                  fetchMoreAttributeValues={undefined}
-                  onAttributeFocus={() => undefined}
+                  fetchAttributeValues={fetchAttributeValues}
+                  fetchMoreAttributeValues={fetchMoreAttributeValues}
+                  onAttributeFocus={onAttributeSelect}
                 />
               )}
               <CardSpacer />
@@ -206,8 +230,8 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
                 errors={errors}
                 disabled={loading}
                 pageTypes={pageTypes}
-                pageType={pageType}
-                pageTypeInputDisplayValue={pageType?.name || ""}
+                pageType={data.pageType}
+                pageTypeInputDisplayValue={data.pageType?.name || ""}
                 onPageTypeChange={handlers.selectPageType}
                 fetchPageTypes={fetchPageTypes}
                 fetchMorePageTypes={fetchMorePageTypes}

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -59,7 +59,7 @@ export interface PageDetailsPageProps {
   fetchMoreAttributeValues?: FetchMoreProps;
   onCloseDialog: () => void;
   onSelectPageType?: (pageTypeId: string) => void;
-  onAttributeSelect: (id: string) => void;
+  onAttributeFocus: (id: string) => void;
 }
 
 const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
@@ -87,7 +87,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
   fetchMoreAttributeValues,
   onCloseDialog,
   onSelectPageType,
-  onAttributeSelect
+  onAttributeFocus
 }) => {
   const intl = useIntl();
   const localizeDate = useDateLocalize();
@@ -191,7 +191,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
                   onReferencesReorder={handlers.reorderAttributeValue}
                   fetchAttributeValues={fetchAttributeValues}
                   fetchMoreAttributeValues={fetchMoreAttributeValues}
-                  onAttributeFocus={onAttributeSelect}
+                  onAttributeFocus={onAttributeFocus}
                 />
               )}
               <CardSpacer />

--- a/src/pages/components/PageOrganizeContent/PageOrganizeContent.tsx
+++ b/src/pages/components/PageOrganizeContent/PageOrganizeContent.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, Typography } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
-import SingleAutocompleteSelectField from "@saleor/components/SingleAutocompleteSelectField";
+import SingleAutocompleteSelectField, {
+  SingleAutocompleteChoiceType
+} from "@saleor/components/SingleAutocompleteSelectField";
 import { PageErrorFragment } from "@saleor/fragments/types/PageErrorFragment";
 import { PageTypeFragment } from "@saleor/fragments/types/PageTypeFragment";
 import { FormChange } from "@saleor/hooks/useForm";
@@ -8,7 +10,6 @@ import { makeStyles } from "@saleor/theme";
 import { FetchMoreProps } from "@saleor/types";
 import { getFormErrors } from "@saleor/utils/errors";
 import getPageErrorMessage from "@saleor/utils/errors/page";
-import { mapNodeToChoice } from "@saleor/utils/maps";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -21,7 +22,7 @@ export interface PageOrganizeContentProps {
   pageTypeInputDisplayValue?: string;
   errors: PageErrorFragment[];
   disabled: boolean;
-  pageTypes: PageTypeFragment[];
+  pageTypes: SingleAutocompleteChoiceType[];
   onPageTypeChange?: FormChange;
   fetchPageTypes?: (data: string) => void;
   fetchMorePageTypes?: FetchMoreProps;
@@ -76,8 +77,8 @@ const PageOrganizeContent: React.FC<PageOrganizeContentProps> = props => {
             helperText={getPageErrorMessage(formErrors.pageType, intl)}
             name={"pageType" as keyof PageFormData}
             onChange={onPageTypeChange}
-            value={data.pageType}
-            choices={pageTypes ? mapNodeToChoice(pageTypes) : []}
+            value={data.pageType?.id}
+            choices={pageTypes}
             InputProps={{
               autoComplete: "off"
             }}

--- a/src/pages/fixtures.ts
+++ b/src/pages/fixtures.ts
@@ -49,35 +49,57 @@ export const page: PageDetails_page = {
         inputType: AttributeInputTypeEnum.DROPDOWN,
         valueRequired: false,
         unit: null,
-        values: [
-          {
-            id: "QXR0cmlidXRlVmFsdWU6ODc=",
-            name: "Suzanne Ellison",
-            slug: "suzanne-ellison",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
+        choices: {
+          __typename: "AttributeValueCountableConnection",
+          pageInfo: {
+            __typename: "PageInfo",
+            endCursor: "",
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: ""
           },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6ODg=",
-            name: "Dennis Perkins",
-            slug: "dennis-perkins",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6ODk=",
-            name: "Dylan Lamb",
-            slug: "dylan-lamb",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          }
-        ],
+          edges: [
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6ODc=",
+                name: "Suzanne Ellison",
+                slug: "suzanne-ellison",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6ODg=",
+                name: "Dennis Perkins",
+                slug: "dennis-perkins",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6ODk=",
+                name: "Dylan Lamb",
+                slug: "dylan-lamb",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            }
+          ]
+        },
         __typename: "Attribute"
       },
       values: [
@@ -102,44 +124,70 @@ export const page: PageDetails_page = {
         inputType: AttributeInputTypeEnum.MULTISELECT,
         valueRequired: false,
         unit: null,
-        values: [
-          {
-            id: "QXR0cmlidXRlVmFsdWU6OTA=",
-            name: "Security",
-            slug: "security",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
+        choices: {
+          __typename: "AttributeValueCountableConnection",
+          pageInfo: {
+            __typename: "PageInfo",
+            endCursor: "",
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: ""
           },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6OTE=",
-            name: "Support",
-            slug: "support",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6OTI=",
-            name: "Medical",
-            slug: "medical",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6OTM=",
-            name: "General",
-            slug: "general",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          }
-        ],
+          edges: [
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6OTA=",
+                name: "Security",
+                slug: "security",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6OTE=",
+                name: "Support",
+                slug: "support",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6OTI=",
+                name: "Medical",
+                slug: "medical",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6OTM=",
+                name: "General",
+                slug: "general",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            }
+          ]
+        },
         __typename: "Attribute"
       },
       values: [
@@ -177,35 +225,57 @@ export const page: PageDetails_page = {
         entityType: null,
         inputType: AttributeInputTypeEnum.DROPDOWN,
         valueRequired: false,
-        values: [
-          {
-            id: "QXR0cmlidXRlVmFsdWU6ODc=",
-            name: "Suzanne Ellison",
-            slug: "suzanne-ellison",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
+        choices: {
+          __typename: "AttributeValueCountableConnection",
+          pageInfo: {
+            __typename: "PageInfo",
+            endCursor: "",
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: ""
           },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6ODg=",
-            name: "Dennis Perkins",
-            slug: "dennis-perkins",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6ODk=",
-            name: "Dylan Lamb",
-            slug: "dylan-lamb",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          }
-        ],
+          edges: [
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6ODc=",
+                name: "Suzanne Ellison",
+                slug: "suzanne-ellison",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6ODg=",
+                name: "Dennis Perkins",
+                slug: "dennis-perkins",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6ODk=",
+                name: "Dylan Lamb",
+                slug: "dylan-lamb",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            }
+          ]
+        },
         __typename: "Attribute"
       },
       {
@@ -214,44 +284,70 @@ export const page: PageDetails_page = {
         entityType: null,
         inputType: AttributeInputTypeEnum.MULTISELECT,
         valueRequired: false,
-        values: [
-          {
-            id: "QXR0cmlidXRlVmFsdWU6OTA=",
-            name: "Security",
-            slug: "security",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
+        choices: {
+          __typename: "AttributeValueCountableConnection",
+          pageInfo: {
+            __typename: "PageInfo",
+            endCursor: "",
+            hasNextPage: false,
+            hasPreviousPage: false,
+            startCursor: ""
           },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6OTE=",
-            name: "Support",
-            slug: "support",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6OTI=",
-            name: "Medical",
-            slug: "medical",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          },
-          {
-            id: "QXR0cmlidXRlVmFsdWU6OTM=",
-            name: "General",
-            slug: "general",
-            reference: null,
-            __typename: "AttributeValue",
-            file: null,
-            richText: null
-          }
-        ],
+          edges: [
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6OTA=",
+                name: "Security",
+                slug: "security",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6OTE=",
+                name: "Support",
+                slug: "support",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6OTI=",
+                name: "Medical",
+                slug: "medical",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            },
+            {
+              __typename: "AttributeValueCountableEdge",
+              cursor: "",
+              node: {
+                id: "QXR0cmlidXRlVmFsdWU6OTM=",
+                name: "General",
+                slug: "general",
+                reference: null,
+                __typename: "AttributeValue",
+                file: null,
+                richText: null
+              }
+            }
+          ]
+        },
         __typename: "Attribute"
       }
     ]

--- a/src/pages/mutations.ts
+++ b/src/pages/mutations.ts
@@ -20,7 +20,6 @@ import { PageRemove, PageRemoveVariables } from "./types/PageRemove";
 import { PageUpdate, PageUpdateVariables } from "./types/PageUpdate";
 
 const pageCreate = gql`
-  ${pageDetailsFragment}
   ${pageErrorWithAttributesFragment}
   mutation PageCreate($input: PageCreateInput!) {
     pageCreate(input: $input) {
@@ -29,7 +28,7 @@ const pageCreate = gql`
         message
       }
       page {
-        ...PageDetailsFragment
+        id
       }
     }
   }
@@ -41,7 +40,14 @@ export const TypedPageCreate = TypedMutation<PageCreate, PageCreateVariables>(
 const pageUpdate = gql`
   ${pageDetailsFragment}
   ${pageErrorWithAttributesFragment}
-  mutation PageUpdate($id: ID!, $input: PageInput!) {
+  mutation PageUpdate(
+    $id: ID!
+    $input: PageInput!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     pageUpdate(id: $id, input: $input) {
       errors {
         ...PageErrorWithAttributesFragment

--- a/src/pages/queries.ts
+++ b/src/pages/queries.ts
@@ -1,3 +1,4 @@
+import { attributeValueListFragment } from "@saleor/fragments/attributes";
 import { pageDetailsFragment, pageFragment } from "@saleor/fragments/pages";
 import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
@@ -5,6 +6,7 @@ import gql from "graphql-tag";
 import { PageCount, PageCountVariables } from "./types/PageCount";
 import { PageDetails, PageDetailsVariables } from "./types/PageDetails";
 import { PageList, PageListVariables } from "./types/PageList";
+import { PageType, PageTypeVariables } from "./types/PageType";
 
 const pageList = gql`
   ${pageFragment}
@@ -42,7 +44,13 @@ export const usePageListQuery = makeQuery<PageList, PageListVariables>(
 
 const pageDetails = gql`
   ${pageDetailsFragment}
-  query PageDetails($id: ID!) {
+  query PageDetails(
+    $id: ID!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
     page(id: $id) {
       ...PageDetailsFragment
     }
@@ -50,6 +58,41 @@ const pageDetails = gql`
 `;
 export const usePageDetailsQuery = makeQuery<PageDetails, PageDetailsVariables>(
   pageDetails
+);
+
+const pageTypeQuery = gql`
+  ${attributeValueListFragment}
+  query PageType(
+    $id: ID!
+    $firstValues: Int
+    $afterValues: String
+    $lastValues: Int
+    $beforeValues: String
+  ) {
+    pageType(id: $id) {
+      id
+      name
+      attributes {
+        id
+        inputType
+        entityType
+        slug
+        name
+        valueRequired
+        choices(
+          first: $firstValues
+          after: $afterValues
+          last: $lastValues
+          before: $beforeValues
+        ) {
+          ...AttributeValueListFragment
+        }
+      }
+    }
+  }
+`;
+export const usePageTypeQuery = makeQuery<PageType, PageTypeVariables>(
+  pageTypeQuery
 );
 
 const pageCountQuery = gql`

--- a/src/pages/types/PageCreate.ts
+++ b/src/pages/types/PageCreate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { PageCreateInput, PageErrorCode, AttributeInputTypeEnum, AttributeEntityTypeEnum, MeasurementUnitsEnum } from "./../../types/globalTypes";
+import { PageCreateInput, PageErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: PageCreate
@@ -17,115 +17,9 @@ export interface PageCreate_pageCreate_errors {
   message: string | null;
 }
 
-export interface PageCreate_pageCreate_page_attributes_attribute_values_file {
-  __typename: "File";
-  url: string;
-  contentType: string | null;
-}
-
-export interface PageCreate_pageCreate_page_attributes_attribute_values {
-  __typename: "AttributeValue";
-  id: string;
-  name: string | null;
-  slug: string | null;
-  file: PageCreate_pageCreate_page_attributes_attribute_values_file | null;
-  reference: string | null;
-  richText: any | null;
-}
-
-export interface PageCreate_pageCreate_page_attributes_attribute {
-  __typename: "Attribute";
-  id: string;
-  slug: string | null;
-  name: string | null;
-  inputType: AttributeInputTypeEnum | null;
-  entityType: AttributeEntityTypeEnum | null;
-  valueRequired: boolean;
-  unit: MeasurementUnitsEnum | null;
-  values: (PageCreate_pageCreate_page_attributes_attribute_values | null)[] | null;
-}
-
-export interface PageCreate_pageCreate_page_attributes_values_file {
-  __typename: "File";
-  url: string;
-  contentType: string | null;
-}
-
-export interface PageCreate_pageCreate_page_attributes_values {
-  __typename: "AttributeValue";
-  id: string;
-  name: string | null;
-  slug: string | null;
-  file: PageCreate_pageCreate_page_attributes_values_file | null;
-  reference: string | null;
-  richText: any | null;
-}
-
-export interface PageCreate_pageCreate_page_attributes {
-  __typename: "SelectedAttribute";
-  attribute: PageCreate_pageCreate_page_attributes_attribute;
-  values: (PageCreate_pageCreate_page_attributes_values | null)[];
-}
-
-export interface PageCreate_pageCreate_page_pageType_attributes_values_file {
-  __typename: "File";
-  url: string;
-  contentType: string | null;
-}
-
-export interface PageCreate_pageCreate_page_pageType_attributes_values {
-  __typename: "AttributeValue";
-  id: string;
-  name: string | null;
-  slug: string | null;
-  file: PageCreate_pageCreate_page_pageType_attributes_values_file | null;
-  reference: string | null;
-  richText: any | null;
-}
-
-export interface PageCreate_pageCreate_page_pageType_attributes {
-  __typename: "Attribute";
-  id: string;
-  name: string | null;
-  inputType: AttributeInputTypeEnum | null;
-  entityType: AttributeEntityTypeEnum | null;
-  valueRequired: boolean;
-  values: (PageCreate_pageCreate_page_pageType_attributes_values | null)[] | null;
-}
-
-export interface PageCreate_pageCreate_page_pageType {
-  __typename: "PageType";
-  id: string;
-  name: string;
-  attributes: (PageCreate_pageCreate_page_pageType_attributes | null)[] | null;
-}
-
-export interface PageCreate_pageCreate_page_metadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
-export interface PageCreate_pageCreate_page_privateMetadata {
-  __typename: "MetadataItem";
-  key: string;
-  value: string;
-}
-
 export interface PageCreate_pageCreate_page {
   __typename: "Page";
   id: string;
-  title: string;
-  slug: string;
-  isPublished: boolean;
-  attributes: PageCreate_pageCreate_page_attributes[];
-  pageType: PageCreate_pageCreate_page_pageType;
-  metadata: (PageCreate_pageCreate_page_metadata | null)[];
-  privateMetadata: (PageCreate_pageCreate_page_privateMetadata | null)[];
-  content: any | null;
-  seoTitle: string | null;
-  seoDescription: string | null;
-  publicationDate: any | null;
 }
 
 export interface PageCreate_pageCreate {

--- a/src/pages/types/PageDetails.ts
+++ b/src/pages/types/PageDetails.ts
@@ -9,20 +9,40 @@ import { AttributeInputTypeEnum, AttributeEntityTypeEnum, MeasurementUnitsEnum }
 // GraphQL query operation: PageDetails
 // ====================================================
 
-export interface PageDetails_page_attributes_attribute_values_file {
+export interface PageDetails_page_attributes_attribute_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageDetails_page_attributes_attribute_choices_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface PageDetails_page_attributes_attribute_values {
+export interface PageDetails_page_attributes_attribute_choices_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: PageDetails_page_attributes_attribute_values_file | null;
+  file: PageDetails_page_attributes_attribute_choices_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface PageDetails_page_attributes_attribute_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageDetails_page_attributes_attribute_choices_edges_node;
+}
+
+export interface PageDetails_page_attributes_attribute_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageDetails_page_attributes_attribute_choices_pageInfo;
+  edges: PageDetails_page_attributes_attribute_choices_edges[];
 }
 
 export interface PageDetails_page_attributes_attribute {
@@ -34,7 +54,7 @@ export interface PageDetails_page_attributes_attribute {
   entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
-  values: (PageDetails_page_attributes_attribute_values | null)[] | null;
+  choices: PageDetails_page_attributes_attribute_choices | null;
 }
 
 export interface PageDetails_page_attributes_values_file {
@@ -59,20 +79,40 @@ export interface PageDetails_page_attributes {
   values: (PageDetails_page_attributes_values | null)[];
 }
 
-export interface PageDetails_page_pageType_attributes_values_file {
+export interface PageDetails_page_pageType_attributes_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageDetails_page_pageType_attributes_choices_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface PageDetails_page_pageType_attributes_values {
+export interface PageDetails_page_pageType_attributes_choices_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: PageDetails_page_pageType_attributes_values_file | null;
+  file: PageDetails_page_pageType_attributes_choices_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface PageDetails_page_pageType_attributes_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageDetails_page_pageType_attributes_choices_edges_node;
+}
+
+export interface PageDetails_page_pageType_attributes_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageDetails_page_pageType_attributes_choices_pageInfo;
+  edges: PageDetails_page_pageType_attributes_choices_edges[];
 }
 
 export interface PageDetails_page_pageType_attributes {
@@ -82,7 +122,7 @@ export interface PageDetails_page_pageType_attributes {
   inputType: AttributeInputTypeEnum | null;
   entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
-  values: (PageDetails_page_pageType_attributes_values | null)[] | null;
+  choices: PageDetails_page_pageType_attributes_choices | null;
 }
 
 export interface PageDetails_page_pageType {
@@ -126,4 +166,8 @@ export interface PageDetails {
 
 export interface PageDetailsVariables {
   id: string;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/pages/types/PageType.ts
+++ b/src/pages/types/PageType.ts
@@ -1,0 +1,76 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: PageType
+// ====================================================
+
+export interface PageType_pageType_attributes_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageType_pageType_attributes_choices_edges_node_file {
+  __typename: "File";
+  url: string;
+  contentType: string | null;
+}
+
+export interface PageType_pageType_attributes_choices_edges_node {
+  __typename: "AttributeValue";
+  id: string;
+  name: string | null;
+  slug: string | null;
+  file: PageType_pageType_attributes_choices_edges_node_file | null;
+  reference: string | null;
+  richText: any | null;
+}
+
+export interface PageType_pageType_attributes_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageType_pageType_attributes_choices_edges_node;
+}
+
+export interface PageType_pageType_attributes_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageType_pageType_attributes_choices_pageInfo;
+  edges: PageType_pageType_attributes_choices_edges[];
+}
+
+export interface PageType_pageType_attributes {
+  __typename: "Attribute";
+  id: string;
+  inputType: AttributeInputTypeEnum | null;
+  entityType: AttributeEntityTypeEnum | null;
+  slug: string | null;
+  name: string | null;
+  valueRequired: boolean;
+  choices: PageType_pageType_attributes_choices | null;
+}
+
+export interface PageType_pageType {
+  __typename: "PageType";
+  id: string;
+  name: string;
+  attributes: (PageType_pageType_attributes | null)[] | null;
+}
+
+export interface PageType {
+  pageType: PageType_pageType | null;
+}
+
+export interface PageTypeVariables {
+  id: string;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
+}

--- a/src/pages/types/PageUpdate.ts
+++ b/src/pages/types/PageUpdate.ts
@@ -16,20 +16,40 @@ export interface PageUpdate_pageUpdate_errors {
   attributes: string[] | null;
 }
 
-export interface PageUpdate_pageUpdate_page_attributes_attribute_values_file {
+export interface PageUpdate_pageUpdate_page_attributes_attribute_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageUpdate_pageUpdate_page_attributes_attribute_choices_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface PageUpdate_pageUpdate_page_attributes_attribute_values {
+export interface PageUpdate_pageUpdate_page_attributes_attribute_choices_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: PageUpdate_pageUpdate_page_attributes_attribute_values_file | null;
+  file: PageUpdate_pageUpdate_page_attributes_attribute_choices_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface PageUpdate_pageUpdate_page_attributes_attribute_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageUpdate_pageUpdate_page_attributes_attribute_choices_edges_node;
+}
+
+export interface PageUpdate_pageUpdate_page_attributes_attribute_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageUpdate_pageUpdate_page_attributes_attribute_choices_pageInfo;
+  edges: PageUpdate_pageUpdate_page_attributes_attribute_choices_edges[];
 }
 
 export interface PageUpdate_pageUpdate_page_attributes_attribute {
@@ -41,7 +61,7 @@ export interface PageUpdate_pageUpdate_page_attributes_attribute {
   entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
   unit: MeasurementUnitsEnum | null;
-  values: (PageUpdate_pageUpdate_page_attributes_attribute_values | null)[] | null;
+  choices: PageUpdate_pageUpdate_page_attributes_attribute_choices | null;
 }
 
 export interface PageUpdate_pageUpdate_page_attributes_values_file {
@@ -66,20 +86,40 @@ export interface PageUpdate_pageUpdate_page_attributes {
   values: (PageUpdate_pageUpdate_page_attributes_values | null)[];
 }
 
-export interface PageUpdate_pageUpdate_page_pageType_attributes_values_file {
+export interface PageUpdate_pageUpdate_page_pageType_attributes_choices_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface PageUpdate_pageUpdate_page_pageType_attributes_choices_edges_node_file {
   __typename: "File";
   url: string;
   contentType: string | null;
 }
 
-export interface PageUpdate_pageUpdate_page_pageType_attributes_values {
+export interface PageUpdate_pageUpdate_page_pageType_attributes_choices_edges_node {
   __typename: "AttributeValue";
   id: string;
   name: string | null;
   slug: string | null;
-  file: PageUpdate_pageUpdate_page_pageType_attributes_values_file | null;
+  file: PageUpdate_pageUpdate_page_pageType_attributes_choices_edges_node_file | null;
   reference: string | null;
   richText: any | null;
+}
+
+export interface PageUpdate_pageUpdate_page_pageType_attributes_choices_edges {
+  __typename: "AttributeValueCountableEdge";
+  cursor: string;
+  node: PageUpdate_pageUpdate_page_pageType_attributes_choices_edges_node;
+}
+
+export interface PageUpdate_pageUpdate_page_pageType_attributes_choices {
+  __typename: "AttributeValueCountableConnection";
+  pageInfo: PageUpdate_pageUpdate_page_pageType_attributes_choices_pageInfo;
+  edges: PageUpdate_pageUpdate_page_pageType_attributes_choices_edges[];
 }
 
 export interface PageUpdate_pageUpdate_page_pageType_attributes {
@@ -89,7 +129,7 @@ export interface PageUpdate_pageUpdate_page_pageType_attributes {
   inputType: AttributeInputTypeEnum | null;
   entityType: AttributeEntityTypeEnum | null;
   valueRequired: boolean;
-  values: (PageUpdate_pageUpdate_page_pageType_attributes_values | null)[] | null;
+  choices: PageUpdate_pageUpdate_page_pageType_attributes_choices | null;
 }
 
 export interface PageUpdate_pageUpdate_page_pageType {
@@ -140,4 +180,8 @@ export interface PageUpdate {
 export interface PageUpdateVariables {
   id: string;
   input: PageInput;
+  firstValues?: number | null;
+  afterValues?: string | null;
+  lastValues?: number | null;
+  beforeValues?: string | null;
 }

--- a/src/pages/utils/data.ts
+++ b/src/pages/utils/data.ts
@@ -1,5 +1,6 @@
 import { getSelectedAttributeValues } from "@saleor/attributes/utils/data";
 import { AttributeInput } from "@saleor/components/Attributes";
+import { mapEdgesToItems } from "@saleor/utils/maps";
 
 import {
   PageDetails_page,
@@ -15,7 +16,7 @@ export function getAttributeInputFromPage(
       inputType: attribute.attribute.inputType,
       isRequired: attribute.attribute.valueRequired,
       selectedValues: attribute.values,
-      values: attribute.attribute.values,
+      values: mapEdgesToItems(attribute.attribute.choices),
       unit: attribute.attribute.unit
     },
     id: attribute.attribute.id,
@@ -32,7 +33,7 @@ export function getAttributeInputFromPageType(
       entityType: attribute.entityType,
       inputType: attribute.inputType,
       isRequired: attribute.valueRequired,
-      values: attribute.values
+      values: mapEdgesToItems(attribute.choices)
     },
     id: attribute.id,
     label: attribute.name,

--- a/src/pages/utils/handlers.ts
+++ b/src/pages/utils/handlers.ts
@@ -1,24 +1,12 @@
-import { AttributeInputData } from "@saleor/components/Attributes";
 import { FormChange } from "@saleor/hooks/useForm";
-import { FormsetData } from "@saleor/hooks/useFormset";
-
-import { PageDetails_page_pageType } from "../types/PageDetails";
-import { getAttributeInputFromPageType } from "./data";
 
 export function createPageTypeSelectHandler(
-  change: FormChange,
-  setAttributes: (data: FormsetData<AttributeInputData>) => void,
-  setPageType: (pageType: PageDetails_page_pageType) => void,
-  pageTypeChoiceList: PageDetails_page_pageType[]
+  setPageType: (pageTypeId: string) => void,
+  triggerChange: () => void
 ): FormChange {
   return (event: React.ChangeEvent<any>) => {
     const id = event.target.value;
-    const selectedPageType = pageTypeChoiceList.find(
-      pageType => pageType.id === id
-    );
-    setPageType(selectedPageType);
-    change(event);
-
-    setAttributes(getAttributeInputFromPageType(selectedPageType));
+    setPageType(id);
+    triggerChange();
   };
 }

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -5,7 +5,10 @@ import {
 } from "@saleor/attributes/utils/handlers";
 import { AttributeInput } from "@saleor/components/Attributes";
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
+import {
+  DEFAULT_INITIAL_SEARCH_DATA,
+  VALUES_PAGINATE_BY
+} from "@saleor/config";
 import { useFileUploadMutation } from "@saleor/files/mutations";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
@@ -86,7 +89,7 @@ export const PageCreate: React.FC<PageCreateProps> = ({ params }) => {
   const { data: selectedPageType } = usePageTypeQuery({
     variables: {
       id: selectedPageTypeId,
-      firstValues: 10
+      firstValues: VALUES_PAGINATE_BY
     },
     skip: !selectedPageTypeId
   });

--- a/src/pages/views/PageCreate.tsx
+++ b/src/pages/views/PageCreate.tsx
@@ -73,17 +73,17 @@ export const PageCreate: React.FC<PageCreateProps> = ({ params }) => {
   } = useProductSearch({
     variables: DEFAULT_INITIAL_SEARCH_DATA
   });
-  const [selectedAttribute, setSelectedAttribute] = useState<string>();
+  const [focusedAttribute, setFocusedAttribute] = useState<string>();
   const {
     loadMore: loadMoreAttributeValues,
     search: searchAttributeValues,
     result: searchAttributeValuesOpts
   } = useAttributeValueSearch({
     variables: {
-      id: selectedAttribute,
+      id: focusedAttribute,
       ...DEFAULT_INITIAL_SEARCH_DATA
     },
-    skip: !selectedAttribute
+    skip: !focusedAttribute
   });
 
   const { data: selectedPageType } = usePageTypeQuery({
@@ -222,7 +222,7 @@ export const PageCreate: React.FC<PageCreateProps> = ({ params }) => {
               onCloseDialog={() => navigate(pageCreateUrl())}
               selectedPageType={selectedPageType?.pageType}
               onSelectPageType={id => setSelectedPageTypeId(id)}
-              onAttributeSelect={setSelectedAttribute}
+              onAttributeFocus={setFocusedAttribute}
             />
           </>
         );

--- a/src/pages/views/PageDetails.tsx
+++ b/src/pages/views/PageDetails.tsx
@@ -173,17 +173,17 @@ export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
   } = useProductSearch({
     variables: DEFAULT_INITIAL_SEARCH_DATA
   });
-  const [selectedAttribute, setSelectedAttribute] = useState<string>();
+  const [focusedAttribute, setFocusedAttribute] = useState<string>();
   const {
     loadMore: loadMoreAttributeValues,
     search: searchAttributeValues,
     result: searchAttributeValuesOpts
   } = useAttributeValueSearch({
     variables: {
-      id: selectedAttribute,
+      id: focusedAttribute,
       ...DEFAULT_INITIAL_SEARCH_DATA
     },
-    skip: !selectedAttribute
+    skip: !focusedAttribute
   });
 
   const attributeValues = mapEdgesToItems(
@@ -243,7 +243,7 @@ export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
         fetchAttributeValues={searchAttributeValues}
         fetchMoreAttributeValues={fetchMoreAttributeValues}
         onCloseDialog={() => navigate(pageUrl(id))}
-        onAttributeSelect={setSelectedAttribute}
+        onAttributeFocus={setFocusedAttribute}
       />
       <ActionDialog
         open={params.action === "remove"}

--- a/src/pages/views/PageDetails.tsx
+++ b/src/pages/views/PageDetails.tsx
@@ -13,7 +13,10 @@ import {
 import ActionDialog from "@saleor/components/ActionDialog";
 import { AttributeInput } from "@saleor/components/Attributes";
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
+import {
+  DEFAULT_INITIAL_SEARCH_DATA,
+  VALUES_PAGINATE_BY
+} from "@saleor/config";
 import { useFileUploadMutation } from "@saleor/files/mutations";
 import { AttributeErrorFragment } from "@saleor/fragments/types/AttributeErrorFragment";
 import { PageErrorFragment } from "@saleor/fragments/types/PageErrorFragment";
@@ -77,7 +80,7 @@ export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
   const pageDetails = usePageDetailsQuery({
     variables: {
       id,
-      firstValues: 10
+      firstValues: VALUES_PAGINATE_BY
     }
   });
 
@@ -135,7 +138,7 @@ export const PageDetails: React.FC<PageDetailsProps> = ({ id, params }) => {
       variables: {
         id,
         input: createPageInput(data, updatedFileAttributes),
-        firstValues: 10
+        firstValues: VALUES_PAGINATE_BY
       }
     });
 

--- a/src/products/components/ProductCreatePage/ProductCreatePage.tsx
+++ b/src/products/components/ProductCreatePage/ProductCreatePage.tsx
@@ -194,7 +194,6 @@ export const ProductCreatePage: React.FC<ProductCreatePageProps> = ({
       taxTypes={taxTypeChoices}
       warehouses={warehouses}
       currentChannels={currentChannels}
-      productTypeChoiceList={productTypeChoiceList}
       fetchReferencePages={fetchReferencePages}
       fetchMoreReferencePages={fetchMoreReferencePages}
       fetchReferenceProducts={fetchReferenceProducts}

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -129,7 +129,6 @@ export interface UseProductCreateFormOpts
   productTypes: SearchProductTypes_search_edges_node[];
   warehouses: SearchWarehouses_search_edges_node[];
   currentChannels: ChannelData[];
-  productTypeChoiceList: SearchProductTypes_search_edges_node[];
   referencePages: SearchPages_search_edges_node[];
   referenceProducts: SearchProducts_search_edges_node[];
   fetchReferencePages?: (data: string) => void;

--- a/src/products/views/ProductCreate/ProductCreate.tsx
+++ b/src/products/views/ProductCreate/ProductCreate.tsx
@@ -3,7 +3,10 @@ import useAppChannel from "@saleor/components/AppLayout/AppChannelContext";
 import { AttributeInput } from "@saleor/components/Attributes";
 import ChannelsAvailabilityDialog from "@saleor/components/ChannelsAvailabilityDialog";
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
+import {
+  DEFAULT_INITIAL_SEARCH_DATA,
+  VALUES_PAGINATE_BY
+} from "@saleor/config";
 import { useFileUploadMutation } from "@saleor/files/mutations";
 import useChannels from "@saleor/hooks/useChannels";
 import useNavigator from "@saleor/hooks/useNavigator";
@@ -127,7 +130,7 @@ export const ProductCreateView: React.FC<ProductCreateProps> = ({ params }) => {
   const { data: selectedProductType } = useProductTypeQuery({
     variables: {
       id: selectedProductTypeId,
-      firstValues: 10
+      firstValues: VALUES_PAGINATE_BY
     },
     skip: !selectedProductTypeId
   });

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -15,7 +15,10 @@ import ChannelsAvailabilityDialog from "@saleor/components/ChannelsAvailabilityD
 import NotFoundPage from "@saleor/components/NotFoundPage";
 import { useShopLimitsQuery } from "@saleor/components/Shop/query";
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
+import {
+  DEFAULT_INITIAL_SEARCH_DATA,
+  VALUES_PAGINATE_BY
+} from "@saleor/config";
 import { useFileUploadMutation } from "@saleor/files/mutations";
 import { getSearchFetchMoreProps } from "@saleor/hooks/makeTopLevelSearch/utils";
 import useBulkActions from "@saleor/hooks/useBulkActions";
@@ -172,7 +175,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     displayLoader: true,
     variables: {
       id,
-      firstValues: 10
+      firstValues: VALUES_PAGINATE_BY
     }
   });
   const limitOpts = useShopLimitsQuery({

--- a/src/products/views/ProductUpdate/handlers/index.ts
+++ b/src/products/views/ProductUpdate/handlers/index.ts
@@ -13,6 +13,7 @@ import {
   prepareAttributesInput
 } from "@saleor/attributes/utils/handlers";
 import { ChannelData } from "@saleor/channels/utils";
+import { VALUES_PAGINATE_BY } from "@saleor/config";
 import {
   FileUpload,
   FileUploadVariables
@@ -146,7 +147,7 @@ export function createUpdateHandler(
         slug: data.slug,
         taxCode: data.changeTaxCode ? data.taxCode : null
       },
-      firstValues: 10
+      firstValues: VALUES_PAGINATE_BY
     };
 
     if (product.productType.hasVariants) {

--- a/src/searches/types/SearchPageTypes.ts
+++ b/src/searches/types/SearchPageTypes.ts
@@ -3,44 +3,14 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { AttributeInputTypeEnum, AttributeEntityTypeEnum } from "./../../types/globalTypes";
-
 // ====================================================
 // GraphQL query operation: SearchPageTypes
 // ====================================================
-
-export interface SearchPageTypes_search_edges_node_attributes_values_file {
-  __typename: "File";
-  url: string;
-  contentType: string | null;
-}
-
-export interface SearchPageTypes_search_edges_node_attributes_values {
-  __typename: "AttributeValue";
-  id: string;
-  name: string | null;
-  slug: string | null;
-  file: SearchPageTypes_search_edges_node_attributes_values_file | null;
-  reference: string | null;
-  richText: any | null;
-}
-
-export interface SearchPageTypes_search_edges_node_attributes {
-  __typename: "Attribute";
-  id: string;
-  inputType: AttributeInputTypeEnum | null;
-  entityType: AttributeEntityTypeEnum | null;
-  slug: string | null;
-  name: string | null;
-  valueRequired: boolean;
-  values: (SearchPageTypes_search_edges_node_attributes_values | null)[] | null;
-}
 
 export interface SearchPageTypes_search_edges_node {
   __typename: "PageType";
   id: string;
   name: string;
-  attributes: (SearchPageTypes_search_edges_node_attributes | null)[] | null;
 }
 
 export interface SearchPageTypes_search_edges {

--- a/src/searches/usePageTypeSearch.ts
+++ b/src/searches/usePageTypeSearch.ts
@@ -1,4 +1,3 @@
-import { attributeValueFragment } from "@saleor/fragments/attributes";
 import { pageInfoFragment } from "@saleor/fragments/pageInfo";
 import makeTopLevelSearch from "@saleor/hooks/makeTopLevelSearch";
 import gql from "graphql-tag";
@@ -9,7 +8,6 @@ import {
 } from "./types/SearchPageTypes";
 
 export const searchPageTypes = gql`
-  ${attributeValueFragment}
   ${pageInfoFragment}
   query SearchPageTypes($after: String, $first: Int!, $query: String!) {
     search: pageTypes(
@@ -21,17 +19,6 @@ export const searchPageTypes = gql`
         node {
           id
           name
-          attributes {
-            id
-            inputType
-            entityType
-            slug
-            name
-            valueRequired
-            # values {
-            #   ...AttributeValueFragment
-            # }
-          }
         }
       }
       pageInfo {

--- a/src/storybook/stories/pages/PageDetailsPage.tsx
+++ b/src/storybook/stories/pages/PageDetailsPage.tsx
@@ -25,7 +25,7 @@ const props: PageDetailsPageProps = {
   saveButtonBarState: "default",
   fetchAttributeValues: () => undefined,
   fetchMoreAttributeValues: fetchMoreProps,
-  onAttributeSelect: () => undefined
+  onAttributeFocus: () => undefined
 };
 
 storiesOf("Views / Pages / Page details", module)

--- a/src/storybook/stories/pages/PageDetailsPage.tsx
+++ b/src/storybook/stories/pages/PageDetailsPage.tsx
@@ -1,3 +1,4 @@
+import { fetchMoreProps } from "@saleor/fixtures";
 import { PageData } from "@saleor/pages/components/PageDetailsPage/form";
 import { PageErrorCode } from "@saleor/types/globalTypes";
 import { storiesOf } from "@storybook/react";
@@ -20,7 +21,11 @@ const props: PageDetailsPageProps = {
   page,
   referencePages: [],
   referenceProducts: [],
-  saveButtonBarState: "default"
+  attributeValues: [],
+  saveButtonBarState: "default",
+  fetchAttributeValues: () => undefined,
+  fetchMoreAttributeValues: fetchMoreProps,
+  onAttributeSelect: () => undefined
 };
 
 storiesOf("Views / Pages / Page details", module)


### PR DESCRIPTION
I want to merge this change because... it adds page attribute values pagination support, in the following views:
- page details view
- page create view (+ optimization: query page type attributes only after page type select)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://saleor-3071-paginate-attributes.api.saleor.rocks/graphql/