### PR TITLE
Fix Category list layout overlapping.

### DIFF
--- a/src/categories/components/CategoryList/CategoryList.tsx
+++ b/src/categories/components/CategoryList/CategoryList.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles(
   theme => ({
     [theme.breakpoints.up("lg")]: {
       colName: {
-        width: 840
+        width: "auto"
       },
       colProducts: {
         width: 160


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
#1138 Category list layout overlap with the side bar.

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Before:
![Screenshot from 2021-06-05 20-54-45](https://user-images.githubusercontent.com/10531092/120902962-85831180-c643-11eb-910a-0d7a767b7089.png)

After:
![Screenshot from 2021-06-05 21-18-35](https://user-images.githubusercontent.com/10531092/120902973-9c296880-c643-11eb-9f68-a9aadf54ae29.png)




<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

- This code contains UI changes

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/