### PR TITLE
transparent bg & thicker selection border

### DIFF
--- a/src/products/components/ProductVariantImageSelectDialog/ProductVariantMediaSelectDialog.tsx
+++ b/src/products/components/ProductVariantImageSelectDialog/ProductVariantMediaSelectDialog.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles(
       width: "100%"
     },
     imageContainer: {
-      background: "#ffffff",
+      background: "transparent",
       border: "1px solid #eaeaea",
       borderRadius: theme.spacing(),
       cursor: "pointer",
@@ -43,7 +43,8 @@ const useStyles = makeStyles(
       }
     },
     selectedImageContainer: {
-      borderColor: theme.palette.primary.main
+      borderColor: theme.palette.primary.main,
+      borderWidth: "2px"
     }
   }),
   { name: "ProductVariantImageSelectDialog" }


### PR DESCRIPTION
I want to merge this change because it resolves the issue of image boxes not having visible selection borders in the variant media dialog in dark mode.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/