### PR TITLE
SALEOR-3521 - replaced skeleton placeholder in warehouse list view

### DIFF
--- a/src/warehouses/components/WarehouseList/WarehouseList.tsx
+++ b/src/warehouses/components/WarehouseList/WarehouseList.tsx
@@ -132,7 +132,7 @@ const WarehouseList: React.FC<WarehouseListProps> = props => {
               className={classes.tableRow}
               hover={!!warehouse}
               onClick={warehouse ? onRowClick(warehouse.id) : undefined}
-              key={warehouse ? warehouse.id : "skeleton"}
+              key={warehouse ? warehouse.id : "n/a"}
               data-test="warehouseEntry"
               data-testid={warehouse?.name.toLowerCase().replace(" ", "")}
             >
@@ -142,7 +142,7 @@ const WarehouseList: React.FC<WarehouseListProps> = props => {
               <TableCell className={classes.colZones} data-test="zones">
                 {mapEdgesToItems(warehouse?.shippingZones)
                   .map(({ name }) => name)
-                  .join(", ") || <Skeleton />}
+                  .join(", ") || "-"}
               </TableCell>
               <TableCell className={classes.colActions}>
                 <div className={classes.actions}>

--- a/src/warehouses/components/WarehouseList/WarehouseList.tsx
+++ b/src/warehouses/components/WarehouseList/WarehouseList.tsx
@@ -132,7 +132,7 @@ const WarehouseList: React.FC<WarehouseListProps> = props => {
               className={classes.tableRow}
               hover={!!warehouse}
               onClick={warehouse ? onRowClick(warehouse.id) : undefined}
-              key={warehouse ? warehouse.id : "n/a"}
+              key={warehouse ? warehouse.id : "skeleton"}
               data-test="warehouseEntry"
               data-testid={warehouse?.name.toLowerCase().replace(" ", "")}
             >
@@ -140,9 +140,13 @@ const WarehouseList: React.FC<WarehouseListProps> = props => {
                 {maybe<React.ReactNode>(() => warehouse.name, <Skeleton />)}
               </TableCell>
               <TableCell className={classes.colZones} data-test="zones">
-                {mapEdgesToItems(warehouse?.shippingZones)
-                  .map(({ name }) => name)
-                  .join(", ") || "-"}
+                {disabled ? (
+                  <Skeleton />
+                ) : (
+                  mapEdgesToItems(warehouse?.shippingZones)
+                    ?.map(({ name }) => name)
+                    .join(", ") || "-"
+                )}
               </TableCell>
               <TableCell className={classes.colActions}>
                 <div className={classes.actions}>

--- a/src/warehouses/components/WarehouseList/WarehouseList.tsx
+++ b/src/warehouses/components/WarehouseList/WarehouseList.tsx
@@ -140,7 +140,7 @@ const WarehouseList: React.FC<WarehouseListProps> = props => {
                 {maybe<React.ReactNode>(() => warehouse.name, <Skeleton />)}
               </TableCell>
               <TableCell className={classes.colZones} data-test="zones">
-                {disabled ? (
+                {warehouse?.shippingZones === undefined ? (
                   <Skeleton />
                 ) : (
                   mapEdgesToItems(warehouse?.shippingZones)


### PR DESCRIPTION
I want to merge this change because the skeleton placeholder for missing shipping zones on warehouse list has been replaced.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/