### PR TITLE
fix grid element height in product variants on safari

### DIFF
--- a/src/products/components/ProductVariantMedia/ProductVariantMedia.tsx
+++ b/src/products/components/ProductVariantMedia/ProductVariantMedia.tsx
@@ -32,7 +32,6 @@ const useStyles = makeStyles(
       gridColumnEnd: "span 4"
     },
     image: {
-      height: "100%",
       objectFit: "contain",
       width: "100%"
     },


### PR DESCRIPTION
I want to merge this change because it fixes the grid element height in the product variant media card on safari.
 
### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/