### PR TITLE
Fix no fetch on focus input in variant creator

### DIFF
--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorValues.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorValues.tsx
@@ -126,6 +126,7 @@ const ProductVariantCreatorValues: React.FC<ProductVariantCreatorValuesProps> = 
                   handleValueClick(attribute.id, event.target.value)
                 }
                 allowCustomValues={true}
+                fetchOnFocus={true}
                 fetchChoices={value =>
                   fetchAttributeValues(value, attribute.id)
                 }


### PR DESCRIPTION
I want to merge this change because... at the first input focus values were not fetched. Partial fix of SALEOR-3589.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/