### PR TITLE
reset metadataChanged state after submitting form

### DIFF
--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -138,7 +138,8 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
   const {
     isMetadataModified,
     isPrivateMetadataModified,
-    makeChangeHandler: makeMetadataChangeHandler
+    makeChangeHandler: makeMetadataChangeHandler,
+    resetMetadataChanged
   } = useMetadataChangeTrigger();
 
   const isOrderUnconfirmed = order?.status === OrderStatus.UNCONFIRMED;
@@ -149,16 +150,18 @@ const OrderDetailsPage: React.FC<OrderDetailsPageProps> = props => {
     line => line.quantityFulfilled < line.quantity
   );
 
-  const handleSubmit = (data: MetadataFormData) => {
+  const handleSubmit = async (data: MetadataFormData) => {
     const metadata = isMetadataModified ? data.metadata : undefined;
     const privateMetadata = isPrivateMetadataModified
       ? data.privateMetadata
       : undefined;
 
-    return onSubmit({
+    const result = await onSubmit({
       metadata,
       privateMetadata
     });
+    resetMetadataChanged();
+    return result;
   };
 
   const initial: MetadataFormData = {

--- a/src/utils/metadata/useMetadataChangeTrigger.ts
+++ b/src/utils/metadata/useMetadataChangeTrigger.ts
@@ -18,10 +18,16 @@ function useMetadataChangeTrigger() {
     onChange(event);
   };
 
+  const resetMetadataChanged = () => {
+    setMetadataModified(false);
+    setPrivateMetadataModified(false);
+  };
+
   return {
     isMetadataModified,
     isPrivateMetadataModified,
-    makeChangeHandler
+    makeChangeHandler,
+    resetMetadataChanged
   };
 }
 


### PR DESCRIPTION
I want to merge this change because it resolves the issue of both private metadata and metadata updates being sent when only one of the fields has been updated.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/