### PR TITLE
Fix app configuration frame embedding

### DIFF
--- a/src/apps/components/AppDetailsSettingsPage/AppDetailsSettingsPage.tsx
+++ b/src/apps/components/AppDetailsSettingsPage/AppDetailsSettingsPage.tsx
@@ -7,12 +7,12 @@ import Hr from "@saleor/components/Hr";
 import useTheme from "@saleor/hooks/useTheme";
 import { sectionNames } from "@saleor/intl";
 import classNames from "classnames";
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import urlJoin from "url-join";
 
 import { App_app } from "../../types/App";
 import { useStyles } from "./styles";
+import useAppConfigLoader from "./useAppConfigLoader";
 import useSettingsBreadcrumbs from "./useSettingsBreadcrumbs";
 
 export interface AppDetailsSettingsPageProps {
@@ -30,45 +30,14 @@ export const AppDetailsSettingsPage: React.FC<AppDetailsSettingsPageProps> = ({
   onBack,
   onError
 }) => {
-  const iframeRef = useRef(null);
   const intl = useIntl();
   const classes = useStyles({});
-  const { sendThemeToExtension } = useTheme();
   const [breadcrumbs, onBreadcrumbClick] = useSettingsBreadcrumbs();
-
-  useEffect(() => {
-    if (!iframeRef.current?.innerHTML && data?.configurationUrl) {
-      fetch(data?.configurationUrl, {
-        headers: {
-          "x-saleor-domain": backendHost,
-          "x-saleor-token": data.accessToken
-        },
-        method: "GET"
-      })
-        .then(async response => {
-          const url = new URL(response.url);
-          const text = await response.text();
-          const content = new DOMParser().parseFromString(text, "text/html");
-
-          const iFrame = document.createElement("iframe");
-          iFrame.src = "about:blank";
-          iFrame.id = "extension-app";
-          iframeRef.current.innerHTML = "";
-          iframeRef.current.appendChild(iFrame);
-          const iFrameDoc =
-            iFrame.contentWindow && iFrame.contentWindow.document;
-
-          const documentElement = content.documentElement;
-          const formScript = documentElement.querySelector("script");
-          const formURL = new URL(documentElement.querySelector("script").src);
-          formScript.src = `${urlJoin(url.origin, formURL.pathname)}`;
-          iFrameDoc.write(content.documentElement.innerHTML);
-          iFrameDoc.close();
-          iFrame.contentWindow.onload = sendThemeToExtension;
-        })
-        .catch(() => onError());
-    }
-  }, [data]);
+  const { sendThemeToExtension } = useTheme();
+  const frameContainer = useAppConfigLoader(data, backendHost, {
+    onError,
+    onLoad: sendThemeToExtension
+  });
 
   return (
     <Container>
@@ -135,7 +104,7 @@ export const AppDetailsSettingsPage: React.FC<AppDetailsSettingsPageProps> = ({
       <Hr />
 
       <CardSpacer />
-      <div ref={iframeRef} className={classes.iframeContainer} />
+      <div ref={frameContainer} className={classes.iframeContainer} />
       <CardSpacer />
     </Container>
   );

--- a/src/apps/components/AppDetailsSettingsPage/useAppConfigLoader.ts
+++ b/src/apps/components/AppDetailsSettingsPage/useAppConfigLoader.ts
@@ -1,5 +1,5 @@
 import { AppFragment } from "@saleor/fragments/types/AppFragment";
-import { MutableRefObject, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import urlJoin from "url-join";
 
 export type UseAppConfigLoaderCallbacks = Record<
@@ -17,17 +17,17 @@ function fixRelativeScriptSrc(origin: string) {
   };
 }
 
-async function _fetchAndSetContent(
-  frameContainer: MutableRefObject<HTMLDivElement>,
+async function fetchAndSetContent(
+  frameContainer: HTMLDivElement,
   data: AppFragment,
-  backendHost: string,
+  backendHostname: string,
   { onError, onLoad }: UseAppConfigLoaderCallbacks
 ) {
-  if (!frameContainer.current?.innerHTML && data?.configurationUrl) {
+  if (!frameContainer?.innerHTML && data?.configurationUrl) {
     try {
       const response = await fetch(data?.configurationUrl, {
         headers: {
-          "x-saleor-domain": backendHost,
+          "x-saleor-domain": backendHostname,
           "x-saleor-token": data.accessToken
         },
         method: "GET"
@@ -40,8 +40,8 @@ async function _fetchAndSetContent(
       const frame = document.createElement("iframe");
       frame.src = "about:blank";
       frame.id = "extension-app";
-      frameContainer.current.innerHTML = "";
-      frameContainer.current.appendChild(frame);
+      frameContainer.innerHTML = "";
+      frameContainer.appendChild(frame);
       const frameContent = frame.contentWindow.document;
 
       const documentElement = content.documentElement;
@@ -66,7 +66,7 @@ function useAppConfigLoader(
   const frameContainer = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    _fetchAndSetContent(frameContainer, data, backendHost, callbacks);
+    fetchAndSetContent(frameContainer.current, data, backendHost, callbacks);
   }, [data]);
 
   return frameContainer;

--- a/src/apps/components/AppDetailsSettingsPage/useAppConfigLoader.ts
+++ b/src/apps/components/AppDetailsSettingsPage/useAppConfigLoader.ts
@@ -1,0 +1,75 @@
+import { AppFragment } from "@saleor/fragments/types/AppFragment";
+import { MutableRefObject, useEffect, useRef } from "react";
+import urlJoin from "url-join";
+
+export type UseAppConfigLoaderCallbacks = Record<
+  "onLoad" | "onError",
+  () => void
+>;
+
+function fixRelativeScriptSrc(origin: string) {
+  return (node: HTMLScriptElement) => {
+    // Using node.getAttribute beacuse node.src returns absolute path
+    const src = node.getAttribute("src");
+    if (src?.startsWith("/")) {
+      node.src = urlJoin(origin, src);
+    }
+  };
+}
+
+async function _fetchAndSetContent(
+  frameContainer: MutableRefObject<HTMLDivElement>,
+  data: AppFragment,
+  backendHost: string,
+  { onError, onLoad }: UseAppConfigLoaderCallbacks
+) {
+  if (!frameContainer.current?.innerHTML && data?.configurationUrl) {
+    try {
+      const response = await fetch(data?.configurationUrl, {
+        headers: {
+          "x-saleor-domain": backendHost,
+          "x-saleor-token": data.accessToken
+        },
+        method: "GET"
+      });
+
+      const url = new URL(response.url);
+      const text = await response.text();
+      const content = new DOMParser().parseFromString(text, "text/html");
+
+      const frame = document.createElement("iframe");
+      frame.src = "about:blank";
+      frame.id = "extension-app";
+      frameContainer.current.innerHTML = "";
+      frameContainer.current.appendChild(frame);
+      const frameContent = frame.contentWindow.document;
+
+      const documentElement = content.documentElement;
+      const scriptNodes = documentElement.querySelectorAll("script");
+
+      scriptNodes.forEach(fixRelativeScriptSrc(url.origin));
+      frameContent.write(content.documentElement.innerHTML);
+      frameContent.close();
+      frame.contentWindow.onload = onLoad;
+    } catch (error) {
+      console.error(error);
+      onError();
+    }
+  }
+}
+
+function useAppConfigLoader(
+  data: AppFragment,
+  backendHost: string,
+  callbacks: UseAppConfigLoaderCallbacks
+) {
+  const frameContainer = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    _fetchAndSetContent(frameContainer, data, backendHost, callbacks);
+  }, [data]);
+
+  return frameContainer;
+}
+
+export default useAppConfigLoader;


### PR DESCRIPTION
I want to merge this change because it fixes problems with iframe scripts embedding - it currently handles cases when configuration page has no `<script />` tags at all or when they don't have `src` property. Also fixes relative path handling.

**PR intended to be tested with API branch:** master

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/