### PR TITLE
Fixed channel picker bug in Orders and Discounts

### DIFF
--- a/src/discounts/queries.ts
+++ b/src/discounts/queries.ts
@@ -24,6 +24,7 @@ export const saleList = gql`
     $before: String
     $first: Int
     $last: Int
+    $channel: String
     $filter: SaleFilterInput
     $sort: SaleSortingInput
   ) {
@@ -32,6 +33,7 @@ export const saleList = gql`
       before: $before
       first: $first
       last: $last
+      channel: $channel
       filter: $filter
       sortBy: $sort
     ) {
@@ -58,6 +60,7 @@ export const voucherList = gql`
     $before: String
     $first: Int
     $last: Int
+    $channel: String
     $filter: VoucherFilterInput
     $sort: VoucherSortingInput
   ) {
@@ -66,6 +69,7 @@ export const voucherList = gql`
       before: $before
       first: $first
       last: $last
+      channel: $channel
       filter: $filter
       sortBy: $sort
     ) {

--- a/src/discounts/views/SaleList/SaleList.tsx
+++ b/src/discounts/views/SaleList/SaleList.tsx
@@ -74,6 +74,7 @@ export const SaleList: React.FC<SaleListProps> = ({ params }) => {
   const queryVariables = React.useMemo(
     () => ({
       ...paginationState,
+      channel: channel.slug,
       filter: getFilterVariables(params),
       sort: getSortQueryVariables(params, channel?.slug)
     }),

--- a/src/discounts/views/VoucherList/VoucherList.tsx
+++ b/src/discounts/views/VoucherList/VoucherList.tsx
@@ -75,6 +75,7 @@ export const VoucherList: React.FC<VoucherListProps> = ({ params }) => {
   const queryVariables = React.useMemo(
     () => ({
       ...paginationState,
+      channel: channel.slug,
       filter: getFilterVariables(params),
       sort: getSortQueryVariables(params, channel?.slug)
     }),

--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -37,6 +37,7 @@ export const orderListQuery = gql`
     $after: String
     $last: Int
     $before: String
+    $channel: String
     $filter: OrderFilterInput
     $sort: OrderSortingInput
   ) {
@@ -45,6 +46,7 @@ export const orderListQuery = gql`
       after: $after
       first: $first
       last: $last
+      channel: $channel
       filter: $filter
       sortBy: $sort
     ) {
@@ -90,6 +92,7 @@ export const orderDraftListQuery = gql`
     $after: String
     $last: Int
     $before: String
+    $channel: String
     $filter: OrderDraftFilterInput
     $sort: OrderSortingInput
   ) {
@@ -98,6 +101,7 @@ export const orderDraftListQuery = gql`
       after: $after
       first: $first
       last: $last
+      channel: $channel
       filter: $filter
       sortBy: $sort
     ) {

--- a/src/orders/views/OrderList/OrderList.tsx
+++ b/src/orders/views/OrderList/OrderList.tsx
@@ -131,6 +131,7 @@ export const OrderList: React.FC<OrderListProps> = ({ params }) => {
   const queryVariables = React.useMemo(
     () => ({
       ...paginationState,
+      channel: channel.slug,
       filter: getFilterVariables(params),
       sort: getSortQueryVariables(params)
     }),


### PR DESCRIPTION
I want to merge this change because the ChannelPicker at the top of the "Orders" and "Discounts" pages wasn't working as expected. Selecting a different channel from the dropdown would list the exact same items (either orders or vouchers/sales) even if they didn't belong to the selected channel. Now depending on the channel you choose, the graphql request will contain the $channel parameter, being able to filter the results based on the channel.slug.

### Screenshots

#### Before (Discounts > Sales)
![before](https://user-images.githubusercontent.com/33222461/122638996-5ebae580-d0ef-11eb-98d2-680e6d249d63.gif)

#### After (Discounts > Sales)
![after](https://user-images.githubusercontent.com/33222461/122639001-637f9980-d0ef-11eb-8465-df198316feac.gif)

Similarly for the other pages

## Pages Affected
#### Orders
![image](https://user-images.githubusercontent.com/33222461/122638758-e1db3c00-d0ed-11eb-829a-1dd2fa8dac1e.png)

#### Discounts > Sales 
![image](https://user-images.githubusercontent.com/33222461/122638832-5b732a00-d0ee-11eb-9055-7b1dd8f4ca4b.png)

#### Discounts > Vouchers
![image](https://user-images.githubusercontent.com/33222461/122638841-675eec00-d0ee-11eb-85fc-45b3be951f19.png)

### Pull Request Checklist

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/