### PR TITLE
add loader to attribute picker

### DIFF
--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
@@ -181,10 +181,7 @@ const MultiAutocompleteSelectFieldComponent: React.FC<MultiAutocompleteSelectFie
                     fullWidth={true}
                     disabled={disabled}
                   />
-                  {// TODO: check if ok
-                  // {isOpen && (!!inputValue || !!choices.length) && (
-
-                  isOpen && (
+                  {isOpen && (
                     <MultiAutocompleteSelectFieldContent
                       add={
                         add && {

--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
@@ -181,7 +181,10 @@ const MultiAutocompleteSelectFieldComponent: React.FC<MultiAutocompleteSelectFie
                     fullWidth={true}
                     disabled={disabled}
                   />
-                  {isOpen && (!!inputValue || !!choices.length) && (
+                  {// TODO: check if ok
+                  // {isOpen && (!!inputValue || !!choices.length) && (
+
+                  isOpen && (
                     <MultiAutocompleteSelectFieldContent
                       add={
                         add && {
@@ -249,16 +252,16 @@ const MultiAutocompleteSelectField: React.FC<MultiAutocompleteSelectFieldProps> 
 
   if (fetchChoices) {
     return (
-      <DebounceAutocomplete debounceFn={fetchChoices}>
-        {debounceFn => (
-          <MultiAutocompleteSelectFieldComponent
-            testId={testId}
-            choices={choices}
-            {...props}
-            fetchChoices={debounceFn}
-          />
-        )}
-      </DebounceAutocomplete>
+      // <DebounceAutocomplete debounceFn={fetchChoices}>
+      //   {debounceFn => (
+      <MultiAutocompleteSelectFieldComponent
+        testId={testId}
+        choices={choices}
+        {...props}
+        fetchChoices={fetchChoices}
+      />
+      //   )}
+      // </DebounceAutocomplete>
     );
   }
 

--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
@@ -252,16 +252,12 @@ const MultiAutocompleteSelectField: React.FC<MultiAutocompleteSelectFieldProps> 
 
   if (fetchChoices) {
     return (
-      // <DebounceAutocomplete debounceFn={fetchChoices}>
-      //   {debounceFn => (
       <MultiAutocompleteSelectFieldComponent
         testId={testId}
         choices={choices}
         {...props}
         fetchChoices={fetchChoices}
       />
-      //   )}
-      // </DebounceAutocomplete>
     );
   }
 

--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectFieldContent.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectFieldContent.tsx
@@ -173,7 +173,6 @@ const MultiAutocompleteSelectFieldContent: React.FC<MultiAutocompleteSelectField
     inputValue,
     onFetchMore
   } = props;
-
   if (!!add && !!displayCustomValue) {
     throw new Error("Add and custom value cannot be displayed simultaneously");
   }
@@ -198,12 +197,12 @@ const MultiAutocompleteSelectFieldContent: React.FC<MultiAutocompleteSelectField
     }
   }, [loading]);
 
+  const hasValuesToDisplay =
+    displayValues.length > 0 || displayCustomValue || choices.length > 0;
   return (
     <Paper className={classes.root}>
       <div className={classes.content} ref={anchor}>
-        {choices.length > 0 ||
-        displayValues.length > 0 ||
-        displayCustomValue ? (
+        {hasValuesToDisplay && (
           <>
             {add && (
               <MenuItem
@@ -298,25 +297,26 @@ const MultiAutocompleteSelectFieldContent: React.FC<MultiAutocompleteSelectField
                 </MenuItem>
               );
             })}
-            {hasMore && (
-              <>
-                <Hr className={classes.hr} />
-                <div className={classes.progressContainer}>
-                  <CircularProgress className={classes.progress} size={24} />
-                </div>
-              </>
-            )}
           </>
-        ) : (
+        )}
+        {!loading && !hasValuesToDisplay && (
           <MenuItem
             disabled={true}
             component="div"
             data-test="multiautocomplete-select-no-options"
           >
-            <FormattedMessage defaultMessage="No results found" />
+            <FormattedMessage defaultMessage={"No results found"} />
           </MenuItem>
         )}
       </div>
+      {(hasMore || loading) && (
+        <>
+          <Hr className={classes.hr} />
+          <div className={classes.progressContainer}>
+            <CircularProgress className={classes.progress} size={24} />
+          </div>
+        </>
+      )}
       {choices.length > maxMenuItems && (
         <div className={classes.arrowContainer}>
           <div

--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectFieldContent.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectFieldContent.tsx
@@ -125,7 +125,8 @@ const useStyles = makeStyles(
     progress: {},
     progressContainer: {
       display: "flex",
-      justifyContent: "center"
+      justifyContent: "center",
+      padding: `${theme.spacing(1)}px 0`
     },
     root: {
       borderBottomLeftRadius: 8,
@@ -201,8 +202,8 @@ const MultiAutocompleteSelectFieldContent: React.FC<MultiAutocompleteSelectField
     displayValues.length > 0 || displayCustomValue || choices.length > 0;
   return (
     <Paper className={classes.root}>
-      <div className={classes.content} ref={anchor}>
-        {hasValuesToDisplay && (
+      {hasValuesToDisplay && (
+        <div className={classes.content} ref={anchor}>
           <>
             {add && (
               <MenuItem
@@ -298,20 +299,20 @@ const MultiAutocompleteSelectFieldContent: React.FC<MultiAutocompleteSelectField
               );
             })}
           </>
-        )}
-        {!loading && !hasValuesToDisplay && (
-          <MenuItem
-            disabled={true}
-            component="div"
-            data-test="multiautocomplete-select-no-options"
-          >
-            <FormattedMessage defaultMessage={"No results found"} />
-          </MenuItem>
-        )}
-      </div>
+        </div>
+      )}
+      {!loading && !hasValuesToDisplay && (
+        <MenuItem
+          disabled={true}
+          component="div"
+          data-test="multiautocomplete-select-no-options"
+        >
+          <FormattedMessage defaultMessage={"No results found"} />
+        </MenuItem>
+      )}
       {(hasMore || loading) && (
         <>
-          <Hr className={classes.hr} />
+          {hasMore && <Hr className={classes.hr} />}
           <div className={classes.progressContainer}>
             <CircularProgress className={classes.progress} size={24} />
           </div>

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -242,15 +242,11 @@ const SingleAutocompleteSelectField: React.FC<SingleAutocompleteSelectFieldProps
 
   if (fetchChoices) {
     return (
-      <DebounceAutocomplete debounceFn={fetchChoices}>
-        {debounceFn => (
-          <SingleAutocompleteSelectFieldComponent
-            choices={choices}
-            {...rest}
-            fetchChoices={debounceFn}
-          />
-        )}
-      </DebounceAutocomplete>
+      <SingleAutocompleteSelectFieldComponent
+        choices={choices}
+        {...rest}
+        fetchChoices={fetchChoices}
+      />
     );
   }
 

--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorValues.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorValues.tsx
@@ -114,7 +114,6 @@ const ProductVariantCreatorValues: React.FC<ProductVariantCreatorValuesProps> = 
             <CardTitle title={attribute?.name || <Skeleton />} />
             <CardContent data-test-id="value-container">
               <MultiAutocompleteSelectField
-                fetchOnFocus
                 choices={getMultiChoices(attributeValues)}
                 displayValues={getMultiDisplayValues(
                   data.attributes,

--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorValues.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorValues.tsx
@@ -114,6 +114,7 @@ const ProductVariantCreatorValues: React.FC<ProductVariantCreatorValuesProps> = 
             <CardTitle title={attribute?.name || <Skeleton />} />
             <CardContent data-test-id="value-container">
               <MultiAutocompleteSelectField
+                fetchOnFocus
                 choices={getMultiChoices(attributeValues)}
                 displayValues={getMultiDisplayValues(
                   data.attributes,

--- a/src/utils/handlers/attributeValueSearchHandler.ts
+++ b/src/utils/handlers/attributeValueSearchHandler.ts
@@ -40,7 +40,6 @@ function createAttributeValueSearchHandler(
       search("");
     }
   }, [state.id]);
-
   return {
     loadMore,
     search: handleSearch,


### PR DESCRIPTION
I want to merge this change because it resolves the issue of the loader not displaying in multiselect dropdowns when values are being fetched

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/