### PR TITLE
fix multiselect dropdowns in variant creator

### DIFF
--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorValues.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorValues.tsx
@@ -10,6 +10,8 @@ import { getById } from "@saleor/orders/components/OrderReturnPage/utils";
 import { ProductDetails_product_productType_variantAttributes } from "@saleor/products/types/ProductDetails";
 import { SearchAttributeValues_attribute_choices_edges_node } from "@saleor/searches/types/SearchAttributeValues";
 import { FetchMoreProps } from "@saleor/types";
+// eslint-disable-next-line no-restricted-imports
+import _ from "lodash";
 import React from "react";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
@@ -89,6 +91,23 @@ const ProductVariantCreatorValues: React.FC<ProductVariantCreatorValuesProps> = 
     });
   };
 
+  const [localAttributeValues, setLocalAttributeValues] = React.useState([]);
+
+  const prevRef = React.useRef<
+    SearchAttributeValues_attribute_choices_edges_node[]
+  >();
+
+  React.useEffect(() => {
+    if (!_.isEqual(attributeValues, prevRef.current)) {
+      setLocalAttributeValues(attributeValues);
+      prevRef.current = attributeValues;
+    }
+  }, [attributeValues]);
+
+  const clearLocalAttributeValues = () => {
+    setLocalAttributeValues([]);
+  };
+
   return (
     <>
       {variantsLeft !== null && (
@@ -114,7 +133,8 @@ const ProductVariantCreatorValues: React.FC<ProductVariantCreatorValuesProps> = 
             <CardTitle title={attribute?.name || <Skeleton />} />
             <CardContent data-test-id="value-container">
               <MultiAutocompleteSelectField
-                choices={getMultiChoices(attributeValues)}
+                fetchOnFocus
+                choices={getMultiChoices(localAttributeValues)}
                 displayValues={getMultiDisplayValues(
                   data.attributes,
                   attribute
@@ -129,6 +149,7 @@ const ProductVariantCreatorValues: React.FC<ProductVariantCreatorValuesProps> = 
                 fetchChoices={value =>
                   fetchAttributeValues(value, attribute.id)
                 }
+                onBlur={clearLocalAttributeValues}
                 {...fetchMoreAttributeValues}
               />
             </CardContent>


### PR DESCRIPTION
I want to merge this change because it fixes the issues present when there's more than one multiselect on the variant creator page.


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/