### PR TITLE
Use Authorization-Bearer header for auth token

### DIFF
--- a/src/auth/link.ts
+++ b/src/auth/link.ts
@@ -29,7 +29,7 @@ export const tokenLink = setContext((_, context) => {
     ...context,
     headers: {
       ...context.headers,
-      Authorization: authToken ? `JWT ${authToken}` : null
+      "Authorization-Bearer": authToken || null
     }
   };
 });


### PR DESCRIPTION
I want to merge this change because Saleor Cloud is ready to support custom authorization header

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/