### PR TITLE
Fix breaking select popups in filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Support staff only voucher - #1174 by @orzechdev
 - Fix label names in reference attributes - #1184 by @orzechdev
 - Fix failing product update with file attribute - #1190 by @orzechdev
+- Fix breaking select popups in filters - #1193 by @orzechdev
 
 # 2.11.1
 

--- a/src/components/Filter/Filter.tsx
+++ b/src/components/Filter/Filter.tsx
@@ -129,6 +129,7 @@ const Filter: React.FC<FilterProps> = props => {
           setFilterMenuOpened(false);
         }
       }}
+      mouseEvent="onMouseUp"
     >
       <div ref={anchor}>
         <ButtonBase


### PR DESCRIPTION
I want to merge this change because... it fixes breaking select popups in filters (price range select is now properly displayed).

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="356" alt="Zrzut ekranu 2021-06-23 o 16 39 56" src="https://user-images.githubusercontent.com/9825562/123117098-c2237b00-d441-11eb-9b59-1534e7979883.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/