### PR TITLE
Fix content type validation in create page view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Disable next step when no value selected in variant selector - #1218 by @orzechdev
 - Fix order links on home page - #1219 by @jwm0
 - Fix huge payload issue for plugins view - #1203 by @kamilpastuszka
+- Fix content type validation in create page view - #1205 by @orzechdev
 
 # 2.11.1
 

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -132,7 +132,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
       assignReferencesAttributeId={assignReferencesAttributeId}
       onSubmit={onSubmit}
     >
-      {({ change, data, disabled, handlers, hasChanged, submit }) => (
+      {({ change, data, valid, handlers, hasChanged, submit }) => (
         <Container>
           <AppHeader onBack={onBack}>
             {intl.formatMessage(sectionNames.pages)}
@@ -237,7 +237,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
             </div>
           </Grid>
           <SaveButtonBar
-            disabled={loading || !hasChanged || disabled}
+            disabled={loading || !hasChanged || !valid}
             state={saveButtonBarState}
             onCancel={onBack}
             onDelete={page === null ? undefined : onRemove}

--- a/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/pages/components/PageDetailsPage/PageDetailsPage.tsx
@@ -132,7 +132,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
       assignReferencesAttributeId={assignReferencesAttributeId}
       onSubmit={onSubmit}
     >
-      {({ change, data, handlers, hasChanged, submit }) => (
+      {({ change, data, disabled, handlers, hasChanged, submit }) => (
         <Container>
           <AppHeader onBack={onBack}>
             {intl.formatMessage(sectionNames.pages)}
@@ -237,7 +237,7 @@ const PageDetailsPage: React.FC<PageDetailsPageProps> = ({
             </div>
           </Grid>
           <SaveButtonBar
-            disabled={loading || !hasChanged}
+            disabled={loading || !hasChanged || disabled}
             state={saveButtonBarState}
             onCancel={onBack}
             onDelete={page === null ? undefined : onRemove}

--- a/src/pages/components/PageDetailsPage/form.tsx
+++ b/src/pages/components/PageDetailsPage/form.tsx
@@ -74,6 +74,7 @@ export interface PageUpdateHandlers {
 export interface UsePageUpdateFormResult {
   change: FormChange;
   data: PageData;
+  disabled: boolean;
   handlers: PageUpdateHandlers;
   hasChanged: boolean;
   submit: () => void;
@@ -223,9 +224,12 @@ function usePageForm(
       ? handleFormSubmit(getSubmitData(), handleSubmit, setChanged)
       : onSubmit(getSubmitData());
 
+  const disabled = !opts.selectedPageType;
+
   return {
     change: handleChange,
     data: getData(),
+    disabled,
     handlers: {
       changeContent,
       changeMetadata,

--- a/src/pages/components/PageDetailsPage/form.tsx
+++ b/src/pages/components/PageDetailsPage/form.tsx
@@ -74,7 +74,7 @@ export interface PageUpdateHandlers {
 export interface UsePageUpdateFormResult {
   change: FormChange;
   data: PageData;
-  disabled: boolean;
+  valid: boolean;
   handlers: PageUpdateHandlers;
   hasChanged: boolean;
   submit: () => void;
@@ -224,12 +224,12 @@ function usePageForm(
       ? handleFormSubmit(getSubmitData(), handleSubmit, setChanged)
       : onSubmit(getSubmitData());
 
-  const disabled = !opts.selectedPageType;
+  const valid = !!opts.selectedPageType;
 
   return {
     change: handleChange,
     data: getData(),
-    disabled,
+    valid,
     handlers: {
       changeContent,
       changeMetadata,


### PR DESCRIPTION
I want to merge this change because... it prevents page from saving if content type is not provided.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/