### PR TITLE
[IMP] expose runtime env in the image, post build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,7 @@ FROM nginx:stable
 WORKDIR /app
 COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/build/ /app/
+
+ENV API_URI ${API_URI:-http://localhost:8000/graphql/}
+ENV APP_MOUNT_URI ${APP_MOUNT_URI:-/dashboard/}
+ENV STATIC_URL ${STATIC_URL:-/dashboard/}


### PR DESCRIPTION
I want to merge this change because...

We want to have the env for the image exposed for runtime to allow the same image to be used on multiple environments. 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/