### PR TITLE
Disable next step when no value selected in variant selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix duplicated labels in column picker - #1197 by @orzechdev
 - Fix forbidden null sending as attribute value - #1201 by @orzechdev
 - Fix missing call for update metadata mutation - #1207 by @orzechdev
+- Disable next step when no value selected in variant selector - #1218 by @orzechdev
 
 # 2.11.1
 

--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorPage.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorPage.tsx
@@ -55,9 +55,8 @@ function canHitNext(
   switch (step) {
     case ProductVariantCreatorStep.values:
       return (
-        (data.attributes.every(attribute => attribute.values.length > 0) &&
-          variantsLeft === null) ||
-        getVariantsNumber(data) <= variantsLeft
+        data.attributes.every(attribute => attribute.values.length > 0) &&
+        (variantsLeft === null || getVariantsNumber(data) <= variantsLeft)
       );
     case ProductVariantCreatorStep.prices:
       if (data.price.mode === "all") {


### PR DESCRIPTION
I want to merge this change because... it fixes crash in variant selector.

Changes take into account that as we retrieve attributes list from query `variantAttributes(variantSelection: VARIANT_SELECTION)` it looks like at least one value in each attribute has to be selected/required in the first step to create a proper variant.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/