### PR TITLE
Fix trimmed quantity inputs in draft order

### DIFF
--- a/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
@@ -32,16 +32,13 @@ const useStyles = makeStyles(
       marginLeft: AVATAR_MARGIN
     },
     colPrice: {
-      textAlign: "right",
-      width: 150
+      textAlign: "right"
     },
     colQuantity: {
-      textAlign: "right",
-      width: 80
+      textAlign: "right"
     },
     colTotal: {
-      textAlign: "right",
-      width: 150
+      textAlign: "right"
     },
     errorInfo: {
       color: theme.palette.error.main

--- a/src/orders/components/OrderDraftDetailsProducts/TableLine.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/TableLine.tsx
@@ -29,16 +29,13 @@ const useStyles = makeStyles(
       marginLeft: AVATAR_MARGIN
     },
     colPrice: {
-      textAlign: "right",
-      width: 150
+      textAlign: "right"
     },
     colQuantity: {
-      textAlign: "right",
-      width: 80
+      textAlign: "right"
     },
     colTotal: {
-      textAlign: "right",
-      width: 150
+      textAlign: "right"
     },
     strike: {
       textDecoration: "line-through",

--- a/src/orders/components/OrderDraftDetailsProducts/TableLine.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/TableLine.tsx
@@ -47,13 +47,6 @@ const useStyles = makeStyles(
     errorInfo: {
       color: theme.palette.error.main
     },
-    quantityField: {
-      "& input": {
-        padding: "12px 12px 10px",
-        textAlign: "right"
-      },
-      width: 60
-    },
     table: {
       tableLayout: "fixed"
     }

--- a/src/orders/components/OrderDraftDetailsProducts/TableLineForm.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/TableLineForm.tsx
@@ -13,9 +13,7 @@ const useStyles = makeStyles(
         padding: "12px 12px 10px",
         textAlign: "right"
       },
-      width: "auto",
-      minWidth: 100,
-      maxWidth: 140
+      width: 100
     }
   }),
   { name: "TableLineForm" }

--- a/src/orders/components/OrderDraftDetailsProducts/TableLineForm.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/TableLineForm.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles(
         padding: "12px 12px 10px",
         textAlign: "right"
       },
-      width: 60
+      width: 80
     }
   }),
   { name: "TableLineForm" }

--- a/src/orders/components/OrderDraftDetailsProducts/TableLineForm.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/TableLineForm.tsx
@@ -13,7 +13,9 @@ const useStyles = makeStyles(
         padding: "12px 12px 10px",
         textAlign: "right"
       },
-      width: 80
+      width: "auto",
+      minWidth: 100,
+      maxWidth: 140
     }
   }),
   { name: "TableLineForm" }


### PR DESCRIPTION
I want to merge this change because... it fixes trimmed quantity inputs in draft order.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/