### PR TITLE
Add variant create options dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix list pagination crash on search - #1230 by @orzechdev
 - Fix positive float number input validation - #1233 by @orzechdev
 - Use MacawUI - #1229 by @dominik-zeglen
+- Add variant create options dialog - #1238 by @orzechdev
 
 # 2.11.1
 

--- a/cypress/elements/catalog/products/product-details.js
+++ b/cypress/elements/catalog/products/product-details.js
@@ -9,6 +9,10 @@ export const PRODUCT_DETAILS = {
   visibleRadioBtn: "[name='isPublished']",
   channelAvailabilityItem: "[data-test='channel-availability-item']",
   addVariantsButton: "[data-test*='button-add-variant']",
+  addVariantsOptionDialog: {
+    optionMultiple: '[data-test-id="variant-create-option-multiple"]',
+    optionSingle: '[data-test-id="variant-create-option-single"]'
+  },
   descriptionInput: "[data-test-id='description']",
   ratingInput: "[name='rating']",
   skuInput: "[name='sku']",

--- a/cypress/steps/catalog/products/VariantsSteps.js
+++ b/cypress/steps/catalog/products/VariantsSteps.js
@@ -16,6 +16,8 @@ export function variantsShouldBeVisible({ name, price }) {
 }
 export function createFirstVariant({ sku, warehouseId, price, attribute }) {
   cy.get(PRODUCT_DETAILS.addVariantsButton).click();
+  cy.get(PRODUCT_DETAILS.addVariantsOptionDialog.optionMultiple).click();
+  cy.get(BUTTON_SELECTORS.submit).click();
   cy.get(VARIANTS_SELECTORS.valueContainer)
     .click()
     .contains(attribute)

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2038,10 +2038,6 @@
   "src_dot_components_dot_CompanyAddressInput_dot_944851093": {
     "string": "Country area"
   },
-  "src_dot_components_dot_ConfirmButton_dot_2845142593": {
-    "context": "button",
-    "string": "Error"
-  },
   "src_dot_components_dot_CountryList_dot_2460766407": {
     "context": "number of countries",
     "string": "{number} Countries"
@@ -2465,18 +2461,6 @@
   "src_dot_components_dot_Weight_dot_2781622322": {
     "context": "weight",
     "string": "{value} {unit}"
-  },
-  "src_dot_components_dot_messages_dot_1219076963": {
-    "context": "snackbar expand",
-    "string": "Expand"
-  },
-  "src_dot_components_dot_messages_dot_2473863536": {
-    "context": "snackbar button undo",
-    "string": "Undo"
-  },
-  "src_dot_components_dot_messages_dot_3444275093": {
-    "context": "snackbar collapse",
-    "string": "Collapse"
   },
   "src_dot_configuration": {
     "context": "configuration section name",
@@ -3368,6 +3352,9 @@
   },
   "src_dot_endHour": {
     "string": "End Hour"
+  },
+  "src_dot_error": {
+    "string": "Error"
   },
   "src_dot_exchangeRates": {
     "context": "Manage and Update your warehouse information",
@@ -5560,27 +5547,27 @@
     "context": "product label",
     "string": "Published"
   },
-  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_1321668459": {
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_description": {
     "context": "create product variants",
     "string": "How would you like to create variants:"
   },
-  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_2124954667": {
-    "context": "option",
-    "string": "Create multiple variant via variant creator"
-  },
-  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_3796072295": {
-    "context": "option description",
-    "string": "Create new variant using variant details view"
-  },
-  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_3824462511": {
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_optionMultipleDescription": {
     "context": "option description",
     "string": "Use variant creator to create matrix of selected attribute values to create variants"
   },
-  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_539249437": {
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_optionMultipleTitle": {
+    "context": "option",
+    "string": "Create multiple variant via variant creator"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_optionSingleDescription": {
+    "context": "option description",
+    "string": "Create new variant using variant details view"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_optionSingleTitle": {
     "context": "option",
     "string": "Create single variant"
   },
-  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_830692292": {
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_title": {
     "context": "dialog header",
     "string": "Create Variants"
   },

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -5560,6 +5560,30 @@
     "context": "product label",
     "string": "Published"
   },
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_1321668459": {
+    "context": "create product variants",
+    "string": "How would you like to create variants:"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_2124954667": {
+    "context": "option",
+    "string": "Create multiple variant via variant creator"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_3796072295": {
+    "context": "option description",
+    "string": "Create new variant using variant details view"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_3824462511": {
+    "context": "option description",
+    "string": "Use variant creator to create matrix of selected attribute values to create variants"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_539249437": {
+    "context": "option",
+    "string": "Create single variant"
+  },
+  "src_dot_products_dot_components_dot_ProductVariantCreateDialog_dot_830692292": {
+    "context": "dialog header",
+    "string": "Create Variants"
+  },
   "src_dot_products_dot_components_dot_ProductVariantCreatePage_dot_attributesHeader": {
     "context": "attributes, section header",
     "string": "Variant Attributes"

--- a/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
+++ b/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
@@ -14,6 +14,9 @@ import { makeStyles } from "@saleor/theme";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { messages } from "./messages";
+import { ProductVariantCreateOptionEnum } from "./types";
+
 const useStyles = makeStyles(
   theme => ({
     option: {
@@ -23,11 +26,6 @@ const useStyles = makeStyles(
   }),
   { name: "ProductVariantCreateDialog" }
 );
-
-enum ProductVariantCreateOptionEnum {
-  MULTIPLE = "multiple",
-  SINGLE = "single"
-}
 
 interface ProductVariantCreateDialogForm {
   option: ProductVariantCreateOptionEnum;
@@ -54,48 +52,14 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
 
   const options = [
     {
-      label: (
-        <div
-          className={classes.option}
-          data-test-id="variant-create-option-multiple"
-        >
-          <Typography variant="body1">
-            <FormattedMessage
-              defaultMessage="Create multiple variant via variant creator"
-              description="option"
-            />
-          </Typography>
-          <Typography color="textSecondary" variant="caption">
-            <FormattedMessage
-              defaultMessage="Use variant creator to create matrix of selected attribute values to create variants"
-              description="option description"
-            />
-          </Typography>
-        </div>
-      ),
-      value: ProductVariantCreateOptionEnum.MULTIPLE
+      title: messages.optionSingleTitle,
+      subtitle: messages.optionSingleDescription,
+      type: ProductVariantCreateOptionEnum.SINGLE
     },
     {
-      label: (
-        <div
-          className={classes.option}
-          data-test-id="variant-create-option-single"
-        >
-          <Typography variant="body1">
-            <FormattedMessage
-              defaultMessage="Create single variant"
-              description="option"
-            />
-          </Typography>
-          <Typography color="textSecondary" variant="caption">
-            <FormattedMessage
-              defaultMessage="Create new variant using variant details view"
-              description="option description"
-            />
-          </Typography>
-        </div>
-      ),
-      value: ProductVariantCreateOptionEnum.SINGLE
+      title: messages.optionMultipleTitle,
+      subtitle: messages.optionMultipleDescription,
+      type: ProductVariantCreateOptionEnum.MULTIPLE
     }
   ];
 
@@ -105,22 +69,31 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
         {({ change, data }) => (
           <>
             <DialogTitle>
-              <FormattedMessage
-                defaultMessage="Create Variants"
-                description="dialog header"
-              />
+              <FormattedMessage {...messages.title} />
             </DialogTitle>
             <DialogContent>
               <Typography variant="body2">
-                <FormattedMessage
-                  defaultMessage="How would you like to create variants:"
-                  description="create product variants"
-                />
+                <FormattedMessage {...messages.description} />
               </Typography>
               <FormSpacer />
               <RadioGroupField
                 alignTop
-                choices={options}
+                choices={options.map(option => ({
+                  label: (
+                    <div
+                      className={classes.option}
+                      data-test-id={`variant-create-option-${option.type}`}
+                    >
+                      <Typography variant="body1">
+                        <FormattedMessage {...option.title} />
+                      </Typography>
+                      <Typography color="textSecondary" variant="caption">
+                        <FormattedMessage {...option.subtitle} />
+                      </Typography>
+                    </div>
+                  ),
+                  value: option.type
+                }))}
                 name="option"
                 value={data.option}
                 onChange={change}

--- a/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
+++ b/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
@@ -10,7 +10,7 @@ import Form from "@saleor/components/Form";
 import FormSpacer from "@saleor/components/FormSpacer";
 import RadioGroupField from "@saleor/components/RadioGroupField";
 import { buttonMessages } from "@saleor/intl";
-import { makeStyles } from "@saleor/theme";
+import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -52,14 +52,14 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
 
   const options = [
     {
-      title: messages.optionSingleTitle,
-      subtitle: messages.optionSingleDescription,
-      type: ProductVariantCreateOptionEnum.SINGLE
-    },
-    {
       title: messages.optionMultipleTitle,
       subtitle: messages.optionMultipleDescription,
       type: ProductVariantCreateOptionEnum.MULTIPLE
+    },
+    {
+      title: messages.optionSingleTitle,
+      subtitle: messages.optionSingleDescription,
+      type: ProductVariantCreateOptionEnum.SINGLE
     }
   ];
 

--- a/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
+++ b/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
@@ -121,7 +121,7 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
               <RadioGroupField
                 alignTop
                 choices={options}
-                name="variantCreateOption"
+                name="option"
                 value={data.option}
                 onChange={change}
               />

--- a/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
+++ b/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
@@ -55,7 +55,10 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
   const options = [
     {
       label: (
-        <div className={classes.option}>
+        <div
+          className={classes.option}
+          data-test-id="variant-create-option-multiple"
+        >
           <Typography variant="body1">
             <FormattedMessage
               defaultMessage="Create multiple variant via variant creator"
@@ -74,7 +77,10 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
     },
     {
       label: (
-        <div className={classes.option}>
+        <div
+          className={classes.option}
+          data-test-id="variant-create-option-single"
+        >
           <Typography variant="body1">
             <FormattedMessage
               defaultMessage="Create single variant"
@@ -126,6 +132,8 @@ const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = pr
                 color="primary"
                 variant="contained"
                 type="submit"
+                data-test-id="submit"
+                data-test="submit"
               >
                 <FormattedMessage {...buttonMessages.create} />
               </ConfirmButton>

--- a/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
+++ b/src/products/components/ProductVariantCreateDialog/ProductVariantCreateDialog.tsx
@@ -1,0 +1,140 @@
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography
+} from "@material-ui/core";
+import ConfirmButton from "@saleor/components/ConfirmButton";
+import Form from "@saleor/components/Form";
+import FormSpacer from "@saleor/components/FormSpacer";
+import RadioGroupField from "@saleor/components/RadioGroupField";
+import { buttonMessages } from "@saleor/intl";
+import { makeStyles } from "@saleor/theme";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+const useStyles = makeStyles(
+  theme => ({
+    option: {
+      marginBottom: theme.spacing(2),
+      width: 400
+    }
+  }),
+  { name: "ProductVariantCreateDialog" }
+);
+
+enum ProductVariantCreateOptionEnum {
+  MULTIPLE = "multiple",
+  SINGLE = "single"
+}
+
+interface ProductVariantCreateDialogForm {
+  option: ProductVariantCreateOptionEnum;
+}
+
+export interface ProductVariantCreateDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (option: ProductVariantCreateOptionEnum) => void;
+}
+
+const ProductVariantCreateDialog: React.FC<ProductVariantCreateDialogProps> = props => {
+  const { open, onConfirm, onClose } = props;
+
+  const classes = useStyles(props);
+
+  const initialForm = {
+    option: ProductVariantCreateOptionEnum.MULTIPLE
+  };
+
+  const handleSubmit = (form: ProductVariantCreateDialogForm) => {
+    onConfirm(form.option);
+  };
+
+  const options = [
+    {
+      label: (
+        <div className={classes.option}>
+          <Typography variant="body1">
+            <FormattedMessage
+              defaultMessage="Create multiple variant via variant creator"
+              description="option"
+            />
+          </Typography>
+          <Typography color="textSecondary" variant="caption">
+            <FormattedMessage
+              defaultMessage="Use variant creator to create matrix of selected attribute values to create variants"
+              description="option description"
+            />
+          </Typography>
+        </div>
+      ),
+      value: ProductVariantCreateOptionEnum.MULTIPLE
+    },
+    {
+      label: (
+        <div className={classes.option}>
+          <Typography variant="body1">
+            <FormattedMessage
+              defaultMessage="Create single variant"
+              description="option"
+            />
+          </Typography>
+          <Typography color="textSecondary" variant="caption">
+            <FormattedMessage
+              defaultMessage="Create new variant using variant details view"
+              description="option description"
+            />
+          </Typography>
+        </div>
+      ),
+      value: ProductVariantCreateOptionEnum.SINGLE
+    }
+  ];
+
+  return (
+    <Dialog onClose={onClose} open={open}>
+      <Form initial={initialForm} onSubmit={handleSubmit}>
+        {({ change, data }) => (
+          <>
+            <DialogTitle>
+              <FormattedMessage
+                defaultMessage="Create Variants"
+                description="dialog header"
+              />
+            </DialogTitle>
+            <DialogContent>
+              <Typography variant="body2">
+                <FormattedMessage
+                  defaultMessage="How would you like to create variants:"
+                  description="create product variants"
+                />
+              </Typography>
+              <FormSpacer />
+              <RadioGroupField
+                alignTop
+                choices={options}
+                name="variantCreateOption"
+                value={data.option}
+                onChange={change}
+              />
+            </DialogContent>
+            <DialogActions>
+              <ConfirmButton
+                transitionState="default"
+                color="primary"
+                variant="contained"
+                type="submit"
+              >
+                <FormattedMessage {...buttonMessages.create} />
+              </ConfirmButton>
+            </DialogActions>
+          </>
+        )}
+      </Form>
+    </Dialog>
+  );
+};
+ProductVariantCreateDialog.displayName = "ProductVariantCreateDialog";
+export default ProductVariantCreateDialog;

--- a/src/products/components/ProductVariantCreateDialog/index.ts
+++ b/src/products/components/ProductVariantCreateDialog/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ProductVariantCreateDialog";
+export * from "./ProductVariantCreateDialog";

--- a/src/products/components/ProductVariantCreateDialog/messages.ts
+++ b/src/products/components/ProductVariantCreateDialog/messages.ts
@@ -1,0 +1,29 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  title: {
+    defaultMessage: "Create Variants",
+    description: "dialog header"
+  },
+  description: {
+    defaultMessage: "How would you like to create variants:",
+    description: "create product variants"
+  },
+  optionMultipleTitle: {
+    defaultMessage: "Create multiple variant via variant creator",
+    description: "option"
+  },
+  optionMultipleDescription: {
+    defaultMessage:
+      "Use variant creator to create matrix of selected attribute values to create variants",
+    description: "option description"
+  },
+  optionSingleTitle: {
+    defaultMessage: "Create single variant",
+    description: "option"
+  },
+  optionSingleDescription: {
+    defaultMessage: "Create new variant using variant details view",
+    description: "option description"
+  }
+});

--- a/src/products/components/ProductVariantCreateDialog/types.ts
+++ b/src/products/components/ProductVariantCreateDialog/types.ts
@@ -1,0 +1,4 @@
+export enum ProductVariantCreateOptionEnum {
+  MULTIPLE = "multiple",
+  SINGLE = "single"
+}

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -67,6 +67,7 @@ export const productListUrl = (params?: ProductListUrlQueryParams): string =>
 
 export const productPath = (id: string) => urlJoin(productSection + id);
 export type ProductUrlDialog =
+  | "add-variants"
   | "remove"
   | "remove-variants"
   | "assign-attribute-value"

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -28,6 +28,7 @@ import useNotifier from "@saleor/hooks/useNotifier";
 import useOnSetDefaultVariant from "@saleor/hooks/useOnSetDefaultVariant";
 import useShop from "@saleor/hooks/useShop";
 import { commonMessages } from "@saleor/intl";
+import ProductVariantCreateDialog from "@saleor/products/components/ProductVariantCreateDialog";
 import {
   useProductChannelListingUpdate,
   useProductDeleteMutation,
@@ -369,6 +370,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     return <NotFoundPage onBack={handleBack} />;
   }
   const handleVariantAdd = () => navigate(productVariantAddUrl(id));
+  const handleVariantsAdd = () => navigate(productVariantCreatorUrl(id));
 
   const handleImageDelete = (id: string) => () =>
     deleteProductImage({ variables: { id } });
@@ -563,7 +565,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
         }}
         onWarehouseConfigure={() => navigate(warehouseAddPath)}
         onVariantAdd={handleVariantAdd}
-        onVariantsAdd={() => navigate(productVariantCreatorUrl(id))}
+        onVariantsAdd={() => openModal("add-variants")}
         onVariantShow={variantId => () =>
           navigate(productVariantEditUrl(product.id, variantId))}
         onVariantReorder={handleVariantReorder}
@@ -643,6 +645,13 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
           />
         </DialogContentText>
       </ActionDialog>
+      <ProductVariantCreateDialog
+        open={params.action === "add-variants"}
+        onClose={closeModal}
+        onConfirm={option =>
+          option === "multiple" ? handleVariantsAdd() : handleVariantAdd()
+        }
+      />
     </>
   );
 };


### PR DESCRIPTION
I want to merge this change because... it adds a dialog to provide the ability to skip the variant creator.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
Dialog displayed when trying to create first variants for product:

<img width="516" alt="Zrzut ekranu 2021-07-16 o 17 49 52" src="https://user-images.githubusercontent.com/9825562/125982010-8ce29c1b-b56c-493f-9669-eeb34f477b34.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://qa.staging.saleor.cloud/graphql/