### PR TITLE
Add fulfillment settings card

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3814,6 +3814,26 @@
     "context": "product's sku",
     "string": "SKU"
   },
+  "src_dot_orders_dot_components_dot_OrderFulfillmentSettings_dot_1154699654": {
+    "context": "checkbox label",
+    "string": "Allow fulfillment without payment"
+  },
+  "src_dot_orders_dot_components_dot_OrderFulfillmentSettings_dot_2478368540": {
+    "context": "checkbox label description",
+    "string": "All fulfillments will be automatically approved"
+  },
+  "src_dot_orders_dot_components_dot_OrderFulfillmentSettings_dot_3336812159": {
+    "context": "checkbox label",
+    "string": "Automatically approve all fulfillments"
+  },
+  "src_dot_orders_dot_components_dot_OrderFulfillmentSettings_dot_3666602886": {
+    "context": "checkbox label description",
+    "string": "You will be able to fulfill products without capturing payment for the order."
+  },
+  "src_dot_orders_dot_components_dot_OrderFulfillmentSettings_dot_4200951094": {
+    "context": "section header",
+    "string": "Fulfillment settings"
+  },
   "src_dot_orders_dot_components_dot_OrderFulfillmentTrackingDialog_dot_3252172269": {
     "string": "Tracking number"
   },

--- a/schema.graphql
+++ b/schema.graphql
@@ -1639,6 +1639,7 @@ type CustomerEvent implements Node {
   date: DateTime
   type: CustomerEventsEnum
   user: User
+  app: App
   message: String
   count: Int
   order: Order
@@ -2075,6 +2076,13 @@ type Fulfillment implements Node & ObjectWithMetadata {
   warehouse: Warehouse
 }
 
+type FulfillmentApprove {
+  fulfillment: Fulfillment
+  order: Order
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
+}
+
 type FulfillmentCancel {
   fulfillment: Fulfillment
   order: Order
@@ -2115,6 +2123,7 @@ enum FulfillmentStatus {
   REPLACED
   REFUNDED_AND_RETURNED
   CANCELED
+  WAITING_FOR_APPROVAL
 }
 
 type FulfillmentUpdateTracking {
@@ -2812,6 +2821,7 @@ type Mutation {
   orderConfirm(id: ID!): OrderConfirm
   orderFulfill(input: OrderFulfillInput!, order: ID): OrderFulfill
   orderFulfillmentCancel(id: ID!, input: FulfillmentCancelInput!): FulfillmentCancel
+  orderFulfillmentApprove(id: ID!, notifyCustomer: Boolean!): FulfillmentApprove
   orderFulfillmentUpdateTracking(id: ID!, input: FulfillmentUpdateTrackingInput!): FulfillmentUpdateTracking
   orderFulfillmentRefundProducts(input: OrderRefundProductsInput!, order: ID!): FulfillmentRefundProducts
   orderFulfillmentReturnProducts(input: OrderReturnProductsInput!, order: ID!): FulfillmentReturnProducts
@@ -3154,6 +3164,7 @@ enum OrderErrorCode {
   CANNOT_DELETE
   CANNOT_DISCOUNT
   CANNOT_REFUND
+  CANNOT_FULFILL_UNPAID_ORDER
   CAPTURE_INACTIVE_PAYMENT
   NOT_EDITABLE
   FULFILL_ORDER_LINE
@@ -3184,6 +3195,7 @@ type OrderEvent implements Node {
   date: DateTime
   type: OrderEventsEnum
   user: User
+  app: App
   message: String
   email: String
   emailType: OrderEventsEmailsEnum
@@ -3283,6 +3295,7 @@ enum OrderEventsEnum {
   FULFILLMENT_REFUNDED
   FULFILLMENT_RETURNED
   FULFILLMENT_REPLACED
+  FULFILLMENT_AWAITS_APPROVAL
   TRACKING_UPDATED
   NOTE_ADDED
   OTHER
@@ -3900,6 +3913,7 @@ type PaymentRefund {
 
 type PaymentSource {
   gateway: String!
+  paymentMethodId: String
   creditCardInfo: CreditCard
 }
 
@@ -4776,7 +4790,6 @@ type Query {
   taxTypes: [TaxType]
   checkout(token: UUID): Checkout
   checkouts(channel: String, before: String, after: String, first: Int, last: Int): CheckoutCountableConnection
-  checkoutLine(id: ID): CheckoutLine
   checkoutLines(before: String, after: String, first: Int, last: Int): CheckoutLineCountableConnection
   channel(id: ID): Channel
   channels: [Channel!]
@@ -4830,12 +4843,14 @@ type RequestPasswordReset {
   errors: [AccountError!]!
 }
 
-type Sale implements Node {
+type Sale implements Node & ObjectWithMetadata {
   id: ID!
   name: String!
   type: SaleType!
   startDate: DateTime!
   endDate: DateTime
+  privateMetadata: [MetadataItem]!
+  metadata: [MetadataItem]!
   categories(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
@@ -4908,6 +4923,7 @@ input SaleFilterInput {
   saleType: DiscountValueTypeEnum
   started: DateTimeRangeInput
   search: String
+  metadata: [MetadataFilter]
 }
 
 input SaleInput {
@@ -5244,6 +5260,8 @@ type Shop {
   phonePrefixes: [String]!
   headerText: String
   includeTaxesInPrices: Boolean!
+  fulfillmentAutoApprove: Boolean!
+  fulfillmentAllowUnpaid: Boolean!
   displayGrossPrices: Boolean!
   chargeTaxesOnShipping: Boolean!
   trackInventoryByDefault: Boolean
@@ -5302,6 +5320,8 @@ input ShopSettingsInput {
   trackInventoryByDefault: Boolean
   defaultWeightUnit: WeightUnitsEnum
   automaticFulfillmentDigitalProducts: Boolean
+  fulfillmentAutoApprove: Boolean
+  fulfillmentAllowUnpaid: Boolean
   defaultDigitalMaxDownloads: Int
   defaultDigitalUrlValidDays: Int
   defaultMailSenderName: String
@@ -5748,7 +5768,7 @@ enum VolumeUnitsEnum {
   ACRE_FT
 }
 
-type Voucher implements Node {
+type Voucher implements Node & ObjectWithMetadata {
   id: ID!
   name: String
   type: VoucherTypeEnum!
@@ -5762,6 +5782,8 @@ type Voucher implements Node {
   onlyForStaff: Boolean!
   discountValueType: DiscountValueTypeEnum!
   minCheckoutItemsQuantity: Int
+  privateMetadata: [MetadataItem]!
+  metadata: [MetadataItem]!
   categories(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
@@ -5845,6 +5867,7 @@ input VoucherFilterInput {
   discountType: [VoucherDiscountType]
   started: DateTimeRangeInput
   search: String
+  metadata: [MetadataFilter]
 }
 
 input VoucherInput {
@@ -6165,7 +6188,7 @@ enum WeightUnitsEnum {
 
 scalar _Any
 
-union _Entity = Address | User | Group | App | ProductVariant | Product | ProductType | Collection | Category | ProductMedia | ProductImage | PageType
+union _Entity = App | Address | User | Group | ProductVariant | Product | ProductType | Collection | Category | ProductMedia | ProductImage | PageType
 
 type _Service {
   sdl: String

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -283,7 +283,7 @@ export const fragmentOrderSettings = gql`
 
 export const fragmentShopOrderSettings = gql`
   fragment ShopOrderSettingsFragment on Shop {
-    fulfillmentAutoConfirm
+    fulfillmentAutoApprove
     fulfillmentAllowUnpaid
   }
 `;

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -280,3 +280,10 @@ export const fragmentOrderSettings = gql`
     automaticallyConfirmAllNewOrders
   }
 `;
+
+export const fragmentShopOrderSettings = gql`
+  fragment ShopOrderSettingsFragment on Shop {
+    fulfillmentAutoConfirm
+    fulfillmentAllowUnpaid
+  }
+`;

--- a/src/fragments/types/MetadataFragment.ts
+++ b/src/fragments/types/MetadataFragment.ts
@@ -20,7 +20,7 @@ export interface MetadataFragment_privateMetadata {
 }
 
 export interface MetadataFragment {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (MetadataFragment_metadata | null)[];
   privateMetadata: (MetadataFragment_privateMetadata | null)[];
 }

--- a/src/fragments/types/ShopOrderSettingsFragment.ts
+++ b/src/fragments/types/ShopOrderSettingsFragment.ts
@@ -9,6 +9,6 @@
 
 export interface ShopOrderSettingsFragment {
   __typename: "Shop";
-  fulfillmentAutoConfirm: boolean;
+  fulfillmentAutoApprove: boolean;
   fulfillmentAllowUnpaid: boolean;
 }

--- a/src/fragments/types/ShopOrderSettingsFragment.ts
+++ b/src/fragments/types/ShopOrderSettingsFragment.ts
@@ -1,0 +1,14 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: ShopOrderSettingsFragment
+// ====================================================
+
+export interface ShopOrderSettingsFragment {
+  __typename: "Shop";
+  fulfillmentAutoConfirm: boolean;
+  fulfillmentAllowUnpaid: boolean;
+}

--- a/src/orders/components/OrderFulfillmentSettings/OrderFulfillmentSettings.tsx
+++ b/src/orders/components/OrderFulfillmentSettings/OrderFulfillmentSettings.tsx
@@ -1,0 +1,80 @@
+import { Card, CardContent, Typography } from "@material-ui/core";
+import CardTitle from "@saleor/components/CardTitle";
+import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
+import FormSpacer from "@saleor/components/FormSpacer";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { OrderSettingsFormData } from "../OrderSettingsPage/form";
+
+export interface OrderFulfillmentSettingsProps {
+  data: OrderSettingsFormData;
+  disabled: boolean;
+  onChange: (event: React.ChangeEvent<any>) => void;
+}
+
+const OrderFulfillmentSettings: React.FC<OrderFulfillmentSettingsProps> = ({
+  data,
+  disabled,
+  onChange
+}) => {
+  const intl = useIntl();
+
+  return (
+    <Card data-test="OrderFulfillmentSettings">
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Fulfillment settings",
+          description: "section header"
+        })}
+      />
+      <CardContent>
+        <ControlledCheckbox
+          name={"fulfillmentAutoConfirm" as keyof OrderSettingsFormData}
+          label={
+            <>
+              <FormattedMessage
+                defaultMessage="Automatically approve all fulfillments"
+                description="checkbox label"
+              />
+              <Typography variant="caption">
+                <FormattedMessage
+                  defaultMessage="All fulfillments will be automatically approved"
+                  description="checkbox label description"
+                />
+              </Typography>
+            </>
+          }
+          checked={data.fulfillmentAutoConfirm}
+          onChange={onChange}
+          disabled={disabled}
+          data-test="fulfillmentAutoConfirmCheckbox"
+        />
+        <FormSpacer />
+        <ControlledCheckbox
+          name={"fulfillmentAllowUnpaid" as keyof OrderSettingsFormData}
+          label={
+            <>
+              <FormattedMessage
+                defaultMessage="Allow fulfillment without payment"
+                description="checkbox label"
+              />
+              <Typography variant="caption">
+                <FormattedMessage
+                  defaultMessage="You will be able to fulfill products without capturing payment for the order."
+                  description="checkbox label description"
+                />
+              </Typography>
+            </>
+          }
+          checked={data.fulfillmentAllowUnpaid}
+          onChange={onChange}
+          disabled={disabled}
+          data-test="fulfillmentAllowUnpaidCheckbox"
+        />
+      </CardContent>
+    </Card>
+  );
+};
+OrderFulfillmentSettings.displayName = "OrderFulfillmentSettings";
+export default OrderFulfillmentSettings;

--- a/src/orders/components/OrderFulfillmentSettings/OrderFulfillmentSettings.tsx
+++ b/src/orders/components/OrderFulfillmentSettings/OrderFulfillmentSettings.tsx
@@ -30,7 +30,7 @@ const OrderFulfillmentSettings: React.FC<OrderFulfillmentSettingsProps> = ({
       />
       <CardContent>
         <ControlledCheckbox
-          name={"fulfillmentAutoConfirm" as keyof OrderSettingsFormData}
+          name={"fulfillmentAutoApprove" as keyof OrderSettingsFormData}
           label={
             <>
               <FormattedMessage
@@ -45,10 +45,10 @@ const OrderFulfillmentSettings: React.FC<OrderFulfillmentSettingsProps> = ({
               </Typography>
             </>
           }
-          checked={data.fulfillmentAutoConfirm}
+          checked={data.fulfillmentAutoApprove}
           onChange={onChange}
           disabled={disabled}
-          data-test="fulfillmentAutoConfirmCheckbox"
+          data-test="fulfillmentAutoApproveCheckbox"
         />
         <FormSpacer />
         <ControlledCheckbox

--- a/src/orders/components/OrderFulfillmentSettings/index.ts
+++ b/src/orders/components/OrderFulfillmentSettings/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./OrderFulfillmentSettings";
+export * from "./OrderFulfillmentSettings";

--- a/src/orders/components/OrderSettingsPage/OrderSettingsPage.stories.tsx
+++ b/src/orders/components/OrderSettingsPage/OrderSettingsPage.stories.tsx
@@ -1,4 +1,7 @@
-import { orderSettings as orderSettingsFixture } from "@saleor/orders/fixtures";
+import {
+  orderSettings as orderSettingsFixture,
+  shopOrderSettings as shopOrderSettingsFixture
+} from "@saleor/orders/fixtures";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -6,7 +9,8 @@ import Decorator from "../../../storybook/Decorator";
 import OrderSettings, { OrderSettingsPageProps } from ".";
 
 const props: OrderSettingsPageProps = {
-  data: orderSettingsFixture,
+  orderSettings: orderSettingsFixture,
+  shop: shopOrderSettingsFixture,
   disabled: false,
   onBack: () => undefined,
   onSubmit: () => undefined,
@@ -17,5 +21,10 @@ storiesOf("Views / Orders / Order settings", module)
   .addDecorator(Decorator)
   .add("default", () => <OrderSettings {...props} />)
   .add("loading", () => (
-    <OrderSettings {...props} disabled={true} data={undefined} />
+    <OrderSettings
+      {...props}
+      disabled={true}
+      orderSettings={undefined}
+      shop={undefined}
+    />
   ));

--- a/src/orders/components/OrderSettingsPage/OrderSettingsPage.tsx
+++ b/src/orders/components/OrderSettingsPage/OrderSettingsPage.tsx
@@ -6,16 +6,19 @@ import Grid from "@saleor/components/Grid";
 import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import { OrderSettingsFragment } from "@saleor/fragments/types/OrderSettingsFragment";
+import { ShopOrderSettingsFragment } from "@saleor/fragments/types/ShopOrderSettingsFragment";
 import { SubmitPromise } from "@saleor/hooks/useForm";
 import { sectionNames } from "@saleor/intl";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
+import OrderFulfillmentSettings from "../OrderFulfillmentSettings";
 import OrderSettings from "../OrderSettings/OrderSettings";
 import OrderSettingsForm, { OrderSettingsFormData } from "./form";
 
 export interface OrderSettingsPageProps {
-  data: OrderSettingsFragment;
+  orderSettings: OrderSettingsFragment;
+  shop: ShopOrderSettingsFragment;
   disabled: boolean;
   saveButtonBarState: ConfirmButtonTransitionState;
   onBack: () => void;
@@ -23,11 +26,22 @@ export interface OrderSettingsPageProps {
 }
 
 const OrderSettingsPage: React.FC<OrderSettingsPageProps> = props => {
-  const { data, disabled, saveButtonBarState, onBack, onSubmit } = props;
+  const {
+    orderSettings,
+    shop,
+    disabled,
+    saveButtonBarState,
+    onBack,
+    onSubmit
+  } = props;
   const intl = useIntl();
 
   return (
-    <OrderSettingsForm orderSettings={data} onSubmit={onSubmit}>
+    <OrderSettingsForm
+      orderSettings={orderSettings}
+      shop={shop}
+      onSubmit={onSubmit}
+    >
       {({ data, submit, hasChanged, change }) => (
         <Container>
           <AppHeader onBack={onBack}>
@@ -46,6 +60,12 @@ const OrderSettingsPage: React.FC<OrderSettingsPageProps> = props => {
               </Typography>
             </div>
             <OrderSettings data={data} disabled={disabled} onChange={change} />
+            <div />
+            <OrderFulfillmentSettings
+              data={data}
+              disabled={disabled}
+              onChange={change}
+            />
           </Grid>
           <SaveButtonBar
             onCancel={onBack}

--- a/src/orders/components/OrderSettingsPage/form.tsx
+++ b/src/orders/components/OrderSettingsPage/form.tsx
@@ -1,10 +1,13 @@
 import { OrderSettingsFragment } from "@saleor/fragments/types/OrderSettingsFragment";
+import { ShopOrderSettingsFragment } from "@saleor/fragments/types/ShopOrderSettingsFragment";
 import useForm, { FormChange, SubmitPromise } from "@saleor/hooks/useForm";
 import handleFormSubmit from "@saleor/utils/handlers/handleFormSubmit";
 import React from "react";
 
 export interface OrderSettingsFormData {
   automaticallyConfirmAllNewOrders: boolean;
+  fulfillmentAutoConfirm: boolean;
+  fulfillmentAllowUnpaid: boolean;
 }
 
 export interface UseOrderSettingsFormResult {
@@ -17,26 +20,31 @@ export interface UseOrderSettingsFormResult {
 export interface OrderSettingsFormProps {
   children: (props: UseOrderSettingsFormResult) => React.ReactNode;
   orderSettings: OrderSettingsFragment;
+  shop: ShopOrderSettingsFragment;
   onSubmit: (data: OrderSettingsFormData) => SubmitPromise;
 }
 
 function getOrderSeettingsFormData(
-  orderSettings: OrderSettingsFragment
+  orderSettings: OrderSettingsFragment,
+  shop: ShopOrderSettingsFragment
 ): OrderSettingsFormData {
   return {
     automaticallyConfirmAllNewOrders:
-      orderSettings?.automaticallyConfirmAllNewOrders
+      orderSettings?.automaticallyConfirmAllNewOrders,
+    fulfillmentAutoConfirm: shop?.fulfillmentAutoConfirm,
+    fulfillmentAllowUnpaid: shop?.fulfillmentAllowUnpaid
   };
 }
 
 function useOrderSettingsForm(
   orderSettings: OrderSettingsFragment,
+  shop: ShopOrderSettingsFragment,
   onSubmit: (data: OrderSettingsFormData) => SubmitPromise
 ): UseOrderSettingsFormResult {
   const [changed, setChanged] = React.useState(false);
   const triggerChange = () => setChanged(true);
 
-  const form = useForm(getOrderSeettingsFormData(orderSettings));
+  const form = useForm(getOrderSeettingsFormData(orderSettings, shop));
 
   const handleChange: FormChange = (event, cb) => {
     form.change(event, cb);
@@ -60,9 +68,10 @@ function useOrderSettingsForm(
 const OrderSettingsForm: React.FC<OrderSettingsFormProps> = ({
   children,
   orderSettings,
+  shop,
   onSubmit
 }) => {
-  const props = useOrderSettingsForm(orderSettings, onSubmit);
+  const props = useOrderSettingsForm(orderSettings, shop, onSubmit);
 
   return <form onSubmit={props.submit}>{children(props)}</form>;
 };

--- a/src/orders/components/OrderSettingsPage/form.tsx
+++ b/src/orders/components/OrderSettingsPage/form.tsx
@@ -6,7 +6,7 @@ import React from "react";
 
 export interface OrderSettingsFormData {
   automaticallyConfirmAllNewOrders: boolean;
-  fulfillmentAutoConfirm: boolean;
+  fulfillmentAutoApprove: boolean;
   fulfillmentAllowUnpaid: boolean;
 }
 
@@ -31,7 +31,7 @@ function getOrderSeettingsFormData(
   return {
     automaticallyConfirmAllNewOrders:
       orderSettings?.automaticallyConfirmAllNewOrders,
-    fulfillmentAutoConfirm: shop?.fulfillmentAutoConfirm,
+    fulfillmentAutoApprove: shop?.fulfillmentAutoApprove,
     fulfillmentAllowUnpaid: shop?.fulfillmentAllowUnpaid
   };
 }

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1,6 +1,7 @@
 import { ShopInfo_shop_countries } from "@saleor/components/Shop/types/ShopInfo";
 import { InvoiceFragment } from "@saleor/fragments/types/InvoiceFragment";
 import { OrderSettingsFragment } from "@saleor/fragments/types/OrderSettingsFragment";
+import { ShopOrderSettingsFragment } from "@saleor/fragments/types/ShopOrderSettingsFragment";
 import { SearchCustomers_search_edges_node } from "@saleor/searches/types/SearchCustomers";
 import { warehouseList } from "@saleor/warehouses/fixtures";
 import { MessageDescriptor } from "react-intl";
@@ -1896,4 +1897,10 @@ export const invoices: InvoiceFragment[] = [
 export const orderSettings: OrderSettingsFragment = {
   __typename: "OrderSettings",
   automaticallyConfirmAllNewOrders: true
+};
+
+export const shopOrderSettings: ShopOrderSettingsFragment = {
+  __typename: "Shop",
+  fulfillmentAutoConfirm: true,
+  fulfillmentAllowUnpaid: true
 };

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1901,6 +1901,6 @@ export const orderSettings: OrderSettingsFragment = {
 
 export const shopOrderSettings: ShopOrderSettingsFragment = {
   __typename: "Shop",
-  fulfillmentAutoConfirm: true,
+  fulfillmentAutoApprove: true,
   fulfillmentAllowUnpaid: true
 };

--- a/src/orders/mutations.ts
+++ b/src/orders/mutations.ts
@@ -743,7 +743,7 @@ const orderSettingsUpdateMutation = gql`
     $orderSettingsInput: OrderSettingsUpdateInput!
     $shopSettingsInput: ShopSettingsInput!
   ) {
-    orderSettingsUpdate(input: $input) {
+    orderSettingsUpdate(input: $orderSettingsInput) {
       errors {
         ...OrderSettingsErrorFragment
       }

--- a/src/orders/mutations.ts
+++ b/src/orders/mutations.ts
@@ -1,12 +1,14 @@
 import {
   invoiceErrorFragment,
   orderErrorFragment,
-  orderSettingsErrorFragment
+  orderSettingsErrorFragment,
+  shopErrorFragment
 } from "@saleor/fragments/errors";
 import {
   fragmentOrderDetails,
   fragmentOrderEvent,
   fragmentOrderSettings,
+  fragmentShopOrderSettings,
   fulfillmentFragment,
   invoiceFragment
 } from "@saleor/fragments/orders";
@@ -734,14 +736,27 @@ export const TypedInvoiceEmailSendMutation = TypedMutation<
 
 const orderSettingsUpdateMutation = gql`
   ${fragmentOrderSettings}
+  ${fragmentShopOrderSettings}
   ${orderSettingsErrorFragment}
-  mutation OrderSettingsUpdate($input: OrderSettingsUpdateInput!) {
+  ${shopErrorFragment}
+  mutation OrderSettingsUpdate(
+    $orderSettingsInput: OrderSettingsUpdateInput!
+    $shopSettingsInput: ShopSettingsInput!
+  ) {
     orderSettingsUpdate(input: $input) {
       errors {
         ...OrderSettingsErrorFragment
       }
       orderSettings {
         ...OrderSettingsFragment
+      }
+    }
+    shopSettingsUpdate(input: $shopSettingsInput) {
+      errors {
+        ...ShopErrorFragment
+      }
+      shop {
+        ...ShopOrderSettingsFragment
       }
     }
   }

--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -2,7 +2,8 @@ import { fragmentAddress } from "@saleor/fragments/address";
 import {
   fragmentOrderDetails,
   fragmentOrderSettings,
-  fragmentRefundOrderLine
+  fragmentRefundOrderLine,
+  fragmentShopOrderSettings
 } from "@saleor/fragments/orders";
 import { fragmentMoney } from "@saleor/fragments/products";
 import makeQuery from "@saleor/hooks/makeQuery";
@@ -267,9 +268,13 @@ export const useOrderFulfillData = makeQuery<
 
 export const orderSettingsQuery = gql`
   ${fragmentOrderSettings}
+  ${fragmentShopOrderSettings}
   query OrderSettings {
     orderSettings {
       ...OrderSettingsFragment
+    }
+    shop {
+      ...ShopOrderSettingsFragment
     }
   }
 `;

--- a/src/orders/types/OrderSettings.ts
+++ b/src/orders/types/OrderSettings.ts
@@ -12,7 +12,7 @@ export interface OrderSettings_orderSettings {
   automaticallyConfirmAllNewOrders: boolean;
 }
 
-export interface ShopOrderSettings_shop {
+export interface OrderSettings_shop {
   __typename: "Shop";
   fulfillmentAutoApprove: boolean;
   fulfillmentAllowUnpaid: boolean;
@@ -20,5 +20,5 @@ export interface ShopOrderSettings_shop {
 
 export interface OrderSettings {
   orderSettings: OrderSettings_orderSettings | null;
-  shop: ShopOrderSettings_shop | null;
+  shop: OrderSettings_shop;
 }

--- a/src/orders/types/OrderSettings.ts
+++ b/src/orders/types/OrderSettings.ts
@@ -12,6 +12,13 @@ export interface OrderSettings_orderSettings {
   automaticallyConfirmAllNewOrders: boolean;
 }
 
+export interface ShopOrderSettings_shop {
+  __typename: "Shop";
+  fulfillmentAutoConfirm: boolean;
+  fulfillmentAllowUnpaid: boolean;
+}
+
 export interface OrderSettings {
   orderSettings: OrderSettings_orderSettings | null;
+  shop: ShopOrderSettings_shop | null;
 }

--- a/src/orders/types/OrderSettings.ts
+++ b/src/orders/types/OrderSettings.ts
@@ -14,7 +14,7 @@ export interface OrderSettings_orderSettings {
 
 export interface ShopOrderSettings_shop {
   __typename: "Shop";
-  fulfillmentAutoConfirm: boolean;
+  fulfillmentAutoApprove: boolean;
   fulfillmentAllowUnpaid: boolean;
 }
 

--- a/src/orders/types/OrderSettingsUpdate.ts
+++ b/src/orders/types/OrderSettingsUpdate.ts
@@ -34,7 +34,7 @@ export interface OrderSettingsUpdate_shopSettingsUpdate_errors {
 
 export interface OrderSettingsUpdate_shopSettingsUpdate_shop {
   __typename: "Shop";
-  fulfillmentAutoConfirm: boolean;
+  fulfillmentAutoApprove: boolean;
   fulfillmentAllowUnpaid: boolean;
 }
 

--- a/src/orders/types/OrderSettingsUpdate.ts
+++ b/src/orders/types/OrderSettingsUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderSettingsUpdateInput, OrderSettingsErrorCode, ShopErrorCode, ShopSettingsInput } from "./../../types/globalTypes";
+import { OrderSettingsUpdateInput, ShopSettingsInput, OrderSettingsErrorCode, ShopErrorCode } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderSettingsUpdate
@@ -39,9 +39,9 @@ export interface OrderSettingsUpdate_shopSettingsUpdate_shop {
 }
 
 export interface OrderSettingsUpdate_shopSettingsUpdate {
-  __typename: "OrderSettingsUpdate";
+  __typename: "ShopSettingsUpdate";
   errors: OrderSettingsUpdate_shopSettingsUpdate_errors[];
-  orderSettings: OrderSettingsUpdate_shopSettingsUpdate_shop | null;
+  shop: OrderSettingsUpdate_shopSettingsUpdate_shop | null;
 }
 
 export interface OrderSettingsUpdate {

--- a/src/orders/types/OrderSettingsUpdate.ts
+++ b/src/orders/types/OrderSettingsUpdate.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderSettingsUpdateInput, OrderSettingsErrorCode } from "./../../types/globalTypes";
+import { OrderSettingsUpdateInput, OrderSettingsErrorCode, ShopErrorCode, ShopSettingsInput } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderSettingsUpdate
@@ -26,10 +26,30 @@ export interface OrderSettingsUpdate_orderSettingsUpdate {
   orderSettings: OrderSettingsUpdate_orderSettingsUpdate_orderSettings | null;
 }
 
+export interface OrderSettingsUpdate_shopSettingsUpdate_errors {
+  __typename: "ShopError";
+  code: ShopErrorCode;
+  field: string | null;
+}
+
+export interface OrderSettingsUpdate_shopSettingsUpdate_shop {
+  __typename: "Shop";
+  fulfillmentAutoConfirm: boolean;
+  fulfillmentAllowUnpaid: boolean;
+}
+
+export interface OrderSettingsUpdate_shopSettingsUpdate {
+  __typename: "OrderSettingsUpdate";
+  errors: OrderSettingsUpdate_shopSettingsUpdate_errors[];
+  orderSettings: OrderSettingsUpdate_shopSettingsUpdate_shop | null;
+}
+
 export interface OrderSettingsUpdate {
   orderSettingsUpdate: OrderSettingsUpdate_orderSettingsUpdate | null;
+  shopSettingsUpdate: OrderSettingsUpdate_shopSettingsUpdate | null;
 }
 
 export interface OrderSettingsUpdateVariables {
-  input: OrderSettingsUpdateInput;
+  orderSettingsInput: OrderSettingsUpdateInput;
+  shopSettingsInput: ShopSettingsInput;
 }

--- a/src/orders/views/OrderSettings.tsx
+++ b/src/orders/views/OrderSettings.tsx
@@ -22,10 +22,20 @@ export const OrderSettings: React.FC = () => {
     orderSettingsUpdateOpts
   ] = useOrderSettingsUpdateMutation({});
 
-  const handleSubmit = async (data: OrderSettingsFormData) => {
+  const handleSubmit = async ({
+    automaticallyConfirmAllNewOrders,
+    fulfillmentAutoConfirm,
+    fulfillmentAllowUnpaid
+  }: OrderSettingsFormData) => {
     const result = await orderSettingsUpdate({
       variables: {
-        input: data
+        orderSettingsInput: {
+          automaticallyConfirmAllNewOrders
+        },
+        shopSettingsInput: {
+          fulfillmentAutoConfirm,
+          fulfillmentAllowUnpaid
+        }
       }
     });
 
@@ -49,7 +59,8 @@ export const OrderSettings: React.FC = () => {
 
   return (
     <OrderSettingsPage
-      data={data?.orderSettings}
+      orderSettings={data?.orderSettings}
+      shop={data?.shop}
       disabled={loading || orderSettingsUpdateOpts.loading}
       onSubmit={handleSubmit}
       onBack={handleBack}

--- a/src/orders/views/OrderSettings.tsx
+++ b/src/orders/views/OrderSettings.tsx
@@ -24,7 +24,7 @@ export const OrderSettings: React.FC = () => {
 
   const handleSubmit = async ({
     automaticallyConfirmAllNewOrders,
-    fulfillmentAutoConfirm,
+    fulfillmentAutoApprove,
     fulfillmentAllowUnpaid
   }: OrderSettingsFormData) => {
     const result = await orderSettingsUpdate({
@@ -33,7 +33,7 @@ export const OrderSettings: React.FC = () => {
           automaticallyConfirmAllNewOrders
         },
         shopSettingsInput: {
-          fulfillmentAutoConfirm,
+          fulfillmentAutoApprove,
           fulfillmentAllowUnpaid
         }
       }

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -464,6 +464,7 @@ export enum FulfillmentStatus {
   REFUNDED_AND_RETURNED = "REFUNDED_AND_RETURNED",
   REPLACED = "REPLACED",
   RETURNED = "RETURNED",
+  WAITING_FOR_APPROVAL = "WAITING_FOR_APPROVAL",
 }
 
 export enum InvoiceErrorCode {
@@ -615,6 +616,7 @@ export enum OrderErrorCode {
   CANNOT_CANCEL_ORDER = "CANNOT_CANCEL_ORDER",
   CANNOT_DELETE = "CANNOT_DELETE",
   CANNOT_DISCOUNT = "CANNOT_DISCOUNT",
+  CANNOT_FULFILL_UNPAID_ORDER = "CANNOT_FULFILL_UNPAID_ORDER",
   CANNOT_REFUND = "CANNOT_REFUND",
   CAPTURE_INACTIVE_PAYMENT = "CAPTURE_INACTIVE_PAYMENT",
   CHANNEL_INACTIVE = "CHANNEL_INACTIVE",
@@ -661,6 +663,7 @@ export enum OrderEventsEnum {
   DRAFT_CREATED_FROM_REPLACE = "DRAFT_CREATED_FROM_REPLACE",
   EMAIL_SENT = "EMAIL_SENT",
   EXTERNAL_SERVICE_NOTIFICATION = "EXTERNAL_SERVICE_NOTIFICATION",
+  FULFILLMENT_AWAITS_APPROVAL = "FULFILLMENT_AWAITS_APPROVAL",
   FULFILLMENT_CANCELED = "FULFILLMENT_CANCELED",
   FULFILLMENT_FULFILLED_ITEMS = "FULFILLMENT_FULFILLED_ITEMS",
   FULFILLMENT_REFUNDED = "FULFILLMENT_REFUNDED",
@@ -1782,6 +1785,7 @@ export interface SaleFilterInput {
   saleType?: DiscountValueTypeEnum | null;
   started?: DateTimeRangeInput | null;
   search?: string | null;
+  metadata?: (MetadataFilter | null)[] | null;
 }
 
 export interface SaleInput {
@@ -1879,13 +1883,13 @@ export interface ShopSettingsInput {
   trackInventoryByDefault?: boolean | null;
   defaultWeightUnit?: WeightUnitsEnum | null;
   automaticFulfillmentDigitalProducts?: boolean | null;
+  fulfillmentAutoApprove?: boolean | null;
+  fulfillmentAllowUnpaid?: boolean | null;
   defaultDigitalMaxDownloads?: number | null;
   defaultDigitalUrlValidDays?: number | null;
   defaultMailSenderName?: string | null;
   defaultMailSenderAddress?: string | null;
   customerSetPasswordUrl?: string | null;
-  fulfillmentAutoApprove?: boolean | null;
-  fulfillmentAllowUnpaid?: boolean | null;
 }
 
 export interface SiteDomainInput {
@@ -1965,6 +1969,7 @@ export interface VoucherFilterInput {
   discountType?: (VoucherDiscountType | null)[] | null;
   started?: DateTimeRangeInput | null;
   search?: string | null;
+  metadata?: (MetadataFilter | null)[] | null;
 }
 
 export interface VoucherInput {

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1884,6 +1884,8 @@ export interface ShopSettingsInput {
   defaultMailSenderName?: string | null;
   defaultMailSenderAddress?: string | null;
   customerSetPasswordUrl?: string | null;
+  fulfillmentAutoConfirm?: boolean | null;
+  fulfillmentAllowUnpaid?: boolean | null;
 }
 
 export interface SiteDomainInput {

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1884,7 +1884,7 @@ export interface ShopSettingsInput {
   defaultMailSenderName?: string | null;
   defaultMailSenderAddress?: string | null;
   customerSetPasswordUrl?: string | null;
-  fulfillmentAutoConfirm?: boolean | null;
+  fulfillmentAutoApprove?: boolean | null;
   fulfillmentAllowUnpaid?: boolean | null;
 }
 

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -39,7 +39,7 @@ export interface UpdateMetadata_deleteMetadata_item_privateMetadata {
 }
 
 export interface UpdateMetadata_deleteMetadata_item {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdateMetadata_deleteMetadata_item_metadata | null)[];
   privateMetadata: (UpdateMetadata_deleteMetadata_item_privateMetadata | null)[];
   id: string;

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -39,7 +39,7 @@ export interface UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadat
 }
 
 export interface UpdatePrivateMetadata_deletePrivateMetadata_item {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_metadata | null)[];
   privateMetadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata | null)[];
   id: string;


### PR DESCRIPTION
I want to merge this change because... it adds fulfillment settings card in orders settings.
Backend: https://github.com/mirumee/saleor/pull/7675

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="693" alt="Zrzut ekranu 2021-07-19 o 14 55 36" src="https://user-images.githubusercontent.com/9825562/126162881-769f1687-75af-4e14-b170-3b2dbe88146c.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://feature-fulfillment-api.api.saleor.rocks/graphql/