### PR TITLE
Add gift card update view #1 - Details Card

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4798,7 +4798,7 @@ type Query {
   menuItem(id: ID!, channel: String): MenuItem
   menuItems(channel: String, sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
   giftCard(id: ID!): GiftCard
-  giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
+  giftCards(filter: GiftCardFilterInput, before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   plugin(id: ID!): Plugin
   plugins(filter: PluginFilterInput, sortBy: PluginSortingInput, before: String, after: String, first: Int, last: Int): PluginCountableConnection
   sale(id: ID!, channel: String): Sale
@@ -4829,6 +4829,10 @@ type Query {
   user(id: ID, email: String): User
   _entities(representations: [_Any]): [_Entity]
   _service: _Service
+}
+
+type GiftCardFilterInput {
+  tag: String 
 }
 
 type ReducedRate {

--- a/schema.graphql
+++ b/schema.graphql
@@ -3,6 +3,54 @@ schema {
   mutation: Mutation
 }
 
+type GiftCard implements Node & ObjectWithMetadata {
+	code: String!
+	user: User @deprecated(reason: "This field will be removed in Saleor 4.0.")
+	createdBy: User
+	usedBy: User
+  usedByEmail: String    # MADZIA
+	createdByEmail: String   # MADZIA
+	app: App
+	created: DateTime!
+	startDate: Date! @deprecated(reason: "This field will be removed in Saleor 4.0.")
+	endDate: Date @deprecated(reason: "This field will be removed in Saleor 4.0.")
+	expiryDate: Date
+  expiryType: GiftCardExpiryType
+  expiryPeriod: TimePeriod
+	lastUsedOn: DateTime
+	isActive: Boolean!
+	initialBalance: Money
+	currentBalance: Money
+	id: ID!
+	displayCode: String
+	product: Product
+  metadata: [MetadataItem]!
+  privateMetadata: [MetadataItem]!
+  tag: String
+}
+
+enum TimePeriodType {
+	MONTH
+	YEAR
+}
+
+type TimePeriod {
+	amount: Int
+	type: TimePeriodType
+}
+
+enum GiftCardExpiryType {
+  NEVER_EXPIRE
+  EXPIRY_PERIOD
+	EXPIRY_DATE
+}
+
+type GiftCardSettings {
+  expiryType: GiftCardExpiryType!
+  expiryPeriod: TimePeriod
+}
+
+
 type AccountAddressCreate {
   user: User
   accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
@@ -2135,20 +2183,6 @@ type GatewayConfigLine {
 }
 
 scalar GenericScalar
-
-type GiftCard implements Node {
-  code: String
-  user: User
-  created: DateTime!
-  startDate: Date!
-  endDate: Date
-  lastUsedOn: DateTime
-  isActive: Boolean!
-  initialBalance: Money
-  currentBalance: Money
-  id: ID!
-  displayCode: String
-}
 
 type GiftCardActivate {
   giftCard: GiftCard

--- a/schema.graphql
+++ b/schema.graphql
@@ -30,6 +30,7 @@ type GiftCard implements Node & ObjectWithMetadata {
 }
 
 enum TimePeriodType {
+  DAY
 	MONTH
 	YEAR
 }

--- a/src/apps/components/VerticalSpacer/VerticalSpacer.tsx
+++ b/src/apps/components/VerticalSpacer/VerticalSpacer.tsx
@@ -1,0 +1,23 @@
+import { makeStyles } from "@saleor/theme";
+import React from "react";
+
+export interface VerticalSpacerProps {
+  spacing?: number;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    container: ({ spacing }: VerticalSpacerProps) => ({
+      height: theme.spacing(spacing)
+    })
+  }),
+  { name: "VerticalSpacer" }
+);
+
+const VerticalSpacer: React.FC<VerticalSpacerProps> = ({ spacing = 1 }) => {
+  const classes = useStyles({ spacing });
+
+  return <div className={classes.container} />;
+};
+
+export default VerticalSpacer;

--- a/src/apps/components/VerticalSpacer/VerticalSpacer.tsx
+++ b/src/apps/components/VerticalSpacer/VerticalSpacer.tsx
@@ -1,4 +1,4 @@
-import { makeStyles } from "@saleor/theme";
+import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 
 export interface VerticalSpacerProps {

--- a/src/apps/components/VerticalSpacer/index.tsx
+++ b/src/apps/components/VerticalSpacer/index.tsx
@@ -1,0 +1,2 @@
+export * from "./VerticalSpacer";
+export { default } from "./VerticalSpacer";

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -11,6 +11,7 @@ import {
   useSavebar,
   useTheme
 } from "@saleor/macaw-ui";
+import { isDarkTheme } from "@saleor/misc";
 import { staffMemberDetailsUrl } from "@saleor/staff/urls";
 import classNames from "classnames";
 import React from "react";
@@ -154,8 +155,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
     });
   };
 
-  const isDark = themeType === "dark";
-  const toggleTheme = () => setTheme(isDark ? "light" : "dark");
+  const toggleTheme = () => setTheme(isDarkTheme(themeType) ? "light" : "dark");
 
   return (
     <>
@@ -204,7 +204,7 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
                         />
                       )}
                       <UserChip
-                        isDarkThemeEnabled={isDark}
+                        isDarkThemeEnabled={isDarkTheme(themeType)}
                         user={user}
                         onLogout={logout}
                         onProfileClick={() =>

--- a/src/components/Money/Money.tsx
+++ b/src/components/Money/Money.tsx
@@ -1,35 +1,39 @@
+import { makeStyles, Typography, TypographyProps } from "@material-ui/core";
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import React from "react";
-
-import { LocaleConsumer } from "../Locale";
 
 export interface IMoney {
   amount: number;
   currency: string;
 }
-export interface MoneyProps {
+
+export interface MoneyProps extends TypographyProps {
   money: IMoney | null;
 }
 
-export const formatMoney = (money: IMoney, locale: string) => {
-  try {
-    const formattedMoney = money.amount.toLocaleString(locale, {
-      currency: money.currency,
-      style: "currency"
-    });
-    return formattedMoney;
-  } catch (error) {
-    return `${money.amount} ${money.currency}`;
-  }
-};
+const useStyles = makeStyles(
+  () => ({
+    container: {
+      display: "flex",
+      alignItems: "baseline"
+    }
+  }),
+  { name: "Money" }
+);
 
-export const Money: React.FC<MoneyProps> = ({ money }) =>
-  money ? (
-    <LocaleConsumer>
-      {({ locale }) => formatMoney(money, locale)}
-    </LocaleConsumer>
-  ) : (
-    <>-</>
+export const Money: React.FC<MoneyProps> = ({ money, ...rest }) => {
+  const classes = useStyles({});
+
+  return (
+    <div className={classes.container}>
+      <Typography variant="caption" {...rest}>
+        {money.currency}
+      </Typography>
+      <HorizontalSpacer spacing={0.5} />
+      <Typography {...rest}>{money.amount.toFixed(2)}</Typography>
+    </div>
   );
+};
 
 Money.displayName = "Money";
 export default Money;

--- a/src/components/Money/Money.tsx
+++ b/src/components/Money/Money.tsx
@@ -24,6 +24,10 @@ const useStyles = makeStyles(
 export const Money: React.FC<MoneyProps> = ({ money, ...rest }) => {
   const classes = useStyles({});
 
+  if (!money) {
+    return null;
+  }
+
   return (
     <div className={classes.container}>
       <Typography variant="caption" {...rest}>

--- a/src/components/PageTitleWithStatusChip/PageTitleWithStatusChip.tsx
+++ b/src/components/PageTitleWithStatusChip/PageTitleWithStatusChip.tsx
@@ -1,0 +1,39 @@
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
+import StatusChip from "@saleor/components/StatusChip";
+import { StatusType } from "@saleor/components/StatusChip/types";
+import { makeStyles } from "@saleor/theme";
+import React from "react";
+
+export interface PageTitleWithStatusChipProps {
+  title: string;
+  statusLabel: string;
+  statusType: StatusType;
+}
+
+const useStyles = makeStyles(
+  () => ({
+    container: {
+      alignItems: "center",
+      display: "flex"
+    }
+  }),
+  { name: "OrderDetailsPageTitleWithStatusChip" }
+);
+
+const PageTitleWithStatusChip: React.FC<PageTitleWithStatusChipProps> = ({
+  title,
+  statusLabel,
+  statusType
+}) => {
+  const classes = useStyles({});
+
+  return (
+    <div className={classes.container}>
+      {title}
+      <HorizontalSpacer spacing={2} />
+      <StatusChip label={statusLabel} status={statusType} />
+    </div>
+  );
+};
+
+export default PageTitleWithStatusChip;

--- a/src/components/PageTitleWithStatusChip/PageTitleWithStatusChip.tsx
+++ b/src/components/PageTitleWithStatusChip/PageTitleWithStatusChip.tsx
@@ -1,7 +1,7 @@
 import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import StatusChip from "@saleor/components/StatusChip";
 import { StatusType } from "@saleor/components/StatusChip/types";
-import { makeStyles } from "@saleor/theme";
+import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 
 export interface PageTitleWithStatusChipProps {

--- a/src/components/PageTitleWithStatusChip/index.tsx
+++ b/src/components/PageTitleWithStatusChip/index.tsx
@@ -1,0 +1,2 @@
+export * from "./PageTitleWithStatusChip";
+export { default } from "./PageTitleWithStatusChip";

--- a/src/components/StatusChip/StatusChip.tsx
+++ b/src/components/StatusChip/StatusChip.tsx
@@ -38,10 +38,10 @@ const StatusChipStyles = {
     color: "#5DC292"
   },
   lg: {
-    padding: "8px 24px"
+    padding: "4px 16px"
   },
   lgLabel: {
-    fontSize: "1rem"
+    fontSize: "1.5rem"
   },
   md: {
     padding: "4px 16px"

--- a/src/components/TablePagination/TablePaginationActions.tsx
+++ b/src/components/TablePagination/TablePaginationActions.tsx
@@ -3,6 +3,7 @@ import { fade } from "@material-ui/core/styles/colorManipulator";
 import ArrowLeft from "@material-ui/icons/ArrowLeft";
 import ArrowRight from "@material-ui/icons/ArrowRight";
 import { makeStyles, useTheme } from "@saleor/macaw-ui";
+import { isDarkTheme } from "@saleor/misc";
 import classNames from "classnames";
 import React from "react";
 
@@ -76,7 +77,7 @@ export const TablePaginationActions: React.FC<TablePaginationActionsProps> = pro
 
   const { direction, themeType } = useTheme();
 
-  const isDark = themeType === "dark";
+  const isDark = isDarkTheme(themeType);
 
   return (
     <div className={classNames(classes.root, className)} {...other}>

--- a/src/fragments/types/MetadataFragment.ts
+++ b/src/fragments/types/MetadataFragment.ts
@@ -20,7 +20,7 @@ export interface MetadataFragment_privateMetadata {
 }
 
 export interface MetadataFragment {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "GiftCard" | "Order" | "Fulfillment" | "Invoice";
   metadata: (MetadataFragment_metadata | null)[];
   privateMetadata: (MetadataFragment_privateMetadata | null)[];
 }

--- a/src/giftCards/GiftCardUpdatePage/GiftCardDetailsProvider.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardDetailsProvider.tsx
@@ -18,10 +18,18 @@ export const GiftCardDetailsContext = createContext<
 const GiftCardDetailsProvider: React.FC<GiftCardDetailsProviderProps> = ({
   children
 }) => {
-  const giftCard = {
+  const giftCard: GiftCardDetails_giftCard = {
     id: "1234",
     code: "8361",
-    isActive: false
+    isActive: false,
+    currentBalance: {
+      amount: 10.67,
+      currency: "USD"
+    },
+    initialBalance: {
+      amount: 17.0,
+      currency: "USD"
+    }
   };
 
   const providerValues: GiftCardDetailsConsumerProps = {

--- a/src/giftCards/GiftCardUpdatePage/GiftCardDetailsProvider.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardDetailsProvider.tsx
@@ -1,3 +1,4 @@
+import { GiftCardExpiryType, TimePeriodType } from "@saleor/types/globalTypes";
 import React, { createContext } from "react";
 
 import { GiftCardDetails_giftCard } from "./types/GiftCardDetails";
@@ -22,6 +23,11 @@ const GiftCardDetailsProvider: React.FC<GiftCardDetailsProviderProps> = ({
     id: "1234",
     code: "8361",
     isActive: false,
+    expiryType: GiftCardExpiryType.EXPIRY_PERIOD,
+    expiryPeriod: {
+      type: TimePeriodType.MONTH,
+      amount: 12
+    },
     currentBalance: {
       amount: 10.67,
       currency: "USD"

--- a/src/giftCards/GiftCardUpdatePage/GiftCardDetailsProvider.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardDetailsProvider.tsx
@@ -1,0 +1,38 @@
+import React, { createContext } from "react";
+
+import { GiftCardDetails_giftCard } from "./types/GiftCardDetails";
+
+interface GiftCardDetailsProviderProps {
+  children: React.ReactNode;
+  id: string;
+}
+
+export interface GiftCardDetailsConsumerProps {
+  giftCard: GiftCardDetails_giftCard;
+}
+
+export const GiftCardDetailsContext = createContext<
+  GiftCardDetailsConsumerProps
+>(null);
+
+const GiftCardDetailsProvider: React.FC<GiftCardDetailsProviderProps> = ({
+  children
+}) => {
+  const giftCard = {
+    id: "1234",
+    code: "8361",
+    isActive: false
+  };
+
+  const providerValues: GiftCardDetailsConsumerProps = {
+    giftCard
+  };
+
+  return (
+    <GiftCardDetailsContext.Provider value={providerValues}>
+      {children}
+    </GiftCardDetailsContext.Provider>
+  );
+};
+
+export default GiftCardDetailsProvider;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsBalanceSection.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsBalanceSection.tsx
@@ -3,43 +3,13 @@ import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import CardSpacer from "@saleor/components/CardSpacer";
 import Money from "@saleor/components/Money";
 import useTheme from "@saleor/hooks/useTheme";
-import { makeStyles } from "@saleor/theme";
 import classNames from "classnames";
 import React, { useContext } from "react";
 import { useIntl } from "react-intl";
 
 import { GiftCardDetailsContext } from "../GiftCardDetailsProvider";
 import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
-
-const useStyles = makeStyles(
-  theme => ({
-    labelsContainer: {
-      display: "flex",
-      alignItems: "baseline"
-    },
-    wideContainer: {
-      justifyContent: "space-between"
-    },
-    balanceBar: {
-      width: "100%",
-      display: "flex",
-      alignItems: "center",
-      height: 36,
-      padding: "0 4px",
-      backgroundColor: theme.palette.background.default,
-      borderRadius: 18
-    },
-    balanceBarProgress: {
-      height: 28,
-      borderRadius: 14,
-      backgroundColor: theme.palette.primary.light
-    },
-    balanceBarProgressDark: {
-      backgroundColor: theme.palette.primary.dark
-    }
-  }),
-  { name: "GiftCardUpdateDetailsBalanceSection" }
-);
+import { useGiftCardDetailsBalanceStyles as useStyles } from "./styles";
 
 const GiftCardUpdateDetailsBalanceSection: React.FC = () => {
   const { isDark } = useTheme();

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsBalanceSection.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsBalanceSection.tsx
@@ -1,0 +1,84 @@
+import { Typography } from "@material-ui/core";
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
+import CardSpacer from "@saleor/components/CardSpacer";
+import Money from "@saleor/components/Money";
+import useTheme from "@saleor/hooks/useTheme";
+import { makeStyles } from "@saleor/theme";
+import classNames from "classnames";
+import React, { useContext } from "react";
+import { useIntl } from "react-intl";
+
+import { GiftCardDetailsContext } from "../GiftCardDetailsProvider";
+import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
+
+const useStyles = makeStyles(
+  theme => ({
+    labelsContainer: {
+      display: "flex",
+      alignItems: "baseline"
+    },
+    wideContainer: {
+      justifyContent: "space-between"
+    },
+    balanceBar: {
+      width: "100%",
+      display: "flex",
+      alignItems: "center",
+      height: 36,
+      padding: "0 4px",
+      backgroundColor: theme.palette.background.default,
+      borderRadius: 18
+    },
+    balanceBarProgress: {
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: theme.palette.primary.light
+    },
+    balanceBarProgressDark: {
+      backgroundColor: theme.palette.primary.dark
+    }
+  }),
+  { name: "GiftCardUpdateDetailsBalanceSection" }
+);
+
+const GiftCardUpdateDetailsBalanceSection: React.FC = () => {
+  const { isDark } = useTheme();
+  const classes = useStyles({});
+  const intl = useIntl();
+
+  const {
+    giftCard: { currentBalance, initialBalance }
+  } = useContext(GiftCardDetailsContext);
+
+  const progressBarWidth = !!currentBalance.amount
+    ? Math.floor((currentBalance.amount / initialBalance.amount) * 100)
+    : 0;
+
+  return (
+    <>
+      <div
+        className={classNames(classes.labelsContainer, classes.wideContainer)}
+      >
+        <Typography>{intl.formatMessage(messages.cardBalanceLabel)}</Typography>
+        <div className={classes.labelsContainer}>
+          <Money money={currentBalance} />
+          <HorizontalSpacer />
+          /
+          <HorizontalSpacer />
+          <Money money={initialBalance} />
+        </div>
+      </div>
+      <CardSpacer />
+      <div className={classes.balanceBar}>
+        <div
+          style={{ width: `${progressBarWidth}%` }}
+          className={classNames(classes.balanceBarProgress, {
+            [classes.balanceBarProgressDark]: isDark
+          })}
+        />
+      </div>
+    </>
+  );
+};
+
+export default GiftCardUpdateDetailsBalanceSection;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsBalanceSection.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsBalanceSection.tsx
@@ -2,7 +2,8 @@ import { Typography } from "@material-ui/core";
 import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import CardSpacer from "@saleor/components/CardSpacer";
 import Money from "@saleor/components/Money";
-import useTheme from "@saleor/hooks/useTheme";
+import { useTheme } from "@saleor/macaw-ui";
+import { isDarkTheme } from "@saleor/misc";
 import classNames from "classnames";
 import React, { useContext } from "react";
 import { useIntl } from "react-intl";
@@ -12,7 +13,7 @@ import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
 import { useGiftCardDetailsBalanceStyles as useStyles } from "./styles";
 
 const GiftCardUpdateDetailsBalanceSection: React.FC = () => {
-  const { isDark } = useTheme();
+  const { themeType } = useTheme();
   const classes = useStyles({});
   const intl = useIntl();
 
@@ -43,7 +44,7 @@ const GiftCardUpdateDetailsBalanceSection: React.FC = () => {
         <div
           style={{ width: `${progressBarWidth}%` }}
           className={classNames(classes.balanceBarProgress, {
-            [classes.balanceBarProgressDark]: isDark
+            [classes.balanceBarProgressDark]: isDarkTheme(themeType)
           })}
         />
       </div>

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
@@ -7,6 +7,7 @@ import { useIntl } from "react-intl";
 
 import { GiftCardUpdateFormContext } from "../GiftCardUpdateFormProvider";
 import GiftCardUpdateDetailsBalanceSection from "./GiftCardUpdateDetailsBalanceSection";
+import GiftCardUpdateDetailsExpirySection from "./GiftCardUpdateDetailsExpirySection";
 import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
 
 const GiftCardUpdateDetailsCard: React.FC = ({}) => {
@@ -33,7 +34,13 @@ const GiftCardUpdateDetailsCard: React.FC = ({}) => {
         <CardSpacer />
         <Divider />
         <CardSpacer />
-        <GiftCardTagInput change={change} setSelected={setSelectedTag} />
+        <GiftCardTagInput
+          withTopLabel
+          change={change}
+          setSelected={setSelectedTag}
+        />
+        <CardSpacer />
+        <GiftCardUpdateDetailsExpirySection />
       </CardContent>
     </Card>
   );

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
@@ -1,24 +1,18 @@
-import {
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Divider,
-  makeStyles
-} from "@material-ui/core";
+import { Button, Card, CardContent, Divider } from "@material-ui/core";
 import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import GiftCardTagInput from "@saleor/giftCards/components/GiftCardTagInput";
-import React from "react";
+import React, { useContext } from "react";
 import { useIntl } from "react-intl";
 
+import { GiftCardUpdateFormContext } from "../GiftCardUpdateFormProvider";
 import GiftCardUpdateDetailsBalanceSection from "./GiftCardUpdateDetailsBalanceSection";
 import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
 
-interface GiftCardUpdateDetailsCardProps {}
-
-const GiftCardUpdateDetailsCard: React.FC<GiftCardUpdateDetailsCardProps> = ({}) => {
+const GiftCardUpdateDetailsCard: React.FC = ({}) => {
   const intl = useIntl();
+
+  const { change, setSelectedTag } = useContext(GiftCardUpdateFormContext);
 
   return (
     <Card>
@@ -39,7 +33,7 @@ const GiftCardUpdateDetailsCard: React.FC<GiftCardUpdateDetailsCardProps> = ({})
         <CardSpacer />
         <Divider />
         <CardSpacer />
-        <GiftCardTagInput />
+        <GiftCardTagInput change={change} setSelected={setSelectedTag} />
       </CardContent>
     </Card>
   );

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
@@ -6,10 +6,12 @@ import {
   Divider,
   makeStyles
 } from "@material-ui/core";
+import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import React from "react";
 import { useIntl } from "react-intl";
 
+import GiftCardUpdateDetailsBalanceSection from "./GiftCardUpdateDetailsBalanceSection";
 import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
 
 interface GiftCardUpdateDetailsCardProps {}
@@ -29,9 +31,9 @@ const GiftCardUpdateDetailsCard: React.FC<GiftCardUpdateDetailsCardProps> = ({})
 
   return (
     <Card>
-      <CardHeader
+      <CardTitle
         title={intl.formatMessage(messages.title)}
-        action={
+        toolbar={
           <Button
             className={classes.setBalanceButton}
             color="primary"
@@ -42,8 +44,12 @@ const GiftCardUpdateDetailsCard: React.FC<GiftCardUpdateDetailsCardProps> = ({})
           </Button>
         }
       />
-      <Divider />
-      <CardContent>lol</CardContent>
+      <CardContent>
+        <GiftCardUpdateDetailsBalanceSection />
+        <CardSpacer />
+        <Divider />
+        <CardSpacer />
+      </CardContent>
     </Card>
   );
 };

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
@@ -1,0 +1,51 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  makeStyles
+} from "@material-ui/core";
+import CardTitle from "@saleor/components/CardTitle";
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
+
+interface GiftCardUpdateDetailsCardProps {}
+
+const useStyles = makeStyles(
+  () => ({
+    setBalanceButton: {
+      marginTop: 10
+    }
+  }),
+  { name: "GiftCardUpdateDetailsCard" }
+);
+
+const GiftCardUpdateDetailsCard: React.FC<GiftCardUpdateDetailsCardProps> = ({}) => {
+  const intl = useIntl();
+  const classes = useStyles({});
+
+  return (
+    <Card>
+      <CardHeader
+        title={intl.formatMessage(messages.title)}
+        action={
+          <Button
+            className={classes.setBalanceButton}
+            color="primary"
+            // onClick={navigateToCustomAppCreate}
+            data-test-id="createApp"
+          >
+            {intl.formatMessage(messages.setBalanceButtonLabel)}
+          </Button>
+        }
+      />
+      <Divider />
+      <CardContent>lol</CardContent>
+    </Card>
+  );
+};
+
+export default GiftCardUpdateDetailsCard;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
@@ -8,6 +8,7 @@ import {
 } from "@material-ui/core";
 import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
+import GiftCardTagInput from "@saleor/giftCards/components/GiftCardTagInput";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -16,18 +17,8 @@ import { giftCardUpdateDetailsCardMessages as messages } from "./messages";
 
 interface GiftCardUpdateDetailsCardProps {}
 
-const useStyles = makeStyles(
-  () => ({
-    setBalanceButton: {
-      marginTop: 10
-    }
-  }),
-  { name: "GiftCardUpdateDetailsCard" }
-);
-
 const GiftCardUpdateDetailsCard: React.FC<GiftCardUpdateDetailsCardProps> = ({}) => {
   const intl = useIntl();
-  const classes = useStyles({});
 
   return (
     <Card>
@@ -35,10 +26,9 @@ const GiftCardUpdateDetailsCard: React.FC<GiftCardUpdateDetailsCardProps> = ({})
         title={intl.formatMessage(messages.title)}
         toolbar={
           <Button
-            className={classes.setBalanceButton}
+            data-test-id="createApp"
             color="primary"
             // onClick={navigateToCustomAppCreate}
-            data-test-id="createApp"
           >
             {intl.formatMessage(messages.setBalanceButtonLabel)}
           </Button>
@@ -49,6 +39,7 @@ const GiftCardUpdateDetailsCard: React.FC<GiftCardUpdateDetailsCardProps> = ({})
         <CardSpacer />
         <Divider />
         <CardSpacer />
+        <GiftCardTagInput />
       </CardContent>
     </Card>
   );

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsCard.tsx
@@ -20,11 +20,7 @@ const GiftCardUpdateDetailsCard: React.FC = ({}) => {
       <CardTitle
         title={intl.formatMessage(messages.title)}
         toolbar={
-          <Button
-            data-test-id="createApp"
-            color="primary"
-            // onClick={navigateToCustomAppCreate}
-          >
+          <Button data-test-id="set-balance-button" color="primary">
             {intl.formatMessage(messages.setBalanceButtonLabel)}
           </Button>
         }

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsExpirySection.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsExpirySection.tsx
@@ -1,0 +1,71 @@
+import { TextField, Typography } from "@material-ui/core";
+import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
+import RadioGroupField from "@saleor/components/RadioGroupField";
+import { GiftCardExpiryType } from "@saleor/types/globalTypes";
+import React, { useContext } from "react";
+import { useIntl } from "react-intl";
+
+import {
+  GiftCardUpdateFormContext,
+  GiftCardUpdateFormData
+} from "../GiftCardUpdateFormProvider";
+import { giftCardUpdateDetailsExpirySectionMessages as messages } from "./messages";
+import { useGiftCardDetailsExpiryStyles as useStyles } from "./styles";
+
+const GiftCardUpdateDetailsExpirySection: React.FC = ({}) => {
+  const intl = useIntl();
+  const classes = useStyles({});
+
+  const {
+    change,
+    data: { expiryType }
+  } = useContext(GiftCardUpdateFormContext);
+
+  const options = [
+    {
+      label: intl.formatMessage(messages.neverExpireLabel),
+      value: GiftCardExpiryType.NEVER_EXPIRE
+    },
+    {
+      label: intl.formatMessage(messages.expiryPeriodLabel),
+      value: GiftCardExpiryType.EXPIRY_PERIOD
+    },
+    {
+      label: intl.formatMessage(messages.expirationDateLabel),
+      value: GiftCardExpiryType.EXPIRY_DATE
+    }
+  ];
+  return (
+    <>
+      <Typography>
+        {intl.formatMessage(messages.expirationDateLabel)}
+      </Typography>
+      <VerticalSpacer />
+      <RadioGroupField
+        innerContainerClassName={classes.radioGroupContainer}
+        choices={options}
+        onChange={change}
+        name={"expiryType" as keyof GiftCardUpdateFormData}
+        value={expiryType}
+      />
+
+      {expiryType === GiftCardExpiryType.EXPIRY_DATE && (
+        <>
+          <VerticalSpacer />
+          <TextField
+            onChange={change}
+            name={"expiryDate" as keyof GiftCardUpdateFormData}
+            className={classes.dateField}
+            label={intl.formatMessage(messages.expiryDateLabel)}
+            InputLabelProps={{
+              shrink: true
+            }}
+            type="date"
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+export default GiftCardUpdateDetailsExpirySection;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsExpirySection.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsExpirySection.tsx
@@ -11,6 +11,8 @@ import {
 } from "../GiftCardUpdateFormProvider";
 import { giftCardUpdateDetailsExpirySectionMessages as messages } from "./messages";
 import { useGiftCardDetailsExpiryStyles as useStyles } from "./styles";
+import TimePeriodTextWithSelectField from "./TimePeriodTextWithSelectField";
+import TextWithSelectField from "./TimePeriodTextWithSelectField";
 
 const GiftCardUpdateDetailsExpirySection: React.FC = ({}) => {
   const intl = useIntl();
@@ -18,7 +20,7 @@ const GiftCardUpdateDetailsExpirySection: React.FC = ({}) => {
 
   const {
     change,
-    data: { expiryType }
+    data: { expiryType, expiryPeriodAmount, expiryPeriodType }
   } = useContext(GiftCardUpdateFormContext);
 
   const options = [
@@ -64,6 +66,12 @@ const GiftCardUpdateDetailsExpirySection: React.FC = ({}) => {
           />
         </>
       )}
+
+      {/* {expiryType === GiftCardExpiryType.EXPIRY_DATE && <TextWithSelectField />} */}
+      <TimePeriodTextWithSelectField
+        periodType={expiryPeriodType}
+        periodAmount={expiryPeriodAmount}
+      />
     </>
   );
 };

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsExpirySection.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/GiftCardUpdateDetailsExpirySection.tsx
@@ -12,7 +12,6 @@ import {
 import { giftCardUpdateDetailsExpirySectionMessages as messages } from "./messages";
 import { useGiftCardDetailsExpiryStyles as useStyles } from "./styles";
 import TimePeriodTextWithSelectField from "./TimePeriodTextWithSelectField";
-import TextWithSelectField from "./TimePeriodTextWithSelectField";
 
 const GiftCardUpdateDetailsExpirySection: React.FC = ({}) => {
   const intl = useIntl();
@@ -20,6 +19,7 @@ const GiftCardUpdateDetailsExpirySection: React.FC = ({}) => {
 
   const {
     change,
+    setSelectedTimePeriodType,
     data: { expiryType, expiryPeriodAmount, expiryPeriodType }
   } = useContext(GiftCardUpdateFormContext);
 
@@ -50,28 +50,31 @@ const GiftCardUpdateDetailsExpirySection: React.FC = ({}) => {
         name={"expiryType" as keyof GiftCardUpdateFormData}
         value={expiryType}
       />
+      <VerticalSpacer />
 
       {expiryType === GiftCardExpiryType.EXPIRY_DATE && (
-        <>
-          <VerticalSpacer />
-          <TextField
-            onChange={change}
-            name={"expiryDate" as keyof GiftCardUpdateFormData}
-            className={classes.dateField}
-            label={intl.formatMessage(messages.expiryDateLabel)}
-            InputLabelProps={{
-              shrink: true
-            }}
-            type="date"
-          />
-        </>
+        <TextField
+          onChange={change}
+          name={"expiryDate" as keyof GiftCardUpdateFormData}
+          className={classes.dateField}
+          label={intl.formatMessage(messages.expiryDateLabel)}
+          InputLabelProps={{
+            shrink: true
+          }}
+          type="date"
+        />
       )}
 
-      {/* {expiryType === GiftCardExpiryType.EXPIRY_DATE && <TextWithSelectField />} */}
-      <TimePeriodTextWithSelectField
-        periodType={expiryPeriodType}
-        periodAmount={expiryPeriodAmount}
-      />
+      {expiryType === GiftCardExpiryType.EXPIRY_PERIOD && (
+        <TimePeriodTextWithSelectField
+          periodType={expiryPeriodType}
+          periodAmount={expiryPeriodAmount}
+          change={change}
+          setSelectedTimePeriod={setSelectedTimePeriodType}
+          textFieldName={"expiryPeriodAmount" as keyof GiftCardUpdateFormData}
+          selectFieldName={"expiryPeriodType" as keyof GiftCardUpdateFormData}
+        />
+      )}
     </>
   );
 };

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/TimePeriodTextWithSelectField.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/TimePeriodTextWithSelectField.tsx
@@ -1,44 +1,30 @@
-import { makeStyles, TextField } from "@material-ui/core";
-import SingleAutocompleteSelectField from "@saleor/components/SingleAutocompleteSelectField";
+import { TextField } from "@material-ui/core";
+import SingleSelectField from "@saleor/components/SingleSelectField";
+import { FormChange } from "@saleor/hooks/useForm";
 import { TimePeriodType } from "@saleor/types/globalTypes";
+import createSingleAutocompleteSelectHandler from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
 import React from "react";
-import { defineMessages, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import { timePeriodTextWithSelectFieldMessages as messages } from "./messages";
-
-const useStyles = makeStyles(
-  () => ({
-    container: {
-      position: "relative",
-      width: 400
-    },
-    textField: {
-      paddingRight: 300,
-      width: "100%"
-    },
-    autocompleteField: {
-      position: "absolute",
-      height: 52,
-      top: 0,
-      right: 0,
-      // bottom: "auto",
-      backgroundColor: "pink"
-    },
-    autocompleteInput: {
-      height: 52
-    }
-  }),
-  { name: "TimePeriodTextWithSelectField" }
-);
+import { useTimePeriodTextWithSelectFieldStyles as useStyles } from "./styles";
 
 interface TimePeriodTextWithSelectFieldProps {
   periodAmount: number;
   periodType: TimePeriodType;
+  change: FormChange;
+  textFieldName: string;
+  selectFieldName: string;
+  setSelectedTimePeriod: (value: TimePeriodType) => void;
 }
 
 const TimePeriodTextWithSelectField: React.FC<TimePeriodTextWithSelectFieldProps> = ({
   periodAmount,
-  periodType
+  periodType,
+  change,
+  textFieldName,
+  selectFieldName,
+  setSelectedTimePeriod
 }) => {
   const classes = useStyles({});
   const intl = useIntl();
@@ -58,22 +44,25 @@ const TimePeriodTextWithSelectField: React.FC<TimePeriodTextWithSelectFieldProps
     }
   ];
 
+  const handleSelect = createSingleAutocompleteSelectHandler(
+    change,
+    setSelectedTimePeriod,
+    options
+  );
+
   return (
     <div className={classes.container}>
       <TextField
+        name={textFieldName}
         InputProps={{ className: classes.textField }}
+        onChange={change}
         value={periodAmount}
-        // InputLabelProps={{ style: { height: 0 } }}
-        // className={classes.textField}
       ></TextField>
-      <SingleAutocompleteSelectField
+      <SingleSelectField
+        name={selectFieldName}
+        onChange={handleSelect}
         value={periodType}
-        displayValue={intl.formatMessage(
-          messages[`${periodType.toLowerCase()}Label`]
-        )}
         className={classes.autocompleteField}
-        InputProps={{ className: classes.autocompleteInput }}
-        nakedInput
         choices={options}
       />
     </div>

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/TimePeriodTextWithSelectField.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/TimePeriodTextWithSelectField.tsx
@@ -1,0 +1,83 @@
+import { makeStyles, TextField } from "@material-ui/core";
+import SingleAutocompleteSelectField from "@saleor/components/SingleAutocompleteSelectField";
+import { TimePeriodType } from "@saleor/types/globalTypes";
+import React from "react";
+import { defineMessages, useIntl } from "react-intl";
+
+import { timePeriodTextWithSelectFieldMessages as messages } from "./messages";
+
+const useStyles = makeStyles(
+  () => ({
+    container: {
+      position: "relative",
+      width: 400
+    },
+    textField: {
+      paddingRight: 300,
+      width: "100%"
+    },
+    autocompleteField: {
+      position: "absolute",
+      height: 52,
+      top: 0,
+      right: 0,
+      // bottom: "auto",
+      backgroundColor: "pink"
+    },
+    autocompleteInput: {
+      height: 52
+    }
+  }),
+  { name: "TimePeriodTextWithSelectField" }
+);
+
+interface TimePeriodTextWithSelectFieldProps {
+  periodAmount: number;
+  periodType: TimePeriodType;
+}
+
+const TimePeriodTextWithSelectField: React.FC<TimePeriodTextWithSelectFieldProps> = ({
+  periodAmount,
+  periodType
+}) => {
+  const classes = useStyles({});
+  const intl = useIntl();
+
+  const options = [
+    {
+      label: intl.formatMessage(messages.yearLabel),
+      value: TimePeriodType.YEAR
+    },
+    {
+      label: intl.formatMessage(messages.monthLabel),
+      value: TimePeriodType.MONTH
+    },
+    {
+      label: intl.formatMessage(messages.dayLabel),
+      value: TimePeriodType.DAY
+    }
+  ];
+
+  return (
+    <div className={classes.container}>
+      <TextField
+        InputProps={{ className: classes.textField }}
+        value={periodAmount}
+        // InputLabelProps={{ style: { height: 0 } }}
+        // className={classes.textField}
+      ></TextField>
+      <SingleAutocompleteSelectField
+        value={periodType}
+        displayValue={intl.formatMessage(
+          messages[`${periodType.toLowerCase()}Label`]
+        )}
+        className={classes.autocompleteField}
+        InputProps={{ className: classes.autocompleteInput }}
+        nakedInput
+        choices={options}
+      />
+    </div>
+  );
+};
+
+export default TimePeriodTextWithSelectField;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/index.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/index.tsx
@@ -1,0 +1,2 @@
+export * from "./GiftCardUpdateDetailsCard";
+export { default } from "./GiftCardUpdateDetailsCard";

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/messages.ts
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/messages.ts
@@ -1,0 +1,16 @@
+import { defineMessages } from "react-intl";
+
+export const giftCardUpdateDetailsCardMessages = defineMessages({
+  title: {
+    defaultMessage: "Details",
+    description: "GiftCardUpdateDetailsCard title"
+  },
+  setBalanceButtonLabel: {
+    defaultMessage: "set balance",
+    description: "GiftCardUpdateDetailsCard set balance button label"
+  },
+  cardBalanceLabel: {
+    defaultMessage: "Card Balance",
+    description: "GiftCardUpdateDetailsCard card balance label"
+  }
+});

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/messages.ts
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/messages.ts
@@ -14,3 +14,22 @@ export const giftCardUpdateDetailsCardMessages = defineMessages({
     description: "GiftCardUpdateDetailsCard card balance label"
   }
 });
+
+export const giftCardUpdateDetailsExpirySectionMessages = defineMessages({
+  expirationDateLabel: {
+    defaultMessage: "Expiration date",
+    description: "GiftCarUpdateDetailsExpirySection expiration date label"
+  },
+  neverExpireLabel: {
+    defaultMessage: "Never expire",
+    description: "GiftCarUpdateDetailsExpirySection never expire label"
+  },
+  expiryPeriodLabel: {
+    defaultMessage: "Expiry period",
+    description: "GiftCarUpdateDetailsExpirySection expiry period label"
+  },
+  expiryDateLabel: {
+    defaultMessage: "Expiration date",
+    description: "GiftCarUpdateDetailsExpirySection expiry date label"
+  }
+});

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/messages.ts
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/messages.ts
@@ -33,3 +33,18 @@ export const giftCardUpdateDetailsExpirySectionMessages = defineMessages({
     description: "GiftCarUpdateDetailsExpirySection expiry date label"
   }
 });
+
+export const timePeriodTextWithSelectFieldMessages = defineMessages({
+  yearLabel: {
+    defaultMessage: "years after usage",
+    description: "TimePeriodTextWithSelectField year label"
+  },
+  monthLabel: {
+    defaultMessage: "months after usage",
+    description: "TimePeriodTextWithSelectField month label"
+  },
+  dayLabel: {
+    defaultMessage: "days after usage",
+    description: "TimePeriodTextWithSelectField day label"
+  }
+});

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/styles.ts
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/styles.ts
@@ -29,3 +29,16 @@ export const useGiftCardDetailsBalanceStyles = makeStyles(
   }),
   { name: "GiftCardUpdateDetailsBalanceSection" }
 );
+
+export const useGiftCardDetailsExpiryStyles = makeStyles(
+  () => ({
+    radioGroupContainer: {
+      display: "flex",
+      flexDirection: "row"
+    },
+    dateField: {
+      width: 400
+    }
+  }),
+  { name: "GiftCardUpdateDetailsExpirySection" }
+);

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/styles.ts
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/styles.ts
@@ -1,0 +1,31 @@
+import { makeStyles } from "@saleor/theme";
+
+export const useGiftCardDetailsBalanceStyles = makeStyles(
+  theme => ({
+    labelsContainer: {
+      display: "flex",
+      alignItems: "baseline"
+    },
+    wideContainer: {
+      justifyContent: "space-between"
+    },
+    balanceBar: {
+      width: "100%",
+      display: "flex",
+      alignItems: "center",
+      height: 36,
+      padding: "0 4px",
+      backgroundColor: theme.palette.background.default,
+      borderRadius: 18
+    },
+    balanceBarProgress: {
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: theme.palette.primary.light
+    },
+    balanceBarProgressDark: {
+      backgroundColor: theme.palette.primary.dark
+    }
+  }),
+  { name: "GiftCardUpdateDetailsBalanceSection" }
+);

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/styles.ts
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateDetailsCard/styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles } from "@saleor/theme";
+import { makeStyles } from "@saleor/macaw-ui";
 
 export const useGiftCardDetailsBalanceStyles = makeStyles(
   theme => ({
@@ -41,4 +41,36 @@ export const useGiftCardDetailsExpiryStyles = makeStyles(
     }
   }),
   { name: "GiftCardUpdateDetailsExpirySection" }
+);
+
+export const useTimePeriodTextWithSelectFieldStyles = makeStyles(
+  () => ({
+    container: {
+      position: "relative",
+      width: 400
+    },
+    textField: {
+      paddingRight: 300,
+      width: "100%",
+      "& input": {
+        paddingTop: 16,
+        paddingBottom: 16
+      }
+    },
+    autocompleteField: {
+      position: "absolute",
+      height: 52,
+      width: 300,
+      top: 0,
+      right: 0,
+      border: "none",
+      "& *": {
+        border: "none"
+      },
+      "& *:focus": {
+        background: "none"
+      }
+    }
+  }),
+  { name: "TimePeriodTextWithSelectField" }
 );

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateFormProvider.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateFormProvider.tsx
@@ -1,0 +1,57 @@
+import Form from "@saleor/components/Form";
+import { UseFormResult } from "@saleor/hooks/useForm";
+import React, { createContext, useContext, useState } from "react";
+
+import { GiftCardDetailsContext } from "./GiftCardDetailsProvider";
+import { GiftCardDetails_giftCard } from "./types/GiftCardDetails";
+
+interface GiftCardUpdateFormProviderProps {
+  children: React.ReactNode;
+}
+
+type GiftCardUpdateFormData = Pick<
+  GiftCardDetails_giftCard,
+  "tag" | "expiryDate" | "expiryType" | "expiryPeriod"
+>;
+
+export interface GiftCardUpdateFormConsumerProps
+  extends UseFormResult<GiftCardUpdateFormData> {
+  selectedTag: string;
+  setSelectedTag: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export const GiftCardUpdateFormContext = createContext<
+  GiftCardUpdateFormConsumerProps
+>(null);
+
+const GiftCardUpdateFormProvider: React.FC<GiftCardUpdateFormProviderProps> = ({
+  children
+}) => {
+  const {
+    giftCard: { tag, expiryDate, expiryPeriod, expiryType }
+  } = useContext(GiftCardDetailsContext);
+
+  const [selectedTag, setSelectedTag] = useState(tag);
+
+  const initialData = { tag, expiryDate, expiryPeriod, expiryType };
+
+  return (
+    <Form initial={initialData}>
+      {formProps => {
+        const providerValues: GiftCardUpdateFormConsumerProps = {
+          ...formProps,
+          selectedTag,
+          setSelectedTag
+        };
+
+        return (
+          <GiftCardUpdateFormContext.Provider value={providerValues}>
+            {children}
+          </GiftCardUpdateFormContext.Provider>
+        );
+      }}
+    </Form>
+  );
+};
+
+export default GiftCardUpdateFormProvider;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateFormProvider.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateFormProvider.tsx
@@ -1,5 +1,6 @@
 import Form from "@saleor/components/Form";
 import { UseFormResult } from "@saleor/hooks/useForm";
+import { TimePeriodType } from "@saleor/types/globalTypes";
 import React, { createContext, useContext, useState } from "react";
 
 import { GiftCardDetailsContext } from "./GiftCardDetailsProvider";
@@ -9,10 +10,11 @@ interface GiftCardUpdateFormProviderProps {
   children: React.ReactNode;
 }
 
-export type GiftCardUpdateFormData = Pick<
-  GiftCardDetails_giftCard,
-  "tag" | "expiryDate" | "expiryType" | "expiryPeriod"
->;
+export interface GiftCardUpdateFormData
+  extends Pick<GiftCardDetails_giftCard, "tag" | "expiryDate" | "expiryType"> {
+  expiryPeriodType: TimePeriodType;
+  expiryPeriodAmount: number;
+}
 
 export interface GiftCardUpdateFormConsumerProps
   extends UseFormResult<GiftCardUpdateFormData> {
@@ -33,7 +35,13 @@ const GiftCardUpdateFormProvider: React.FC<GiftCardUpdateFormProviderProps> = ({
 
   const [selectedTag, setSelectedTag] = useState(tag);
 
-  const initialData = { tag, expiryDate, expiryPeriod, expiryType };
+  const initialData: GiftCardUpdateFormData = {
+    tag,
+    expiryDate,
+    expiryType,
+    expiryPeriodType: expiryPeriod.type,
+    expiryPeriodAmount: expiryPeriod.amount
+  };
 
   return (
     <Form initial={initialData}>

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateFormProvider.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateFormProvider.tsx
@@ -1,7 +1,13 @@
 import Form from "@saleor/components/Form";
 import { UseFormResult } from "@saleor/hooks/useForm";
 import { TimePeriodType } from "@saleor/types/globalTypes";
-import React, { createContext, useContext, useState } from "react";
+import React, {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useState
+} from "react";
 
 import { GiftCardDetailsContext } from "./GiftCardDetailsProvider";
 import { GiftCardDetails_giftCard } from "./types/GiftCardDetails";
@@ -19,7 +25,8 @@ export interface GiftCardUpdateFormData
 export interface GiftCardUpdateFormConsumerProps
   extends UseFormResult<GiftCardUpdateFormData> {
   selectedTag: string;
-  setSelectedTag: React.Dispatch<React.SetStateAction<string>>;
+  setSelectedTag: (value: string) => void;
+  setSelectedTimePeriodType: Dispatch<SetStateAction<TimePeriodType>>;
 }
 
 export const GiftCardUpdateFormContext = createContext<
@@ -34,6 +41,9 @@ const GiftCardUpdateFormProvider: React.FC<GiftCardUpdateFormProviderProps> = ({
   } = useContext(GiftCardDetailsContext);
 
   const [selectedTag, setSelectedTag] = useState(tag);
+  const [selectedTimePeriodType, setSelectedTimePeriodType] = useState(
+    expiryPeriod.type
+  );
 
   const initialData: GiftCardUpdateFormData = {
     tag,
@@ -49,7 +59,8 @@ const GiftCardUpdateFormProvider: React.FC<GiftCardUpdateFormProviderProps> = ({
         const providerValues: GiftCardUpdateFormConsumerProps = {
           ...formProps,
           selectedTag,
-          setSelectedTag
+          setSelectedTag,
+          setSelectedTimePeriodType
         };
 
         return (

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdateFormProvider.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdateFormProvider.tsx
@@ -9,7 +9,7 @@ interface GiftCardUpdateFormProviderProps {
   children: React.ReactNode;
 }
 
-type GiftCardUpdateFormData = Pick<
+export type GiftCardUpdateFormData = Pick<
   GiftCardDetails_giftCard,
   "tag" | "expiryDate" | "expiryType" | "expiryPeriod"
 >;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdatePage.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdatePage.tsx
@@ -1,0 +1,23 @@
+import Container from "@saleor/components/Container";
+import React from "react";
+
+import GiftCardDetailsProvider from "./GiftCardDetailsProvider";
+import GiftCardUpdateDetailsCard from "./GiftCardUpdateDetailsCard";
+import GiftCardUpdatePageHeader from "./GiftCardUpdatePageHeader";
+
+interface GiftCardUpdatePageProps {
+  id: string;
+}
+
+const GiftCardUpdatePage: React.FC<GiftCardUpdatePageProps> = ({ id }) => {
+  return (
+    <GiftCardDetailsProvider id={id}>
+      <Container>
+        <GiftCardUpdatePageHeader />
+        <GiftCardUpdateDetailsCard />
+      </Container>
+    </GiftCardDetailsProvider>
+  );
+};
+
+export default GiftCardUpdatePage;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdatePage.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdatePage.tsx
@@ -3,21 +3,22 @@ import React from "react";
 
 import GiftCardDetailsProvider from "./GiftCardDetailsProvider";
 import GiftCardUpdateDetailsCard from "./GiftCardUpdateDetailsCard";
+import GiftCardUpdateFormProvider from "./GiftCardUpdateFormProvider";
 import GiftCardUpdatePageHeader from "./GiftCardUpdatePageHeader";
 
 interface GiftCardUpdatePageProps {
   id: string;
 }
 
-const GiftCardUpdatePage: React.FC<GiftCardUpdatePageProps> = ({ id }) => {
-  return (
-    <GiftCardDetailsProvider id={id}>
+const GiftCardUpdatePage: React.FC<GiftCardUpdatePageProps> = ({ id }) => (
+  <GiftCardDetailsProvider id={id}>
+    <GiftCardUpdateFormProvider>
       <Container>
         <GiftCardUpdatePageHeader />
         <GiftCardUpdateDetailsCard />
       </Container>
-    </GiftCardDetailsProvider>
-  );
-};
+    </GiftCardUpdateFormProvider>
+  </GiftCardDetailsProvider>
+);
 
 export default GiftCardUpdatePage;

--- a/src/giftCards/GiftCardUpdatePage/GiftCardUpdatePageHeader.tsx
+++ b/src/giftCards/GiftCardUpdatePage/GiftCardUpdatePageHeader.tsx
@@ -1,0 +1,33 @@
+import PageHeader from "@saleor/components/PageHeader";
+import PageTitleWithStatusChip from "@saleor/components/PageTitleWithStatusChip";
+import { StatusType } from "@saleor/components/StatusChip/types";
+import React, { useContext } from "react";
+import { useIntl } from "react-intl";
+
+import { giftCardsListTableMessages as tableMessages } from "../GiftCardsList/messages";
+import { GiftCardDetailsContext } from "./GiftCardDetailsProvider";
+
+interface GiftCardUpdatePageHeaderProps {}
+
+const GiftCardUpdatePageHeader: React.FC<GiftCardUpdatePageHeaderProps> = ({}) => {
+  const intl = useIntl();
+  const { giftCard } = useContext(GiftCardDetailsContext);
+  const { code } = giftCard;
+
+  return (
+    <PageHeader
+      inline
+      title={
+        <PageTitleWithStatusChip
+          title={`${intl.formatMessage(
+            tableMessages.codeEndingWithLabel
+          )} ${code}`}
+          statusLabel={intl.formatMessage(tableMessages.giftCardDisabledLabel)}
+          statusType={StatusType.ERROR}
+        />
+      }
+    />
+  );
+};
+
+export default GiftCardUpdatePageHeader;

--- a/src/giftCards/GiftCardUpdatePage/index.tsx
+++ b/src/giftCards/GiftCardUpdatePage/index.tsx
@@ -1,0 +1,2 @@
+export * from "./GiftCardUpdatePage";
+export { default } from "./GiftCardUpdatePage";

--- a/src/giftCards/GiftCardUpdatePage/messages.ts
+++ b/src/giftCards/GiftCardUpdatePage/messages.ts
@@ -1,0 +1,12 @@
+import { defineMessages } from "react-intl";
+
+export const giftCardUpdateDetailsCardMessages = defineMessages({
+  title: {
+    defaultMessage: "Details",
+    description: "GiftCardUpdateDetailsCard title"
+  },
+  setBalanceButtonLabel: {
+    defaultMessage: "Set balance",
+    description: "GiftCardUpdateDetailsCard set balance button label"
+  }
+});

--- a/src/giftCards/GiftCardUpdatePage/queries.ts
+++ b/src/giftCards/GiftCardUpdatePage/queries.ts
@@ -1,0 +1,48 @@
+import { metadataFragment } from "@saleor/fragments/metadata";
+import { fragmentMoney } from "@saleor/fragments/products";
+import gql from "graphql-tag";
+
+export const giftCardDetails = gql`
+  ${fragmentMoney}
+  ${metadataFragment}
+  query GiftCardDetails($id: ID!) {
+    giftCard(id: $id) {
+      ...MetadataFragment
+      code
+      user {
+        id
+        firstName
+        lastName
+      }
+      usedBy {
+        id
+        firstName
+        lastName
+      }
+      usedByEmail
+      createdByEmail
+      app {
+        id
+        name
+      }
+      created
+      expiryDate
+      expiryType
+      expiryPeriod {
+        amount
+        type
+      }
+      lastUsedOn
+      isActive
+      initialBalance {
+        ...Money
+      }
+      currentBalance {
+        ...Money
+      }
+      id
+      displayCode
+      tag
+    }
+  }
+`;

--- a/src/giftCards/GiftCardUpdatePage/types/GiftCardDetails.ts
+++ b/src/giftCards/GiftCardUpdatePage/types/GiftCardDetails.ts
@@ -1,0 +1,91 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { GiftCardExpiryType, TimePeriodType } from "./../../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: GiftCardDetails
+// ====================================================
+
+export interface GiftCardDetails_giftCard_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface GiftCardDetails_giftCard_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface GiftCardDetails_giftCard_user {
+  __typename: "User";
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface GiftCardDetails_giftCard_usedBy {
+  __typename: "User";
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface GiftCardDetails_giftCard_app {
+  __typename: "App";
+  id: string;
+  name: string | null;
+}
+
+export interface GiftCardDetails_giftCard_expiryPeriod {
+  __typename: "TimePeriod";
+  amount: number | null;
+  type: TimePeriodType | null;
+}
+
+export interface GiftCardDetails_giftCard_initialBalance {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface GiftCardDetails_giftCard_currentBalance {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface GiftCardDetails_giftCard {
+  __typename: "GiftCard";
+  metadata: (GiftCardDetails_giftCard_metadata | null)[];
+  privateMetadata: (GiftCardDetails_giftCard_privateMetadata | null)[];
+  code: string;
+  user: GiftCardDetails_giftCard_user | null;
+  usedBy: GiftCardDetails_giftCard_usedBy | null;
+  usedByEmail: string | null;
+  createdByEmail: string | null;
+  app: GiftCardDetails_giftCard_app | null;
+  created: any;
+  expiryDate: any | null;
+  expiryType: GiftCardExpiryType | null;
+  expiryPeriod: GiftCardDetails_giftCard_expiryPeriod | null;
+  lastUsedOn: any | null;
+  isActive: boolean;
+  initialBalance: GiftCardDetails_giftCard_initialBalance | null;
+  currentBalance: GiftCardDetails_giftCard_currentBalance | null;
+  id: string;
+  displayCode: string | null;
+  tag: string | null;
+}
+
+export interface GiftCardDetails {
+  giftCard: GiftCardDetails_giftCard | null;
+}
+
+export interface GiftCardDetailsVariables {
+  id: string;
+}

--- a/src/giftCards/GiftCardsList/GiftCardsList.tsx
+++ b/src/giftCards/GiftCardsList/GiftCardsList.tsx
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 import Container from "@saleor/components/Container";
 import React from "react";
 
@@ -11,20 +10,13 @@ interface GiftCardsListProps {
   params: GiftCardListUrlQueryParams;
 }
 
-const GiftCardsList: React.FC<GiftCardsListProps> = ({ params }) => {
-  return (
-    <GiftCardsListProvider params={params}>
-      <Container>
-        <GiftCardsListHeader />
-        <GiftCardsListTable />
-      </Container>
-    </GiftCardsListProvider>
-  );
-};
-=======
-import React from "react";
-
-const GiftCardsList: React.FC = () => null;
->>>>>>> Add gift cards section to menu and add empty list component
+const GiftCardsList: React.FC<GiftCardsListProps> = ({ params }) => (
+  <GiftCardsListProvider params={params}>
+    <Container>
+      <GiftCardsListHeader />
+      <GiftCardsListTable />
+    </Container>
+  </GiftCardsListProvider>
+);
 
 export default GiftCardsList;

--- a/src/giftCards/GiftCardsList/GiftCardsList.tsx
+++ b/src/giftCards/GiftCardsList/GiftCardsList.tsx
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import Container from "@saleor/components/Container";
 import React from "react";
 
@@ -20,5 +21,10 @@ const GiftCardsList: React.FC<GiftCardsListProps> = ({ params }) => {
     </GiftCardsListProvider>
   );
 };
+=======
+import React from "react";
+
+const GiftCardsList: React.FC = () => null;
+>>>>>>> Add gift cards section to menu and add empty list component
 
 export default GiftCardsList;

--- a/src/giftCards/GiftCardsList/GiftCardsListTable/GiftCardsListTable.tsx
+++ b/src/giftCards/GiftCardsList/GiftCardsListTable/GiftCardsListTable.tsx
@@ -13,6 +13,7 @@ import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import StatusChip from "@saleor/components/StatusChip";
 import { StatusType } from "@saleor/components/StatusChip/types";
 import { customerUrl } from "@saleor/customers/urls";
+import { giftCardPath } from "@saleor/giftCards/urls";
 import useNavigator from "@saleor/hooks/useNavigator";
 import { renderCollection } from "@saleor/misc";
 import { productUrl } from "@saleor/products/urls";
@@ -42,6 +43,9 @@ const GiftCardsListTable: React.FC = ({}) => {
     // disabled
   };
 
+  const redirectToGiftCardUpdate = (id: string) => () =>
+    navigate(giftCardPath(id));
+
   return (
     <Card>
       <ResponsiveTable>
@@ -60,7 +64,11 @@ const GiftCardsListTable: React.FC = ({}) => {
               product,
               currentBalance
             }) => (
-              <TableRow className={classes.row} key={id}>
+              <TableRow
+                onClick={redirectToGiftCardUpdate(id)}
+                className={classes.row}
+                key={id}
+              >
                 <TableCell padding="checkbox">
                   <Checkbox
                     disableClickPropagation

--- a/src/giftCards/GiftCardsList/styles.ts
+++ b/src/giftCards/GiftCardsList/styles.ts
@@ -1,4 +1,4 @@
-import { makeStyles } from "@saleor/theme";
+import { makeStyles } from "@saleor/macaw-ui";
 
 export const useTableStyles = makeStyles(
   () => ({

--- a/src/giftCards/GiftCardsList/styles.ts
+++ b/src/giftCards/GiftCardsList/styles.ts
@@ -21,6 +21,7 @@ export const useTableStyles = makeStyles(
       width: 135
     },
     row: {
+      cursor: "pointer",
       height: 80,
       "& td": {
         padding: "0px 20px",

--- a/src/giftCards/components/GiftCardTagInput/GiftCardTagInput.tsx
+++ b/src/giftCards/components/GiftCardTagInput/GiftCardTagInput.tsx
@@ -1,0 +1,66 @@
+import { Typography } from "@material-ui/core";
+import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
+import SingleAutocompleteSelectField from "@saleor/components/SingleAutocompleteSelectField";
+import { DEFAULT_INITIAL_SEARCH_DATA } from "@saleor/config";
+import createSingleAutocompleteSelectHandler, {
+  SingleAutocompleteSelectedChangeHandlerProps
+} from "@saleor/utils/handlers/singleAutocompleteSelectChangeHandler";
+import { mapEdgesToItems, mapTagNodeToChoice } from "@saleor/utils/maps";
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { giftCardTagInputMessages as messages } from "./messages";
+import useGiftCardTagsSearch from "./useGiftCardTagsSearch";
+
+interface GiftCardTagInputProps
+  extends Pick<
+    SingleAutocompleteSelectedChangeHandlerProps,
+    "change" | "setSelected"
+  > {
+  withTopLabel?: boolean;
+}
+
+const GiftCardTagInput: React.FC<GiftCardTagInputProps> = ({
+  withTopLabel = false,
+  change,
+  setSelected
+}) => {
+  const intl = useIntl();
+
+  const { loadMore, search, result } = useGiftCardTagsSearch({
+    variables: DEFAULT_INITIAL_SEARCH_DATA
+  });
+
+  const choices = mapTagNodeToChoice(mapEdgesToItems(result?.data?.search));
+
+  const handleSelect = createSingleAutocompleteSelectHandler(
+    change,
+    setSelected,
+    choices
+  );
+
+  return (
+    <>
+      {withTopLabel && (
+        <>
+          <Typography>{intl.formatMessage(messages.label)}</Typography>
+          <VerticalSpacer />
+        </>
+      )}
+      <SingleAutocompleteSelectField
+        name="giftCardTag"
+        allowCustomValues
+        label={intl.formatMessage(messages.placeholder)}
+        data-test-id="gift-card-tag-select-field"
+        value=""
+        displayValue=""
+        choices={choices}
+        fetchChoices={search}
+        onChange={handleSelect}
+        onFetchMore={loadMore}
+      />
+    </>
+  );
+};
+
+export default GiftCardTagInput;

--- a/src/giftCards/components/GiftCardTagInput/index.tsx
+++ b/src/giftCards/components/GiftCardTagInput/index.tsx
@@ -1,0 +1,2 @@
+export * from "./GiftCardTagInput";
+export { default } from "./GiftCardTagInput";

--- a/src/giftCards/components/GiftCardTagInput/messages.ts
+++ b/src/giftCards/components/GiftCardTagInput/messages.ts
@@ -1,0 +1,12 @@
+import { defineMessages } from "react-intl";
+
+export const giftCardTagInputMessages = defineMessages({
+  label: {
+    defaultMessage: "Card Tag",
+    description: "GiftCardTagInput tag label"
+  },
+  placeholder: {
+    defaultMessage: "Tag",
+    description: "GiftCardTagInput tag placeholder"
+  }
+});

--- a/src/giftCards/components/GiftCardTagInput/types/SearchGiftCardTags.ts
+++ b/src/giftCards/components/GiftCardTagInput/types/SearchGiftCardTags.ts
@@ -1,0 +1,46 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SearchGiftCardTags
+// ====================================================
+
+export interface SearchGiftCardTags_search_edges_node {
+  __typename: "GiftCard";
+  id: string;
+  tag: string | null;
+}
+
+export interface SearchGiftCardTags_search_edges {
+  __typename: "GiftCardCountableEdge";
+  node: SearchGiftCardTags_search_edges_node;
+}
+
+export interface SearchGiftCardTags_search_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface SearchGiftCardTags_search {
+  __typename: "GiftCardCountableConnection";
+  totalCount: number | null;
+  edges: SearchGiftCardTags_search_edges[];
+  pageInfo: SearchGiftCardTags_search_pageInfo;
+}
+
+export interface SearchGiftCardTags {
+  search: SearchGiftCardTags_search | null;
+}
+
+export interface SearchGiftCardTagsVariables {
+  query: string;
+  first: number;
+  after?: string | null;
+  last?: number | null;
+  before?: string | null;
+}

--- a/src/giftCards/components/GiftCardTagInput/useGiftCardTagsSearch.ts
+++ b/src/giftCards/components/GiftCardTagInput/useGiftCardTagsSearch.ts
@@ -1,0 +1,43 @@
+import { pageInfoFragment } from "@saleor/fragments/pageInfo";
+import makeTopLevelSearch from "@saleor/hooks/makeTopLevelSearch";
+import gql from "graphql-tag";
+
+import {
+  SearchGiftCardTags,
+  SearchGiftCardTagsVariables
+} from "./types/SearchGiftCardTags";
+
+const searchGiftCardTags = gql`
+  ${pageInfoFragment}
+  query SearchGiftCardTags(
+    $query: String!
+    $first: Int!
+    $after: String
+    $last: Int
+    $before: String
+  ) {
+    search: giftCards(
+      filter: { tag: $query }
+      first: $first
+      after: $after
+      last: $last
+      before: $before
+    ) {
+      totalCount
+      edges {
+        node {
+          id
+          tag
+        }
+      }
+      pageInfo {
+        ...PageInfoFragment
+      }
+    }
+  }
+`;
+
+export default makeTopLevelSearch<
+  SearchGiftCardTags,
+  SearchGiftCardTagsVariables
+>(searchGiftCardTags);

--- a/src/giftCards/index.tsx
+++ b/src/giftCards/index.tsx
@@ -1,0 +1,29 @@
+import { WindowTitle } from "@saleor/components/WindowTitle";
+import { sectionNames } from "@saleor/intl";
+import React from "react";
+import { useIntl } from "react-intl";
+import { Route, RouteComponentProps, Switch } from "react-router-dom";
+
+import GiftCardsList from "./GiftCardsList";
+import GiftCardUpdatePage from "./GiftCardUpdatePage";
+import { giftCardPath, giftCardsListPath } from "./urls";
+
+const GiftCardUpdate: React.FC<RouteComponentProps<any>> = ({ match }) => (
+  <GiftCardUpdatePage id={decodeURIComponent(match.params.id)} />
+);
+
+const Component: React.FC = ({}) => {
+  const intl = useIntl();
+
+  return (
+    <>
+      <WindowTitle title={intl.formatMessage(sectionNames.giftCards)} />
+      <Switch>
+        <Route exact path={giftCardsListPath} component={GiftCardsList} />
+        <Route path={giftCardPath(":id")} component={GiftCardUpdate} />
+      </Switch>
+    </>
+  );
+};
+
+export default Component;

--- a/src/giftCards/index.tsx
+++ b/src/giftCards/index.tsx
@@ -8,9 +8,9 @@ import GiftCardsList from "./GiftCardsList";
 import GiftCardUpdatePage from "./GiftCardUpdatePage";
 import { giftCardPath, giftCardsListPath } from "./urls";
 
-const GiftCardUpdate: React.FC<RouteComponentProps<any>> = ({ match }) => (
-  <GiftCardUpdatePage id={decodeURIComponent(match.params.id)} />
-);
+const GiftCardUpdate: React.FC<RouteComponentProps<{ id: string }>> = ({
+  match
+}) => <GiftCardUpdatePage id={decodeURIComponent(match.params.id)} />;
 
 const Component: React.FC = ({}) => {
   const intl = useIntl();

--- a/src/giftCards/urls.ts
+++ b/src/giftCards/urls.ts
@@ -1,3 +1,9 @@
+import urlJoin from "url-join";
+
 export const giftCardsSectionUrlName = "/gift-cards";
 
-export const giftCardsListUrl = () => `${giftCardsSectionUrlName}/`;
+export const giftCardsListPath = `${giftCardsSectionUrlName}/`;
+
+export const giftCardsListUrl = () => giftCardsListPath;
+
+export const giftCardPath = (id: string) => urlJoin(giftCardsListPath, id);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,7 @@ import BackgroundTasksProvider from "./containers/BackgroundTasks";
 import ServiceWorker from "./containers/ServiceWorker/ServiceWorker";
 import { CustomerSection } from "./customers";
 import DiscountSection from "./discounts";
-import GiftCardSection from "./giftCards/GiftCardsList";
+import GiftCardSection from "./giftCards";
 import { giftCardsSectionUrlName } from "./giftCards/urls";
 import HomePage from "./home";
 import { commonMessages } from "./intl";

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -1,3 +1,4 @@
+import { ThemeType } from "@saleor/macaw-ui";
 import moment from "moment-timezone";
 import { MutationFunction, MutationResult } from "react-apollo";
 import { defineMessages, IntlShape } from "react-intl";
@@ -441,6 +442,8 @@ export const getDatePeriod = (days: number): DateRangeInput => {
     lte: end.format(format)
   };
 };
+
+export const isDarkTheme = (themeType: ThemeType) => themeType === "dark";
 
 export const transformAddressToAddressInput = (data?: AddressType) => ({
   city: data?.city || "",

--- a/src/orders/components/OrderDetailsPage/Title.tsx
+++ b/src/orders/components/OrderDetailsPage/Title.tsx
@@ -1,31 +1,15 @@
-import StatusChip from "@saleor/components/StatusChip";
-import { makeStyles } from "@saleor/macaw-ui";
+import PageTitleWithStatusChip from "@saleor/components/PageTitleWithStatusChip";
 import { transformOrderStatus } from "@saleor/misc";
 import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
 import React from "react";
 import { useIntl } from "react-intl";
 
-export interface TitleProps {
+interface TitleProps {
   order?: OrderDetails_order;
 }
 
-const useStyles = makeStyles(
-  theme => ({
-    container: {
-      alignItems: "center",
-      display: "flex"
-    },
-    statusContainer: {
-      marginLeft: theme.spacing(2)
-    }
-  }),
-  { name: "OrderDetailsTitle" }
-);
-
-const Title: React.FC<TitleProps> = props => {
+const Title: React.FC<TitleProps> = ({ order }) => {
   const intl = useIntl();
-  const classes = useStyles(props);
-  const { order } = props;
 
   if (!order) {
     return null;
@@ -34,12 +18,11 @@ const Title: React.FC<TitleProps> = props => {
   const { localized, status } = transformOrderStatus(order.status, intl);
 
   return (
-    <div className={classes.container}>
-      {`#${order.number}`}
-      <div className={classes.statusContainer}>
-        <StatusChip label={localized} status={status} />
-      </div>
-    </div>
+    <PageTitleWithStatusChip
+      title={order?.number}
+      statusLabel={localized}
+      statusType={status}
+    />
   );
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,10 @@ export interface SlugNode {
   slug: string;
 }
 
+export interface TagNode {
+  tag: string;
+}
+
 export type Pagination = Partial<{
   after: string;
   before: string;

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -962,6 +962,7 @@ export enum StockErrorCode {
 }
 
 export enum TimePeriodType {
+  DAY = "DAY",
   MONTH = "MONTH",
   YEAR = "YEAR",
 }

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -466,6 +466,12 @@ export enum FulfillmentStatus {
   RETURNED = "RETURNED",
 }
 
+export enum GiftCardExpiryType {
+  EXPIRY_DATE = "EXPIRY_DATE",
+  EXPIRY_PERIOD = "EXPIRY_PERIOD",
+  NEVER_EXPIRE = "NEVER_EXPIRE",
+}
+
 export enum InvoiceErrorCode {
   EMAIL_NOT_SET = "EMAIL_NOT_SET",
   INVALID_STATUS = "INVALID_STATUS",
@@ -953,6 +959,11 @@ export enum StockErrorCode {
   NOT_FOUND = "NOT_FOUND",
   REQUIRED = "REQUIRED",
   UNIQUE = "UNIQUE",
+}
+
+export enum TimePeriodType {
+  MONTH = "MONTH",
+  YEAR = "YEAR",
 }
 
 export enum UploadErrorCode {

--- a/src/utils/handlers/singleAutocompleteSelectChangeHandler.ts
+++ b/src/utils/handlers/singleAutocompleteSelectChangeHandler.ts
@@ -1,6 +1,12 @@
 import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
 import { FormChange } from "@saleor/hooks/useForm";
 
+export interface SingleAutocompleteSelectedChangeHandlerProps {
+  change: FormChange;
+  setSelected: (value: string) => void;
+  choices: SingleAutocompleteChoiceType[];
+}
+
 function createSingleAutocompleteSelectHandler(
   change: FormChange,
   setSelected: (value: string) => void,

--- a/src/utils/maps.ts
+++ b/src/utils/maps.ts
@@ -5,7 +5,7 @@ import {
 } from "@saleor/components/SingleAutocompleteSelectField";
 import { MetadataItem } from "@saleor/fragments/types/MetadataItem";
 import { SearchPages_search_edges_node } from "@saleor/searches/types/SearchPages";
-import { Node, SlugNode } from "@saleor/types";
+import { Node, SlugNode, TagNode } from "@saleor/types";
 import { MetadataInput } from "@saleor/types/globalTypes";
 
 interface Edge<T> {
@@ -36,13 +36,14 @@ export function mapPagesToChoices(pages: SearchPages_search_edges_node[]) {
 }
 
 type ExtendedNode = Node & Record<"name", string>;
+
 export function mapNodeToChoice<T extends ExtendedNode>(
   nodes: T[]
 ): Array<SingleAutocompleteChoiceType<string>>;
-export function mapNodeToChoice<T extends ExtendedNode, K extends ChoiceValue>(
-  nodes: T[],
-  getterFn: (node: T) => K
-): Array<SingleAutocompleteChoiceType<K>>;
+export function mapNodeToChoice<
+  T extends ExtendedNode | Node,
+  K extends ChoiceValue
+>(nodes: T[], getterFn: (node: T) => K): Array<SingleAutocompleteChoiceType<K>>;
 export function mapNodeToChoice<T extends ExtendedNode>(
   nodes: T[],
   getterFn?: (node: T) => any
@@ -60,7 +61,13 @@ export function mapNodeToChoice<T extends ExtendedNode>(
 export function mapSlugNodeToChoice(
   nodes: Array<ExtendedNode & SlugNode>
 ): SingleAutocompleteChoiceType[] {
-  return mapNodeToChoice(nodes, nodes => nodes.slug);
+  return mapNodeToChoice(nodes, node => node.slug);
+}
+
+export function mapTagNodeToChoice(
+  nodes: Array<Node & TagNode>
+): SingleAutocompleteChoiceType[] {
+  return mapNodeToChoice(nodes, node => node.tag);
 }
 
 export function mapMetadataItemToInput(item: MetadataItem): MetadataInput {

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -39,7 +39,7 @@ export interface UpdateMetadata_deleteMetadata_item_privateMetadata {
 }
 
 export interface UpdateMetadata_deleteMetadata_item {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "GiftCard" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdateMetadata_deleteMetadata_item_metadata | null)[];
   privateMetadata: (UpdateMetadata_deleteMetadata_item_privateMetadata | null)[];
   id: string;

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -39,7 +39,7 @@ export interface UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadat
 }
 
 export interface UpdatePrivateMetadata_deletePrivateMetadata_item {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "MenuItem" | "Menu" | "User" | "Checkout" | "GiftCard" | "Order" | "Fulfillment" | "Invoice";
   metadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_metadata | null)[];
   privateMetadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata | null)[];
   id: string;


### PR DESCRIPTION
I want to merge this change because it adds gift card update view with details card. More details and other added stuff:
- Minor change: add isDarkTheme helper to avoid rewriting `themeType === "dark"` every time
- Major change: change money component as agreed with @pwgryglak to always show `USD 15.00` instead of `$ 15.00`
- Add vertical spacer component, similar to horizontal spacer
- Move order details page title (thus far only one with status chip) to generic Page title with status chip
- Add gift card details provider
- Add gift card update form provider
- Add time period text select component
- Add option to use `mapEdgesToItems` with Node without `name` prop, since tag items only use tag field

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
