### PR TITLE
Display warehouse name for each fulfillment

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4412,6 +4412,10 @@
     "context": "section header",
     "string": "Fulfilled ({quantity})"
   },
+  "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_fulfilledFrom": {
+    "context": "fulfilled fulfillment, section header",
+    "string": "Fulfilled from {warehouseName}"
+  },
   "src_dot_orders_dot_components_dot_OrderReturnPage_dot_OrderReturnRefundItemsCard_dot_improperValue": {
     "context": "error message",
     "string": "Improper value"

--- a/src/components/StatusLabel/StatusLabel.tsx
+++ b/src/components/StatusLabel/StatusLabel.tsx
@@ -29,7 +29,8 @@ export const useStyles = makeStyles(
       textContainer: {
         marginLeft: theme.spacing(1),
         display: "flex",
-        flexDirection: "column"
+        flexDirection: "column",
+        width: "100%"
       },
       dotVertical: {
         marginTop: theme.spacing(1)

--- a/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
+++ b/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
@@ -73,6 +73,7 @@ const OrderFulfilledProductsCard: React.FC<OrderFulfilledProductsCardProps> = pr
           fulfillmentOrder={fulfillment?.fulfillmentOrder}
           status={fulfillment?.status}
           orderNumber={orderNumber}
+          warehouseName={fulfillment?.warehouse?.name}
           toolbar={
             maybe(() => fulfillment.status) === FulfillmentStatus.FULFILLED && (
               <CardMenu

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/CardTitle.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/CardTitle.tsx
@@ -6,14 +6,24 @@ import { makeStyles } from "@saleor/theme";
 import { FulfillmentStatus } from "@saleor/types/globalTypes";
 import camelCase from "lodash/camelCase";
 import React from "react";
+import { FormattedMessage } from "react-intl";
 import { defineMessages } from "react-intl";
 import { useIntl } from "react-intl";
 
 const useStyles = makeStyles(
   theme => ({
+    title: {
+      width: "100%",
+      display: "flex"
+    },
     orderNumber: {
       display: "inline",
       marginLeft: theme.spacing(1)
+    },
+    warehouseName: {
+      float: "right",
+      color: theme.palette.text.secondary,
+      margin: `auto ${theme.spacing(1)}px auto auto`
     }
   }),
   { name: "CardTitle" }
@@ -47,6 +57,10 @@ const messages = defineMessages({
   unfulfilled: {
     defaultMessage: "Unfulfilled",
     description: "section header"
+  },
+  fulfilledFrom: {
+    defaultMessage: "Fulfilled from {warehouseName}",
+    description: "fulfilled fulfillment, section header"
   }
 });
 
@@ -62,6 +76,7 @@ interface CardTitleProps {
   status: CardTitleStatus;
   toolbar?: React.ReactNode;
   orderNumber?: string;
+  warehouseName?: string;
   withStatus?: boolean;
 }
 
@@ -89,6 +104,7 @@ const CardTitle: React.FC<CardTitleProps> = ({
   fulfillmentOrder,
   status,
   orderNumber = "",
+  warehouseName,
   withStatus = false,
   toolbar
 }) => {
@@ -108,7 +124,7 @@ const CardTitle: React.FC<CardTitleProps> = ({
   );
 
   const title = (
-    <>
+    <div className={classes.title}>
       {intl.formatMessage(messageForStatus, {
         fulfillmentName,
         quantity: totalQuantity
@@ -116,7 +132,17 @@ const CardTitle: React.FC<CardTitleProps> = ({
       <Typography className={classes.orderNumber} variant="body1">
         {fulfillmentName}
       </Typography>
-    </>
+      {!!warehouseName && (
+        <Typography className={classes.warehouseName} variant="caption">
+          <FormattedMessage
+            {...messages.fulfilledFrom}
+            values={{
+              warehouseName
+            }}
+          />
+        </Typography>
+      )}
+    </div>
   );
 
   return (


### PR DESCRIPTION
I want to merge this change because... it adds display warehouse name for each fulfillment.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<img width="768" alt="Zrzut ekranu 2021-07-26 o 15 22 57" src="https://user-images.githubusercontent.com/9825562/126998413-62397f68-d01a-43d0-ad20-43684a31b504.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
