### PR TITLE
Hide no-stocks columns in fulfillment view

### DIFF
--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -5,6 +5,7 @@ import {
   fragmentRefundOrderLine
 } from "@saleor/fragments/orders";
 import { fragmentMoney } from "@saleor/fragments/products";
+import { warehouseFragment } from "@saleor/fragments/warehouses";
 import makeQuery from "@saleor/hooks/makeQuery";
 import makeTopLevelSearch from "@saleor/hooks/makeTopLevelSearch";
 import gql from "graphql-tag";
@@ -217,6 +218,7 @@ export const useOrderVariantSearch = makeTopLevelSearch<
 >(searchOrderVariant);
 
 const orderFulfillData = gql`
+  ${warehouseFragment}
   query OrderFulfillData($orderId: ID!) {
     order(id: $orderId) {
       id
@@ -245,7 +247,7 @@ const orderFulfillData = gql`
           stocks {
             id
             warehouse {
-              id
+              ...WarehouseFragment
             }
             quantity
             quantityAllocated

--- a/src/orders/types/OrderFulfillData.ts
+++ b/src/orders/types/OrderFulfillData.ts
@@ -32,6 +32,7 @@ export interface OrderFulfillData_order_lines_variant_attributes {
 export interface OrderFulfillData_order_lines_variant_stocks_warehouse {
   __typename: "Warehouse";
   id: string;
+  name: string;
 }
 
 export interface OrderFulfillData_order_lines_variant_stocks {

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -12,18 +12,18 @@ import {
   OrderDetails_order_fulfillments_lines,
   OrderDetails_order_lines
 } from "../types/OrderDetails";
-import { OrderFulfillData_order } from "../types/OrderFulfillData";
+import { OrderFulfillData_order_lines } from "../types/OrderFulfillData";
 import {
   OrderRefundData_order_fulfillments,
   OrderRefundData_order_lines
 } from "../types/OrderRefundData";
 import {
   getAllFulfillmentLinesPriceSum,
-  getOrderWarehouses,
   getPreviouslyRefundedPrice,
   getRefundedLinesPriceSum,
   getReplacedProductsAmount,
   getReturnSelectedProductsAmount,
+  getWarehousesFromOrderLines,
   mergeRepeatedOrderLines,
   OrderWithTotalAndTotalCaptured
 } from "./data";
@@ -71,99 +71,136 @@ const orderBase: OrderDetails_order = {
 
 describe("Get warehouses used in order", () => {
   it("is able to calculate number of used warehouses from order", () => {
-    const order = {
-      __typename: "Order",
-      id: "order-1",
-      number: "1",
-      lines: [
-        {
-          __typename: "OrderLine",
-          id: "order-line-1",
-          productName: "Product 1",
-          variant: {
-            __typename: "ProductVariant",
-            id: "product-variant-1",
-            name: "Product variant 1",
-            stocks: [
-              {
-                __typename: "Stock",
-                warehouse: {
-                  __typename: "Warehouse",
-                  id: "warehouse-1",
-                  name: "Warehouse 1"
-                }
-              },
-              {
-                __typename: "Stock",
-                warehouse: {
-                  __typename: "Warehouse",
-                  id: "warehouse-2",
-                  name: "Warehouse 2"
-                }
+    const lines: OrderFulfillData_order_lines[] = [
+      {
+        __typename: "OrderLine",
+        id: "order-line-1",
+        productName: "Product 1",
+        isShippingRequired: false,
+        quantity: 1,
+        allocations: [],
+        quantityFulfilled: 0,
+        thumbnail: null,
+        variant: {
+          __typename: "ProductVariant",
+          id: "product-variant-1",
+          name: "Product variant 1",
+          sku: "product-variant-1",
+          attributes: [],
+          trackInventory: false,
+          stocks: [
+            {
+              __typename: "Stock",
+              id: "stock-1",
+              quantity: 100,
+              quantityAllocated: 10,
+              warehouse: {
+                __typename: "Warehouse",
+                id: "warehouse-1",
+                name: "Warehouse 1"
               }
-            ]
-          }
-        },
-        {
-          __typename: "OrderLine",
-          id: "order-line-2",
-          productName: "Product 2",
-          variant: {
-            __typename: "ProductVariant",
-            id: "product-variant-2",
-            name: "Product variant 2",
-            stocks: [
-              {
-                __typename: "Stock",
-                warehouse: {
-                  __typename: "Warehouse",
-                  id: "warehouse-1",
-                  name: "Warehouse 1"
-                }
-              },
-              {
-                __typename: "Stock",
-                warehouse: {
-                  __typename: "Warehouse",
-                  id: "warehouse-2",
-                  name: "Warehouse 2"
-                }
+            },
+            {
+              __typename: "Stock",
+              id: "stock-2",
+              quantity: 100,
+              quantityAllocated: 10,
+              warehouse: {
+                __typename: "Warehouse",
+                id: "warehouse-2",
+                name: "Warehouse 2"
               }
-            ]
-          }
-        },
-        {
-          __typename: "OrderLine",
-          id: "order-line-3",
-          productName: "Product 3",
-          variant: {
-            __typename: "ProductVariant",
-            id: "product-variant-3",
-            name: "Product variant 3",
-            stocks: [
-              {
-                __typename: "Stock",
-                warehouse: {
-                  __typename: "Warehouse",
-                  id: "warehouse-2",
-                  name: "Warehouse 2"
-                }
-              },
-              {
-                __typename: "Stock",
-                warehouse: {
-                  __typename: "Warehouse",
-                  id: "warehouse-3",
-                  name: "Warehouse 3"
-                }
-              }
-            ]
-          }
+            }
+          ]
         }
-      ]
-    } as OrderFulfillData_order;
+      },
+      {
+        __typename: "OrderLine",
+        id: "order-line-2",
+        productName: "Product 2",
+        isShippingRequired: false,
+        quantity: 1,
+        allocations: [],
+        quantityFulfilled: 0,
+        thumbnail: null,
+        variant: {
+          __typename: "ProductVariant",
+          id: "product-variant-2",
+          name: "Product variant 2",
+          sku: "product-variant-2",
+          attributes: [],
+          trackInventory: false,
+          stocks: [
+            {
+              __typename: "Stock",
+              id: "stock-1",
+              quantity: 100,
+              quantityAllocated: 10,
+              warehouse: {
+                __typename: "Warehouse",
+                id: "warehouse-1",
+                name: "Warehouse 1"
+              }
+            },
+            {
+              __typename: "Stock",
+              id: "stock-2",
+              quantity: 100,
+              quantityAllocated: 10,
+              warehouse: {
+                __typename: "Warehouse",
+                id: "warehouse-2",
+                name: "Warehouse 2"
+              }
+            }
+          ]
+        }
+      },
+      {
+        __typename: "OrderLine",
+        id: "order-line-3",
+        productName: "Product 3",
+        isShippingRequired: false,
+        quantity: 1,
+        allocations: [],
+        quantityFulfilled: 0,
+        thumbnail: null,
+        variant: {
+          __typename: "ProductVariant",
+          id: "product-variant-3",
+          name: "Product variant 3",
+          sku: "product-variant-3",
+          attributes: [],
+          trackInventory: false,
+          stocks: [
+            {
+              __typename: "Stock",
+              id: "stock-2",
+              quantity: 100,
+              quantityAllocated: 10,
+              warehouse: {
+                __typename: "Warehouse",
+                id: "warehouse-2",
+                name: "Warehouse 2"
+              }
+            },
+            {
+              __typename: "Stock",
+              id: "stock-3",
+              quantity: 100,
+              quantityAllocated: 10,
+              warehouse: {
+                __typename: "Warehouse",
+                id: "warehouse-3",
+                name: "Warehouse 3"
+              }
+            }
+          ]
+        }
+      }
+    ];
 
-    const orderWarehouses = getOrderWarehouses(order);
+    const orderWarehouses = getWarehousesFromOrderLines(lines);
 
     expect(orderWarehouses.length).toBe(3);
   });

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -12,12 +12,14 @@ import {
   OrderDetails_order_fulfillments_lines,
   OrderDetails_order_lines
 } from "../types/OrderDetails";
+import { OrderFulfillData_order } from "../types/OrderFulfillData";
 import {
   OrderRefundData_order_fulfillments,
   OrderRefundData_order_lines
 } from "../types/OrderRefundData";
 import {
   getAllFulfillmentLinesPriceSum,
+  getOrderWarehouses,
   getPreviouslyRefundedPrice,
   getRefundedLinesPriceSum,
   getReplacedProductsAmount,
@@ -66,6 +68,106 @@ const orderBase: OrderDetails_order = {
     }
   }
 };
+
+describe("Get warehouses used in order", () => {
+  it("is able to calculate number of used warehouses from order", () => {
+    const order = {
+      __typename: "Order",
+      id: "order-1",
+      number: "1",
+      lines: [
+        {
+          __typename: "OrderLine",
+          id: "order-line-1",
+          productName: "Product 1",
+          variant: {
+            __typename: "ProductVariant",
+            id: "product-variant-1",
+            name: "Product variant 1",
+            stocks: [
+              {
+                __typename: "Stock",
+                warehouse: {
+                  __typename: "Warehouse",
+                  id: "warehouse-1",
+                  name: "Warehouse 1"
+                }
+              },
+              {
+                __typename: "Stock",
+                warehouse: {
+                  __typename: "Warehouse",
+                  id: "warehouse-2",
+                  name: "Warehouse 2"
+                }
+              }
+            ]
+          }
+        },
+        {
+          __typename: "OrderLine",
+          id: "order-line-2",
+          productName: "Product 2",
+          variant: {
+            __typename: "ProductVariant",
+            id: "product-variant-2",
+            name: "Product variant 2",
+            stocks: [
+              {
+                __typename: "Stock",
+                warehouse: {
+                  __typename: "Warehouse",
+                  id: "warehouse-1",
+                  name: "Warehouse 1"
+                }
+              },
+              {
+                __typename: "Stock",
+                warehouse: {
+                  __typename: "Warehouse",
+                  id: "warehouse-2",
+                  name: "Warehouse 2"
+                }
+              }
+            ]
+          }
+        },
+        {
+          __typename: "OrderLine",
+          id: "order-line-3",
+          productName: "Product 3",
+          variant: {
+            __typename: "ProductVariant",
+            id: "product-variant-3",
+            name: "Product variant 3",
+            stocks: [
+              {
+                __typename: "Stock",
+                warehouse: {
+                  __typename: "Warehouse",
+                  id: "warehouse-2",
+                  name: "Warehouse 2"
+                }
+              },
+              {
+                __typename: "Stock",
+                warehouse: {
+                  __typename: "Warehouse",
+                  id: "warehouse-3",
+                  name: "Warehouse 3"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    } as OrderFulfillData_order;
+
+    const orderWarehouses = getOrderWarehouses(order);
+
+    expect(orderWarehouses.length).toBe(3);
+  });
+});
 
 describe("Get previously refunded price", () => {
   it("is able to calculate refunded price from order", () => {

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -12,7 +12,6 @@ import {
   OrderDetails_order_fulfillments_lines,
   OrderDetails_order_lines
 } from "../types/OrderDetails";
-import { OrderFulfillData_order_lines } from "../types/OrderFulfillData";
 import {
   OrderRefundData_order_fulfillments,
   OrderRefundData_order_lines
@@ -25,6 +24,7 @@ import {
   getReturnSelectedProductsAmount,
   getWarehousesFromOrderLines,
   mergeRepeatedOrderLines,
+  OrderLineWithStockWarehouses,
   OrderWithTotalAndTotalCaptured
 } from "./data";
 
@@ -71,29 +71,11 @@ const orderBase: OrderDetails_order = {
 
 describe("Get warehouses used in order", () => {
   it("is able to calculate number of used warehouses from order", () => {
-    const lines: OrderFulfillData_order_lines[] = [
+    const lines: OrderLineWithStockWarehouses[] = [
       {
-        __typename: "OrderLine",
-        id: "order-line-1",
-        productName: "Product 1",
-        isShippingRequired: false,
-        quantity: 1,
-        allocations: [],
-        quantityFulfilled: 0,
-        thumbnail: null,
         variant: {
-          __typename: "ProductVariant",
-          id: "product-variant-1",
-          name: "Product variant 1",
-          sku: "product-variant-1",
-          attributes: [],
-          trackInventory: false,
           stocks: [
             {
-              __typename: "Stock",
-              id: "stock-1",
-              quantity: 100,
-              quantityAllocated: 10,
               warehouse: {
                 __typename: "Warehouse",
                 id: "warehouse-1",
@@ -101,10 +83,6 @@ describe("Get warehouses used in order", () => {
               }
             },
             {
-              __typename: "Stock",
-              id: "stock-2",
-              quantity: 100,
-              quantityAllocated: 10,
               warehouse: {
                 __typename: "Warehouse",
                 id: "warehouse-2",
@@ -115,27 +93,9 @@ describe("Get warehouses used in order", () => {
         }
       },
       {
-        __typename: "OrderLine",
-        id: "order-line-2",
-        productName: "Product 2",
-        isShippingRequired: false,
-        quantity: 1,
-        allocations: [],
-        quantityFulfilled: 0,
-        thumbnail: null,
         variant: {
-          __typename: "ProductVariant",
-          id: "product-variant-2",
-          name: "Product variant 2",
-          sku: "product-variant-2",
-          attributes: [],
-          trackInventory: false,
           stocks: [
             {
-              __typename: "Stock",
-              id: "stock-1",
-              quantity: 100,
-              quantityAllocated: 10,
               warehouse: {
                 __typename: "Warehouse",
                 id: "warehouse-1",
@@ -143,10 +103,6 @@ describe("Get warehouses used in order", () => {
               }
             },
             {
-              __typename: "Stock",
-              id: "stock-2",
-              quantity: 100,
-              quantityAllocated: 10,
               warehouse: {
                 __typename: "Warehouse",
                 id: "warehouse-2",
@@ -157,27 +113,9 @@ describe("Get warehouses used in order", () => {
         }
       },
       {
-        __typename: "OrderLine",
-        id: "order-line-3",
-        productName: "Product 3",
-        isShippingRequired: false,
-        quantity: 1,
-        allocations: [],
-        quantityFulfilled: 0,
-        thumbnail: null,
         variant: {
-          __typename: "ProductVariant",
-          id: "product-variant-3",
-          name: "Product variant 3",
-          sku: "product-variant-3",
-          attributes: [],
-          trackInventory: false,
           stocks: [
             {
-              __typename: "Stock",
-              id: "stock-2",
-              quantity: 100,
-              quantityAllocated: 10,
               warehouse: {
                 __typename: "Warehouse",
                 id: "warehouse-2",
@@ -185,10 +123,6 @@ describe("Get warehouses used in order", () => {
               }
             },
             {
-              __typename: "Stock",
-              id: "stock-3",
-              quantity: 100,
-              quantityAllocated: 10,
               warehouse: {
                 __typename: "Warehouse",
                 id: "warehouse-3",

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -1,4 +1,5 @@
 import { IMoney, subtractMoney } from "@saleor/components/Money";
+import { WarehouseFragment } from "@saleor/fragments/types/WarehouseFragment";
 import { FormsetData } from "@saleor/hooks/useFormset";
 
 import {
@@ -14,6 +15,7 @@ import {
   OrderDetails_order_fulfillments_lines,
   OrderDetails_order_lines
 } from "../types/OrderDetails";
+import { OrderFulfillData_order } from "../types/OrderFulfillData";
 import {
   OrderRefundData_order,
   OrderRefundData_order_fulfillments,
@@ -24,6 +26,20 @@ export type OrderWithTotalAndTotalCaptured = Pick<
   OrderRefundData_order,
   "total" | "totalCaptured"
 >;
+
+export function getOrderWarehouses(order: OrderFulfillData_order) {
+  return order?.lines?.reduce(
+    (warehouses, line) =>
+      line.variant.stocks?.reduce(
+        (warehouses, stock) =>
+          warehouses.every(warehouse => warehouse.id !== stock.warehouse.id)
+            ? [...warehouses, stock.warehouse]
+            : warehouses,
+        warehouses
+      ),
+    [] as WarehouseFragment[]
+  );
+}
 
 export function getPreviouslyRefundedPrice(
   order: OrderWithTotalAndTotalCaptured

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -15,7 +15,6 @@ import {
   OrderDetails_order_fulfillments_lines,
   OrderDetails_order_lines
 } from "../types/OrderDetails";
-import { OrderFulfillData_order } from "../types/OrderFulfillData";
 import {
   OrderRefundData_order,
   OrderRefundData_order_fulfillments,
@@ -27,14 +26,22 @@ export type OrderWithTotalAndTotalCaptured = Pick<
   "total" | "totalCaptured"
 >;
 
-export function getOrderWarehouses(order: OrderFulfillData_order) {
-  return order?.lines?.reduce(
+export interface OrderLineWithStockWarehouses {
+  variant: {
+    stocks: Array<{ warehouse: WarehouseFragment }>;
+  };
+}
+
+export function getWarehousesFromOrderLines<
+  T extends OrderLineWithStockWarehouses
+>(lines?: T[]) {
+  return lines?.reduce(
     (warehouses, line) =>
       line.variant.stocks?.reduce(
         (warehouses, stock) =>
-          warehouses.every(warehouse => warehouse.id !== stock.warehouse.id)
-            ? [...warehouses, stock.warehouse]
-            : warehouses,
+          warehouses.some(getById(stock.warehouse.id))
+            ? warehouses
+            : [...warehouses, stock.warehouse],
         warehouses
       ),
     [] as WarehouseFragment[]

--- a/src/orders/views/OrderFulfill/OrderFulfill.tsx
+++ b/src/orders/views/OrderFulfill/OrderFulfill.tsx
@@ -5,7 +5,7 @@ import OrderFulfillPage from "@saleor/orders/components/OrderFulfillPage";
 import { useOrderFulfill } from "@saleor/orders/mutations";
 import { useOrderFulfillData } from "@saleor/orders/queries";
 import { orderUrl } from "@saleor/orders/urls";
-import { getOrderWarehouses } from "@saleor/orders/utils/data";
+import { getWarehousesFromOrderLines } from "@saleor/orders/utils/data";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -25,7 +25,7 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
     }
   });
 
-  const orderWarehouses = getOrderWarehouses(data?.order);
+  const orderLinesWarehouses = getWarehousesFromOrderLines(data?.order?.lines);
 
   const [fulfillOrder, fulfillOrderOpts] = useOrderFulfill({
     onCompleted: data => {
@@ -82,7 +82,7 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
         }
         order={data?.order}
         saveButtonBar="default"
-        warehouses={orderWarehouses}
+        warehouses={orderLinesWarehouses}
       />
     </>
   );

--- a/src/orders/views/OrderFulfill/OrderFulfill.tsx
+++ b/src/orders/views/OrderFulfill/OrderFulfill.tsx
@@ -5,8 +5,7 @@ import OrderFulfillPage from "@saleor/orders/components/OrderFulfillPage";
 import { useOrderFulfill } from "@saleor/orders/mutations";
 import { useOrderFulfillData } from "@saleor/orders/queries";
 import { orderUrl } from "@saleor/orders/urls";
-import { mapEdgesToItems } from "@saleor/utils/maps";
-import { useWarehouseList } from "@saleor/warehouses/queries";
+import { getOrderWarehouses } from "@saleor/orders/utils/data";
 import React from "react";
 import { useIntl } from "react-intl";
 
@@ -18,6 +17,7 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
+
   const { data, loading } = useOrderFulfillData({
     displayLoader: true,
     variables: {
@@ -25,12 +25,7 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
     }
   });
 
-  const { data: warehouseData, loading: warehousesLoading } = useWarehouseList({
-    displayLoader: true,
-    variables: {
-      first: 20
-    }
-  });
+  const orderWarehouses = getOrderWarehouses(data?.order);
 
   const [fulfillOrder, fulfillOrderOpts] = useOrderFulfill({
     onCompleted: data => {
@@ -68,7 +63,7 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
         }
       />
       <OrderFulfillPage
-        loading={loading || warehousesLoading || fulfillOrderOpts.loading}
+        loading={loading || fulfillOrderOpts.loading}
         errors={fulfillOrderOpts.data?.orderFulfill.errors}
         onBack={() => navigate(orderUrl(orderId))}
         onSubmit={formData =>
@@ -87,7 +82,7 @@ const OrderFulfill: React.FC<OrderFulfillProps> = ({ orderId }) => {
         }
         order={data?.order}
         saveButtonBar="default"
-        warehouses={mapEdgesToItems(warehouseData?.warehouses)}
+        warehouses={orderWarehouses}
       />
     </>
   );


### PR DESCRIPTION
I want to merge this change because... it hides no-stocks columns in fulfillment view.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
before:
<img width="1271" alt="Zrzut ekranu 2021-07-26 o 17 00 49" src="https://user-images.githubusercontent.com/9825562/127019350-31df60ed-d977-4fb1-a545-88c049449307.png">
after:
<img width="1270" alt="Zrzut ekranu 2021-07-26 o 17 04 32" src="https://user-images.githubusercontent.com/9825562/127019363-949f2c3d-c4f7-4d47-bbd7-1c26ab24b6af.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
