### PR TITLE
Render history events regarding waiting fulfillments

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3947,6 +3947,10 @@
     "context": "order history message",
     "string": "Products were added to an order"
   },
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_3927123907": {
+    "context": "order history message",
+    "string": "Fulfilled {quantity} items awaits approval"
+  },
   "src_dot_orders_dot_components_dot_OrderHistory_dot_393045022": {
     "context": "order history message",
     "string": "Invoice no. {invoiceNumber} was updated"

--- a/schema.graphql
+++ b/schema.graphql
@@ -666,6 +666,7 @@ input AttributeValueInput {
 type AttributeValueTranslatableContent implements Node {
   id: ID!
   name: String!
+  richText: JSONString
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
   attributeValue: AttributeValue @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
@@ -3688,6 +3689,7 @@ type PageTranslatableContent implements Node {
   contentJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   page: Page @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type PageTranslate {
@@ -4434,6 +4436,7 @@ type ProductTranslatableContent implements Node {
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   product: Product @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductTranslate {
@@ -4708,6 +4711,7 @@ type ProductVariantTranslatableContent implements Node {
   name: String!
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
   productVariant: ProductVariant @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductVariantTranslate {

--- a/src/orders/components/OrderHistory/OrderHistory.tsx
+++ b/src/orders/components/OrderHistory/OrderHistory.tsx
@@ -142,6 +142,16 @@ export const getEventMessage = (
           sentBy: event.user ? event.user.email : null
         }
       );
+    case OrderEventsEnum.FULFILLMENT_AWAITS_APPROVAL:
+      return intl.formatMessage(
+        {
+          defaultMessage: "Fulfilled {quantity} items awaits approval",
+          description: "order history message"
+        },
+        {
+          quantity: event.quantity
+        }
+      );
     case OrderEventsEnum.FULFILLMENT_FULFILLED_ITEMS:
       return intl.formatMessage(
         {

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/CardTitle.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/CardTitle.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles(
     warehouseName: {
       float: "right",
       color: theme.palette.text.secondary,
-      margin: `auto ${theme.spacing(1)}px auto auto`
+      margin: `auto ${theme.spacing(1)} auto auto`
     }
   }),
   { name: "CardTitle" }


### PR DESCRIPTION
I want to merge this change because... it adds awaiting for approval fulfillment order event.
Backend: https://github.com/mirumee/saleor/pull/7675

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="692" alt="Zrzut ekranu 2021-07-28 o 11 05 16" src="https://user-images.githubusercontent.com/9825562/127296452-1a4ecff0-4ef6-42ae-98b0-0a2ac6541a70.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://feature-fulfillment-api.api.saleor.rocks/graphql/
