### PR TITLE
Add product variant translation view

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1583,6 +1583,10 @@
     "context": "alert",
     "string": "Channel limit reached"
   },
+  "src_dot_channels_dot_pages_dot_ChannelsListPage_dot_3277722884": {
+    "context": "created channels counter",
+    "string": "{count}/{max} channels used"
+  },
   "src_dot_channels_dot_pages_dot_ChannelsListPage_dot_3511613983": {
     "context": "channel name",
     "string": "Channel Name"
@@ -3445,6 +3449,13 @@
     "context": "orders section name",
     "string": "Orders"
   },
+  "src_dot_orders_dot_components_dot_2214147779": {
+    "context": "alert",
+    "string": "Order limit reached"
+  },
+  "src_dot_orders_dot_components_dot_3769643084": {
+    "string": "You have reached your order limit, you will be billed extra for orders above limit. If you would like to up your limit, contact your administration staff about raising your limits."
+  },
   "src_dot_orders_dot_components_dot_DraftOrderChannelSectionCard_dot_1243773440": {
     "context": "section header",
     "string": "Sales channel"
@@ -3669,6 +3680,10 @@
   "src_dot_orders_dot_components_dot_OrderDraftDetails_dot_2528459381": {
     "context": "button",
     "string": "Add products"
+  },
+  "src_dot_orders_dot_components_dot_OrderDraftListPage_dot_1629108523": {
+    "context": "placed orders counter",
+    "string": "{count}/{max} orders"
   },
   "src_dot_orders_dot_components_dot_OrderDraftListPage_dot_2826235371": {
     "context": "button",
@@ -4010,9 +4025,9 @@
     "context": "generate invoice button",
     "string": "Generate"
   },
-  "src_dot_orders_dot_components_dot_OrderListPage_dot_2214147779": {
-    "context": "alert",
-    "string": "Order limit reached"
+  "src_dot_orders_dot_components_dot_OrderListPage_dot_1629108523": {
+    "context": "placed order counter",
+    "string": "{count}/{max} orders"
   },
   "src_dot_orders_dot_components_dot_OrderListPage_dot_2225897825": {
     "context": "button",
@@ -4024,9 +4039,6 @@
   },
   "src_dot_orders_dot_components_dot_OrderListPage_dot_355376157": {
     "string": "Search Orders..."
-  },
-  "src_dot_orders_dot_components_dot_OrderListPage_dot_3769643084": {
-    "string": "You have reached your order limit, you will be billed extra for orders above limit. If you would like to up your limit, contact your administration staff about raising your limits."
   },
   "src_dot_orders_dot_components_dot_OrderListPage_dot_875489544": {
     "context": "tab name",
@@ -5382,6 +5394,10 @@
     "context": "alert",
     "string": "SKU limit reached"
   },
+  "src_dot_products_dot_components_dot_ProductListPage_dot_3155791658": {
+    "context": "created products counter",
+    "string": "{count}/{max} SKUs used"
+  },
   "src_dot_products_dot_components_dot_ProductListPage_dot_3550330425": {
     "string": "Search Products..."
   },
@@ -6508,6 +6524,10 @@
     "context": "button",
     "string": "Invite staff member"
   },
+  "src_dot_staff_dot_components_dot_StaffListPage_dot_938945387": {
+    "context": "used staff users counter",
+    "string": "{count}/{max} members"
+  },
   "src_dot_staff_dot_components_dot_StaffListPage_dot_active": {
     "context": "staff member's account",
     "string": "Active"
@@ -6675,6 +6695,12 @@
     "context": "translations section name",
     "string": "Translations"
   },
+  "src_dot_translations_dot_components_dot_ProductContextSwitcher_dot_1932340772": {
+    "string": "Translating"
+  },
+  "src_dot_translations_dot_components_dot_ProductContextSwitcher_dot_197468239": {
+    "string": "Main Product"
+  },
   "src_dot_translations_dot_components_dot_TranslationFields_dot_1308081812": {
     "string": "{numberOfFields} Translations, {numberOfTranslatedFields} Completed"
   },
@@ -6814,6 +6840,17 @@
   },
   "src_dot_translations_dot_components_dot_TranslationsPagesPage_dot_432157284": {
     "string": "Page Title"
+  },
+  "src_dot_translations_dot_components_dot_TranslationsProductVariantsPage_dot_4165966072": {
+    "context": "attribute list",
+    "string": "Attribute {number}"
+  },
+  "src_dot_translations_dot_components_dot_TranslationsProductVariantsPage_dot_847507870": {
+    "context": "header",
+    "string": "Translation Product Variant \"{productName}\" - {languageCode}"
+  },
+  "src_dot_translations_dot_components_dot_TranslationsProductVariantsPage_dot_953327101": {
+    "string": "Variant Name"
   },
   "src_dot_translations_dot_components_dot_TranslationsProductsPage_dot_1406947243": {
     "string": "Search Engine Description"
@@ -7117,6 +7154,10 @@
   },
   "src_dot_warehouses_dot_components_dot_WarehouseInfo_dot_2622674857": {
     "string": "Warehouse Name"
+  },
+  "src_dot_warehouses_dot_components_dot_WarehouseListPage_dot_1082745946": {
+    "context": "used warehouses counter",
+    "string": "{count}/{max} warehouses used"
   },
   "src_dot_warehouses_dot_components_dot_WarehouseListPage_dot_2304765290": {
     "string": "Search Warehouse"

--- a/src/fragments/translations.ts
+++ b/src/fragments/translations.ts
@@ -84,6 +84,41 @@ export const productTranslationFragment = gql`
     }
   }
 `;
+
+export const productVariantTranslationFragment = gql`
+  fragment ProductVariantTranslationFragment on ProductVariantTranslatableContent {
+    productVariant {
+      id
+    }
+    name
+    translation(languageCode: $language) {
+      id
+      name
+      language {
+        code
+        language
+      }
+    }
+    attributeValues {
+      id
+      name
+      richText
+      attributeValue {
+        id
+      }
+      translation(languageCode: $language) {
+        id
+        name
+        richText
+        language {
+          code
+          language
+        }
+      }
+    }
+  }
+`;
+
 export const saleTranslationFragment = gql`
   fragment SaleTranslationFragment on SaleTranslatableContent {
     sale {

--- a/src/fragments/types/ProductVariantTranslationFragment.ts
+++ b/src/fragments/types/ProductVariantTranslationFragment.ts
@@ -1,0 +1,64 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { LanguageCodeEnum } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL fragment: ProductVariantTranslationFragment
+// ====================================================
+
+export interface ProductVariantTranslationFragment_productVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
+export interface ProductVariantTranslationFragment_translation_language {
+  __typename: "LanguageDisplay";
+  code: LanguageCodeEnum;
+  language: string;
+}
+
+export interface ProductVariantTranslationFragment_translation {
+  __typename: "ProductVariantTranslation";
+  id: string;
+  name: string;
+  language: ProductVariantTranslationFragment_translation_language;
+}
+
+export interface ProductVariantTranslationFragment_attributeValues_attributeValue {
+  __typename: "AttributeValue";
+  id: string;
+}
+
+export interface ProductVariantTranslationFragment_attributeValues_translation_language {
+  __typename: "LanguageDisplay";
+  code: LanguageCodeEnum;
+  language: string;
+}
+
+export interface ProductVariantTranslationFragment_attributeValues_translation {
+  __typename: "AttributeValueTranslation";
+  id: string;
+  name: string;
+  richText: any | null;
+  language: ProductVariantTranslationFragment_attributeValues_translation_language;
+}
+
+export interface ProductVariantTranslationFragment_attributeValues {
+  __typename: "AttributeValueTranslatableContent";
+  id: string;
+  name: string;
+  richText: any | null;
+  attributeValue: ProductVariantTranslationFragment_attributeValues_attributeValue | null;
+  translation: ProductVariantTranslationFragment_attributeValues_translation | null;
+}
+
+export interface ProductVariantTranslationFragment {
+  __typename: "ProductVariantTranslatableContent";
+  productVariant: ProductVariantTranslationFragment_productVariant | null;
+  name: string;
+  translation: ProductVariantTranslationFragment_translation | null;
+  attributeValues: ProductVariantTranslationFragment_attributeValues[];
+}

--- a/src/translations/components/ProductContextSwitcher/ProductContextSwitcher.tsx
+++ b/src/translations/components/ProductContextSwitcher/ProductContextSwitcher.tsx
@@ -18,7 +18,7 @@ import {
 } from "@saleor/translations/urls";
 import classNames from "classnames";
 import React from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import { useProductVariantList } from "../../queries";
 
@@ -35,7 +35,13 @@ const useStyles = makeStyles(
       transition: theme.transitions.duration.standard + "ms"
     },
     container: {
-      paddingBottom: theme.spacing(1)
+      display: "flex",
+      alignItems: "center",
+      paddingBottom: theme.spacing(1),
+      marginRight: theme.spacing(1)
+    },
+    label: {
+      paddingRight: theme.spacing(1)
     },
     menuContainer: {
       cursor: "pointer",
@@ -89,68 +95,73 @@ const ProductContextSwitcher: React.FC<ProductContextSwitcherProps> = ({
           )
         )
     },
-    ...(data?.product?.variants?.map(({ name, id }) => ({
-      label: name,
+    ...(data?.product?.variants?.map(({ name, sku, id }) => ({
+      label: name || sku,
       value: id,
       onClick: () => navigate(productVariantUrl(languageCode, productId, id))
     })) || [])
   ];
 
   return (
-    <div className={classes.container} ref={anchor}>
-      <Card
-        className={classes.menuContainer}
-        onClick={() => setExpandedState(!isExpanded)}
-      >
-        <Typography>
-          {items.find(({ value }) => value === selectedId)?.label || "-"}
-        </Typography>
-        <ArrowDropDown
-          className={classNames(classes.arrow, {
-            [classes.rotate]: isExpanded
-          })}
-        />
-      </Card>
-      <Popper
-        className={classes.popover}
-        open={isExpanded}
-        anchorEl={anchor.current}
-        transition
-        disablePortal
-        placement="bottom-end"
-      >
-        {({ TransitionProps, placement }) => (
-          <Grow
-            {...TransitionProps}
-            style={{
-              transformOrigin:
-                placement === "bottom" ? "right top" : "right bottom"
-            }}
-          >
-            <Paper className={classes.menuPaper}>
-              <ClickAwayListener
-                onClickAway={() => setExpandedState(false)}
-                mouseEvent="onClick"
-              >
-                <Menu>
-                  {items.map(({ label, value, onClick }) => (
-                    <MenuItem
-                      key={value}
-                      className={classes.menuItem}
-                      onClick={() => {
-                        setExpandedState(false);
-                        onClick();
-                      }}
-                    >
-                      {label}
-                    </MenuItem>
-                  ))}
-                </Menu>
-              </ClickAwayListener>
-            </Paper>
-          </Grow>
-        )}
-      </Popper>
+    <div className={classes.container}>
+      <Typography className={classes.label}>
+        <FormattedMessage defaultMessage="Translating" />:
+      </Typography>
+      <div ref={anchor}>
+        <Card
+          className={classes.menuContainer}
+          onClick={() => setExpandedState(!isExpanded)}
+        >
+          <Typography>
+            {items.find(({ value }) => value === selectedId)?.label || "-"}
+          </Typography>
+          <ArrowDropDown
+            className={classNames(classes.arrow, {
+              [classes.rotate]: isExpanded
+            })}
+          />
+        </Card>
+        <Popper
+          className={classes.popover}
+          open={isExpanded}
+          anchorEl={anchor.current}
+          transition
+          disablePortal
+          placement="bottom-end"
+        >
+          {({ TransitionProps, placement }) => (
+            <Grow
+              {...TransitionProps}
+              style={{
+                transformOrigin:
+                  placement === "bottom" ? "right top" : "right bottom"
+              }}
+            >
+              <Paper className={classes.menuPaper}>
+                <ClickAwayListener
+                  onClickAway={() => setExpandedState(false)}
+                  mouseEvent="onClick"
+                >
+                  <Menu>
+                    {items.map(({ label, value, onClick }) => (
+                      <MenuItem
+                        key={value}
+                        className={classes.menuItem}
+                        onClick={() => {
+                          setExpandedState(false);
+                          onClick();
+                        }}
+                      >
+                        {label}
+                      </MenuItem>
+                    ))}
+                  </Menu>
+                </ClickAwayListener>
+              </Paper>
+            </Grow>
+          )}
+        </Popper>
+      </div>
     </div>
   );
 };

--- a/src/translations/components/ProductContextSwitcher/ProductContextSwitcher.tsx
+++ b/src/translations/components/ProductContextSwitcher/ProductContextSwitcher.tsx
@@ -1,0 +1,158 @@
+import {
+  Card,
+  ClickAwayListener,
+  Grow,
+  MenuItem,
+  MenuList as Menu,
+  Paper,
+  Popper,
+  Typography
+} from "@material-ui/core";
+import ArrowDropDown from "@material-ui/icons/ArrowDropDown";
+import useNavigator from "@saleor/hooks/useNavigator";
+import { makeStyles } from "@saleor/macaw-ui";
+import {
+  languageEntityUrl,
+  productVariantUrl,
+  TranslatableEntities
+} from "@saleor/translations/urls";
+import classNames from "classnames";
+import React from "react";
+import { useIntl } from "react-intl";
+
+import { useProductVariantList } from "../../queries";
+
+export interface ProductContextSwitcherProps {
+  productId: string;
+  selectedId: string;
+  languageCode: string;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    arrow: {
+      color: theme.palette.primary.main,
+      transition: theme.transitions.duration.standard + "ms"
+    },
+    container: {
+      paddingBottom: theme.spacing(1)
+    },
+    menuContainer: {
+      cursor: "pointer",
+      display: "flex",
+      justifyContent: "space-between",
+      minWidth: 90,
+      padding: theme.spacing(),
+      position: "relative"
+    },
+    menuItem: {
+      textAlign: "justify"
+    },
+    menuPaper: {
+      maxHeight: `calc(100vh - ${theme.spacing(2)}px)`,
+      overflow: "scroll"
+    },
+    popover: {
+      zIndex: 1
+    },
+    rotate: {
+      transform: "rotate(180deg)"
+    }
+  }),
+  { name: "ProductContextSwitcher" }
+);
+const ProductContextSwitcher: React.FC<ProductContextSwitcherProps> = ({
+  languageCode,
+  productId,
+  selectedId
+}) => {
+  const classes = useStyles();
+  const navigate = useNavigator();
+  const intl = useIntl();
+  const { data } = useProductVariantList({
+    variables: { id: productId }
+  });
+
+  const [isExpanded, setExpandedState] = React.useState(false);
+  const anchor = React.useRef();
+
+  const items = [
+    {
+      label: intl.formatMessage({ defaultMessage: "Main Product" }),
+      value: productId,
+      onClick: () =>
+        navigate(
+          languageEntityUrl(
+            languageCode,
+            TranslatableEntities.products,
+            productId
+          )
+        )
+    },
+    ...(data?.product?.variants?.map(({ name, id }) => ({
+      label: name,
+      value: id,
+      onClick: () => navigate(productVariantUrl(languageCode, productId, id))
+    })) || [])
+  ];
+
+  return (
+    <div className={classes.container} ref={anchor}>
+      <Card
+        className={classes.menuContainer}
+        onClick={() => setExpandedState(!isExpanded)}
+      >
+        <Typography>
+          {items.find(({ value }) => value === selectedId)?.label || "-"}
+        </Typography>
+        <ArrowDropDown
+          className={classNames(classes.arrow, {
+            [classes.rotate]: isExpanded
+          })}
+        />
+      </Card>
+      <Popper
+        className={classes.popover}
+        open={isExpanded}
+        anchorEl={anchor.current}
+        transition
+        disablePortal
+        placement="bottom-end"
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === "bottom" ? "right top" : "right bottom"
+            }}
+          >
+            <Paper className={classes.menuPaper}>
+              <ClickAwayListener
+                onClickAway={() => setExpandedState(false)}
+                mouseEvent="onClick"
+              >
+                <Menu>
+                  {items.map(({ label, value, onClick }) => (
+                    <MenuItem
+                      key={value}
+                      className={classes.menuItem}
+                      onClick={() => {
+                        setExpandedState(false);
+                        onClick();
+                      }}
+                    >
+                      {label}
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </div>
+  );
+};
+ProductContextSwitcher.displayName = "ProductContextSwitcher";
+export default ProductContextSwitcher;

--- a/src/translations/components/ProductContextSwitcher/index.ts
+++ b/src/translations/components/ProductContextSwitcher/index.ts
@@ -1,0 +1,2 @@
+export * from "./ProductContextSwitcher";
+export { default } from "./ProductContextSwitcher";

--- a/src/translations/components/TranslationFields/TranslationFields.tsx
+++ b/src/translations/components/TranslationFields/TranslationFields.tsx
@@ -38,6 +38,7 @@ export interface TranslationFieldsProps {
   initialState: boolean;
   saveButtonState: ConfirmButtonTransitionState;
   pagination?: Pagination;
+  richTextResetKey: string; // temporary workaround TODO: fix rich text editor
   onEdit: (field: string) => void;
   onDiscard: () => void;
   onSubmit: (field: TranslationField, data: string | OutputData) => void;
@@ -120,6 +121,7 @@ const TranslationFields: React.FC<TranslationFieldsProps> = props => {
     title,
     saveButtonState,
     pagination,
+    richTextResetKey,
     onEdit,
     onDiscard,
     onSubmit
@@ -187,6 +189,7 @@ const TranslationFields: React.FC<TranslationFieldsProps> = props => {
                       />
                     ) : (
                       <TranslationFieldsRich
+                        resetKey={richTextResetKey}
                         disabled={disabled}
                         edit={false}
                         initial={field.value}
@@ -221,6 +224,7 @@ const TranslationFields: React.FC<TranslationFieldsProps> = props => {
                       />
                     ) : (
                       <TranslationFieldsRich
+                        resetKey={richTextResetKey}
                         disabled={disabled}
                         edit={activeField === field.name}
                         initial={field.translation}

--- a/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
+++ b/src/translations/components/TranslationFields/TranslationFieldsRich.tsx
@@ -14,6 +14,7 @@ interface TranslationFieldsRichProps {
   edit: boolean;
   initial: string;
   saveButtonState: ConfirmButtonTransitionState;
+  resetKey: string;
   onDiscard: () => void;
   onSubmit: (data: OutputData) => void;
 }
@@ -23,6 +24,7 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
   edit,
   initial,
   saveButtonState,
+  resetKey,
   onDiscard,
   onSubmit
 }) => {
@@ -59,7 +61,7 @@ const TranslationFieldsRich: React.FC<TranslationFieldsRichProps> = ({
     </Typography>
   ) : (
     <Typography>
-      <RichTextEditorContent data={JSON.parse(initial)} />
+      <RichTextEditorContent key={resetKey} data={JSON.parse(initial)} />
     </Typography>
   );
 };

--- a/src/translations/components/TranslationsAttributesPage/TranslationsAttributesPage.tsx
+++ b/src/translations/components/TranslationsAttributesPage/TranslationsAttributesPage.tsx
@@ -107,6 +107,7 @@ const TranslationsAttributesPage: React.FC<TranslationsAttributesPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}
@@ -142,6 +143,7 @@ const TranslationsAttributesPage: React.FC<TranslationsAttributesPageProps> = ({
             ) || []
           }
           saveButtonState={saveButtonState}
+          richTextResetKey={languageCode}
           pagination={{
             settings,
             onUpdateListSettings,

--- a/src/translations/components/TranslationsCategoriesPage/TranslationsCategoriesPage.tsx
+++ b/src/translations/components/TranslationsCategoriesPage/TranslationsCategoriesPage.tsx
@@ -83,6 +83,7 @@ const TranslationsCategoriesPage: React.FC<TranslationsCategoriesPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}
@@ -116,6 +117,7 @@ const TranslationsCategoriesPage: React.FC<TranslationsCategoriesPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}

--- a/src/translations/components/TranslationsCollectionsPage/TranslationsCollectionsPage.tsx
+++ b/src/translations/components/TranslationsCollectionsPage/TranslationsCollectionsPage.tsx
@@ -84,6 +84,7 @@ const TranslationsCollectionsPage: React.FC<TranslationsCollectionsPageProps> = 
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}
@@ -117,6 +118,7 @@ const TranslationsCollectionsPage: React.FC<TranslationsCollectionsPageProps> = 
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}

--- a/src/translations/components/TranslationsPagesPage/TranslationsPagesPage.tsx
+++ b/src/translations/components/TranslationsPagesPage/TranslationsPagesPage.tsx
@@ -88,6 +88,7 @@ const TranslationsPagesPage: React.FC<TranslationsPagesPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}
@@ -122,6 +123,7 @@ const TranslationsPagesPage: React.FC<TranslationsPagesPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}
@@ -153,6 +155,7 @@ const TranslationsPagesPage: React.FC<TranslationsPagesPageProps> = ({
               })) || []
             }
             saveButtonState={saveButtonState}
+            richTextResetKey={languageCode}
             onEdit={onEdit}
             onDiscard={onDiscard}
             onSubmit={onAttributeValueSubmit}

--- a/src/translations/components/TranslationsProductVariantsPage/TranslationsProductVariantsPage.tsx
+++ b/src/translations/components/TranslationsProductVariantsPage/TranslationsProductVariantsPage.tsx
@@ -2,7 +2,7 @@ import CardSpacer from "@saleor/components/CardSpacer";
 import Container from "@saleor/components/Container";
 import LanguageSwitch from "@saleor/components/LanguageSwitch";
 import PageHeader from "@saleor/components/PageHeader";
-import { ProductTranslationFragment } from "@saleor/fragments/types/ProductTranslationFragment";
+import { ProductVariantTranslationFragment } from "@saleor/fragments/types/ProductVariantTranslationFragment";
 import { commonMessages, sectionNames } from "@saleor/intl";
 import { Backlink } from "@saleor/macaw-ui";
 import { getStringOrPlaceholder } from "@saleor/misc";
@@ -19,19 +19,21 @@ import TranslationFields from "../TranslationFields";
 
 export interface TranslationsProductsPageProps
   extends TranslationsEntitiesPageProps {
-  data: ProductTranslationFragment;
+  data: ProductVariantTranslationFragment;
   productId: string;
+  variantId: string;
   onAttributeValueSubmit: TranslationsEntitiesPageProps["onSubmit"];
 }
 
 const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
-  productId,
   activeField,
   disabled,
   languageCode,
   languages,
   data,
   saveButtonState,
+  productId,
+  variantId,
   onBack,
   onDiscard,
   onEdit,
@@ -44,25 +46,25 @@ const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
   return (
     <Container>
       <Backlink onClick={onBack}>
-        {intl.formatMessage(sectionNames.translations)}
+        {intl.formatMessage(sectionNames.products)}
       </Backlink>
       <PageHeader
         title={intl.formatMessage(
           {
             defaultMessage:
-              'Translation Product "{productName}" - {languageCode}',
+              'Translation Product Variant "{productName}" - {languageCode}',
             description: "header"
           },
           {
             languageCode,
-            productName: getStringOrPlaceholder(data?.product?.name)
+            productName: getStringOrPlaceholder(data?.name)
           }
         )}
       >
         <ProductContextSwitcher
           languageCode={languageCode}
           productId={productId}
-          selectedId={productId}
+          selectedId={variantId}
         />
         <LanguageSwitch
           currentLanguage={LanguageCodeEnum[languageCode]}
@@ -78,54 +80,12 @@ const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
         fields={[
           {
             displayName: intl.formatMessage({
-              defaultMessage: "Product Name"
+              defaultMessage: "Variant Name"
             }),
             name: TranslationInputFieldName.name,
             translation: data?.translation?.name || null,
             type: "short" as "short",
-            value: data?.product?.name
-          },
-          {
-            displayName: intl.formatMessage({
-              defaultMessage: "Description"
-            }),
-            name: TranslationInputFieldName.description,
-            translation: data?.translation?.description || null,
-            type: "rich" as "rich",
-            value: data?.product?.description
-          }
-        ]}
-        saveButtonState={saveButtonState}
-        onEdit={onEdit}
-        onDiscard={onDiscard}
-        onSubmit={onSubmit}
-      />
-      <CardSpacer />
-      <TranslationFields
-        activeField={activeField}
-        disabled={disabled}
-        initialState={true}
-        title={intl.formatMessage({
-          defaultMessage: "Search Engine Preview"
-        })}
-        fields={[
-          {
-            displayName: intl.formatMessage({
-              defaultMessage: "Search Engine Title"
-            }),
-            name: TranslationInputFieldName.seoTitle,
-            translation: data?.translation?.seoTitle || null,
-            type: "short" as "short",
-            value: data?.product?.seoTitle
-          },
-          {
-            displayName: intl.formatMessage({
-              defaultMessage: "Search Engine Description"
-            }),
-            name: TranslationInputFieldName.seoDescription,
-            translation: data?.translation?.seoDescription || null,
-            type: "long" as "long",
-            value: data?.product?.seoDescription
+            value: data?.name
           }
         ]}
         saveButtonState={saveButtonState}

--- a/src/translations/components/TranslationsProductVariantsPage/TranslationsProductVariantsPage.tsx
+++ b/src/translations/components/TranslationsProductVariantsPage/TranslationsProductVariantsPage.tsx
@@ -89,6 +89,7 @@ const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}
@@ -120,6 +121,7 @@ const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
               })) || []
             }
             saveButtonState={saveButtonState}
+            richTextResetKey={languageCode}
             onEdit={onEdit}
             onDiscard={onDiscard}
             onSubmit={onAttributeValueSubmit}

--- a/src/translations/components/TranslationsProductVariantsPage/index.ts
+++ b/src/translations/components/TranslationsProductVariantsPage/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./TranslationsProductVariantsPage";
+export * from "./TranslationsProductVariantsPage";

--- a/src/translations/components/TranslationsProductsPage/TranslationsProductsPage.tsx
+++ b/src/translations/components/TranslationsProductsPage/TranslationsProductsPage.tsx
@@ -96,6 +96,7 @@ const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}
@@ -129,6 +130,7 @@ const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}
@@ -160,6 +162,7 @@ const TranslationsProductsPage: React.FC<TranslationsProductsPageProps> = ({
               })) || []
             }
             saveButtonState={saveButtonState}
+            richTextResetKey={languageCode}
             onEdit={onEdit}
             onDiscard={onDiscard}
             onSubmit={onAttributeValueSubmit}

--- a/src/translations/components/TranslationsSalesPage/TranslationsSalesPage.tsx
+++ b/src/translations/components/TranslationsSalesPage/TranslationsSalesPage.tsx
@@ -76,6 +76,7 @@ const TranslationsSalesPage: React.FC<TranslationsSalesPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}

--- a/src/translations/components/TranslationsShippingMethodPage/TranslationsShippingMethodPage.tsx
+++ b/src/translations/components/TranslationsShippingMethodPage/TranslationsShippingMethodPage.tsx
@@ -87,6 +87,7 @@ const TranslationsShippingMethodPage: React.FC<TranslationsShippingMethodPagePro
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}

--- a/src/translations/components/TranslationsVouchersPage/TranslationsVouchersPage.tsx
+++ b/src/translations/components/TranslationsVouchersPage/TranslationsVouchersPage.tsx
@@ -77,6 +77,7 @@ const TranslationsVouchersPage: React.FC<TranslationsVouchersPageProps> = ({
           }
         ]}
         saveButtonState={saveButtonState}
+        richTextResetKey={languageCode}
         onEdit={onEdit}
         onDiscard={onDiscard}
         onSubmit={onSubmit}

--- a/src/translations/index.tsx
+++ b/src/translations/index.tsx
@@ -29,6 +29,9 @@ import TranslationsPagesComponent, {
 import TranslationsProductsComponent, {
   TranslationsProductsQueryParams
 } from "./views/TranslationsProducts";
+import TranslationsProductVariantsComponent, {
+  TranslationsProductVariantsQueryParams
+} from "./views/TranslationsProductVariants";
 import TranslationsSaleComponent, {
   TranslationsSalesQueryParams
 } from "./views/TranslationsSales";
@@ -102,6 +105,28 @@ const TranslationsProducts: React.FC<TranslationsEntityRouteProps> = ({
   return (
     <TranslationsProductsComponent
       id={decodeURIComponent(match.params.id)}
+      languageCode={LanguageCodeEnum[match.params.languageCode]}
+      params={params}
+    />
+  );
+};
+type TranslationsProductVariantProps = RouteComponentProps<{
+  productId: string;
+  id: string;
+  languageCode: string;
+}>;
+const TranslationsProductVariants: React.FC<TranslationsProductVariantProps> = ({
+  location,
+  match
+}) => {
+  const qs = parseQs(location.search.substr(1));
+  const params: TranslationsProductVariantsQueryParams = {
+    activeField: qs.activeField
+  };
+  return (
+    <TranslationsProductVariantsComponent
+      id={decodeURIComponent(match.params.id)}
+      productId={decodeURIComponent(match.params.productId)}
       languageCode={LanguageCodeEnum[match.params.languageCode]}
       params={params}
     />
@@ -213,6 +238,17 @@ const TranslationsRouter: React.FC = () => {
             ":id"
           )}
           component={TranslationsProducts}
+        />
+        <Route
+          exact
+          path={languageEntityPath(
+            ":languageCode",
+            TranslatableEntities.products,
+            ":productId",
+            TranslatableEntities.productVariants,
+            ":id"
+          )}
+          component={TranslationsProductVariants}
         />
         <Route
           exact

--- a/src/translations/mutations.ts
+++ b/src/translations/mutations.ts
@@ -27,6 +27,10 @@ import {
   UpdateProductTranslationsVariables
 } from "./types/UpdateProductTranslations";
 import {
+  UpdateProductVariantTranslations,
+  UpdateProductVariantTranslationsVariables
+} from "./types/UpdateProductVariantTranslations";
+import {
   UpdateSaleTranslations,
   UpdateSaleTranslationsVariables
 } from "./types/UpdateSaleTranslations";
@@ -75,6 +79,37 @@ export const TypedUpdateProductTranslations = TypedMutation<
   UpdateProductTranslations,
   UpdateProductTranslationsVariables
 >(updateProductTranslations);
+
+const updateProductVariantTranslations = gql`
+  mutation UpdateProductVariantTranslations(
+    $id: ID!
+    $input: NameTranslationInput!
+    $language: LanguageCodeEnum!
+  ) {
+    productVariantTranslate(id: $id, input: $input, languageCode: $language) {
+      errors {
+        field
+        message
+      }
+      productVariant {
+        id
+        name
+        translation(languageCode: $language) {
+          id
+          name
+          language {
+            code
+            language
+          }
+        }
+      }
+    }
+  }
+`;
+export const TypedUpdateProductVariantTranslations = TypedMutation<
+  UpdateProductVariantTranslations,
+  UpdateProductVariantTranslationsVariables
+>(updateProductVariantTranslations);
 
 const updateCategoryTranslations = gql`
   mutation UpdateCategoryTranslations(

--- a/src/translations/queries.ts
+++ b/src/translations/queries.ts
@@ -372,6 +372,7 @@ const productVariantList = gql`
       variants {
         id
         name
+        sku
       }
     }
   }

--- a/src/translations/queries.ts
+++ b/src/translations/queries.ts
@@ -6,6 +6,7 @@ import {
   collectionTranslationFragment,
   pageTranslationFragment,
   productTranslationFragment,
+  productVariantTranslationFragment,
   saleTranslationFragment,
   shippingMethodTranslationFragment,
   voucherTranslationFragment
@@ -54,6 +55,14 @@ import {
   ProductTranslations,
   ProductTranslationsVariables
 } from "./types/ProductTranslations";
+import {
+  ProductVariantList,
+  ProductVariantListVariables
+} from "./types/ProductVariantList";
+import {
+  ProductVariantTranslationDetails,
+  ProductVariantTranslationDetailsVariables
+} from "./types/ProductVariantTranslationDetails";
 import {
   SaleTranslationDetails,
   SaleTranslationDetailsVariables
@@ -355,6 +364,38 @@ export const useProductTranslationDetails = makeQuery<
   ProductTranslationDetails,
   ProductTranslationDetailsVariables
 >(productTranslationDetails);
+
+const productVariantList = gql`
+  query ProductVariantList($id: ID!) {
+    product(id: $id) {
+      id
+      variants {
+        id
+        name
+      }
+    }
+  }
+`;
+export const useProductVariantList = makeQuery<
+  ProductVariantList,
+  ProductVariantListVariables
+>(productVariantList);
+
+const productVariantTranslationDetails = gql`
+  ${productVariantTranslationFragment}
+  query ProductVariantTranslationDetails(
+    $id: ID!
+    $language: LanguageCodeEnum!
+  ) {
+    translation(kind: VARIANT, id: $id) {
+      ...ProductVariantTranslationFragment
+    }
+  }
+`;
+export const useProductVariantTranslationDetails = makeQuery<
+  ProductVariantTranslationDetails,
+  ProductVariantTranslationDetailsVariables
+>(productVariantTranslationDetails);
 
 const categoryTranslationDetails = gql`
   ${categoryTranslationFragment}

--- a/src/translations/types/ProductVariantList.ts
+++ b/src/translations/types/ProductVariantList.ts
@@ -11,6 +11,7 @@ export interface ProductVariantList_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
+  sku: string;
 }
 
 export interface ProductVariantList_product {

--- a/src/translations/types/ProductVariantList.ts
+++ b/src/translations/types/ProductVariantList.ts
@@ -1,0 +1,28 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: ProductVariantList
+// ====================================================
+
+export interface ProductVariantList_product_variants {
+  __typename: "ProductVariant";
+  id: string;
+  name: string;
+}
+
+export interface ProductVariantList_product {
+  __typename: "Product";
+  id: string;
+  variants: (ProductVariantList_product_variants | null)[] | null;
+}
+
+export interface ProductVariantList {
+  product: ProductVariantList_product | null;
+}
+
+export interface ProductVariantListVariables {
+  id: string;
+}

--- a/src/translations/types/ProductVariantTranslationDetails.ts
+++ b/src/translations/types/ProductVariantTranslationDetails.ts
@@ -1,0 +1,79 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { LanguageCodeEnum } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL query operation: ProductVariantTranslationDetails
+// ====================================================
+
+export interface ProductVariantTranslationDetails_translation_ProductTranslatableContent {
+  __typename: "ProductTranslatableContent" | "CollectionTranslatableContent" | "CategoryTranslatableContent" | "AttributeTranslatableContent" | "AttributeValueTranslatableContent" | "PageTranslatableContent" | "ShippingMethodTranslatableContent" | "SaleTranslatableContent" | "VoucherTranslatableContent" | "MenuItemTranslatableContent";
+}
+
+export interface ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_productVariant {
+  __typename: "ProductVariant";
+  id: string;
+}
+
+export interface ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_translation_language {
+  __typename: "LanguageDisplay";
+  code: LanguageCodeEnum;
+  language: string;
+}
+
+export interface ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_translation {
+  __typename: "ProductVariantTranslation";
+  id: string;
+  name: string;
+  language: ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_translation_language;
+}
+
+export interface ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_attributeValues_attributeValue {
+  __typename: "AttributeValue";
+  id: string;
+}
+
+export interface ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_attributeValues_translation_language {
+  __typename: "LanguageDisplay";
+  code: LanguageCodeEnum;
+  language: string;
+}
+
+export interface ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_attributeValues_translation {
+  __typename: "AttributeValueTranslation";
+  id: string;
+  name: string;
+  richText: any | null;
+  language: ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_attributeValues_translation_language;
+}
+
+export interface ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_attributeValues {
+  __typename: "AttributeValueTranslatableContent";
+  id: string;
+  name: string;
+  richText: any | null;
+  attributeValue: ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_attributeValues_attributeValue | null;
+  translation: ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_attributeValues_translation | null;
+}
+
+export interface ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent {
+  __typename: "ProductVariantTranslatableContent";
+  productVariant: ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_productVariant | null;
+  name: string;
+  translation: ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_translation | null;
+  attributeValues: ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent_attributeValues[];
+}
+
+export type ProductVariantTranslationDetails_translation = ProductVariantTranslationDetails_translation_ProductTranslatableContent | ProductVariantTranslationDetails_translation_ProductVariantTranslatableContent;
+
+export interface ProductVariantTranslationDetails {
+  translation: ProductVariantTranslationDetails_translation | null;
+}
+
+export interface ProductVariantTranslationDetailsVariables {
+  id: string;
+  language: LanguageCodeEnum;
+}

--- a/src/translations/types/UpdateProductVariantTranslations.ts
+++ b/src/translations/types/UpdateProductVariantTranslations.ts
@@ -1,0 +1,52 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { NameTranslationInput, LanguageCodeEnum } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UpdateProductVariantTranslations
+// ====================================================
+
+export interface UpdateProductVariantTranslations_productVariantTranslate_errors {
+  __typename: "TranslationError";
+  field: string | null;
+  message: string | null;
+}
+
+export interface UpdateProductVariantTranslations_productVariantTranslate_productVariant_translation_language {
+  __typename: "LanguageDisplay";
+  code: LanguageCodeEnum;
+  language: string;
+}
+
+export interface UpdateProductVariantTranslations_productVariantTranslate_productVariant_translation {
+  __typename: "ProductVariantTranslation";
+  id: string;
+  name: string;
+  language: UpdateProductVariantTranslations_productVariantTranslate_productVariant_translation_language;
+}
+
+export interface UpdateProductVariantTranslations_productVariantTranslate_productVariant {
+  __typename: "ProductVariant";
+  id: string;
+  name: string;
+  translation: UpdateProductVariantTranslations_productVariantTranslate_productVariant_translation | null;
+}
+
+export interface UpdateProductVariantTranslations_productVariantTranslate {
+  __typename: "ProductVariantTranslate";
+  errors: UpdateProductVariantTranslations_productVariantTranslate_errors[];
+  productVariant: UpdateProductVariantTranslations_productVariantTranslate_productVariant | null;
+}
+
+export interface UpdateProductVariantTranslations {
+  productVariantTranslate: UpdateProductVariantTranslations_productVariantTranslate | null;
+}
+
+export interface UpdateProductVariantTranslationsVariables {
+  id: string;
+  input: NameTranslationInput;
+  language: LanguageCodeEnum;
+}

--- a/src/translations/urls.ts
+++ b/src/translations/urls.ts
@@ -7,6 +7,7 @@ import { TranslationsEntitiesListFilterTab } from "./components/TranslationsEnti
 export enum TranslatableEntities {
   categories = "categories",
   products = "products",
+  productVariants = "variants",
   collections = "collections",
   sales = "sales",
   vouchers = "vouchers",
@@ -35,10 +36,25 @@ export const languageEntitiesUrl = (
 export const languageEntityPath = (
   code: string,
   entity: TranslatableEntities,
-  id: string
-) => urlJoin(languageEntitiesPath(code), entity.toString(), id);
+  id: string,
+  ...args: string[]
+) => urlJoin(languageEntitiesPath(code), entity.toString(), id, ...args);
 export const languageEntityUrl = (
   code: string,
   entity: TranslatableEntities,
-  id: string
-) => languageEntityPath(code, entity, encodeURIComponent(id));
+  id: string,
+  ...args: string[]
+) => languageEntityPath(code, entity, encodeURIComponent(id), ...args);
+
+export const productVariantUrl = (
+  code: string,
+  productId: string,
+  variantId: string
+) =>
+  languageEntityUrl(
+    code,
+    TranslatableEntities.products,
+    productId,
+    TranslatableEntities.productVariants,
+    variantId
+  );

--- a/src/translations/views/TranslationsEntities.tsx
+++ b/src/translations/views/TranslationsEntities.tsx
@@ -194,9 +194,12 @@ const TranslationsEntities: React.FC<TranslationsEntitiesProps> = ({
                           node.translation?.description,
                           node.translation?.name,
                           node.translation?.seoDescription,
-                          node.translation?.seoTitle
+                          node.translation?.seoTitle,
+                          ...(node.attributeValues?.map(
+                            ({ translation }) => translation?.richText
+                          ) || [])
                         ]),
-                        max: 4
+                        max: 4 + (node.attributeValues?.length || 0)
                       },
                       id: node?.product?.id,
                       name: node?.product?.name

--- a/src/translations/views/TranslationsProductVariants.tsx
+++ b/src/translations/views/TranslationsProductVariants.tsx
@@ -9,31 +9,33 @@ import { useIntl } from "react-intl";
 
 import { maybe } from "../../misc";
 import { LanguageCodeEnum } from "../../types/globalTypes";
-import TranslationsProductsPage from "../components/TranslationsProductsPage";
+import TranslationsProductVariantsPage from "../components/TranslationsProductVariantsPage";
 import {
   TypedUpdateAttributeValueTranslations,
-  TypedUpdateProductTranslations
+  TypedUpdateProductVariantTranslations
 } from "../mutations";
-import { useProductTranslationDetails } from "../queries";
+import { useProductVariantTranslationDetails } from "../queries";
 import { TranslationField, TranslationInputFieldName } from "../types";
 import {
   languageEntitiesUrl,
-  languageEntityUrl,
+  productVariantUrl,
   TranslatableEntities
 } from "../urls";
 import { getParsedTranslationInputData } from "../utils";
 
-export interface TranslationsProductsQueryParams {
+export interface TranslationsProductVariantsQueryParams {
   activeField: string;
 }
-export interface TranslationsProductsProps {
+export interface TranslationsProductVariantsProps {
   id: string;
+  productId: string;
   languageCode: LanguageCodeEnum;
-  params: TranslationsProductsQueryParams;
+  params: TranslationsProductVariantsQueryParams;
 }
 
-const TranslationsProducts: React.FC<TranslationsProductsProps> = ({
+const TranslationsProductVariants: React.FC<TranslationsProductVariantsProps> = ({
   id,
+  productId,
   languageCode,
   params
 }) => {
@@ -42,7 +44,7 @@ const TranslationsProducts: React.FC<TranslationsProductsProps> = ({
   const shop = useShop();
   const intl = useIntl();
 
-  const productTranslations = useProductTranslationDetails({
+  const productVariantTranslations = useProductVariantTranslationDetails({
     variables: { id, language: languageCode }
   });
 
@@ -57,7 +59,7 @@ const TranslationsProducts: React.FC<TranslationsProductsProps> = ({
 
   const onUpdate = (errors: unknown[]) => {
     if (errors.length === 0) {
-      productTranslations.refetch();
+      productVariantTranslations.refetch();
       notify({
         status: "success",
         text: intl.formatMessage(commonMessages.savedChanges)
@@ -71,8 +73,8 @@ const TranslationsProducts: React.FC<TranslationsProductsProps> = ({
   };
 
   return (
-    <TypedUpdateProductTranslations
-      onCompleted={data => onUpdate(data.productTranslate.errors)}
+    <TypedUpdateProductVariantTranslations
+      onCompleted={data => onUpdate(data.productVariantTranslate.errors)}
     >
       {(updateTranslations, updateTranslationsOpts) => (
         <TypedUpdateAttributeValueTranslations
@@ -108,14 +110,16 @@ const TranslationsProducts: React.FC<TranslationsProductsProps> = ({
               });
             };
 
-            const translation = productTranslations?.data?.translation;
+            const translation = productVariantTranslations?.data?.translation;
 
             return (
-              <TranslationsProductsPage
-                productId={id}
+              <TranslationsProductVariantsPage
+                productId={productId}
+                variantId={id}
                 activeField={params.activeField}
                 disabled={
-                  productTranslations.loading || updateTranslationsOpts.loading
+                  productVariantTranslations.loading ||
+                  updateTranslationsOpts.loading
                 }
                 languageCode={languageCode}
                 languages={maybe(() => shop.languages, [])}
@@ -130,14 +134,13 @@ const TranslationsProducts: React.FC<TranslationsProductsProps> = ({
                 onEdit={onEdit}
                 onDiscard={onDiscard}
                 onLanguageChange={lang =>
-                  navigate(
-                    languageEntityUrl(lang, TranslatableEntities.products, id)
-                  )
+                  navigate(productVariantUrl(lang, productId, id))
                 }
                 onSubmit={handleSubmit}
                 onAttributeValueSubmit={handleAttributeValueSubmit}
                 data={
-                  translation?.__typename === "ProductTranslatableContent"
+                  translation?.__typename ===
+                  "ProductVariantTranslatableContent"
                     ? translation
                     : null
                 }
@@ -146,8 +149,8 @@ const TranslationsProducts: React.FC<TranslationsProductsProps> = ({
           }}
         </TypedUpdateAttributeValueTranslations>
       )}
-    </TypedUpdateProductTranslations>
+    </TypedUpdateProductVariantTranslations>
   );
 };
-TranslationsProducts.displayName = "TranslationsProducts";
-export default TranslationsProducts;
+TranslationsProductVariants.displayName = "TranslationsProductVariants";
+export default TranslationsProductVariants;


### PR DESCRIPTION
I want to merge this change because it adds support for translating product variants.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
![image](https://user-images.githubusercontent.com/28310983/128885529-38f3e9aa-9bf8-495d-b770-8962ea83a35d.png)


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
