### PR TITLE
Add possibility to cancel "waiting" fulfillments

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3944,9 +3944,9 @@
     "context": "order history message",
     "string": "Products were added to an order"
   },
-  "src_dot_orders_dot_components_dot_OrderHistory_dot_3927123907": {
+  "src_dot_orders_dot_components_dot_OrderHistory_dot_3854352507": {
     "context": "order history message",
-    "string": "Fulfilled {quantity} items awaits approval"
+    "string": "Fulfillment awaits approval"
   },
   "src_dot_orders_dot_components_dot_OrderHistory_dot_393045022": {
     "context": "order history message",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3770,10 +3770,6 @@
     "context": "add tracking button",
     "string": "Add tracking"
   },
-  "src_dot_orders_dot_components_dot_OrderFulfilledProductsCard_dot_cancelFulfillment": {
-    "context": "button",
-    "string": "Cancel Fulfillment"
-  },
   "src_dot_orders_dot_components_dot_OrderFulfilledProductsCard_dot_editTracking": {
     "context": "edit tracking button",
     "string": "Edit tracking"

--- a/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
+++ b/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
@@ -1,12 +1,11 @@
-import { Card, TableBody } from "@material-ui/core";
-import CardMenu from "@saleor/components/CardMenu";
+import { Card, IconButton, TableBody } from "@material-ui/core";
 import CardSpacer from "@saleor/components/CardSpacer";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import { OrderDetailsFragment } from "@saleor/fragments/types/OrderDetailsFragment";
+import TrashIcon from "@saleor/icons/Trash";
 import { makeStyles } from "@saleor/macaw-ui";
 import { mergeRepeatedOrderLines } from "@saleor/orders/utils/data";
 import React from "react";
-import { useIntl } from "react-intl";
 
 import { renderCollection } from "../../../misc";
 import { FulfillmentStatus } from "../../../types/globalTypes";
@@ -16,12 +15,17 @@ import TableLine from "../OrderProductsCardElements/OrderProductsTableRow";
 import CardTitle from "../OrderReturnPage/OrderReturnRefundItemsCard/CardTitle";
 import ActionButtons from "./ActionButtons";
 import ExtraInfoLines from "./ExtraInfoLines";
-import { messages } from "./messages";
 
 const useStyles = makeStyles(
-  () => ({
+  theme => ({
     table: {
       tableLayout: "fixed"
+    },
+    deleteIcon: {
+      height: 40,
+      paddingRight: 0,
+      paddingLeft: theme.spacing(1),
+      width: 40
     }
   }),
   { name: "OrderFulfillment" }
@@ -60,8 +64,6 @@ const OrderFulfilledProductsCard: React.FC<OrderFulfilledProductsCardProps> = pr
   } = props;
   const classes = useStyles(props);
 
-  const intl = useIntl();
-
   if (!fulfillment) {
     return null;
   }
@@ -86,15 +88,13 @@ const OrderFulfilledProductsCard: React.FC<OrderFulfilledProductsCardProps> = pr
           orderNumber={order?.number}
           toolbar={
             cancelableStatuses.includes(fulfillment?.status) && (
-              <CardMenu
-                menuItems={[
-                  {
-                    label: intl.formatMessage(messages.cancelFulfillment),
-                    onSelect: onOrderFulfillmentCancel,
-                    testId: "cancelFulfillmentButton"
-                  }
-                ]}
-              />
+              <IconButton
+                className={classes.deleteIcon}
+                onClick={onOrderFulfillmentCancel}
+                data-test-id="cancelFulfillmentButton"
+              >
+                <TrashIcon />
+              </IconButton>
             )
           }
         />

--- a/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
+++ b/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
@@ -8,7 +8,7 @@ import { mergeRepeatedOrderLines } from "@saleor/orders/utils/data";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { maybe, renderCollection } from "../../../misc";
+import { renderCollection } from "../../../misc";
 import { FulfillmentStatus } from "../../../types/globalTypes";
 import { OrderDetails_order_fulfillments } from "../../types/OrderDetails";
 import TableHeader from "../OrderProductsCardElements/OrderProductsCardHeader";
@@ -37,6 +37,17 @@ interface OrderFulfilledProductsCardProps {
   onRefund: () => void;
 }
 
+const statusesToMergeLines = [
+  FulfillmentStatus.REFUNDED,
+  FulfillmentStatus.REFUNDED_AND_RETURNED,
+  FulfillmentStatus.RETURNED,
+  FulfillmentStatus.REPLACED
+];
+const cancelableStatuses = [
+  FulfillmentStatus.FULFILLED,
+  FulfillmentStatus.WAITING_FOR_APPROVAL
+];
+
 const OrderFulfilledProductsCard: React.FC<OrderFulfilledProductsCardProps> = props => {
   const {
     fulfillment,
@@ -56,13 +67,6 @@ const OrderFulfilledProductsCard: React.FC<OrderFulfilledProductsCardProps> = pr
   }
 
   const getLines = () => {
-    const statusesToMergeLines = [
-      FulfillmentStatus.REFUNDED,
-      FulfillmentStatus.REFUNDED_AND_RETURNED,
-      FulfillmentStatus.RETURNED,
-      FulfillmentStatus.REPLACED
-    ];
-
     if (statusesToMergeLines.includes(fulfillment?.status)) {
       return mergeRepeatedOrderLines(fulfillment.lines);
     }
@@ -81,7 +85,7 @@ const OrderFulfilledProductsCard: React.FC<OrderFulfilledProductsCardProps> = pr
           warehouseName={fulfillment?.warehouse?.name}
           orderNumber={order?.number}
           toolbar={
-            maybe(() => fulfillment.status) === FulfillmentStatus.FULFILLED && (
+            cancelableStatuses.includes(fulfillment?.status) && (
               <CardMenu
                 menuItems={[
                   {

--- a/src/orders/components/OrderFulfilledProductsCard/messages.ts
+++ b/src/orders/components/OrderFulfilledProductsCard/messages.ts
@@ -1,12 +1,5 @@
 import { defineMessages } from "react-intl";
 
-export const messages = defineMessages({
-  cancelFulfillment: {
-    defaultMessage: "Cancel Fulfillment",
-    description: "button"
-  }
-});
-
 export const actionButtonsMessages = defineMessages({
   refund: {
     defaultMessage: "Refund",

--- a/src/orders/components/OrderHistory/OrderHistory.tsx
+++ b/src/orders/components/OrderHistory/OrderHistory.tsx
@@ -143,15 +143,10 @@ export const getEventMessage = (
         }
       );
     case OrderEventsEnum.FULFILLMENT_AWAITS_APPROVAL:
-      return intl.formatMessage(
-        {
-          defaultMessage: "Fulfilled {quantity} items awaits approval",
-          description: "order history message"
-        },
-        {
-          quantity: event.quantity
-        }
-      );
+      return intl.formatMessage({
+        defaultMessage: "Fulfillment awaits approval",
+        description: "order history message"
+      });
     case OrderEventsEnum.FULFILLMENT_FULFILLED_ITEMS:
       return intl.formatMessage(
         {


### PR DESCRIPTION
I want to merge this change because... it adds delete button for waiting for approval fulfillment.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="702" alt="Zrzut ekranu 2021-08-11 o 19 11 16" src="https://user-images.githubusercontent.com/9825562/129074861-ac47842b-536c-4a9d-9631-cf212d9713ae.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://feature-fulfillment-api.api.saleor.rocks/graphql/
