### PR TITLE
Handle waiting fulfillments on refund page

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4225,10 +4225,6 @@
     "context": "order line total price",
     "string": "Total"
   },
-  "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_1097582574": {
-    "context": "section header returned",
-    "string": "Fulfillment returned"
-  },
   "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_1134347598": {
     "context": "tabel column header",
     "string": "Price"
@@ -4248,10 +4244,6 @@
     "context": "button",
     "string": "Set maximal quantities"
   },
-  "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_615325604": {
-    "context": "section header",
-    "string": "Fulfillment"
-  },
   "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_878013594": {
     "context": "tabel column header",
     "string": "Total"
@@ -4259,6 +4251,18 @@
   "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_937914544": {
     "context": "error message",
     "string": "Improper value"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_fulfillment": {
+    "context": "section header",
+    "string": "Fulfillment"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_fulfillmentReturned": {
+    "context": "section header returned",
+    "string": "Fulfillment returned"
+  },
+  "src_dot_orders_dot_components_dot_OrderRefundFulfilledProducts_dot_fulfillmentWaitingForApproval": {
+    "context": "section header returned",
+    "string": "Fulfillment waiting for approval"
   },
   "src_dot_orders_dot_components_dot_OrderRefundPage_dot_194531545": {
     "context": "page header",

--- a/src/orders/components/OrderRefundFulfilledProducts/OrderRefundFulfilledProducts.tsx
+++ b/src/orders/components/OrderRefundFulfilledProducts/OrderRefundFulfilledProducts.tsx
@@ -18,11 +18,11 @@ import { FormsetChange } from "@saleor/hooks/useFormset";
 import { makeStyles } from "@saleor/macaw-ui";
 import { renderCollection } from "@saleor/misc";
 import { OrderRefundData_order_fulfillments } from "@saleor/orders/types/OrderRefundData";
-import { FulfillmentStatus } from "@saleor/types/globalTypes";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { OrderRefundFormData } from "../OrderRefundPage/form";
+import { getTitle } from "./messages";
 
 const useStyles = makeStyles(
   theme => {
@@ -93,15 +93,7 @@ const OrderRefundFulfilledProducts: React.FC<OrderRefundFulfilledProductsProps> 
       <CardTitle
         title={
           <>
-            {fulfillment.status === FulfillmentStatus.RETURNED
-              ? intl.formatMessage({
-                  defaultMessage: "Fulfillment returned",
-                  description: "section header returned"
-                })
-              : intl.formatMessage({
-                  defaultMessage: "Fulfillment",
-                  description: "section header"
-                })}
+            {getTitle(fulfillment.status, intl)}
             {fulfillment && (
               <Typography className={classes.orderNumber} variant="body1">
                 {`#${orderNumber}-${fulfillment?.fulfillmentOrder}`}

--- a/src/orders/components/OrderRefundFulfilledProducts/messages.ts
+++ b/src/orders/components/OrderRefundFulfilledProducts/messages.ts
@@ -1,0 +1,31 @@
+import { FulfillmentStatus } from "@saleor/types/globalTypes";
+import { defineMessages, IntlShape } from "react-intl";
+
+export const messages = defineMessages({
+  fulfillment: {
+    defaultMessage: "Fulfillment",
+    description: "section header"
+  },
+  fulfillmentReturned: {
+    defaultMessage: "Fulfillment returned",
+    description: "section header returned"
+  },
+  fulfillmentWaitingForApproval: {
+    defaultMessage: "Fulfillment waiting for approval",
+    description: "section header returned"
+  }
+});
+
+export const getTitle = (
+  fulfillmentStatus: FulfillmentStatus,
+  intl: IntlShape
+) => {
+  switch (fulfillmentStatus) {
+    case FulfillmentStatus.RETURNED:
+      return intl.formatMessage(messages.fulfillmentReturned);
+    case FulfillmentStatus.WAITING_FOR_APPROVAL:
+      return intl.formatMessage(messages.fulfillmentWaitingForApproval);
+    default:
+      return intl.formatMessage(messages.fulfillment);
+  }
+};

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
@@ -26,7 +26,8 @@ import OrderRefundForm, {
 
 export const refundFulfilledStatuses = [
   FulfillmentStatus.FULFILLED,
-  FulfillmentStatus.RETURNED
+  FulfillmentStatus.RETURNED,
+  FulfillmentStatus.WAITING_FOR_APPROVAL
 ];
 
 export interface OrderRefundPageProps {

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
@@ -52,7 +52,7 @@ const OrderRefundPage: React.FC<OrderRefundPageProps> = props => {
   const intl = useIntl();
 
   const unfulfilledLines = order?.lines.filter(
-    line => line.quantity !== line.quantityFulfilled
+    line => line.quantityToFulfill > 0
   );
 
   const fulfilledFulfillemnts =

--- a/src/orders/components/OrderRefundPage/fixtures.ts
+++ b/src/orders/components/OrderRefundPage/fixtures.ts
@@ -34,7 +34,7 @@ export const orderToRefund = (placeholder: string): OrderRefundData_order => ({
       id: "diufhdsif",
       productName: "Milk",
       quantity: 19,
-      quantityFulfilled: 3,
+      quantityToFulfill: 16,
       thumbnail: {
         __typename: "Image",
         url: placeholder
@@ -53,7 +53,7 @@ export const orderToRefund = (placeholder: string): OrderRefundData_order => ({
       id: "fdsfdfdsf",
       productName: "Coffee",
       quantity: 13,
-      quantityFulfilled: 5,
+      quantityToFulfill: 8,
       thumbnail: {
         __typename: "Image",
         url: placeholder

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -78,7 +78,7 @@ function useOrderRefundForm(
   const form = useForm(getOrderRefundPageFormData(defaultType));
   const refundedProductQuantities = useFormset<null, string>(
     order?.lines
-      .filter(line => line.quantityFulfilled !== line.quantity)
+      .filter(line => line.quantityToFulfill > 0)
       .map(line => ({
         data: null,
         id: line.id,
@@ -132,7 +132,7 @@ function useOrderRefundForm(
         data: null,
         id: line.id,
         label: null,
-        value: (line.quantity - line.quantityFulfilled).toString()
+        value: line.quantityToFulfill.toString()
       };
     });
     refundedProductQuantities.set(newQuantities);

--- a/src/orders/components/OrderRefundUnfulfilledProducts/OrderRefundUnfulfilledProducts.tsx
+++ b/src/orders/components/OrderRefundUnfulfilledProducts/OrderRefundUnfulfilledProducts.tsx
@@ -148,7 +148,7 @@ const OrderRefundUnfulfilledProducts: React.FC<OrderRefundUnfulfilledProductsPro
               const selectedLineQuantity = data.refundedProductQuantities.find(
                 refundedLine => refundedLine.id === line.id
               );
-              const lineQuantity = line?.quantity - line?.quantityFulfilled;
+              const lineQuantity = line?.quantityToFulfill;
               const isError =
                 Number(selectedLineQuantity?.value) > lineQuantity ||
                 Number(selectedLineQuantity?.value) < 0;

--- a/src/orders/queries.ts
+++ b/src/orders/queries.ts
@@ -324,7 +324,7 @@ const orderRefundData = gql`
       }
       lines {
         ...RefundOrderLineFragment
-        quantityFulfilled
+        quantityToFulfill
       }
       fulfillments {
         id

--- a/src/orders/types/OrderRefundData.ts
+++ b/src/orders/types/OrderRefundData.ts
@@ -60,7 +60,7 @@ export interface OrderRefundData_order_lines {
   quantity: number;
   unitPrice: OrderRefundData_order_lines_unitPrice;
   thumbnail: OrderRefundData_order_lines_thumbnail | null;
-  quantityFulfilled: number;
+  quantityToFulfill: number;
 }
 
 export interface OrderRefundData_order_fulfillments_lines_orderLine_unitPrice_gross {

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -171,7 +171,7 @@ describe("Get refunded lines price sum", () => {
       id: "1",
       productName: "Milk 1",
       quantity: 1,
-      quantityFulfilled: 1,
+      quantityToFulfill: 0,
       thumbnail: undefined,
       unitPrice: {
         __typename: "TaxedMoney",
@@ -187,7 +187,7 @@ describe("Get refunded lines price sum", () => {
       id: "2",
       productName: "Milk 2",
       quantity: 2,
-      quantityFulfilled: 2,
+      quantityToFulfill: 0,
       thumbnail: undefined,
       unitPrice: {
         __typename: "TaxedMoney",
@@ -203,7 +203,7 @@ describe("Get refunded lines price sum", () => {
       id: "3",
       productName: "Milk 3",
       quantity: 4,
-      quantityFulfilled: 4,
+      quantityToFulfill: 0,
       thumbnail: undefined,
       unitPrice: {
         __typename: "TaxedMoney",


### PR DESCRIPTION
I want to merge this change because... it fixes incorrectly handled "waiting" fulfillments are on refund page.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
Added displaying "fulfillment waiting for approval":
<img width="705" alt="Zrzut ekranu 2021-08-13 o 10 30 20" src="https://user-images.githubusercontent.com/9825562/129328787-906c8b57-159b-4133-ac54-d24e69509c85.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [x] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://feature-fulfillment-api.api.saleor.rocks/graphql/
