### PR TITLE
Add gift card resend code modal

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3448,6 +3448,30 @@
     "context": "GiftCardCreateDialog title",
     "string": "Issue gift card"
   },
+  "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardResendCodeDialog_dot_consentCheckboxLabel": {
+    "context": "GiftCardResendCodeDialog consentCheckboxLabel",
+    "string": "Yes, I want to send gift card to different address"
+  },
+  "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardResendCodeDialog_dot_description": {
+    "context": "GiftCardResendCodeDialog description",
+    "string": "Gift Card Code will be resent to email provided during checkout. You can provide a different email address if you want to:"
+  },
+  "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardResendCodeDialog_dot_emailInputPlaceholder": {
+    "context": "GiftCardResendCodeDialog emailInputPlaceholder",
+    "string": "Provided email address"
+  },
+  "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardResendCodeDialog_dot_submitButtonLabel": {
+    "context": "GiftCardResendCodeDialog submitButtonLabel",
+    "string": "Resend"
+  },
+  "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardResendCodeDialog_dot_successResendAlertText": {
+    "context": "GiftCardResendCodeDialog successResendAlertText",
+    "string": "Successfully resent code to customer!"
+  },
+  "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardResendCodeDialog_dot_title": {
+    "context": "GiftCardResendCodeDialog title",
+    "string": "Resend code to customer"
+  },
   "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardUpdateBalanceDialog_dot_changeButtonLabel": {
     "context": "GiftCardUpdateDetailsCard set balance dialog change button label",
     "string": "Change"
@@ -3515,6 +3539,10 @@
   "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardUpdatePageHeader_dot_enableLabel": {
     "context": "GiftCardEnableDisableSection enable label",
     "string": "Enable"
+  },
+  "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardUpdatePageHeader_dot_resendButtonLabel": {
+    "context": "giftCardUpdatePageHeader resendButtonLabel",
+    "string": "Resend code"
   },
   "src_dot_giftCards_dot_GiftCardUpdate_dot_GiftCardUpdatePageHeader_dot_successfullyDisabledTitle": {
     "context": "GiftCardEnableDisableSection disable success",

--- a/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/GiftCardResendCodeDialog.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/GiftCardResendCodeDialog.tsx
@@ -1,0 +1,133 @@
+import { TextField, Typography } from "@material-ui/core";
+import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
+import ActionDialog from "@saleor/components/ActionDialog";
+import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
+import { IMessage } from "@saleor/components/messages";
+import useForm from "@saleor/hooks/useForm";
+import useNotifier from "@saleor/hooks/useNotifier";
+import commonErrorMessages from "@saleor/utils/errors/common";
+import { DialogActionHandlersProps } from "@saleor/utils/handlers/dialogActionHandlers";
+import React, { useEffect, useState } from "react";
+import { useIntl } from "react-intl";
+
+import { useUpdateBalanceDialogStyles as useStyles } from "../GiftCardUpdateBalanceDialog/styles";
+import { getGiftCardErrorMessage } from "../messages";
+import useGiftCardDetails from "../providers/GiftCardDetailsProvider/hooks/useGiftCardDetails";
+import { giftCardResendCodeDialogMessages as messages } from "./messages";
+import { useGiftCardResendCodeMutation } from "./mutations";
+import { GiftCardResend } from "./types/GiftCardResend";
+import { useDialogFormReset } from "./utils";
+
+export interface GiftCardResendCodeFormData {
+  email: string;
+}
+
+const initialFormData: GiftCardResendCodeFormData = {
+  email: ""
+};
+
+const GiftCardResendCodeDialog: React.FC<DialogActionHandlersProps> = ({
+  open,
+  closeDialog
+}) => {
+  const intl = useIntl();
+  const notify = useNotifier();
+  const classes = useStyles();
+
+  const [consentSelected, setConsentSelected] = useState(false);
+
+  const {
+    giftCard: { id }
+  } = useGiftCardDetails();
+
+  const handleSubmit = async ({ email }: GiftCardResendCodeFormData) => {
+    const result = await resendGiftCardCode({
+      variables: {
+        input: { id, email: email ? email : null }
+      }
+    });
+
+    return result?.data?.giftCardResend?.errors;
+  };
+
+  const { data, change, submit, reset } = useForm(
+    initialFormData,
+    handleSubmit
+  );
+
+  const onCompleted = (data: GiftCardResend) => {
+    const errors = data?.giftCardResend?.errors;
+
+    const notifierData: IMessage = !!errors?.length
+      ? {
+          status: "error",
+          text: intl.formatMessage(commonErrorMessages.unknownError)
+        }
+      : {
+          status: "success",
+          text: intl.formatMessage(messages.successResendAlertText)
+        };
+
+    notify(notifierData);
+
+    if (!errors.length) {
+      closeDialog();
+      reset();
+    }
+  };
+
+  const [
+    resendGiftCardCode,
+    resendGiftCardCodeOpts
+  ] = useGiftCardResendCodeMutation({
+    onCompleted
+  });
+
+  const { loading, status, data: submitData } = resendGiftCardCodeOpts;
+
+  const { formErrors } = useDialogFormReset({
+    open,
+    reset,
+    apiErrors: submitData?.giftCardResend?.errors,
+    keys: ["email"]
+  });
+
+  useEffect(reset, [consentSelected]);
+
+  return (
+    <ActionDialog
+      maxWidth="sm"
+      open={open}
+      onConfirm={submit}
+      confirmButtonLabel={intl.formatMessage(messages.submitButtonLabel)}
+      onClose={closeDialog}
+      title={intl.formatMessage(messages.title)}
+      confirmButtonState={status}
+      disabled={loading}
+    >
+      <Typography>{intl.formatMessage(messages.description)}</Typography>
+      <VerticalSpacer spacing={0.5} />
+      <ControlledCheckbox
+        name="differentMailConsent"
+        label={intl.formatMessage(messages.consentCheckboxLabel)}
+        checked={consentSelected}
+        onChange={(event: React.ChangeEvent<any>) =>
+          setConsentSelected(event.target.value)
+        }
+      />
+      <VerticalSpacer />
+      <TextField
+        disabled={!consentSelected}
+        error={!!formErrors?.email}
+        helperText={getGiftCardErrorMessage(formErrors?.email, intl)}
+        name="email"
+        value={data.email}
+        onChange={change}
+        className={classes.inputContainer}
+        label={intl.formatMessage(messages.emailInputPlaceholder)}
+      />
+    </ActionDialog>
+  );
+};
+
+export default GiftCardResendCodeDialog;

--- a/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/index.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/index.tsx
@@ -1,0 +1,2 @@
+export * from "./GiftCardResendCodeDialog";
+export { default } from "./GiftCardResendCodeDialog";

--- a/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/messages.ts
+++ b/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/messages.ts
@@ -1,0 +1,29 @@
+import { defineMessages } from "react-intl";
+
+export const giftCardResendCodeDialogMessages = defineMessages({
+  title: {
+    defaultMessage: "Resend code to customer",
+    description: "GiftCardResendCodeDialog title"
+  },
+  description: {
+    defaultMessage:
+      "Gift Card Code will be resent to email provided during checkout. You can provide a different email address if you want to:",
+    description: "GiftCardResendCodeDialog description"
+  },
+  consentCheckboxLabel: {
+    defaultMessage: "Yes, I want to send gift card to different address",
+    description: "GiftCardResendCodeDialog consentCheckboxLabel"
+  },
+  submitButtonLabel: {
+    defaultMessage: "Resend",
+    description: "GiftCardResendCodeDialog submitButtonLabel"
+  },
+  emailInputPlaceholder: {
+    defaultMessage: "Provided email address",
+    description: "GiftCardResendCodeDialog emailInputPlaceholder"
+  },
+  successResendAlertText: {
+    defaultMessage: "Successfully resent code to customer!",
+    description: "GiftCardResendCodeDialog successResendAlertText"
+  }
+});

--- a/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/mutations.ts
+++ b/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/mutations.ts
@@ -1,0 +1,29 @@
+import { giftCardErrorFragment } from "@saleor/fragments/errors";
+import makeMutation from "@saleor/hooks/makeMutation";
+import gql from "graphql-tag";
+
+import { giftCardDataFragment } from "../queries";
+import {
+  GiftCardResend,
+  GiftCardResendVariables
+} from "./types/GiftCardResend";
+
+const giftCardResend = gql`
+  ${giftCardDataFragment}
+  ${giftCardErrorFragment}
+  mutation GiftCardResend($input: GiftCardResendInput!) {
+    giftCardResend(input: $input) {
+      errors {
+        ...GiftCardError
+      }
+      giftCard {
+        ...GiftCardData
+      }
+    }
+  }
+`;
+
+export const useGiftCardResendCodeMutation = makeMutation<
+  GiftCardResend,
+  GiftCardResendVariables
+>(giftCardResend);

--- a/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/types/GiftCardResend.ts
+++ b/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/types/GiftCardResend.ts
@@ -1,0 +1,109 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { GiftCardResendInput, GiftCardErrorCode, GiftCardExpiryTypeEnum, TimePeriodTypeEnum } from "./../../../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: GiftCardResend
+// ====================================================
+
+export interface GiftCardResend_giftCardResend_errors {
+  __typename: "GiftCardError";
+  code: GiftCardErrorCode;
+  field: string | null;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_metadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_privateMetadata {
+  __typename: "MetadataItem";
+  key: string;
+  value: string;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_createdBy {
+  __typename: "User";
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_product {
+  __typename: "Product";
+  id: string;
+  name: string;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_usedBy {
+  __typename: "User";
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_app {
+  __typename: "App";
+  id: string;
+  name: string | null;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_expiryPeriod {
+  __typename: "TimePeriod";
+  amount: number;
+  type: TimePeriodTypeEnum;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_initialBalance {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard_currentBalance {
+  __typename: "Money";
+  amount: number;
+  currency: string;
+}
+
+export interface GiftCardResend_giftCardResend_giftCard {
+  __typename: "GiftCard";
+  metadata: (GiftCardResend_giftCardResend_giftCard_metadata | null)[];
+  privateMetadata: (GiftCardResend_giftCardResend_giftCard_privateMetadata | null)[];
+  displayCode: string;
+  createdBy: GiftCardResend_giftCardResend_giftCard_createdBy | null;
+  product: GiftCardResend_giftCardResend_giftCard_product | null;
+  usedBy: GiftCardResend_giftCardResend_giftCard_usedBy | null;
+  usedByEmail: string | null;
+  createdByEmail: string | null;
+  app: GiftCardResend_giftCardResend_giftCard_app | null;
+  created: any;
+  expiryDate: any | null;
+  expiryType: GiftCardExpiryTypeEnum;
+  expiryPeriod: GiftCardResend_giftCardResend_giftCard_expiryPeriod | null;
+  lastUsedOn: any | null;
+  isActive: boolean;
+  initialBalance: GiftCardResend_giftCardResend_giftCard_initialBalance | null;
+  currentBalance: GiftCardResend_giftCardResend_giftCard_currentBalance | null;
+  id: string;
+  tag: string | null;
+}
+
+export interface GiftCardResend_giftCardResend {
+  __typename: "GiftCardResend";
+  errors: GiftCardResend_giftCardResend_errors[];
+  giftCard: GiftCardResend_giftCardResend_giftCard | null;
+}
+
+export interface GiftCardResend {
+  giftCardResend: GiftCardResend_giftCardResend | null;
+}
+
+export interface GiftCardResendVariables {
+  input: GiftCardResendInput;
+}

--- a/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/utils.ts
+++ b/src/giftCards/GiftCardUpdate/GiftCardResendCodeDialog/utils.ts
@@ -1,0 +1,34 @@
+import { UserError } from "@saleor/types";
+import { FormErrors, getFormErrors } from "@saleor/utils/errors";
+import { useEffect, useState } from "react";
+
+export function useDialogFormReset<
+  TError extends UserError,
+  TKey extends string
+>({
+  reset,
+  apiErrors,
+  keys,
+  open
+}: {
+  reset: () => void;
+  apiErrors: TError[];
+  keys: TKey[];
+  open: boolean;
+}) {
+  const [formErrors, setFormErrors] = useState<FormErrors<TKey, TError>>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setFormErrors(null);
+      reset();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const errors = getFormErrors(keys, apiErrors);
+    setFormErrors(errors);
+  }, [apiErrors]);
+
+  return { formErrors };
+}

--- a/src/giftCards/GiftCardUpdate/GiftCardUpdateBalanceDialog/GiftCardUpdateBalanceDialog.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardUpdateBalanceDialog/GiftCardUpdateBalanceDialog.tsx
@@ -1,16 +1,16 @@
 import { TextField, Typography } from "@material-ui/core";
 import ActionDialog from "@saleor/components/ActionDialog";
 import CardSpacer from "@saleor/components/CardSpacer";
-import Form from "@saleor/components/Form";
 import { IMessage } from "@saleor/components/messages";
+import useForm from "@saleor/hooks/useForm";
 import useNotifier from "@saleor/hooks/useNotifier";
-import { getFormErrors } from "@saleor/utils/errors";
 import commonErrorMessages from "@saleor/utils/errors/common";
 import { DialogActionHandlersProps } from "@saleor/utils/handlers/dialogActionHandlers";
 import React from "react";
 import { useIntl } from "react-intl";
 
 import { giftCardsListTableMessages as tableMessages } from "../../GiftCardsList/messages";
+import { useDialogFormReset } from "../GiftCardResendCodeDialog/utils";
 import { getGiftCardErrorMessage } from "../messages";
 import { useGiftCardUpdateMutation } from "../mutations";
 import useGiftCardDetails from "../providers/GiftCardDetailsProvider/hooks/useGiftCardDetails";
@@ -83,54 +83,57 @@ const GiftCardUpdateBalanceDialog: React.FC<DialogActionHandlersProps> = ({
     return result?.data?.giftCardUpdate?.errors;
   };
 
-  const { loading, status, data } = updateGiftCardBalanceOpts;
-
-  const formErrors = getFormErrors(
-    ["initialBalanceAmount"],
-    data?.giftCardUpdate?.errors
+  const { data, change, submit, reset, hasChanged } = useForm(
+    initialFormData,
+    handleSubmit
   );
 
+  const { loading, status, data: submitData } = updateGiftCardBalanceOpts;
+
+  const { formErrors } = useDialogFormReset({
+    open,
+    reset,
+    keys: ["initialBalanceAmount"],
+    apiErrors: submitData?.giftCardUpdate?.errors
+  });
+
   return (
-    <Form initial={initialFormData} onSubmit={handleSubmit}>
-      {({ data, change, submit, hasChanged }) => (
-        <ActionDialog
-          maxWidth="sm"
-          open={open}
-          onConfirm={submit}
-          confirmButtonLabel={intl.formatMessage(messages.changeButtonLabel)}
-          onClose={closeDialog}
-          title={intl.formatMessage(messages.title)}
-          confirmButtonState={status}
-          disabled={loading || !hasChanged}
-        >
-          <Typography>{intl.formatMessage(messages.subtitle)}</Typography>
-          <CardSpacer />
-          <TextField
-            inputProps={{ min: 0 }}
-            error={!!formErrors?.initialBalanceAmount}
-            helperText={getGiftCardErrorMessage(
-              formErrors?.initialBalanceAmount,
-              intl
-            )}
-            name="balanceAmount"
-            value={data.balanceAmount}
-            onChange={change}
-            className={classes.inputContainer}
-            label={intl.formatMessage(
-              tableMessages.giftCardsTableColumnBalanceTitle
-            )}
-            type="number"
-            InputProps={{
-              startAdornment: (
-                <div className={classes.currencyCodeContainer}>
-                  <Typography variant="caption">{currency}</Typography>
-                </div>
-              )
-            }}
-          />
-        </ActionDialog>
-      )}
-    </Form>
+    <ActionDialog
+      maxWidth="sm"
+      open={open}
+      onConfirm={submit}
+      confirmButtonLabel={intl.formatMessage(messages.changeButtonLabel)}
+      onClose={closeDialog}
+      title={intl.formatMessage(messages.title)}
+      confirmButtonState={status}
+      disabled={loading || !hasChanged}
+    >
+      <Typography>{intl.formatMessage(messages.subtitle)}</Typography>
+      <CardSpacer />
+      <TextField
+        inputProps={{ min: 0 }}
+        error={!!formErrors?.initialBalanceAmount}
+        helperText={getGiftCardErrorMessage(
+          formErrors?.initialBalanceAmount,
+          intl
+        )}
+        name="balanceAmount"
+        value={data.balanceAmount}
+        onChange={change}
+        className={classes.inputContainer}
+        label={intl.formatMessage(
+          tableMessages.giftCardsTableColumnBalanceTitle
+        )}
+        type="number"
+        InputProps={{
+          startAdornment: (
+            <div className={classes.currencyCodeContainer}>
+              <Typography variant="caption">{currency}</Typography>
+            </div>
+          )
+        }}
+      />
+    </ActionDialog>
   );
 };
 

--- a/src/giftCards/GiftCardUpdate/GiftCardUpdatePageHeader/GiftCardUpdatePageHeader.tsx
+++ b/src/giftCards/GiftCardUpdate/GiftCardUpdatePageHeader/GiftCardUpdatePageHeader.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@material-ui/core";
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import PageHeader from "@saleor/components/PageHeader";
 import PageTitleWithStatusChip from "@saleor/components/PageTitleWithStatusChip";
 import { StatusType } from "@saleor/components/StatusChip/types";
@@ -10,6 +12,7 @@ import { giftCardsListTableMessages as tableMessages } from "../../GiftCardsList
 import useGiftCardDetails from "../providers/GiftCardDetailsProvider/hooks/useGiftCardDetails";
 import useGiftCardUpdateDialogs from "../providers/GiftCardUpdateDialogsProvider/hooks/useGiftCardUpdateDialogs";
 import GiftCardEnableDisableSection from "./GiftCardEnableDisableSection";
+import { giftCardUpdatePageHeaderMessages as messages } from "./messages";
 
 const GiftCardUpdatePageHeader: React.FC = () => {
   const intl = useIntl();
@@ -19,6 +22,8 @@ const GiftCardUpdatePageHeader: React.FC = () => {
   if (!giftCard) {
     return null;
   }
+
+  const { openResendCodeDialog } = useGiftCardUpdateDialogs();
 
   const { displayCode, isActive } = giftCard;
 
@@ -48,6 +53,14 @@ const GiftCardUpdatePageHeader: React.FC = () => {
         }
       >
         <GiftCardEnableDisableSection />
+        <HorizontalSpacer />
+        <Button
+          color="primary"
+          variant="contained"
+          onClick={openResendCodeDialog}
+        >
+          {intl.formatMessage(messages.resendButtonLabel)}
+        </Button>
       </PageHeader>
     </>
   );

--- a/src/giftCards/GiftCardUpdate/GiftCardUpdatePageHeader/messages.ts
+++ b/src/giftCards/GiftCardUpdate/GiftCardUpdatePageHeader/messages.ts
@@ -18,3 +18,10 @@ export const giftCardEnableDisableSectionMessages = defineMessages({
     description: "GiftCardEnableDisableSection disable success"
   }
 });
+
+export const giftCardUpdatePageHeaderMessages = defineMessages({
+  resendButtonLabel: {
+    defaultMessage: "Resend code",
+    description: "giftCardUpdatePageHeader resendButtonLabel"
+  }
+});

--- a/src/giftCards/GiftCardUpdate/providers/GiftCardUpdateDialogsProvider/GiftCardUpdateDialogsProvider.tsx
+++ b/src/giftCards/GiftCardUpdate/providers/GiftCardUpdateDialogsProvider/GiftCardUpdateDialogsProvider.tsx
@@ -4,6 +4,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import React, { createContext } from "react";
 
+import GiftCardResendCodeDialog from "../../GiftCardResendCodeDialog";
 import GiftCardUpdateBalanceDialog from "../../GiftCardUpdateBalanceDialog";
 import {
   GiftCardUpdatePageActionParamsEnum,
@@ -19,10 +20,10 @@ interface GiftCardUpdateDialogsProviderProps {
 
 export interface GiftCardUpdateDialogsConsumerProps {
   navigateBack: () => void;
-  openSetBalanceDialog: () => void;
   closeDialog: () => void;
+  openSetBalanceDialog: () => void;
   openDeleteDialog: () => void;
-  isDeleteDialogOpen: boolean;
+  openResendCodeDialog: () => void;
 }
 
 export const GiftCardUpdateDialogsContext = createContext<
@@ -38,29 +39,26 @@ const GiftCardUpdateDialogsProvider: React.FC<GiftCardUpdateDialogsProviderProps
 
   const { loading: loadingGiftCard } = useGiftCardDetails();
 
+  const {
+    SET_BALANCE,
+    DELETE,
+    RESEND_CODE
+  } = GiftCardUpdatePageActionParamsEnum;
+
   const [openDialog, closeDialog] = createDialogActionHandlers<
     GiftCardUpdatePageActionParamsEnum,
     GiftCardUpdatePageUrlQueryParams
   >(navigate, params => giftCardUrl(id, params), params);
 
-  const openSetBalanceDialog = () =>
-    openDialog(GiftCardUpdatePageActionParamsEnum.SET_BALANCE);
-
-  const isSetBalanceDialogOpen =
-    params?.action === GiftCardUpdatePageActionParamsEnum.SET_BALANCE;
-
-  const openDeleteDialog = () =>
-    openDialog(GiftCardUpdatePageActionParamsEnum.DELETE);
-
-  const isDeleteDialogOpen =
-    params?.action === GiftCardUpdatePageActionParamsEnum.DELETE;
+  const isDialogOpen = (action: GiftCardUpdatePageActionParamsEnum) =>
+    params?.action === action;
 
   const navigateBack = () => navigate(giftCardsListPath);
 
   const providerValues: GiftCardUpdateDialogsConsumerProps = {
-    openSetBalanceDialog,
-    openDeleteDialog,
-    isDeleteDialogOpen,
+    openSetBalanceDialog: () => openDialog(SET_BALANCE),
+    openDeleteDialog: () => openDialog(DELETE),
+    openResendCodeDialog: () => openDialog(RESEND_CODE),
     closeDialog,
     navigateBack
   };
@@ -72,12 +70,16 @@ const GiftCardUpdateDialogsProvider: React.FC<GiftCardUpdateDialogsProviderProps
         <>
           <GiftCardUpdateBalanceDialog
             closeDialog={closeDialog}
-            open={isSetBalanceDialogOpen}
+            open={isDialogOpen(SET_BALANCE)}
           />
           <GiftCardUpdatePageDeleteDialog
             closeDialog={closeDialog}
-            open={isDeleteDialogOpen}
+            open={isDialogOpen(DELETE)}
             navigateBack={navigateBack}
+          />
+          <GiftCardResendCodeDialog
+            open={isDialogOpen(RESEND_CODE)}
+            closeDialog={closeDialog}
           />
         </>
       )}

--- a/src/giftCards/GiftCardUpdate/types.ts
+++ b/src/giftCards/GiftCardUpdate/types.ts
@@ -2,7 +2,8 @@ import { Dialog } from "@saleor/types";
 
 export enum GiftCardUpdatePageActionParamsEnum {
   SET_BALANCE = "set-balance",
-  DELETE = "delete"
+  DELETE = "delete",
+  RESEND_CODE = "resend-code"
 }
 
 export type GiftCardUpdatePageUrlQueryParams = Dialog<

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1421,6 +1421,11 @@ export interface GiftCardExpirySettingsInput {
   expiryPeriod?: TimePeriodInputType | null;
 }
 
+export interface GiftCardResendInput {
+  id: string;
+  email?: string | null;
+}
+
 export interface GiftCardUpdateInput {
   tag?: string | null;
   startDate?: any | null;

--- a/src/utils/errors/index.ts
+++ b/src/utils/errors/index.ts
@@ -13,10 +13,15 @@ export function getErrors(errors: UserError[]): string[] {
     .map(err => err.message);
 }
 
+export type FormErrors<
+  TField extends string,
+  TError extends UserError
+> = Record<TField, TError>;
+
 export function getFormErrors<TField extends string, TError extends UserError>(
   fields: TField[],
   errors: TError[] = []
-): Record<TField, TError> {
+): FormErrors<TField, TError> {
   return fields.reduce((errs, field) => {
     errs[field] = getFieldError(errors, field);
     return errs;


### PR DESCRIPTION
I want to merge this change because it adds ability to resend gift card code. There is a hook added called `useDialogFormReset` - it handles resetting form errors and form data for modals where submit logic is in the same component as form modal body. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://feature-gift-cards-pre-mvp.api.saleor.rocks/graphql/