### PR TITLE
Saleor 3611/3.0/warehouse settings card fix

### DIFF
--- a/src/shipping/components/ShippingZoneSettingsCard/ShippingZoneSettingsCard.tsx
+++ b/src/shipping/components/ShippingZoneSettingsCard/ShippingZoneSettingsCard.tsx
@@ -51,38 +51,28 @@ export const ShippingZoneSettingsCard: React.FC<ShippingZoneSettingsCardProps> =
   return (
     <Card>
       <CardTitle title={intl.formatMessage(messages.title)} />
-      {loading && (
-        <CardContent>
-          <Skeleton />
-        </CardContent>
-      )}
-
-      {!loading && (
-        <>
-          <CardContent>
-            <ChannelsSection
-              channelsDisplayValues={channelsDisplayValues}
-              onChange={onChannelChange}
-              allChannels={allChannels}
-              selectedChannels={formData.channels}
-            />
-          </CardContent>
-          <Divider />
-          <CardContent>
-            <WarehousesSection
-              onAdd={onWarehouseAdd}
-              onSearchChange={onWarehousesSearchChange}
-              onChange={onWarehouseChange}
-              onFetchMore={onFetchMoreWarehouses}
-              displayValues={warehousesDisplayValues}
-              choices={warehousesChoices}
-              selectedWarehouses={formData.warehouses}
-              hasMore={hasMoreWarehouses}
-              loading={false}
-            />
-          </CardContent>
-        </>
-      )}
+      <CardContent>
+        <ChannelsSection
+          channelsDisplayValues={channelsDisplayValues}
+          onChange={onChannelChange}
+          allChannels={allChannels}
+          selectedChannels={formData.channels}
+        />
+      </CardContent>
+      <Divider />
+      <CardContent>
+        <WarehousesSection
+          onAdd={onWarehouseAdd}
+          onSearchChange={onWarehousesSearchChange}
+          onChange={onWarehouseChange}
+          onFetchMore={onFetchMoreWarehouses}
+          displayValues={warehousesDisplayValues}
+          choices={warehousesChoices}
+          selectedWarehouses={formData.warehouses}
+          hasMore={hasMoreWarehouses}
+          loading={loading}
+        />
+      </CardContent>
     </Card>
   );
 };

--- a/src/shipping/components/ShippingZoneSettingsCard/ShippingZoneSettingsCard.tsx
+++ b/src/shipping/components/ShippingZoneSettingsCard/ShippingZoneSettingsCard.tsx
@@ -2,7 +2,6 @@ import { Card, CardContent, Divider } from "@material-ui/core";
 import { BaseChannels_channels } from "@saleor/channels/types/BaseChannels";
 import CardTitle from "@saleor/components/CardTitle";
 import { MultiAutocompleteChoiceType } from "@saleor/components/MultiAutocompleteSelectField";
-import Skeleton from "@saleor/components/Skeleton";
 import { FormChange } from "@saleor/hooks/useForm";
 import React from "react";
 import { defineMessages, useIntl } from "react-intl";


### PR DESCRIPTION
I want to merge this change because it resolves the issue of the warehouse settings card remounting on autocomplete input changes.


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
