### PR TITLE
Add gift card option to order settings

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4793,6 +4793,14 @@
     "context": "section header",
     "string": "Settings"
   },
+  "src_dot_orders_dot_components_dot_OrderSettings_dot_2116402092": {
+    "context": "checkbox gift cards label",
+    "string": "Automatically fulfill non shippable gift cards"
+  },
+  "src_dot_orders_dot_components_dot_OrderSettings_dot_2879928595": {
+    "context": "checkbox gift cards label description",
+    "string": "when activated non-shippable gift cards will be automatically set as fulfilled and sent to customer"
+  },
   "src_dot_orders_dot_components_dot_OrderSettings_dot_3281882935": {
     "context": "checkbox label description",
     "string": "All orders will be automatically confirmed and all payments will be captured."

--- a/src/fragments/orders.ts
+++ b/src/fragments/orders.ts
@@ -278,5 +278,6 @@ export const fragmentOrderDetails = gql`
 export const fragmentOrderSettings = gql`
   fragment OrderSettingsFragment on OrderSettings {
     automaticallyConfirmAllNewOrders
+    automaticallyFulfillNonShippableGiftCard
   }
 `;

--- a/src/fragments/types/OrderSettingsFragment.ts
+++ b/src/fragments/types/OrderSettingsFragment.ts
@@ -10,4 +10,5 @@
 export interface OrderSettingsFragment {
   __typename: "OrderSettings";
   automaticallyConfirmAllNewOrders: boolean;
+  automaticallyFulfillNonShippableGiftCard: boolean;
 }

--- a/src/orders/components/OrderSettings/OrderSettings.tsx
+++ b/src/orders/components/OrderSettings/OrderSettings.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, Typography } from "@material-ui/core";
+import CardSpacer from "@saleor/components/CardSpacer";
 import CardTitle from "@saleor/components/CardTitle";
 import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import React from "react";
@@ -50,6 +51,30 @@ const OrderSettings: React.FC<OrderSettingsProps> = ({
           onChange={onChange}
           disabled={disabled}
           data-test="automaticallyConfirmAllNewOrdersCheckbox"
+        />
+        <CardSpacer />
+        <ControlledCheckbox
+          name={
+            "automaticallyFulfillNonShippableGiftCard" as keyof OrderSettingsFormData
+          }
+          label={
+            <>
+              <FormattedMessage
+                defaultMessage="Automatically fulfill non shippable gift cards"
+                description="checkbox gift cards label"
+              />
+              <Typography variant="caption">
+                <FormattedMessage
+                  defaultMessage="when activated non-shippable gift cards will be automatically set as fulfilled and sent to customer"
+                  description="checkbox gift cards label description"
+                />
+              </Typography>
+            </>
+          }
+          checked={data.automaticallyFulfillNonShippableGiftCard}
+          onChange={onChange}
+          disabled={disabled}
+          data-test="automaticallyFulfillNonShippableGiftCardsCheckbox"
         />
       </CardContent>
     </Card>

--- a/src/orders/components/OrderSettingsPage/form.tsx
+++ b/src/orders/components/OrderSettingsPage/form.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 export interface OrderSettingsFormData {
   automaticallyConfirmAllNewOrders: boolean;
+  automaticallyFulfillNonShippableGiftCard: boolean;
 }
 
 export interface UseOrderSettingsFormResult {
@@ -24,6 +25,8 @@ function getOrderSeettingsFormData(
   orderSettings: OrderSettingsFragment
 ): OrderSettingsFormData {
   return {
+    automaticallyFulfillNonShippableGiftCard:
+      orderSettings?.automaticallyFulfillNonShippableGiftCard,
     automaticallyConfirmAllNewOrders:
       orderSettings?.automaticallyConfirmAllNewOrders
   };

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1895,5 +1895,6 @@ export const invoices: InvoiceFragment[] = [
 
 export const orderSettings: OrderSettingsFragment = {
   __typename: "OrderSettings",
-  automaticallyConfirmAllNewOrders: true
+  automaticallyConfirmAllNewOrders: true,
+  automaticallyFulfillNonShippableGiftCard: false
 };

--- a/src/orders/types/OrderSettings.ts
+++ b/src/orders/types/OrderSettings.ts
@@ -10,6 +10,7 @@
 export interface OrderSettings_orderSettings {
   __typename: "OrderSettings";
   automaticallyConfirmAllNewOrders: boolean;
+  automaticallyFulfillNonShippableGiftCard: boolean;
 }
 
 export interface OrderSettings {

--- a/src/orders/types/OrderSettingsUpdate.ts
+++ b/src/orders/types/OrderSettingsUpdate.ts
@@ -18,6 +18,7 @@ export interface OrderSettingsUpdate_orderSettingsUpdate_errors {
 export interface OrderSettingsUpdate_orderSettingsUpdate_orderSettings {
   __typename: "OrderSettings";
   automaticallyConfirmAllNewOrders: boolean;
+  automaticallyFulfillNonShippableGiftCard: boolean;
 }
 
 export interface OrderSettingsUpdate_orderSettingsUpdate {


### PR DESCRIPTION
I want to merge this change because it adds auto fullfill non shippable gift cards to order settings

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
