### PR TITLE
fix dashboard crash when using the channel selector search field in product view

### DIFF
--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -136,7 +136,13 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
   return (
     <>
       {map(channelsWithVariants, ({ selectedVariantsIds }, channelId) => {
-        const { name } = channels.find(getById(channelId));
+        const channel = channels.find(getById(channelId));
+
+        if (!channel) {
+          return null;
+        }
+
+        const { name } = channel;
 
         const isVariantSelected = (variantId: string) =>
           selectedVariantsIds.includes(variantId);

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -136,13 +136,13 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
   return (
     <>
       {map(channelsWithVariants, ({ selectedVariantsIds }, channelId) => {
-        const channel = channels.find(getById(channelId));
+        const filteredChannel = channels.find(getById(channelId));
 
-        if (!channel) {
+        if (!filteredChannel) {
           return null;
         }
 
-        const { name } = channel;
+        const { name } = filteredChannel;
 
         const isVariantSelected = (variantId: string) =>
           selectedVariantsIds.includes(variantId);


### PR DESCRIPTION
I want to merge this change because it fixes the dashboard crash when using the channel selector search field in product view.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
