### PR TITLE
keep multiselect open after making a selection

### DIFF
--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
@@ -129,7 +129,7 @@ const MultiAutocompleteSelectFieldComponent: React.FC<MultiAutocompleteSelectFie
     downshiftOpts?: ControllerStateAndHelpers
   ) => {
     if (downshiftOpts) {
-      downshiftOpts.reset({ inputValue: "" });
+      downshiftOpts.reset({ inputValue: "", isOpen: true });
     }
     onChange({
       target: { name, value: item }


### PR DESCRIPTION
I want to merge this change because it prevents multiselects from closing upon making a selection.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
