### PR TITLE
fallback title for address books for customers with no name set

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2599,6 +2599,10 @@
   "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_noAddressToShow": {
     "string": "There is no address to show for this customer"
   },
+  "src_dot_customers_dot_components_dot_CustomerAddressListPage_dot_noNameToShow": {
+    "context": "customer's address book when no customer name is available, header",
+    "string": "Address Book"
+  },
   "src_dot_customers_dot_components_dot_CustomerAddress_dot_defaultAddress": {
     "string": "Default Address"
   },

--- a/src/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
+++ b/src/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
@@ -34,6 +34,11 @@ const messages = defineMessages({
     defaultMessage: "{fullName}'s Address Book",
     description: "customer's address book, header"
   },
+  noNameToShow: {
+    defaultMessage: "Address Book",
+    description:
+      "customer's address book when no customer name is available, header"
+  },
   fullNameDetail: {
     defaultMessage: "{fullName} Details",
     description: "customer details, header"
@@ -93,11 +98,17 @@ const CustomerAddressListPage: React.FC<CustomerAddressListPageProps> = props =>
   return (
     <Container>
       <Backlink onClick={onBack}>
-        {intl.formatMessage(messages.fullNameDetail, { fullName })}
+        {fullName.trim().length > 0
+          ? intl.formatMessage(messages.fullNameDetail, { fullName })
+          : intl.formatMessage(messages.noNameToShow)}
       </Backlink>
       {!isEmpty && (
         <PageHeader
-          title={intl.formatMessage(messages.fullNameAddress, { fullName })}
+          title={
+            fullName.trim().length > 0
+              ? intl.formatMessage(messages.fullNameAddress, { fullName })
+              : intl.formatMessage(messages.noNameToShow)
+          }
         >
           <Button color="primary" variant="contained" onClick={onAdd}>
             {intl.formatMessage(messages.addAddress)}


### PR DESCRIPTION
I want to merge this change because it adds a fallback title for address books when the customer has no name set.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
