### PR TITLE
Modify order return page to handle waiting fulfillments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.0.0-b.5",
+  "version": "3.0.0-b.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/orders/components/OrderDetailsPage/utils.ts
+++ b/src/orders/components/OrderDetailsPage/utils.ts
@@ -2,7 +2,8 @@ import { OrderDetails_order } from "@saleor/orders/types/OrderDetails";
 
 import {
   getFulfilledFulfillemnts,
-  getUnfulfilledLines
+  getUnfulfilledLines,
+  getWaitingFulfillments
 } from "../OrderReturnPage/utils";
 
 export const hasAnyItemsReplaceable = (order?: OrderDetails_order) => {
@@ -12,9 +13,13 @@ export const hasAnyItemsReplaceable = (order?: OrderDetails_order) => {
 
   const hasAnyUnfulfilledItems = getUnfulfilledLines(order).length > 0;
 
+  const hasAnyWaitingLines = getWaitingFulfillments(order).length > 0;
+
   const hasAnyFulfilmentsToReturn = getFulfilledFulfillemnts(order).length > 0;
 
-  return hasAnyUnfulfilledItems || hasAnyFulfilmentsToReturn;
+  return (
+    hasAnyUnfulfilledItems || hasAnyFulfilmentsToReturn || hasAnyWaitingLines
+  );
 };
 
 export interface ConditionalItem {

--- a/src/orders/components/OrderRefundReturnAmount/utils.ts
+++ b/src/orders/components/OrderRefundReturnAmount/utils.ts
@@ -43,6 +43,7 @@ const getMaxRefund = (order: OrderRefundData_order) => order?.totalCaptured;
 export const getProductsAmountValues = (
   order: OrderRefundData_order,
   fulfilledItemsQuantities: FormsetData<null | LineItemData, string | number>,
+  waitingItemsQuantities: FormsetData<null | LineItemData, string | number>,
   unfulfilledItemsQuantities: FormsetData<null | LineItemData, string | number>,
   shipmentCosts
 ): OrderRefundAmountValuesProps => {
@@ -55,11 +56,16 @@ export const getProductsAmountValues = (
     order?.lines,
     unfulfilledItemsQuantities as FormsetData<null, string>
   );
+  const waitingLinesSum = getAllFulfillmentLinesPriceSum(
+    order?.fulfillments,
+    waitingItemsQuantities as FormsetData<null, string>
+  );
   const allFulfillmentLinesSum = getAllFulfillmentLinesPriceSum(
     order?.fulfillments,
     fulfilledItemsQuantities as FormsetData<null, string>
   );
-  const allLinesSum = refundedLinesSum + allFulfillmentLinesSum;
+  const allLinesSum =
+    refundedLinesSum + allFulfillmentLinesSum + waitingLinesSum;
   const calculatedTotalAmount = getCalculatedTotalAmount({
     allLinesSum,
     maxRefund,
@@ -150,6 +156,7 @@ export const getReturnProductsAmountValues = (
 
   const {
     fulfilledItemsQuantities,
+    waitingItemsQuantities,
     unfulfilledItemsQuantities,
     refundShipmentCosts
   } = formData;
@@ -178,6 +185,7 @@ export const getReturnProductsAmountValues = (
     ...getProductsAmountValues(
       order,
       fulfilledItemsQuantities,
+      waitingItemsQuantities,
       unfulfilledItemsQuantities,
       refundShipmentCosts
     ),
@@ -198,6 +206,7 @@ export const getRefundProductsAmountValues = (
   getProductsAmountValues(
     order,
     refundedFulfilledProductQuantities,
+    null,
     refundedProductQuantities,
     refundShipmentCosts
   );

--- a/src/orders/components/OrderRefundReturnAmount/utils.ts
+++ b/src/orders/components/OrderRefundReturnAmount/utils.ts
@@ -40,13 +40,19 @@ const getShipmentCost = (order: OrderRefundData_order) =>
 
 const getMaxRefund = (order: OrderRefundData_order) => order?.totalCaptured;
 
-export const getProductsAmountValues = (
-  order: OrderRefundData_order,
-  fulfilledItemsQuantities: FormsetData<null | LineItemData, string | number>,
-  waitingItemsQuantities: FormsetData<null | LineItemData, string | number>,
-  unfulfilledItemsQuantities: FormsetData<null | LineItemData, string | number>,
-  shipmentCosts
-): OrderRefundAmountValuesProps => {
+export const getProductsAmountValues = ({
+  order,
+  fulfilledItemsQuantities,
+  waitingItemsQuantities,
+  unfulfilledItemsQuantities,
+  refundShipmentCosts
+}: {
+  order: OrderRefundData_order;
+  fulfilledItemsQuantities: FormsetData<null | LineItemData, string | number>;
+  waitingItemsQuantities: FormsetData<null | LineItemData, string | number>;
+  unfulfilledItemsQuantities: FormsetData<null | LineItemData, string | number>;
+  refundShipmentCosts: any;
+}): OrderRefundAmountValuesProps => {
   const authorizedAmount = getAuthorizedAmount(order);
   const shipmentCost = getShipmentCost(order);
 
@@ -71,7 +77,7 @@ export const getProductsAmountValues = (
     maxRefund,
     previouslyRefunded,
     shipmentCost,
-    shipmentCosts
+    shipmentCosts: refundShipmentCosts
   });
 
   const selectedProductsValue = authorizedAmount?.currency && {
@@ -182,13 +188,13 @@ export const getReturnProductsAmountValues = (
   };
 
   return {
-    ...getProductsAmountValues(
+    ...getProductsAmountValues({
       order,
       fulfilledItemsQuantities,
       waitingItemsQuantities,
       unfulfilledItemsQuantities,
       refundShipmentCosts
-    ),
+    }),
     refundTotalAmount,
     replacedProductsValue,
     selectedProductsValue
@@ -203,10 +209,10 @@ export const getRefundProductsAmountValues = (
     refundedProductQuantities
   }: OrderRefundFormData
 ) =>
-  getProductsAmountValues(
+  getProductsAmountValues({
     order,
-    refundedFulfilledProductQuantities,
-    [],
-    refundedProductQuantities,
+    fulfilledItemsQuantities: refundedFulfilledProductQuantities,
+    waitingItemsQuantities: [],
+    unfulfilledItemsQuantities: refundedProductQuantities,
     refundShipmentCosts
-  );
+  });

--- a/src/orders/components/OrderRefundReturnAmount/utils.ts
+++ b/src/orders/components/OrderRefundReturnAmount/utils.ts
@@ -206,7 +206,7 @@ export const getRefundProductsAmountValues = (
   getProductsAmountValues(
     order,
     refundedFulfilledProductQuantities,
-    null,
+    [],
     refundedProductQuantities,
     refundShipmentCosts
   );

--- a/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
@@ -16,8 +16,9 @@ import OrderRefundForm, { OrderRefundSubmitData } from "./form";
 import ItemsCard from "./OrderReturnRefundItemsCard/ReturnItemsCard";
 import {
   getFulfilledFulfillemnts,
-  getParsedFulfiledLines,
-  getUnfulfilledLines
+  getParsedLines,
+  getUnfulfilledLines,
+  getWaitingFulfillments
 } from "./utils";
 
 const messages = defineMessages({
@@ -46,10 +47,15 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
   return (
     <OrderRefundForm order={order} onSubmit={onSubmit}>
       {({ data, handlers, change, submit }) => {
-        const { fulfilledItemsQuantities, unfulfilledItemsQuantities } = data;
+        const {
+          fulfilledItemsQuantities,
+          waitingItemsQuantities,
+          unfulfilledItemsQuantities
+        } = data;
 
         const hasAnyItemsSelected =
           fulfilledItemsQuantities.some(({ value }) => !!value) ||
+          waitingItemsQuantities.some(({ value }) => !!value) ||
           unfulfilledItemsQuantities.some(({ value }) => !!value);
 
         return (
@@ -84,6 +90,27 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
                   </>
                 )}
                 {renderCollection(
+                  getWaitingFulfillments(order),
+                  ({ id, lines }) => (
+                    <React.Fragment key={id}>
+                      <ItemsCard
+                        errors={errors}
+                        order={order}
+                        fulfilmentId={id}
+                        lines={getParsedLines(lines)}
+                        itemsQuantities={data.waitingItemsQuantities}
+                        itemsSelections={data.itemsToBeReplaced}
+                        onChangeQuantity={handlers.changeWaitingItemsQuantity}
+                        onSetMaxQuantity={handlers.handleSetMaximalWaitingItemsQuantities(
+                          id
+                        )}
+                        onChangeSelected={handlers.changeItemsToBeReplaced}
+                      />
+                      <CardSpacer />
+                    </React.Fragment>
+                  )
+                )}
+                {renderCollection(
                   getFulfilledFulfillemnts(order),
                   ({ id, lines }) => (
                     <React.Fragment key={id}>
@@ -91,7 +118,7 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
                         errors={errors}
                         order={order}
                         fulfilmentId={id}
-                        lines={getParsedFulfiledLines(lines)}
+                        lines={getParsedLines(lines)}
                         itemsQuantities={data.fulfilledItemsQuantities}
                         itemsSelections={data.itemsToBeReplaced}
                         onChangeQuantity={handlers.changeFulfiledItemsQuantity}

--- a/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
@@ -101,7 +101,7 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
                         itemsQuantities={data.waitingItemsQuantities}
                         itemsSelections={data.itemsToBeReplaced}
                         onChangeQuantity={handlers.changeWaitingItemsQuantity}
-                        onSetMaxQuantity={handlers.handleSetMaximalWaitingItemsQuantities(
+                        onSetMaxQuantity={handlers.handleSetMaximalItemsQuantities(
                           id
                         )}
                         onChangeSelected={handlers.changeItemsToBeReplaced}
@@ -122,7 +122,7 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
                         itemsQuantities={data.fulfilledItemsQuantities}
                         itemsSelections={data.itemsToBeReplaced}
                         onChangeQuantity={handlers.changeFulfiledItemsQuantity}
-                        onSetMaxQuantity={handlers.handleSetMaximalFulfiledItemsQuantities(
+                        onSetMaxQuantity={handlers.handleSetMaximalItemsQuantities(
                           id
                         )}
                         onChangeSelected={handlers.changeItemsToBeReplaced}

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
@@ -171,8 +171,8 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
                 variant
               } = line;
               const isValueError = false;
-              const isRefunded = itemsQuantities.find(getById(id))?.data
-                ?.isRefunded;
+              const isRefunded = itemsQuantities.find(getById(id)).data
+                .isRefunded;
               const isReplacable = !!variant && !isRefunded;
               const isReturnable = !!variant;
               const lineQuantity = fulfilmentId ? quantity : quantityToFulfill;

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
@@ -163,7 +163,7 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
             line => {
               const {
                 quantity,
-                quantityFulfilled,
+                quantityToFulfill,
                 id,
                 thumbnail,
                 unitPrice,
@@ -175,9 +175,7 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
                 .isRefunded;
               const isReplacable = !!variant && !isRefunded;
               const isReturnable = !!variant;
-              const lineQuantity = fulfilmentId
-                ? quantity
-                : quantity - quantityFulfilled;
+              const lineQuantity = fulfilmentId ? quantity : quantityToFulfill;
               const isSelected = itemsSelections.find(getById(id))?.value;
               const currentQuantity = itemsQuantities.find(getById(id))?.value;
               const anyLineWithoutVariant = lines.some(

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
@@ -171,8 +171,8 @@ const ItemsCard: React.FC<OrderReturnRefundLinesCardProps> = ({
                 variant
               } = line;
               const isValueError = false;
-              const isRefunded = itemsQuantities.find(getById(id)).data
-                .isRefunded;
+              const isRefunded = itemsQuantities.find(getById(id))?.data
+                ?.isRefunded;
               const isReplacable = !!variant && !isRefunded;
               const isReturnable = !!variant;
               const lineQuantity = fulfilmentId ? quantity : quantityToFulfill;

--- a/src/orders/components/OrderReturnPage/form.tsx
+++ b/src/orders/components/OrderReturnPage/form.tsx
@@ -175,7 +175,7 @@ function useOrderReturnForm(
     const newQuantities: FormsetQuantityData = unfulfiledItemsQuantites.data.map(
       ({ id }) => {
         const line = order.lines.find(getById(id));
-        const initialValue = line.quantity - line.quantityFulfilled;
+        const initialValue = line.quantityToFulfill;
 
         return getLineItem(line, { initialValue });
       }

--- a/src/orders/components/OrderReturnPage/form.tsx
+++ b/src/orders/components/OrderReturnPage/form.tsx
@@ -156,7 +156,7 @@ function useOrderReturnForm(
     const waitingFulfillmentsItems = getParsedLineDataForFulfillmentStatus(
       order,
       FulfillmentStatus.WAITING_FOR_APPROVAL,
-      { initialValue: false, isFulfillment: false }
+      { initialValue: false, isFulfillment: true }
     );
 
     return [

--- a/src/orders/components/OrderReturnPage/utils.tsx
+++ b/src/orders/components/OrderReturnPage/utils.tsx
@@ -23,7 +23,7 @@ export const getFulfilledFulfillemnts = (order?: OrderDetails_order) =>
   order?.fulfillments.filter(getFulfilledFulfillment) || [];
 
 export const getUnfulfilledLines = (order?: OrderDetails_order) =>
-  order?.lines.filter(line => line.quantity !== line.quantityFulfilled) || [];
+  order?.lines.filter(line => line.quantityToFulfill > 0) || [];
 
 export const getAllOrderFulfilledLines = (order?: OrderDetails_order) =>
   getFulfilledFulfillemnts(order).reduce(

--- a/src/orders/components/OrderReturnPage/utils.tsx
+++ b/src/orders/components/OrderReturnPage/utils.tsx
@@ -14,7 +14,7 @@ const fulfiledStatuses = [
 ];
 
 export const getOrderUnfulfilledLines = (order: OrderDetails_order) =>
-  order?.lines.filter(line => line.quantityFulfilled !== line.quantity) || [];
+  order?.lines.filter(line => line.quantityToFulfill > 0) || [];
 
 export const getFulfilledFulfillment = fulfillment =>
   fulfiledStatuses.includes(fulfillment.status);

--- a/src/orders/components/OrderReturnPage/utils.tsx
+++ b/src/orders/components/OrderReturnPage/utils.tsx
@@ -22,12 +22,23 @@ export const getFulfilledFulfillment = fulfillment =>
 export const getFulfilledFulfillemnts = (order?: OrderDetails_order) =>
   order?.fulfillments.filter(getFulfilledFulfillment) || [];
 
+export const getWaitingFulfillments = (order: OrderDetails_order) =>
+  order?.fulfillments.filter(
+    f => f.status === FulfillmentStatus.WAITING_FOR_APPROVAL
+  ) || [];
+
 export const getUnfulfilledLines = (order?: OrderDetails_order) =>
   order?.lines.filter(line => line.quantityToFulfill > 0) || [];
 
 export const getAllOrderFulfilledLines = (order?: OrderDetails_order) =>
   getFulfilledFulfillemnts(order).reduce(
-    (result, { lines }) => [...result, ...getParsedFulfiledLines(lines)],
+    (result, { lines }) => [...result, ...getParsedLines(lines)],
+    []
+  );
+
+export const getAllOrderWaitingLines = (order?: OrderDetails_order) =>
+  getWaitingFulfillments(order).reduce(
+    (result, { lines }) => [...result, ...getParsedLines(lines)],
     []
   );
 
@@ -77,11 +88,11 @@ export const getParsedLinesOfFulfillments = (
   fullfillments: OrderDetails_order_fulfillments[]
 ) =>
   fullfillments.reduce(
-    (result, { lines }) => [...result, ...getParsedFulfiledLines(lines)],
+    (result, { lines }) => [...result, ...getParsedLines(lines)],
     []
   );
 
-export const getParsedFulfiledLines = (
+export const getParsedLines = (
   lines: OrderDetailsFragment_fulfillments_lines[]
 ) =>
   lines.map(({ id, quantity, orderLine }) => ({

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -1501,27 +1501,6 @@ describe("Get the total value of all selected products", () => {
       }
     ];
 
-    const waitingItemsQuantities: FormsetData<LineItemData, number> = [
-      {
-        data: { isFulfillment: false, isRefunded: false },
-        id: "1",
-        label: null,
-        value: 0
-      },
-      {
-        data: { isFulfillment: false, isRefunded: false },
-        id: "2",
-        label: null,
-        value: 2
-      },
-      {
-        data: { isFulfillment: false, isRefunded: false },
-        id: "3",
-        label: null,
-        value: 1
-      }
-    ];
-
     const fulfilledItemsQuantities: FormsetData<LineItemData, number> = [
       {
         data: { isFulfillment: true, isRefunded: false },
@@ -1542,6 +1521,8 @@ describe("Get the total value of all selected products", () => {
         value: 3
       }
     ];
+
+    const waitingItemsQuantities: FormsetData<LineItemData, number> = [];
 
     const itemsToBeReplaced: FormsetData<LineItemData, boolean> = [
       {

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -1501,6 +1501,27 @@ describe("Get the total value of all selected products", () => {
       }
     ];
 
+    const waitingItemsQuantities: FormsetData<LineItemData, number> = [
+      {
+        data: { isFulfillment: false, isRefunded: false },
+        id: "1",
+        label: null,
+        value: 0
+      },
+      {
+        data: { isFulfillment: false, isRefunded: false },
+        id: "2",
+        label: null,
+        value: 2
+      },
+      {
+        data: { isFulfillment: false, isRefunded: false },
+        id: "3",
+        label: null,
+        value: 1
+      }
+    ];
+
     const fulfilledItemsQuantities: FormsetData<LineItemData, number> = [
       {
         data: { isFulfillment: true, isRefunded: false },
@@ -1591,6 +1612,7 @@ describe("Get the total value of all selected products", () => {
       },
       {
         itemsToBeReplaced,
+        waitingItemsQuantities,
         unfulfilledItemsQuantities,
         fulfilledItemsQuantities
       }

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -100,7 +100,7 @@ const selectItemPriceAndQuantity = (
   isFulfillment: boolean
 ) => {
   const fulfillment = getFulfillmentByFulfillmentLineId(order, id);
-  if (fulfillment.status === FulfillmentStatus.WAITING_FOR_APPROVAL) {
+  if (fulfillment?.status === FulfillmentStatus.WAITING_FOR_APPROVAL) {
     return getItemPriceAndQuantity({
       id,
       itemsQuantities: waitingItemsQuantities,
@@ -184,7 +184,7 @@ export const getReturnSelectedProductsAmount = (
     orderLines: getAllOrderFulfilledLines(order)
   });
 
-  const waitingItemsValue = getWaitingProductsValue({
+  const waitingItemsValue = getPartialProductsValue({
     itemsQuantities: waitingItemsQuantities,
     itemsToBeReplaced,
     orderLines: getAllOrderWaitingLines(order)
@@ -194,34 +194,6 @@ export const getReturnSelectedProductsAmount = (
 };
 
 const getPartialProductsValue = ({
-  orderLines,
-  itemsQuantities,
-  itemsToBeReplaced
-}: {
-  itemsToBeReplaced: FormsetData<LineItemData, boolean>;
-  itemsQuantities: FormsetData<LineItemData, number>;
-  orderLines: OrderDetails_order_lines[];
-}) =>
-  itemsQuantities.reduce(
-    (resultAmount, { id, value: quantity, data: { isRefunded } }) => {
-      const { value: isItemToBeReplaced } = itemsToBeReplaced.find(getById(id));
-
-      if (quantity < 1 || isItemToBeReplaced || isRefunded) {
-        return resultAmount;
-      }
-
-      const { selectedQuantity, unitPrice } = getItemPriceAndQuantity({
-        id,
-        itemsQuantities,
-        orderLines
-      });
-
-      return resultAmount + unitPrice.gross.amount * selectedQuantity;
-    },
-    0
-  );
-
-const getWaitingProductsValue = ({
   orderLines,
   itemsQuantities,
   itemsToBeReplaced

--- a/src/orders/views/OrderReturn/utils.tsx
+++ b/src/orders/views/OrderReturn/utils.tsx
@@ -24,6 +24,7 @@ class ReturnFormDataParser {
   public getParsedData = (): OrderReturnProductsInput => {
     const {
       fulfilledItemsQuantities,
+      waitingItemsQuantities,
       unfulfilledItemsQuantities,
       refundShipmentCosts
     } = this.formData;
@@ -32,6 +33,10 @@ class ReturnFormDataParser {
       OrderReturnFulfillmentLineInput
     >(fulfilledItemsQuantities, "fulfillmentLineId");
 
+    const waitingLines = this.getParsedLineData<
+      OrderReturnFulfillmentLineInput
+    >(waitingItemsQuantities, "fulfillmentLineId");
+
     const orderLines = this.getParsedLineData<OrderReturnLineInput>(
       unfulfilledItemsQuantities,
       "orderLineId"
@@ -39,7 +44,7 @@ class ReturnFormDataParser {
 
     return {
       amountToRefund: this.getAmountToRefund(),
-      fulfillmentLines,
+      fulfillmentLines: fulfillmentLines.concat(waitingLines),
       includeShippingCosts: refundShipmentCosts,
       orderLines,
       refund: this.getShouldRefund(orderLines, fulfillmentLines)


### PR DESCRIPTION
I want to merge this change because order return page used to show (for unfulfilled items) quantity - quantity fulfilled. It should utilize new backend order line property - quantityToFulfill instead.

More importantly, the return view didn't show waiting fulfillments, didn't calculate their values properly, etc.
Now it is handled.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://fulfillments-refactor.api.saleor.rocks/graphql/
