### PR TITLE
Add channel picker product details

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1366,20 +1366,8 @@
     "context": "number of products",
     "string": "No. of Products"
   },
-  "src_dot_categories_dot_components_dot_CategoryProductList_dot_1134347598": {
-    "context": "product price",
-    "string": "Price"
-  },
   "src_dot_categories_dot_components_dot_CategoryProductList_dot_1657559629": {
     "string": "No products found"
-  },
-  "src_dot_categories_dot_components_dot_CategoryProductList_dot_1952810469": {
-    "context": "product type",
-    "string": "Type"
-  },
-  "src_dot_categories_dot_components_dot_CategoryProductList_dot_3326160357": {
-    "context": "availability status",
-    "string": "Availability"
   },
   "src_dot_categories_dot_components_dot_CategoryProductList_dot_636461959": {
     "context": "product",
@@ -1388,6 +1376,10 @@
   "src_dot_categories_dot_components_dot_CategoryProducts_dot_3554578821": {
     "context": "button",
     "string": "Add product"
+  },
+  "src_dot_categories_dot_components_dot_CategoryProducts_dot_4078580795": {
+    "context": "button",
+    "string": "View products"
   },
   "src_dot_categories_dot_components_dot_CategoryProducts_dot_4164156574": {
     "context": "header",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor-dashboard",
-  "version": "3.0.0-b.11",
+  "version": "3.0.0-b.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4182,8 +4182,9 @@
       }
     },
     "@saleor/macaw-ui": {
-      "version": "github:mirumee/macaw-ui#03d63cd1342d2dc7fe18e9f8a9249ba27a52d9c2",
-      "from": "github:mirumee/macaw-ui#03d63cd",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@saleor/macaw-ui/-/macaw-ui-0.2.3.tgz",
+      "integrity": "sha512-9vcjY27lbxmySEnesJIefjjZAb/H8Hqm0AtCLUx6gZA2gvUkmJWQuYqcUljTY5VKEIuBpsG9BJtItRTWhQUG9g==",
       "requires": {
         "clsx": "^1.1.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
     "@material-ui/styles": "^4.11.4",
-    "@saleor/macaw-ui": "github:mirumee/macaw-ui#03d63cd",
+    "@saleor/macaw-ui": "^0.2.3",
     "@sentry/react": "^6.0.0",
     "@types/faker": "^5.1.6",
     "apollo": "^2.32.5",

--- a/src/categories/components/CategoryProductList/CategoryProductList.tsx
+++ b/src/categories/components/CategoryProductList/CategoryProductList.tsx
@@ -1,7 +1,5 @@
 import { TableBody, TableCell, TableFooter, TableRow } from "@material-ui/core";
-import { ChannelsAvailabilityDropdown } from "@saleor/components/ChannelsAvailabilityDropdown";
 import Checkbox from "@saleor/components/Checkbox";
-import MoneyRange from "@saleor/components/MoneyRange";
 import ResponsiveTable from "@saleor/components/ResponsiveTable";
 import Skeleton from "@saleor/components/Skeleton";
 import TableCellAvatar from "@saleor/components/TableCellAvatar";
@@ -10,7 +8,7 @@ import TableHead from "@saleor/components/TableHead";
 import TablePagination from "@saleor/components/TablePagination";
 import { makeStyles } from "@saleor/macaw-ui";
 import { maybe, renderCollection } from "@saleor/misc";
-import { ChannelProps, ListActions, ListProps } from "@saleor/types";
+import { ListActions, ListProps } from "@saleor/types";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -21,15 +19,6 @@ const useStyles = makeStyles(
     [theme.breakpoints.up("lg")]: {
       colName: {
         width: "auto"
-      },
-      colPrice: {
-        width: 300
-      },
-      colPublished: {
-        width: 200
-      },
-      colType: {
-        width: 200
       }
     },
     colFill: {
@@ -40,11 +29,6 @@ const useStyles = makeStyles(
     colNameHeader: {
       marginLeft: AVATAR_MARGIN
     },
-    colPrice: {
-      textAlign: "right"
-    },
-    colPublished: {},
-    colType: {},
     link: {
       cursor: "pointer"
     },
@@ -66,17 +50,12 @@ const useStyles = makeStyles(
   }
 );
 
-interface CategoryProductListProps
-  extends ListProps,
-    ListActions,
-    ChannelProps {
-  channelsCount: number;
+interface CategoryProductListProps extends ListProps, ListActions {
   products: CategoryDetails_category_products_edges_node[];
 }
 
 export const CategoryProductList: React.FC<CategoryProductListProps> = props => {
   const {
-    channelsCount,
     disabled,
     isChecked,
     pageInfo,
@@ -87,13 +66,12 @@ export const CategoryProductList: React.FC<CategoryProductListProps> = props => 
     toolbar,
     onNextPage,
     onPreviousPage,
-    onRowClick,
-    selectedChannelId
+    onRowClick
   } = props;
 
   const classes = useStyles(props);
 
-  const numberOfColumns = 5;
+  const numberOfColumns = 2;
 
   return (
     <div className={classes.tableContainer}>
@@ -101,9 +79,6 @@ export const CategoryProductList: React.FC<CategoryProductListProps> = props => 
         <colgroup>
           <col />
           <col className={classes.colName} />
-          <col className={classes.colType} />
-          <col className={classes.colPublished} />
-          <col className={classes.colPrice} />
         </colgroup>
         <TableHead
           colSpan={numberOfColumns}
@@ -117,24 +92,6 @@ export const CategoryProductList: React.FC<CategoryProductListProps> = props => 
             <span className={classes.colNameHeader}>
               <FormattedMessage defaultMessage="Name" description="product" />
             </span>
-          </TableCell>
-          <TableCell className={classes.colType}>
-            <FormattedMessage
-              defaultMessage="Type"
-              description="product type"
-            />
-          </TableCell>
-          <TableCell className={classes.colPublished}>
-            <FormattedMessage
-              defaultMessage="Availability"
-              description="availability status"
-            />
-          </TableCell>
-          <TableCell className={classes.colPrice}>
-            <FormattedMessage
-              defaultMessage="Price"
-              description="product price"
-            />
           </TableCell>
         </TableHead>
         <TableFooter>
@@ -155,9 +112,6 @@ export const CategoryProductList: React.FC<CategoryProductListProps> = props => 
             products,
             product => {
               const isSelected = product ? isChecked(product.id) : false;
-              const channel = product?.channelListings.find(
-                listing => listing.channel.id === selectedChannelId
-              );
 
               return (
                 <TableRow
@@ -182,35 +136,6 @@ export const CategoryProductList: React.FC<CategoryProductListProps> = props => 
                   >
                     {product ? product.name : <Skeleton />}
                   </TableCellAvatar>
-                  <TableCell className={classes.colType}>
-                    {product && product.productType ? (
-                      product.productType.name
-                    ) : (
-                      <Skeleton />
-                    )}
-                  </TableCell>
-                  <TableCell className={classes.colPublished}>
-                    {product && !product?.channelListings?.length ? (
-                      "-"
-                    ) : product?.channelListings !== undefined ? (
-                      <ChannelsAvailabilityDropdown
-                        allChannelsCount={channelsCount}
-                        channels={product?.channelListings}
-                      />
-                    ) : (
-                      <Skeleton />
-                    )}
-                  </TableCell>
-                  <TableCell className={classes.colPrice}>
-                    {product?.channelListings ? (
-                      <MoneyRange
-                        from={channel?.pricing?.priceRange?.start?.net}
-                        to={channel?.pricing?.priceRange?.stop?.net}
-                      />
-                    ) : (
-                      <Skeleton />
-                    )}
-                  </TableCell>
                 </TableRow>
               );
             },

--- a/src/categories/components/CategoryProducts/CategoryProducts.tsx
+++ b/src/categories/components/CategoryProducts/CategoryProducts.tsx
@@ -53,7 +53,11 @@ export const CategoryProducts: React.FC<CategoryProductsProps> = ({
                 categories: [categoryId]
               })}
             >
-              <Button color="primary" variant="text" data-test-id="addProducts">
+              <Button
+                color="primary"
+                variant="text"
+                data-test-id="viewProducts"
+              >
                 <FormattedMessage
                   defaultMessage="View products"
                   description="button"

--- a/src/categories/components/CategoryProducts/CategoryProducts.tsx
+++ b/src/categories/components/CategoryProducts/CategoryProducts.tsx
@@ -1,25 +1,23 @@
 import { Button, Card } from "@material-ui/core";
+import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import CardTitle from "@saleor/components/CardTitle";
-import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
+import { InternalLink } from "@saleor/components/InternalLink";
+import { productListUrl } from "@saleor/products/urls";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
-import { ChannelProps, ListActions, PageListProps } from "../../../types";
+import { ListActions, PageListProps } from "../../../types";
 import { CategoryDetails_category_products_edges_node } from "../../types/CategoryDetails";
 import CategoryProductList from "../CategoryProductList";
+import { useStyles } from "./styles";
 
-interface CategoryProductsProps
-  extends PageListProps,
-    ListActions,
-    ChannelProps {
+interface CategoryProductsProps extends PageListProps, ListActions {
   products: CategoryDetails_category_products_edges_node[];
-  channelChoices: SingleAutocompleteChoiceType[];
-  channelsCount: number;
   categoryName: string;
+  categoryId: string;
 }
 
 export const CategoryProducts: React.FC<CategoryProductsProps> = ({
-  channelsCount,
   products,
   disabled,
   pageInfo,
@@ -27,15 +25,16 @@ export const CategoryProducts: React.FC<CategoryProductsProps> = ({
   onNextPage,
   onPreviousPage,
   onRowClick,
+  categoryId,
   categoryName,
   isChecked,
   selected,
-  selectedChannelId,
   toggle,
   toggleAll,
   toolbar
 }) => {
   const intl = useIntl();
+  const classes = useStyles();
 
   return (
     <Card>
@@ -48,22 +47,35 @@ export const CategoryProducts: React.FC<CategoryProductsProps> = ({
           { categoryName }
         )}
         toolbar={
-          <Button
-            color="primary"
-            variant="text"
-            onClick={onAdd}
-            data-test-id="addProducts"
-          >
-            <FormattedMessage
-              defaultMessage="Add product"
-              description="button"
-            />
-          </Button>
+          <div className={classes.toolbar}>
+            <InternalLink
+              to={productListUrl({
+                categories: [categoryId]
+              })}
+            >
+              <Button color="primary" variant="text" data-test-id="addProducts">
+                <FormattedMessage
+                  defaultMessage="View products"
+                  description="button"
+                />
+              </Button>
+            </InternalLink>
+            <HorizontalSpacer />
+            <Button
+              color="primary"
+              variant="text"
+              onClick={onAdd}
+              data-test-id="addProducts"
+            >
+              <FormattedMessage
+                defaultMessage="Add product"
+                description="button"
+              />
+            </Button>
+          </div>
         }
       />
       <CategoryProductList
-        channelsCount={channelsCount}
-        selectedChannelId={selectedChannelId}
         products={products}
         disabled={disabled}
         pageInfo={pageInfo}

--- a/src/categories/components/CategoryProducts/styles.ts
+++ b/src/categories/components/CategoryProducts/styles.ts
@@ -1,0 +1,10 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  () => ({
+    toolbar: {
+      display: "flex"
+    }
+  }),
+  { name: "CategoryProducts" }
+);

--- a/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
+++ b/src/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
@@ -7,7 +7,6 @@ import Metadata from "@saleor/components/Metadata/Metadata";
 import PageHeader from "@saleor/components/PageHeader";
 import Savebar from "@saleor/components/Savebar";
 import SeoForm from "@saleor/components/SeoForm";
-import { SingleAutocompleteChoiceType } from "@saleor/components/SingleAutocompleteSelectField";
 import { Tab, TabContainer } from "@saleor/components/Tab";
 import { ProductErrorFragment } from "@saleor/fragments/types/ProductErrorFragment";
 import { SubmitPromise } from "@saleor/hooks/useForm";
@@ -17,7 +16,7 @@ import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { maybe } from "../../../misc";
-import { ChannelProps, TabListActions } from "../../../types";
+import { TabListActions } from "../../../types";
 import CategoryDetailsForm from "../../components/CategoryDetailsForm";
 import CategoryList from "../../components/CategoryList";
 import {
@@ -35,8 +34,7 @@ export enum CategoryPageTab {
 }
 
 export interface CategoryUpdatePageProps
-  extends TabListActions<"productListToolbar" | "subcategoryListToolbar">,
-    ChannelProps {
+  extends TabListActions<"productListToolbar" | "subcategoryListToolbar"> {
   changeTab: (index: CategoryPageTab) => void;
   currentTab: CategoryPageTab;
   errors: ProductErrorFragment[];
@@ -49,8 +47,6 @@ export interface CategoryUpdatePageProps
     hasPreviousPage: boolean;
   };
   saveButtonBarState: ConfirmButtonTransitionState;
-  channelChoices: SingleAutocompleteChoiceType[];
-  channelsCount: number;
   onImageDelete: () => void;
   onSubmit: (data: CategoryUpdateData) => SubmitPromise;
   onImageUpload(file: File);
@@ -69,8 +65,6 @@ const ProductsTab = Tab(CategoryPageTab.products);
 
 export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
   changeTab,
-  channelChoices,
-  channelsCount,
   currentTab,
   category,
   disabled,
@@ -93,7 +87,6 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
   isChecked,
   productListToolbar,
   selected,
-  selectedChannelId,
   subcategoryListToolbar,
   toggle,
   toggleAll
@@ -206,8 +199,7 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
           )}
           {currentTab === CategoryPageTab.products && (
             <CategoryProducts
-              channelsCount={channelsCount}
-              channelChoices={channelChoices}
+              categoryId={category?.id}
               categoryName={category?.name}
               products={products}
               disabled={disabled}
@@ -219,7 +211,6 @@ export const CategoryUpdatePage: React.FC<CategoryUpdatePageProps> = ({
               toggle={toggle}
               toggleAll={toggleAll}
               selected={selected}
-              selectedChannelId={selectedChannelId}
               isChecked={isChecked}
               toolbar={productListToolbar}
             />

--- a/src/categories/queries.ts
+++ b/src/categories/queries.ts
@@ -3,7 +3,6 @@ import {
   categoryFragment
 } from "@saleor/fragments/categories";
 import { pageInfoFragment } from "@saleor/fragments/pageInfo";
-import { channelListingProductFragment } from "@saleor/fragments/products";
 import makeQuery from "@saleor/hooks/makeQuery";
 import gql from "graphql-tag";
 
@@ -49,7 +48,6 @@ export const useRootCategoriesQuery = makeQuery<RootCategories, {}>(
 );
 
 export const categoryDetails = gql`
-  ${channelListingProductFragment}
   ${categoryFragment}
   ${categoryDetailsFragment}
   ${pageInfoFragment}
@@ -83,13 +81,6 @@ export const categoryDetails = gql`
             name
             thumbnail {
               url
-            }
-            productType {
-              id
-              name
-            }
-            channelListings {
-              ...ChannelListingProductFragment
             }
           }
         }

--- a/src/categories/types/CategoryDetails.ts
+++ b/src/categories/types/CategoryDetails.ts
@@ -80,70 +80,11 @@ export interface CategoryDetails_category_products_edges_node_thumbnail {
   url: string;
 }
 
-export interface CategoryDetails_category_products_edges_node_productType {
-  __typename: "ProductType";
-  id: string;
-  name: string;
-}
-
-export interface CategoryDetails_category_products_edges_node_channelListings_channel {
-  __typename: "Channel";
-  id: string;
-  name: string;
-  currencyCode: string;
-}
-
-export interface CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange_start_net {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
-export interface CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange_start {
-  __typename: "TaxedMoney";
-  net: CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange_start_net;
-}
-
-export interface CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange_stop_net {
-  __typename: "Money";
-  amount: number;
-  currency: string;
-}
-
-export interface CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange_stop {
-  __typename: "TaxedMoney";
-  net: CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange_stop_net;
-}
-
-export interface CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange {
-  __typename: "TaxedMoneyRange";
-  start: CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange_start | null;
-  stop: CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange_stop | null;
-}
-
-export interface CategoryDetails_category_products_edges_node_channelListings_pricing {
-  __typename: "ProductPricingInfo";
-  priceRange: CategoryDetails_category_products_edges_node_channelListings_pricing_priceRange | null;
-}
-
-export interface CategoryDetails_category_products_edges_node_channelListings {
-  __typename: "ProductChannelListing";
-  isPublished: boolean;
-  publicationDate: any | null;
-  isAvailableForPurchase: boolean | null;
-  availableForPurchase: any | null;
-  visibleInListings: boolean;
-  channel: CategoryDetails_category_products_edges_node_channelListings_channel;
-  pricing: CategoryDetails_category_products_edges_node_channelListings_pricing | null;
-}
-
 export interface CategoryDetails_category_products_edges_node {
   __typename: "Product";
   id: string;
   name: string;
   thumbnail: CategoryDetails_category_products_edges_node_thumbnail | null;
-  productType: CategoryDetails_category_products_edges_node_productType;
-  channelListings: CategoryDetails_category_products_edges_node_channelListings[] | null;
 }
 
 export interface CategoryDetails_category_products_edges {

--- a/src/categories/views/CategoryDetails.tsx
+++ b/src/categories/views/CategoryDetails.tsx
@@ -1,9 +1,7 @@
 import { DialogContentText, IconButton } from "@material-ui/core";
 import DeleteIcon from "@material-ui/icons/Delete";
 import ActionDialog from "@saleor/components/ActionDialog";
-import useAppChannel from "@saleor/components/AppLayout/AppChannelContext";
 import NotFoundPage from "@saleor/components/NotFoundPage";
-import Skeleton from "@saleor/components/Skeleton";
 import { WindowTitle } from "@saleor/components/WindowTitle";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
@@ -14,7 +12,7 @@ import usePaginator, {
 import { commonMessages, errorMessages } from "@saleor/intl";
 import createDialogActionHandlers from "@saleor/utils/handlers/dialogActionHandlers";
 import createMetadataUpdateHandler from "@saleor/utils/handlers/metadataUpdateHandler";
-import { mapEdgesToItems, mapNodeToChoice } from "@saleor/utils/maps";
+import { mapEdgesToItems } from "@saleor/utils/maps";
 import {
   useMetadataUpdate,
   usePrivateMetadataUpdate
@@ -80,10 +78,6 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
     displayLoader: true,
     variables: { ...paginationState, id }
   });
-
-  const { availableChannels, channel } = useAppChannel(false);
-
-  const channelChoices = mapNodeToChoice(availableChannels);
 
   const category = data?.category;
 
@@ -209,16 +203,10 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
     variables => updatePrivateMetadata({ variables })
   );
 
-  if (typeof channel === "undefined") {
-    return <Skeleton />;
-  }
-
   return (
     <>
       <WindowTitle title={maybe(() => data.category.name)} />
       <CategoryUpdatePage
-        channelsCount={availableChannels.length}
-        channelChoices={channelChoices}
         changeTab={changeTab}
         currentTab={params.activeTab}
         category={maybe(() => data.category)}
@@ -260,7 +248,6 @@ export const CategoryDetails: React.FC<CategoryDetailsProps> = ({
         onSubmit={handleSubmit}
         products={mapEdgesToItems(data?.category?.products)}
         saveButtonBarState={updateResult.status}
-        selectedChannelId={channel?.id}
         subcategories={mapEdgesToItems(data?.category?.children)}
         subcategoryListToolbar={
           <IconButton

--- a/src/components/InternalLink/InternalLink.tsx
+++ b/src/components/InternalLink/InternalLink.tsx
@@ -1,0 +1,13 @@
+import classNames from "classnames";
+import React from "react";
+import { Link, LinkProps } from "react-router-dom";
+
+import { useStyles } from "./styles";
+
+export const InternalLink: React.FC<LinkProps> = ({ className, ...props }) => {
+  const classes = useStyles();
+
+  return <Link className={classNames(classes.root, className)} {...props} />;
+};
+
+export default InternalLink;

--- a/src/components/InternalLink/index.ts
+++ b/src/components/InternalLink/index.ts
@@ -1,0 +1,1 @@
+export * from "./InternalLink";

--- a/src/components/InternalLink/styles.ts
+++ b/src/components/InternalLink/styles.ts
@@ -1,0 +1,10 @@
+import { makeStyles } from "@saleor/macaw-ui";
+
+export const useStyles = makeStyles(
+  () => ({
+    root: {
+      textDecoration: "none"
+    }
+  }),
+  { name: "InternalLink" }
+);

--- a/src/fragments/types/MetadataFragment.ts
+++ b/src/fragments/types/MetadataFragment.ts
@@ -20,7 +20,7 @@ export interface MetadataFragment_privateMetadata {
 }
 
 export interface MetadataFragment {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Attribute" | "Category" | "Checkout" | "Collection" | "DigitalContent" | "Fulfillment" | "Invoice" | "Menu" | "MenuItem" | "Order" | "Page" | "PageType" | "Product" | "ProductType" | "ProductVariant" | "Sale" | "ShippingMethod" | "ShippingZone" | "User" | "Voucher" | "Warehouse";
   metadata: (MetadataFragment_metadata | null)[];
   privateMetadata: (MetadataFragment_privateMetadata | null)[];
 }

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -165,7 +165,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     productVariantCreateOpts
   ] = useVariantCreateMutation({});
 
-  const { availableChannels, channel } = useAppChannel(false);
+  const { availableChannels, channel } = useAppChannel();
   const { data, loading, refetch } = useProductDetails({
     displayLoader: true,
     variables: {

--- a/src/shipping/views/ShippingZoneDetails/index.tsx
+++ b/src/shipping/views/ShippingZoneDetails/index.tsx
@@ -73,7 +73,7 @@ const ShippingZoneDetails: React.FC<ShippingZoneDetailsProps> = ({
     displayLoader: true,
     variables: { id, ...paginationState }
   });
-  const { availableChannels, channel } = useAppChannel(false);
+  const { availableChannels, channel } = useAppChannel();
 
   const [openModal, closeModal] = createDialogActionHandlers<
     ShippingZoneUrlDialog,

--- a/src/storybook/stories/categories/CategoryUpdatePage.tsx
+++ b/src/storybook/stories/categories/CategoryUpdatePage.tsx
@@ -1,6 +1,6 @@
 import placeholderImage from "@assets/images/placeholder255x255.png";
 import { ProductErrorCode } from "@saleor/types/globalTypes";
-import { mapEdgesToItems, mapNodeToChoice } from "@saleor/utils/maps";
+import { mapEdgesToItems } from "@saleor/utils/maps";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
@@ -14,13 +14,9 @@ import Decorator from "../../Decorator";
 
 const category = categoryFixture(placeholderImage);
 
-const channelChoices = mapNodeToChoice(mapEdgesToItems(category?.products));
-
 const updateProps: Omit<CategoryUpdatePageProps, "classes"> = {
   category,
   changeTab: undefined,
-  channelChoices,
-  channelsCount: 2,
   currentTab: CategoryPageTab.categories,
   disabled: false,
   errors: [],
@@ -42,7 +38,6 @@ const updateProps: Omit<CategoryUpdatePageProps, "classes"> = {
   productListToolbar: null,
   products: mapEdgesToItems(category.products),
   saveButtonBarState: "default",
-  selectedChannelId: "123",
   subcategories: mapEdgesToItems(category.children),
   subcategoryListToolbar: null,
   ...listActionsProps

--- a/src/utils/metadata/types/UpdateMetadata.ts
+++ b/src/utils/metadata/types/UpdateMetadata.ts
@@ -39,7 +39,7 @@ export interface UpdateMetadata_deleteMetadata_item_privateMetadata {
 }
 
 export interface UpdateMetadata_deleteMetadata_item {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Attribute" | "Category" | "Checkout" | "Collection" | "DigitalContent" | "Fulfillment" | "Invoice" | "Menu" | "MenuItem" | "Order" | "Page" | "PageType" | "Product" | "ProductType" | "ProductVariant" | "Sale" | "ShippingMethod" | "ShippingZone" | "User" | "Voucher" | "Warehouse";
   metadata: (UpdateMetadata_deleteMetadata_item_metadata | null)[];
   privateMetadata: (UpdateMetadata_deleteMetadata_item_privateMetadata | null)[];
   id: string;

--- a/src/utils/metadata/types/UpdatePrivateMetadata.ts
+++ b/src/utils/metadata/types/UpdatePrivateMetadata.ts
@@ -39,7 +39,7 @@ export interface UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadat
 }
 
 export interface UpdatePrivateMetadata_deletePrivateMetadata_item {
-  __typename: "App" | "Warehouse" | "ShippingZone" | "ShippingMethod" | "Product" | "ProductType" | "Attribute" | "Category" | "ProductVariant" | "DigitalContent" | "Collection" | "Page" | "PageType" | "Sale" | "Voucher" | "MenuItem" | "Menu" | "User" | "Checkout" | "Order" | "Fulfillment" | "Invoice";
+  __typename: "App" | "Attribute" | "Category" | "Checkout" | "Collection" | "DigitalContent" | "Fulfillment" | "Invoice" | "Menu" | "MenuItem" | "Order" | "Page" | "PageType" | "Product" | "ProductType" | "ProductVariant" | "Sale" | "ShippingMethod" | "ShippingZone" | "User" | "Voucher" | "Warehouse";
   metadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_metadata | null)[];
   privateMetadata: (UpdatePrivateMetadata_deletePrivateMetadata_item_privateMetadata | null)[];
   id: string;


### PR DESCRIPTION
I want to merge this change because it adds a channel picker to Product Details and simplifies the query/view of category details. New component is introduced called `InternalLink` which will be used in upcoming refactor to move all navigation actions from `onClick`. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** master/3.0<!-- For example: feature/warehouses  -->

### Screenshots
![image](https://user-images.githubusercontent.com/28310983/131988246-dd6cc7b2-682f-4a79-9b4c-0cdf5ac40c8f.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
