### PR TITLE
Fix draft order incorrect label

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -3655,13 +3655,13 @@
     "context": "total price of ordered products",
     "string": "Total"
   },
-  "src_dot_orders_dot_components_dot_OrderDraftDetailsSummary_dot_addCustomerInfo": {
-    "context": "add customer first label",
-    "string": "add customer first"
-  },
   "src_dot_orders_dot_components_dot_OrderDraftDetailsSummary_dot_addDiscount": {
     "context": "add discount button",
     "string": "Add Discount"
+  },
+  "src_dot_orders_dot_components_dot_OrderDraftDetailsSummary_dot_addShippingAddressInfo": {
+    "context": "add shipping address first label",
+    "string": "add shipping address first"
   },
   "src_dot_orders_dot_components_dot_OrderDraftDetailsSummary_dot_addShippingCarrier": {
     "context": "add shipping carrier button",

--- a/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
+++ b/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
@@ -12,7 +12,7 @@ import { useIntl } from "react-intl";
 import { OrderDetails_order } from "../../types/OrderDetails";
 import OrderDiscountCommonModal from "../OrderDiscountCommonModal";
 import { ORDER_DISCOUNT } from "../OrderDiscountCommonModal/types";
-import messages from "./messages";
+import { messages } from "./messages";
 
 const useStyles = makeStyles(
   theme => ({

--- a/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
+++ b/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
@@ -47,9 +47,9 @@ const useStyles = makeStyles(
 );
 
 const messages = defineMessages({
-  addCustomerInfo: {
-    defaultMessage: "add customer first",
-    description: "add customer first label"
+  addShippingAddressInfo: {
+    defaultMessage: "add shipping address first",
+    description: "add shipping address first label"
   },
   subtotal: {
     defaultMessage: "Subtotal",
@@ -181,7 +181,9 @@ const OrderDraftDetailsSummary: React.FC<OrderDraftDetailsSummaryProps> = props 
       );
     }
 
-    const addCustomerInfo = intl.formatMessage(messages.addCustomerInfo);
+    const addShippingAddressInfo = intl.formatMessage(
+      messages.addShippingAddressInfo
+    );
 
     return (
       <div className={classes.shippingMethodContainer}>
@@ -189,7 +191,7 @@ const OrderDraftDetailsSummary: React.FC<OrderDraftDetailsSummaryProps> = props 
           {shippingCarrierBase}
         </Link>
         <HorizontalSpacer />
-        <Typography variant="caption">{`(${addCustomerInfo})`}</Typography>
+        <Typography variant="caption">{`(${addShippingAddressInfo})`}</Typography>
       </div>
     );
   };

--- a/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
+++ b/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
@@ -8,11 +8,11 @@ import { OrderDiscountData } from "@saleor/products/components/OrderDiscountProv
 import { DiscountValueTypeEnum } from "@saleor/types/globalTypes";
 import React, { useRef } from "react";
 import { useIntl } from "react-intl";
-import { defineMessages } from "react-intl";
 
 import { OrderDetails_order } from "../../types/OrderDetails";
 import OrderDiscountCommonModal from "../OrderDiscountCommonModal";
 import { ORDER_DISCOUNT } from "../OrderDiscountCommonModal/types";
+import messages from "./messages";
 
 const useStyles = makeStyles(
   theme => ({
@@ -45,41 +45,6 @@ const useStyles = makeStyles(
   }),
   { name: "OrderDraftDetailsSummary" }
 );
-
-const messages = defineMessages({
-  addShippingAddressInfo: {
-    defaultMessage: "add shipping address first",
-    description: "add shipping address first label"
-  },
-  subtotal: {
-    defaultMessage: "Subtotal",
-    description: "subtotal price"
-  },
-  addDiscount: {
-    defaultMessage: "Add Discount",
-    description: "add discount button"
-  },
-  discount: {
-    defaultMessage: "Discount",
-    description: "discount button"
-  },
-  addShippingCarrier: {
-    defaultMessage: "Add shipping carrier",
-    description: "add shipping carrier button"
-  },
-  noShippingCarriers: {
-    defaultMessage: "No applicable shipping carriers",
-    description: "no shipping carriers title"
-  },
-  total: {
-    defaultMessage: "Total",
-    description: "total price"
-  },
-  taxes: {
-    defaultMessage: "Taxes (VAT included)",
-    description: "taxes title"
-  }
-});
 
 const PRICE_PLACEHOLDER = "---";
 

--- a/src/orders/components/OrderDraftDetailsSummary/messages.ts
+++ b/src/orders/components/OrderDraftDetailsSummary/messages.ts
@@ -1,6 +1,6 @@
 import { defineMessages } from "react-intl";
 
-export default defineMessages({
+export const messages = defineMessages({
   addShippingAddressInfo: {
     defaultMessage: "add shipping address first",
     description: "add shipping address first label"

--- a/src/orders/components/OrderDraftDetailsSummary/messages.ts
+++ b/src/orders/components/OrderDraftDetailsSummary/messages.ts
@@ -1,0 +1,36 @@
+import { defineMessages } from "react-intl";
+
+export default defineMessages({
+  addShippingAddressInfo: {
+    defaultMessage: "add shipping address first",
+    description: "add shipping address first label"
+  },
+  subtotal: {
+    defaultMessage: "Subtotal",
+    description: "subtotal price"
+  },
+  addDiscount: {
+    defaultMessage: "Add Discount",
+    description: "add discount button"
+  },
+  discount: {
+    defaultMessage: "Discount",
+    description: "discount button"
+  },
+  addShippingCarrier: {
+    defaultMessage: "Add shipping carrier",
+    description: "add shipping carrier button"
+  },
+  noShippingCarriers: {
+    defaultMessage: "No applicable shipping carriers",
+    description: "no shipping carriers title"
+  },
+  total: {
+    defaultMessage: "Total",
+    description: "total price"
+  },
+  taxes: {
+    defaultMessage: "Taxes (VAT included)",
+    description: "taxes title"
+  }
+});


### PR DESCRIPTION
I want to merge this change because it fixes the incorrect label in order drafts.

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots
before:
![image](https://user-images.githubusercontent.com/41952692/132657962-93176b38-6fe0-420c-93b0-dc97239782c1.png)

after:
![image](https://user-images.githubusercontent.com/41952692/132657773-9b1cbe54-adff-464c-af29-add786b8f872.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
