### PR TITLE
Hiding channel picker on simple product edit page

### DIFF
--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -165,7 +165,6 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     productVariantCreateOpts
   ] = useVariantCreateMutation({});
 
-  const { availableChannels, channel } = useAppChannel();
   const { data, loading, refetch } = useProductDetails({
     displayLoader: true,
     variables: {
@@ -173,6 +172,11 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
       firstValues: VALUES_PAGINATE_BY
     }
   });
+
+  const isSimpleProduct = !data?.product?.productType?.hasVariants;
+
+  const { availableChannels, channel } = useAppChannel(!isSimpleProduct);
+
   const limitOpts = useShopLimitsQuery({
     variables: {
       productVariants: true
@@ -269,8 +273,6 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
   ).sort((channel, nextChannel) =>
     channel.name.localeCompare(nextChannel.name)
   );
-
-  const isSimpleProduct = !data?.product?.productType?.hasVariants;
 
   const {
     channelsWithVariantsData,


### PR DESCRIPTION
I want to merge this change because channel picker can be hidden on `simple` products. Changing channels doesn't affect edition of a simple product.

**PR intended to be tested with API branch:** 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
Before:
![image](https://user-images.githubusercontent.com/41952692/132707384-77e5a1cd-93d5-4cd9-bedc-7533c657a3bc.png)
After:
![image](https://user-images.githubusercontent.com/41952692/132707761-abdc5184-0f24-4bec-a5a6-ba50338fd57e.png)

Channel picker remains available on `non-simple` products:

![image](https://user-images.githubusercontent.com/41952692/132707971-1d90a3f5-8ee9-4936-821a-adb536c27b47.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [x] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
