### PR TITLE
Fix back button on manage channels at product details

### DIFF
--- a/src/channels/ChannelsWithVariantsAvailabilityCard/ChannelWithVariantAvailabilityItemWrapper.tsx
+++ b/src/channels/ChannelsWithVariantsAvailabilityCard/ChannelWithVariantAvailabilityItemWrapper.tsx
@@ -111,9 +111,12 @@ const ChannelWithVariantsAvailabilityItemWrapper: React.FC<ChannelAvailabilityIt
 
   const variantsCount = selectedVariantsIds.length;
 
-  const variantsLabel = areAllChannelVariantsSelected(variants, {
-    selectedVariantsIds
-  })
+  const variantsLabel = areAllChannelVariantsSelected(
+    variants?.map(variant => variant.id),
+    {
+      selectedVariantsIds
+    }
+  )
     ? messages.allVariantsLabel
     : messages.variantCountLabel;
 

--- a/src/channels/ChannelsWithVariantsAvailabilityCard/ChannelWithVariantAvailabilityItemWrapper.tsx
+++ b/src/channels/ChannelsWithVariantsAvailabilityCard/ChannelWithVariantAvailabilityItemWrapper.tsx
@@ -113,9 +113,7 @@ const ChannelWithVariantsAvailabilityItemWrapper: React.FC<ChannelAvailabilityIt
 
   const variantsLabel = areAllChannelVariantsSelected(
     variants?.map(variant => variant.id),
-    {
-      selectedVariantsIds
-    }
+    selectedVariantsIds
   )
     ? messages.allVariantsLabel
     : messages.variantCountLabel;

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.stories.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.stories.tsx
@@ -1,4 +1,3 @@
-import { ChannelData } from "@saleor/channels/utils";
 import { ProductDetails_product_variants } from "@saleor/products/types/ProductDetails";
 import CommonDecorator from "@saleor/storybook/Decorator";
 import { storiesOf } from "@storybook/react";
@@ -12,17 +11,20 @@ const props: ChannelsAvailabilityDialogProps = {
   channels: [
     {
       id: "1",
-      name: "Channel 1"
+      name: "Channel 1",
+      variantsIds: []
     },
     {
       id: "2",
-      name: "Channel 2"
+      name: "Channel 2",
+      variantsIds: []
     },
     {
       id: "3",
-      name: "Channel 3"
+      name: "Channel 3",
+      variantsIds: []
     }
-  ] as ChannelData[],
+  ],
   variants: [
     {
       id: "variantA",

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.stories.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.stories.tsx
@@ -51,30 +51,8 @@ const props: ChannelsAvailabilityDialogProps = {
     }
   ] as ProductDetails_product_variants[],
   onClose: () => undefined,
-  addVariantToChannel: () => undefined,
-  removeVariantFromChannel: () => undefined,
-  channelsWithVariantsData: {
-    ["1"]: {
-      selectedVariantsIds: ["variantA", "variantB"],
-      variantsIdsToRemove: [],
-      variantsIdsToAdd: []
-    },
-    ["2"]: {
-      selectedVariantsIds: ["variantA", "variantC"],
-      variantsIdsToRemove: [],
-      variantsIdsToAdd: []
-    },
-    ["3"]: {
-      selectedVariantsIds: [],
-      variantsIdsToRemove: [],
-      variantsIdsToAdd: []
-    }
-  },
   onConfirm: () => undefined,
-  open: true,
-  toggleAllChannels: () => undefined,
-  toggleAllChannelVariants: () => () => undefined,
-  haveChannelsWithVariantsDataChanged: true
+  open: true
 };
 
 storiesOf("Channels / Channels with Variants Availability Dialog", module)

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.stories.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.stories.tsx
@@ -50,7 +50,7 @@ const props: ChannelsAvailabilityDialogProps = {
       media: []
     }
   ] as ProductDetails_product_variants[],
-  onChannelsWithVariantsConfirm: () => undefined,
+  onClose: () => undefined,
   addVariantToChannel: () => undefined,
   removeVariantFromChannel: () => undefined,
   channelsWithVariantsData: {
@@ -70,8 +70,8 @@ const props: ChannelsAvailabilityDialogProps = {
       variantsIdsToAdd: []
     }
   },
-  onChannelsAvailiabilityModalClose: () => undefined,
-  isChannelsAvailabilityModalOpen: true,
+  onConfirm: () => undefined,
+  open: true,
   toggleAllChannels: () => undefined,
   toggleAllChannelVariants: () => () => undefined,
   haveChannelsWithVariantsDataChanged: true

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
@@ -6,6 +6,7 @@ import {
   areAllVariantsAtAllChannelsSelected,
   areAnyChannelVariantsSelected
 } from "@saleor/products/views/ProductUpdate/utils";
+import { DialogProps } from "@saleor/types";
 import React, { useState } from "react";
 import { useIntl } from "react-intl";
 import { defineMessages } from "react-intl";
@@ -30,21 +31,23 @@ type UseChannelsWithVariantsCommonProps = Omit<
 >;
 
 export interface ChannelsAvailabilityDialogProps
-  extends UseChannelsWithVariantsCommonProps {
+  extends UseChannelsWithVariantsCommonProps,
+    DialogProps {
   channels: ChannelData[];
   contentType?: string;
   variants: ProductDetails_product_variants[];
+  onConfirm: () => void;
 }
 
 export const ChannelsWithVariantsAvailabilityDialog: React.FC<ChannelsAvailabilityDialogProps> = ({
   channels,
   contentType,
   variants,
-  isChannelsAvailabilityModalOpen,
+  open,
   toggleAllChannels,
   channelsWithVariantsData,
-  onChannelsAvailiabilityModalClose,
-  onChannelsWithVariantsConfirm,
+  onClose,
+  onConfirm,
   addVariantToChannel,
   removeVariantFromChannel,
   toggleAllChannelVariants
@@ -76,9 +79,9 @@ export const ChannelsWithVariantsAvailabilityDialog: React.FC<ChannelsAvailabili
   return (
     <ActionDialog
       confirmButtonState="default"
-      open={isChannelsAvailabilityModalOpen}
-      onClose={withChange(onChannelsAvailiabilityModalClose, false)}
-      onConfirm={withChange(onChannelsWithVariantsConfirm, false)}
+      open={open}
+      onClose={withChange(onClose, false)}
+      onConfirm={withChange(onConfirm, false)}
       title={intl.formatMessage(messages.title)}
       disabled={!changed}
     >

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
@@ -1,6 +1,7 @@
 import { ChannelData } from "@saleor/channels/utils";
 import ActionDialog from "@saleor/components/ActionDialog";
 import { ProductDetails_product_variants } from "@saleor/products/types/ProductDetails";
+import { channelVariantListing } from "@saleor/products/views/ProductUpdate/types";
 import useChannelsWithProductVariants from "@saleor/products/views/ProductUpdate/useChannelsWithProductVariants";
 import {
   areAllVariantsAtAllChannelsSelected,
@@ -27,7 +28,7 @@ export interface ChannelsAvailabilityDialogProps extends DialogProps {
   channels: ChannelData[];
   contentType?: string;
   variants: ProductDetails_product_variants[];
-  onConfirm: (listings: Record<string, string[]>) => void;
+  onConfirm: (listings: channelVariantListing) => void;
 }
 
 export const ChannelsWithVariantsAvailabilityDialog: React.FC<ChannelsAvailabilityDialogProps> = ({

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
@@ -28,6 +28,7 @@ type UseChannelsWithVariantsCommonProps = Omit<
   | "setHaveChannelsWithVariantsChanged"
   | "channelsData"
   | "setChannelsData"
+  | "hasChanged"
 >;
 
 export interface ChannelsAvailabilityDialogProps

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
@@ -4,7 +4,8 @@ import { ProductDetails_product_variants } from "@saleor/products/types/ProductD
 import { UseChannelsWithProductVariants } from "@saleor/products/views/ProductUpdate/types";
 import {
   areAllVariantsAtAllChannelsSelected,
-  areAnyChannelVariantsSelected
+  areAnyChannelVariantsSelected,
+  channelVariantListingDiffToDict
 } from "@saleor/products/views/ProductUpdate/utils";
 import { DialogProps } from "@saleor/types";
 import React, { useState } from "react";
@@ -61,7 +62,7 @@ export const ChannelsWithVariantsAvailabilityDialog: React.FC<ChannelsAvailabili
 
   const hasAllChannelsSelected = areAllVariantsAtAllChannelsSelected(
     variants.map(variant => variant.id),
-    channelsWithVariantsData
+    channelVariantListingDiffToDict(channelsWithVariantsData)
   );
 
   const isChannelSelected = (channelId: string) =>

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
@@ -59,7 +59,7 @@ export const ChannelsWithVariantsAvailabilityDialog: React.FC<ChannelsAvailabili
   );
 
   const hasAllChannelsSelected = areAllVariantsAtAllChannelsSelected(
-    variants,
+    variants.map(variant => variant.id),
     channelsWithVariantsData
   );
 

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
@@ -1,5 +1,6 @@
 import { ChannelData } from "@saleor/channels/utils";
 import ActionDialog from "@saleor/components/ActionDialog";
+import useModalDialogOpen from "@saleor/hooks/useModalDialogOpen";
 import { ProductDetails_product_variants } from "@saleor/products/types/ProductDetails";
 import { channelVariantListing } from "@saleor/products/views/ProductUpdate/types";
 import useChannelsWithProductVariants from "@saleor/products/views/ProductUpdate/useChannelsWithProductVariants";
@@ -47,11 +48,16 @@ export const ChannelsWithVariantsAvailabilityDialog: React.FC<ChannelsAvailabili
     addVariantToChannel,
     removeVariantFromChannel,
     toggleAllChannelVariants,
-    channelVariantListing
+    channelVariantListing,
+    reset
   } = useChannelsWithProductVariants(
     channels,
     variants?.map(variant => variant.id)
   );
+
+  useModalDialogOpen(open, {
+    onClose: reset
+  });
 
   const { query, onQueryChange, filteredChannels } = useChannelsSearch(
     channels

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialog.tsx
@@ -2,7 +2,7 @@ import { ChannelData } from "@saleor/channels/utils";
 import ActionDialog from "@saleor/components/ActionDialog";
 import useModalDialogOpen from "@saleor/hooks/useModalDialogOpen";
 import { ProductDetails_product_variants } from "@saleor/products/types/ProductDetails";
-import { channelVariantListing } from "@saleor/products/views/ProductUpdate/types";
+import { ChannelVariantListing } from "@saleor/products/views/ProductUpdate/types";
 import useChannelsWithProductVariants from "@saleor/products/views/ProductUpdate/useChannelsWithProductVariants";
 import {
   areAllVariantsAtAllChannelsSelected,
@@ -29,7 +29,7 @@ export interface ChannelsAvailabilityDialogProps extends DialogProps {
   channels: ChannelData[];
   contentType?: string;
   variants: ProductDetails_product_variants[];
-  onConfirm: (listings: channelVariantListing) => void;
+  onConfirm: (listings: ChannelVariantListing) => void;
 }
 
 export const ChannelsWithVariantsAvailabilityDialog: React.FC<ChannelsAvailabilityDialogProps> = ({

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -96,7 +96,7 @@ interface ChannelsWithVariantsAvailabilityDialogContentProps {
   addVariantToChannel: (channelId: string, variantId: string) => void;
   removeVariantFromChannel: (channelId: string, variantId: string) => void;
   channelsWithVariants: ChannelsWithVariantsData;
-  toggleAllChannelVariants: (channelId: string) => () => void;
+  toggleAllChannelVariants: (channelId: string) => void;
   isChannelSelected: (channelId: string) => boolean;
   channels: ChannelData[];
   allVariants: ProductDetails_product_variants[];
@@ -183,7 +183,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
                         />
                       </div>
                     }
-                    onChange={toggleAllChannelVariants(channelId)}
+                    onChange={() => toggleAllChannelVariants(channelId)}
                   />
                 </div>
                 <Divider />

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -14,7 +14,10 @@ import Label from "@saleor/orders/components/OrderHistory/Label";
 import { getById } from "@saleor/orders/components/OrderReturnPage/utils";
 import { ProductDetails_product_variants } from "@saleor/products/types/ProductDetails";
 import { ChannelsWithVariantsData } from "@saleor/products/views/ProductUpdate/types";
-import { areAllChannelVariantsSelected } from "@saleor/products/views/ProductUpdate/utils";
+import {
+  areAllChannelVariantsSelected,
+  channelVariantListingDiffToDict
+} from "@saleor/products/views/ProductUpdate/utils";
 import map from "lodash/map";
 import React, { ChangeEvent } from "react";
 import { defineMessages, useIntl } from "react-intl";
@@ -126,7 +129,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
   const selectChannelIcon = (channelId: string) =>
     areAllChannelVariantsSelected(
       allVariants?.map(variant => variant.id),
-      channelsWithVariants[channelId]
+      channelVariantListingDiffToDict(channelsWithVariants)[channelId]
     ) ? (
       <IconCheckboxChecked />
     ) : (

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -125,7 +125,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
 
   const selectChannelIcon = (channelId: string) =>
     areAllChannelVariantsSelected(
-      allVariants,
+      allVariants?.map(variant => variant.id),
       channelsWithVariants[channelId]
     ) ? (
       <IconCheckboxChecked />

--- a/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
+++ b/src/channels/components/ChannelsWithVariantsAvailabilityDialog/ChannelsWithVariantsAvailabilityDialogContent.tsx
@@ -158,6 +158,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
           <ExpansionPanel
             classes={expanderClasses}
             data-test-id="expand-channel-row"
+            key={channelId}
           >
             <ExpansionPanelSummary
               expandIcon={<IconChevronDown />}
@@ -193,7 +194,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
               </div>
             </ExpansionPanelSummary>
             {allVariants.map(({ id: variantId, name }) => (
-              <>
+              <React.Fragment key={variantId}>
                 <div
                   data-test-id="channel-variant-row"
                   key={variantId}
@@ -212,7 +213,7 @@ const ChannelsWithVariantsAvailabilityDialogContent: React.FC<ChannelsWithVarian
                   />
                 </div>
                 <Divider />
-              </>
+              </React.Fragment>
             ))}
           </ExpansionPanel>
         );

--- a/src/components/ActionDialog/ActionDialog.tsx
+++ b/src/components/ActionDialog/ActionDialog.tsx
@@ -18,10 +18,10 @@ interface ActionDialogProps extends DialogProps {
 }
 
 const ActionDialog: React.FC<ActionDialogProps> = props => {
-  const { children, open, title, onClose, variant, ...rest } = props;
+  const { children, open, title, onClose, variant, maxWidth, ...rest } = props;
 
   return (
-    <Dialog fullWidth onClose={onClose} open={open} {...rest}>
+    <Dialog fullWidth onClose={onClose} open={open} maxWidth={maxWidth}>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>{children}</DialogContent>
       <DialogButtons {...rest} onClose={onClose} variant={variant} />

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -278,7 +278,6 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
   const {
     channelsWithVariantsData,
     haveChannelsWithVariantsDataChanged,
-    setHaveChannelsWithVariantsChanged,
     channelsData,
     setChannelsData,
     ...channelsWithVariantsProps
@@ -563,10 +562,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
         onDelete={() => openModal("remove")}
         onImageReorder={handleImageReorder}
         onMediaUrlUpload={handleMediaUrlUpload}
-        onSubmit={(formData: ProductUpdatePageSubmitData) => {
-          setHaveChannelsWithVariantsChanged(false);
-          return handleSubmit(formData);
-        }}
+        onSubmit={handleSubmit}
         onWarehouseConfigure={() => navigate(warehouseAddPath)}
         onVariantAdd={handleVariantAdd}
         onVariantsAdd={() => openModal("add-variants")}

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -280,7 +280,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
   const {
     channelsWithVariantsData,
     hasChanged: hasChannelVariantListingChanged,
-    ...channelsWithVariantsProps
+    setChannelVariantListing
   } = useChannelsWithProductVariants(
     allChannels,
     product?.variants.map(variant => variant.id)
@@ -513,13 +513,14 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
           />
         ) : (
           <ChannelsWithVariantsAvailabilityDialog
-            {...channelsWithVariantsProps}
-            channelsWithVariantsData={channelsWithVariantsData}
             channels={allChannels}
             variants={product?.variants}
             open={params.action === CHANNELS_AVAILIABILITY_MODAL_SELECTOR}
             onClose={closeModal}
-            onConfirm={closeModal}
+            onConfirm={listings => {
+              closeModal();
+              setChannelVariantListing(listings);
+            }}
           />
         ))}
       <ProductUpdatePage

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -27,6 +27,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import useOnSetDefaultVariant from "@saleor/hooks/useOnSetDefaultVariant";
 import useShop from "@saleor/hooks/useShop";
+import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import { commonMessages, errorMessages } from "@saleor/intl";
 import ProductVariantCreateDialog from "@saleor/products/components/ProductVariantCreateDialog";
 import {
@@ -275,11 +276,12 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     channel.name.localeCompare(nextChannel.name)
   );
 
+  const isSimpleProduct = !data?.product?.productType?.hasVariants;
+
+  const [channelsData, setChannelsData] = useStateFromProps(allChannels);
   const {
     channelsWithVariantsData,
     hasChanged: hasChannelVariantListingChanged,
-    channelsData,
-    setChannelsData,
     ...channelsWithVariantsProps
   } = useChannelsWithProductVariants(
     allChannels,

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -276,6 +276,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
 
   const [channelsData, setChannelsData] = useStateFromProps(allChannels);
   const {
+    channels: updatedChannels,
     channelsWithVariantsData,
     hasChanged: hasChannelVariantListingChanged,
     setChannelVariantListing
@@ -508,7 +509,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
           />
         ) : (
           <ChannelsWithVariantsAvailabilityDialog
-            channels={allChannels}
+            channels={updatedChannels}
             variants={product?.variants}
             open={params.action === CHANNELS_AVAILIABILITY_MODAL_SELECTOR}
             onClose={closeModal}

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -83,7 +83,7 @@ import {
   createUpdateHandler,
   createVariantReorderHandler
 } from "./handlers";
-import useChannelsWithProductVariants from "./useChannelsWithProductVariants";
+import useChannelVariantListings from "./useChannelVariantListings";
 
 const messages = defineMessages({
   deleteProductDialogTitle: {
@@ -281,10 +281,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     channelsWithVariantsData,
     hasChanged: hasChannelVariantListingChanged,
     setChannelVariantListing
-  } = useChannelsWithProductVariants(
-    allChannels,
-    product?.variants.map(variant => variant.id)
-  );
+  } = useChannelVariantListings(allChannels);
 
   const productChannelsChoices: ChannelData[] = createSortedChannelsDataFromProduct(
     product

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -282,10 +282,10 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     channelsData,
     setChannelsData,
     ...channelsWithVariantsProps
-  } = useChannelsWithProductVariants({
-    channels: allChannels,
-    variants: product?.variants
-  });
+  } = useChannelsWithProductVariants(
+    allChannels,
+    product?.variants.map(variant => variant.id)
+  );
 
   const productChannelsChoices: ChannelData[] = createSortedChannelsDataFromProduct(
     product

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -277,7 +277,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
 
   const {
     channelsWithVariantsData,
-    haveChannelsWithVariantsDataChanged,
+    hasChanged: hasChannelVariantListingChanged,
     channelsData,
     setChannelsData,
     ...channelsWithVariantsProps
@@ -513,11 +513,8 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
           />
         ) : (
           <ChannelsWithVariantsAvailabilityDialog
-            channelsWithVariantsData={channelsWithVariantsData}
-            haveChannelsWithVariantsDataChanged={
-              haveChannelsWithVariantsDataChanged
-            }
             {...channelsWithVariantsProps}
+            channelsWithVariantsData={channelsWithVariantsData}
             channels={allChannels}
             variants={product?.variants}
             open={params.action === CHANNELS_AVAILIABILITY_MODAL_SELECTOR}
@@ -527,7 +524,7 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
         ))}
       <ProductUpdatePage
         hasChannelChanged={
-          haveChannelsWithVariantsDataChanged ||
+          hasChannelVariantListingChanged ||
           productChannelsChoices?.length !== currentChannels?.length
         }
         isSimpleProduct={isSimpleProduct}

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -274,8 +274,6 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     channel.name.localeCompare(nextChannel.name)
   );
 
-  const isSimpleProduct = !data?.product?.productType?.hasVariants;
-
   const [channelsData, setChannelsData] = useStateFromProps(allChannels);
   const {
     channelsWithVariantsData,

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -62,9 +62,7 @@ import React from "react";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
 import { getMutationState } from "../../../misc";
-import ProductUpdatePage, {
-  ProductUpdatePageSubmitData
-} from "../../components/ProductUpdatePage";
+import ProductUpdatePage from "../../components/ProductUpdatePage";
 import { useProductDetails } from "../../queries";
 import { ProductMediaCreateVariables } from "../../types/ProductMediaCreate";
 import { ProductUpdate as ProductUpdateMutationResult } from "../../types/ProductUpdate";

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -77,6 +77,7 @@ import {
   productVariantCreatorUrl,
   productVariantEditUrl
 } from "../../urls";
+import { CHANNELS_AVAILIABILITY_MODAL_SELECTOR } from "./consts";
 import {
   createImageReorderHandler,
   createImageUploadHandler,
@@ -278,16 +279,12 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
     channelsWithVariantsData,
     haveChannelsWithVariantsDataChanged,
     setHaveChannelsWithVariantsChanged,
-    onChannelsAvailiabilityModalOpen,
     channelsData,
     setChannelsData,
     ...channelsWithVariantsProps
   } = useChannelsWithProductVariants({
     channels: allChannels,
-    variants: product?.variants,
-    action: params?.action,
-    openModal,
-    closeModal
+    variants: product?.variants
   });
 
   const productChannelsChoices: ChannelData[] = createSortedChannelsDataFromProduct(
@@ -524,6 +521,9 @@ export const ProductUpdate: React.FC<ProductUpdateProps> = ({ id, params }) => {
             {...channelsWithVariantsProps}
             channels={allChannels}
             variants={product?.variants}
+            open={params.action === CHANNELS_AVAILIABILITY_MODAL_SELECTOR}
+            onClose={closeModal}
+            onConfirm={closeModal}
           />
         ))}
       <ProductUpdatePage

--- a/src/products/views/ProductUpdate/consts.ts
+++ b/src/products/views/ProductUpdate/consts.ts
@@ -1,0 +1,9 @@
+import { ChannelWithVariantData } from "./types";
+
+export const CHANNELS_AVAILIABILITY_MODAL_SELECTOR = "open-channels-picker";
+
+export const initialChannelWithVariantData: ChannelWithVariantData = {
+  variantsIdsToRemove: [],
+  variantsIdsToAdd: [],
+  selectedVariantsIds: []
+};

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -1,5 +1,3 @@
-import { ChannelData } from "@saleor/channels/utils";
-
 export interface ChannelWithVariantData {
   selectedVariantsIds: string[];
   variantsIdsToRemove: string[];
@@ -9,8 +7,6 @@ export interface ChannelWithVariantData {
 export type ChannelsWithVariantsData = Record<string, ChannelWithVariantData>;
 
 export interface UseChannelsWithProductVariants {
-  channelsData: ChannelData[];
-  setChannelsData: (data: ChannelData[]) => void;
   addVariantToChannel: (channelId: string, variantId: string) => void;
   removeVariantFromChannel: (channelId: string, variantId: string) => void;
   channelsWithVariantsData: ChannelsWithVariantsData;

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -4,7 +4,7 @@ export interface ChannelWithVariantData {
   variantsIdsToAdd: string[];
 }
 
-export type channelVariantListing = Record<string, string[]>;
+export type ChannelVariantListing = Record<string, string[]>;
 export type ChannelsWithVariantsData = Record<string, ChannelWithVariantData>;
 
 export interface UseChannelsWithProductVariants {
@@ -14,7 +14,7 @@ export interface UseChannelsWithProductVariants {
   toggleAllChannels: () => void;
   toggleAllChannelVariants: (channelId: string) => void;
   hasChanged: boolean;
-  channelVariantListing: channelVariantListing;
-  setChannelVariantListing: (listings: channelVariantListing) => void;
+  channelVariantListing: ChannelVariantListing;
+  setChannelVariantListing: (listings: ChannelVariantListing) => void;
   reset: () => void;
 }

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -16,5 +16,5 @@ export interface UseChannelsWithProductVariants {
   channelsWithVariantsData: ChannelsWithVariantsData;
   toggleAllChannels: () => void;
   toggleAllChannelVariants: (channelId: string) => void;
-  haveChannelsWithVariantsDataChanged: boolean;
+  hasChanged: boolean;
 }

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -4,6 +4,7 @@ export interface ChannelWithVariantData {
   variantsIdsToAdd: string[];
 }
 
+export type channelVariantListing = Record<string, string[]>;
 export type ChannelsWithVariantsData = Record<string, ChannelWithVariantData>;
 
 export interface UseChannelsWithProductVariants {
@@ -13,6 +14,6 @@ export interface UseChannelsWithProductVariants {
   toggleAllChannels: () => void;
   toggleAllChannelVariants: (channelId: string) => void;
   hasChanged: boolean;
-  channelVariantListing: Record<string, string[]>;
-  setChannelVariantListing: (listings: Record<string, string[]>) => void;
+  channelVariantListing: channelVariantListing;
+  setChannelVariantListing: (listings: channelVariantListing) => void;
 }

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -1,14 +1,9 @@
-import { ChannelsAction } from "@saleor/channels/urls";
 import { ChannelData } from "@saleor/channels/utils";
 import { ProductDetails_product_variants } from "@saleor/products/types/ProductDetails";
-import { ProductUrlDialog } from "@saleor/products/urls";
 
 export interface UseChannelsWithProductVariantsProps {
   channels: ChannelData[];
   variants: ProductDetails_product_variants[];
-  action: ProductUrlDialog;
-  openModal: (action: ChannelsAction) => void;
-  closeModal: () => void;
 }
 
 export interface ChannelWithVariantData {
@@ -19,24 +14,12 @@ export interface ChannelWithVariantData {
 
 export type ChannelsWithVariantsData = Record<string, ChannelWithVariantData>;
 
-export const initialChannelWithVariantData: ChannelWithVariantData = {
-  variantsIdsToRemove: [],
-  variantsIdsToAdd: [],
-  selectedVariantsIds: []
-};
-
-export const CHANNELS_AVAILIABILITY_MODAL_SELECTOR = "open-channels-picker";
-
 export interface UseChannelsWithProductVariants {
   channelsData: ChannelData[];
   setChannelsData: (data: ChannelData[]) => void;
-  onChannelsWithVariantsConfirm: () => void;
   addVariantToChannel: (channelId: string, variantId: string) => void;
   removeVariantFromChannel: (channelId: string, variantId: string) => void;
   channelsWithVariantsData: ChannelsWithVariantsData;
-  onChannelsAvailiabilityModalOpen: () => void;
-  onChannelsAvailiabilityModalClose: () => void;
-  isChannelsAvailabilityModalOpen: boolean;
   toggleAllChannels: () => void;
   toggleAllChannelVariants: (channelId: string) => void;
   haveChannelsWithVariantsDataChanged: boolean;

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -1,10 +1,4 @@
 import { ChannelData } from "@saleor/channels/utils";
-import { ProductDetails_product_variants } from "@saleor/products/types/ProductDetails";
-
-export interface UseChannelsWithProductVariantsProps {
-  channels: ChannelData[];
-  variants: ProductDetails_product_variants[];
-}
 
 export interface ChannelWithVariantData {
   selectedVariantsIds: string[];

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -38,7 +38,7 @@ export interface UseChannelsWithProductVariants {
   onChannelsAvailiabilityModalClose: () => void;
   isChannelsAvailabilityModalOpen: boolean;
   toggleAllChannels: () => void;
-  toggleAllChannelVariants: (channelId: string) => () => void;
+  toggleAllChannelVariants: (channelId: string) => void;
   haveChannelsWithVariantsDataChanged: boolean;
   setHaveChannelsWithVariantsChanged: (hasChanged: boolean) => void;
 }

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -13,4 +13,6 @@ export interface UseChannelsWithProductVariants {
   toggleAllChannels: () => void;
   toggleAllChannelVariants: (channelId: string) => void;
   hasChanged: boolean;
+  channelVariantListing: Record<string, string[]>;
+  setChannelVariantListing: (listings: Record<string, string[]>) => void;
 }

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -16,4 +16,5 @@ export interface UseChannelsWithProductVariants {
   hasChanged: boolean;
   channelVariantListing: channelVariantListing;
   setChannelVariantListing: (listings: channelVariantListing) => void;
+  reset: () => void;
 }

--- a/src/products/views/ProductUpdate/types.ts
+++ b/src/products/views/ProductUpdate/types.ts
@@ -17,5 +17,4 @@ export interface UseChannelsWithProductVariants {
   toggleAllChannels: () => void;
   toggleAllChannelVariants: (channelId: string) => void;
   haveChannelsWithVariantsDataChanged: boolean;
-  setHaveChannelsWithVariantsChanged: (hasChanged: boolean) => void;
 }

--- a/src/products/views/ProductUpdate/useChannelVariantListings.ts
+++ b/src/products/views/ProductUpdate/useChannelVariantListings.ts
@@ -5,7 +5,7 @@ import isEqual from "lodash/isEqual";
 import { useMemo } from "react";
 
 import { ChannelsWithVariantsData } from "./types";
-import { createFromChannels } from "./utils";
+import { createFromChannels, createUpdatedChannels } from "./utils";
 
 function useChannelVariantListings(channels: ChannelData[]) {
   const initialChannelVariantListing = useMemo(
@@ -40,11 +40,21 @@ function useChannelVariantListings(channels: ChannelData[]) {
     [initialChannelVariantListing, updatedChannelVariantListing]
   );
 
+  const reset = () =>
+    setUpdatedChannelVariantListing(initialChannelVariantListing);
+
+  const updatedChannels: ChannelData[] = useMemo(
+    () => createUpdatedChannels(channels, updatedChannelVariantListing),
+    [channels, updatedChannelVariantListing]
+  );
+
   return {
+    channels: updatedChannels,
     channelsWithVariantsData,
     channelVariantListing: updatedChannelVariantListing,
     setChannelVariantListing: setUpdatedChannelVariantListing,
-    hasChanged
+    hasChanged,
+    reset
   };
 }
 

--- a/src/products/views/ProductUpdate/useChannelVariantListings.ts
+++ b/src/products/views/ProductUpdate/useChannelVariantListings.ts
@@ -1,0 +1,51 @@
+import { ChannelData } from "@saleor/channels/utils";
+import useStateFromProps from "@saleor/hooks/useStateFromProps";
+import { arrayDiff } from "@saleor/utils/arrays";
+import isEqual from "lodash/isEqual";
+import { useMemo } from "react";
+
+import { ChannelsWithVariantsData } from "./types";
+import { createFromChannels } from "./utils";
+
+function useChannelVariantListings(channels: ChannelData[]) {
+  const initialChannelVariantListing = useMemo(
+    () => createFromChannels(channels, ({ variantsIds }) => variantsIds),
+    [channels]
+  );
+
+  const [
+    updatedChannelVariantListing,
+    setUpdatedChannelVariantListing
+  ] = useStateFromProps(initialChannelVariantListing);
+
+  const hasChanged = useMemo(
+    () => !isEqual(initialChannelVariantListing, updatedChannelVariantListing),
+    [initialChannelVariantListing, updatedChannelVariantListing]
+  );
+
+  const channelsWithVariantsData = useMemo<ChannelsWithVariantsData>(
+    () =>
+      createFromChannels(channels, channel => {
+        const diff = arrayDiff(
+          initialChannelVariantListing[channel.id],
+          updatedChannelVariantListing[channel.id]
+        );
+
+        return {
+          selectedVariantsIds: updatedChannelVariantListing[channel.id],
+          variantsIdsToAdd: diff.added,
+          variantsIdsToRemove: diff.removed
+        };
+      }),
+    [initialChannelVariantListing, updatedChannelVariantListing]
+  );
+
+  return {
+    channelsWithVariantsData,
+    channelVariantListing: updatedChannelVariantListing,
+    setChannelVariantListing: setUpdatedChannelVariantListing,
+    hasChanged
+  };
+}
+
+export default useChannelVariantListings;

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
@@ -34,6 +34,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(0);
+    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(false);
   });
 
   it("properly adds variants", () => {
@@ -50,6 +51,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(0);
+    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(true);
   });
 
   it("properly removes variants", () => {
@@ -66,6 +68,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(1);
+    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(true);
   });
 
   it("properly toggles all variants in channel", () => {
@@ -83,6 +86,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(5);
+    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(true);
 
     // Select all
     act(() => result.current.toggleAllChannelVariants("channel1"));
@@ -122,6 +126,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel2.variantsIdsToRemove
     ).toHaveLength(0);
+    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(true);
 
     // Deselect all
     act(result.current.toggleAllChannels);

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
@@ -34,7 +34,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(0);
-    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(false);
+    expect(result.current.hasChanged).toBe(false);
   });
 
   it("properly adds variants", () => {
@@ -51,7 +51,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(0);
-    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(true);
+    expect(result.current.hasChanged).toBe(true);
   });
 
   it("properly removes variants", () => {
@@ -68,7 +68,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(1);
-    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(true);
+    expect(result.current.hasChanged).toBe(true);
   });
 
   it("properly toggles all variants in channel", () => {
@@ -86,7 +86,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(5);
-    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(true);
+    expect(result.current.hasChanged).toBe(true);
 
     // Select all
     act(() => result.current.toggleAllChannelVariants("channel1"));
@@ -126,7 +126,7 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel2.variantsIdsToRemove
     ).toHaveLength(0);
-    expect(result.current.haveChannelsWithVariantsDataChanged).toBe(true);
+    expect(result.current.hasChanged).toBe(true);
 
     // Deselect all
     act(result.current.toggleAllChannels);

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
@@ -1,0 +1,65 @@
+import { ChannelData } from "@saleor/channels/utils";
+import { act, renderHook } from "@testing-library/react-hooks";
+
+import useChannelsWithProductVariants from "./useChannelsWithProductVariants";
+
+const channels: ChannelData[] = [
+  {
+    id: "channel1",
+    name: "Channel 1",
+    variantsIds: ["variant1", "variant2"]
+  }
+];
+
+const variants = [];
+
+const setupHook = () =>
+  renderHook(() => useChannelsWithProductVariants({ channels, variants }));
+
+describe("useChannelsWithProductVariants", () => {
+  it("properly initializes state", () => {
+    const { result } = setupHook();
+
+    expect(
+      result.current.channelsWithVariantsData.channel1.selectedVariantsIds
+    ).toHaveLength(2);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToAdd
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
+    ).toHaveLength(0);
+  });
+
+  it("properly adds variants", () => {
+    const { result } = setupHook();
+
+    act(() => result.current.addVariantToChannel("channel1", "variant3"));
+
+    expect(
+      result.current.channelsWithVariantsData.channel1.selectedVariantsIds
+    ).toHaveLength(3);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToAdd
+    ).toHaveLength(1);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
+    ).toHaveLength(0);
+  });
+
+  it("properly removes variants", () => {
+    const { result } = setupHook();
+
+    act(() => result.current.removeVariantFromChannel("channel1", "variant2"));
+
+    expect(
+      result.current.channelsWithVariantsData.channel1.selectedVariantsIds
+    ).toHaveLength(1);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToAdd
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
+    ).toHaveLength(1);
+  });
+});

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
@@ -8,13 +8,18 @@ const channels: ChannelData[] = [
     id: "channel1",
     name: "Channel 1",
     variantsIds: ["variant1", "variant2"]
+  },
+  {
+    id: "channel2",
+    name: "Channel 2",
+    variantsIds: []
   }
 ];
 
-const variants = [];
+const variants = ["variant1", "variant2", "variant3", "variant4", "variant5"];
 
 const setupHook = () =>
-  renderHook(() => useChannelsWithProductVariants({ channels, variants }));
+  renderHook(() => useChannelsWithProductVariants(channels, variants));
 
 describe("useChannelsWithProductVariants", () => {
   it("properly initializes state", () => {
@@ -61,5 +66,83 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(1);
+  });
+
+  it("properly toggles all variants in channel", () => {
+    const { result } = setupHook();
+
+    // Deselect all because it's partially selected
+    act(() => result.current.toggleAllChannelVariants("channel1"));
+
+    expect(
+      result.current.channelsWithVariantsData.channel1.selectedVariantsIds
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToAdd
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
+    ).toHaveLength(5);
+
+    // Select all
+    act(() => result.current.toggleAllChannelVariants("channel1"));
+
+    expect(
+      result.current.channelsWithVariantsData.channel1.selectedVariantsIds
+    ).toHaveLength(5);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToAdd
+    ).toHaveLength(3);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
+    ).toHaveLength(0);
+  });
+
+  it("properly toggles all", () => {
+    const { result } = setupHook();
+
+    // Select all
+    act(result.current.toggleAllChannels);
+
+    expect(
+      result.current.channelsWithVariantsData.channel1.selectedVariantsIds
+    ).toHaveLength(5);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToAdd
+    ).toHaveLength(3);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.selectedVariantsIds
+    ).toHaveLength(5);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToAdd
+    ).toHaveLength(5);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToRemove
+    ).toHaveLength(0);
+
+    // Deselect all
+    act(result.current.toggleAllChannels);
+
+    expect(
+      result.current.channelsWithVariantsData.channel1.selectedVariantsIds
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToAdd
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
+    ).toHaveLength(5);
+    expect(
+      result.current.channelsWithVariantsData.channel2.selectedVariantsIds
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToAdd
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToRemove
+    ).toHaveLength(0);
   });
 });

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.test.ts
@@ -34,6 +34,17 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(0);
+
+    expect(
+      result.current.channelsWithVariantsData.channel2.selectedVariantsIds
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToAdd
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToRemove
+    ).toHaveLength(0);
+
     expect(result.current.hasChanged).toBe(false);
   });
 
@@ -51,6 +62,17 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(0);
+
+    expect(
+      result.current.channelsWithVariantsData.channel2.selectedVariantsIds
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToAdd
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToRemove
+    ).toHaveLength(0);
+
     expect(result.current.hasChanged).toBe(true);
   });
 
@@ -68,6 +90,17 @@ describe("useChannelsWithProductVariants", () => {
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
     ).toHaveLength(1);
+
+    expect(
+      result.current.channelsWithVariantsData.channel2.selectedVariantsIds
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToAdd
+    ).toHaveLength(0);
+    expect(
+      result.current.channelsWithVariantsData.channel2.variantsIdsToRemove
+    ).toHaveLength(0);
+
     expect(result.current.hasChanged).toBe(true);
   });
 
@@ -85,7 +118,7 @@ describe("useChannelsWithProductVariants", () => {
     ).toHaveLength(0);
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
-    ).toHaveLength(5);
+    ).toHaveLength(2);
     expect(result.current.hasChanged).toBe(true);
 
     // Select all
@@ -139,7 +172,7 @@ describe("useChannelsWithProductVariants", () => {
     ).toHaveLength(0);
     expect(
       result.current.channelsWithVariantsData.channel1.variantsIdsToRemove
-    ).toHaveLength(5);
+    ).toHaveLength(2);
     expect(
       result.current.channelsWithVariantsData.channel2.selectedVariantsIds
     ).toHaveLength(0);

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -81,7 +81,7 @@ const useChannelsWithProductVariants = ({
       })
     });
 
-  const toggleAllChannelVariants = (channelId: string) => () => {
+  const toggleAllChannelVariants = (channelId: string) => {
     const isChannelSelected = areAnyChannelVariantsSelected(
       channelsWithVariantsData[channelId]
     );

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -22,8 +22,6 @@ const useChannelsWithProductVariants = (
   channels: ChannelData[],
   variants: string[]
 ): UseChannelsWithProductVariants => {
-  const [channelsData, setChannelsData] = useStateFromProps(channels);
-
   const initialChannelsWithVariantsData = getParsedChannelsWithVariantsDataFromChannels(
     channels
   );
@@ -94,8 +92,6 @@ const useChannelsWithProductVariants = (
 
   return {
     channelsWithVariantsData,
-    setChannelsData,
-    channelsData,
     addVariantToChannel: handleAddVariant,
     removeVariantFromChannel: handleRemoveVariant,
     hasChanged,

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -115,7 +115,7 @@ const useChannelsWithProductVariants = ({
     channelsData,
     addVariantToChannel: handleAddVariant,
     removeVariantFromChannel: handleRemoveVariant,
-    haveChannelsWithVariantsDataChanged: hasChanged,
+    haveChannelsWithVariantsDataChanged: hasChanged, // Used only to make pdp submit disabled
     toggleAllChannelVariants,
     toggleAllChannels,
     setHaveChannelsWithVariantsChanged: setHasChanged

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -16,7 +16,8 @@ const useChannelsWithProductVariants = (
     channelsWithVariantsData,
     hasChanged,
     setChannelVariantListing,
-    channelVariantListing
+    channelVariantListing,
+    reset
   } = useChannelVariantListings(channels);
 
   const handleAddVariant = (channelId: string, variantId: string) =>
@@ -55,7 +56,8 @@ const useChannelsWithProductVariants = (
     hasChanged,
     toggleAllChannelVariants,
     toggleAllChannels,
-    setChannelVariantListing
+    setChannelVariantListing,
+    reset
   };
 };
 

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -1,3 +1,4 @@
+import { ChannelData } from "@saleor/channels/utils";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import isEmpty from "lodash/isEmpty";
 import reduce from "lodash/reduce";
@@ -5,8 +6,7 @@ import { useEffect, useRef, useState } from "react";
 
 import {
   ChannelsWithVariantsData,
-  UseChannelsWithProductVariants,
-  UseChannelsWithProductVariantsProps
+  UseChannelsWithProductVariants
 } from "./types";
 import {
   areAllVariantsAtAllChannelsSelected,
@@ -17,10 +17,10 @@ import {
   getParsedChannelsWithVariantsDataFromChannels
 } from "./utils";
 
-const useChannelsWithProductVariants = ({
-  channels,
-  variants
-}: UseChannelsWithProductVariantsProps): UseChannelsWithProductVariants => {
+const useChannelsWithProductVariants = (
+  channels: ChannelData[],
+  variants: string[]
+): UseChannelsWithProductVariants => {
   const [channelsData, setChannelsData] = useStateFromProps(channels);
 
   const initialChannelsWithVariantsData = getParsedChannelsWithVariantsDataFromChannels(

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -98,7 +98,7 @@ const useChannelsWithProductVariants = (
     channelsData,
     addVariantToChannel: handleAddVariant,
     removeVariantFromChannel: handleRemoveVariant,
-    haveChannelsWithVariantsDataChanged: hasChanged, // Used only to make pdp submit disabled
+    hasChanged,
     toggleAllChannelVariants,
     toggleAllChannels
   };

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -1,8 +1,9 @@
 import { ChannelData } from "@saleor/channels/utils";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import isEmpty from "lodash/isEmpty";
+import isEqual from "lodash/isEqual";
 import reduce from "lodash/reduce";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   ChannelsWithVariantsData,
@@ -34,28 +35,10 @@ const useChannelsWithProductVariants = (
     initialChannelsWithVariantsData
   );
 
-  const channelsWithVariantsDataRef = useRef(channelsWithVariantsData);
-
-  const [hasChanged, setHasChanged] = useState(false);
-
-  const handleSetHasChanged = () => {
-    const isDataRefEmpty = isEmpty(channelsWithVariantsDataRef.current);
-    const isDataEmpty = isEmpty(channelsWithVariantsData);
-
-    const hasFilledInitialData = isDataRefEmpty && !isDataEmpty;
-
-    const hasNoDataFilled = isDataRefEmpty && isDataEmpty;
-
-    channelsWithVariantsDataRef.current = channelsWithVariantsData;
-
-    if (hasNoDataFilled || hasFilledInitialData) {
-      return;
-    }
-
-    setHasChanged(true);
-  };
-
-  useEffect(handleSetHasChanged, [channelsWithVariantsData]);
+  const hasChanged = useMemo(
+    () => !isEqual(initialChannelsWithVariantsData, channelsWithVariantsData),
+    [initialChannelsWithVariantsData, channelsWithVariantsData]
+  );
 
   const handleAddVariant = (channelId: string, variantId: string) =>
     setChannelsWithVariantsData({
@@ -117,8 +100,7 @@ const useChannelsWithProductVariants = (
     removeVariantFromChannel: handleRemoveVariant,
     haveChannelsWithVariantsDataChanged: hasChanged, // Used only to make pdp submit disabled
     toggleAllChannelVariants,
-    toggleAllChannels,
-    setHaveChannelsWithVariantsChanged: setHasChanged
+    toggleAllChannels
   };
 };
 

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -82,11 +82,13 @@ const useChannelsWithProductVariants = (
 
   return {
     channelsWithVariantsData,
+    channelVariantListing: updatedChannelVariantListing,
     addVariantToChannel: handleAddVariant,
     removeVariantFromChannel: handleRemoveVariant,
     hasChanged,
     toggleAllChannelVariants,
-    toggleAllChannels
+    toggleAllChannels,
+    setChannelVariantListing: setUpdatedChannelVariantListing
   };
 };
 

--- a/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
+++ b/src/products/views/ProductUpdate/useChannelsWithProductVariants.ts
@@ -4,7 +4,6 @@ import reduce from "lodash/reduce";
 import { useEffect, useRef, useState } from "react";
 
 import {
-  CHANNELS_AVAILIABILITY_MODAL_SELECTOR,
   ChannelsWithVariantsData,
   UseChannelsWithProductVariants,
   UseChannelsWithProductVariantsProps
@@ -20,10 +19,7 @@ import {
 
 const useChannelsWithProductVariants = ({
   channels,
-  variants,
-  openModal,
-  closeModal,
-  action
+  variants
 }: UseChannelsWithProductVariantsProps): UseChannelsWithProductVariants => {
   const [channelsData, setChannelsData] = useStateFromProps(channels);
 
@@ -113,26 +109,15 @@ const useChannelsWithProductVariants = ({
     setChannelsWithVariantsData(updatedData);
   };
 
-  const onChannelsWithVariantsConfirm = () => closeModal();
-
-  const handleModalOpen = () =>
-    openModal(CHANNELS_AVAILIABILITY_MODAL_SELECTOR);
-
-  const isModalOpen = action === CHANNELS_AVAILIABILITY_MODAL_SELECTOR;
-
   return {
     channelsWithVariantsData,
     setChannelsData,
     channelsData,
     addVariantToChannel: handleAddVariant,
     removeVariantFromChannel: handleRemoveVariant,
-    onChannelsAvailiabilityModalOpen: handleModalOpen,
-    onChannelsAvailiabilityModalClose: closeModal,
-    isChannelsAvailabilityModalOpen: isModalOpen,
     haveChannelsWithVariantsDataChanged: hasChanged,
     toggleAllChannelVariants,
     toggleAllChannels,
-    onChannelsWithVariantsConfirm,
     setHaveChannelsWithVariantsChanged: setHasChanged
   };
 };

--- a/src/products/views/ProductUpdate/utils.ts
+++ b/src/products/views/ProductUpdate/utils.ts
@@ -3,7 +3,11 @@ import every from "lodash/every";
 import reduce from "lodash/reduce";
 
 import { initialChannelWithVariantData } from "./consts";
-import { ChannelsWithVariantsData, ChannelWithVariantData } from "./types";
+import {
+  ChannelsWithVariantsData,
+  channelVariantListing,
+  ChannelWithVariantData
+} from "./types";
 
 export function createFromChannels<T>(
   channels: ChannelData[],
@@ -37,7 +41,7 @@ export const getChannelVariantToggleData = (
 
 export const areAllVariantsAtAllChannelsSelected = (
   variants: string[] = [],
-  channelsWithVariants: Record<string, string[]> = {}
+  channelsWithVariants: channelVariantListing = {}
 ) =>
   every(channelsWithVariants, channelWithVariantsData =>
     areAllChannelVariantsSelected(variants, channelWithVariantsData)
@@ -60,9 +64,9 @@ export const getTotalSelectedChannelsCount = (
   ).length;
 
 export const addAllVariantsToAllChannels = (
-  listings: Record<string, string[]>,
+  listings: channelVariantListing,
   variants: string[]
-): Record<string, string[]> => {
+): channelVariantListing => {
   const areAllChannelsSelected = areAllVariantsAtAllChannelsSelected(
     variants,
     listings
@@ -70,7 +74,7 @@ export const addAllVariantsToAllChannels = (
 
   const updatedListing = reduce(
     listings,
-    (result: Record<string, string[]>, _, channelId) => ({
+    (result: channelVariantListing, _, channelId) => ({
       ...result,
       [channelId]: getChannelVariantToggleData(variants, areAllChannelsSelected)
     }),
@@ -82,11 +86,11 @@ export const addAllVariantsToAllChannels = (
 
 export const channelVariantListingDiffToDict = (
   listing: ChannelsWithVariantsData
-): Record<string, string[]> =>
+): channelVariantListing =>
   reduce(
     listing,
     (
-      listingDict: Record<string, string[]>,
+      listingDict: channelVariantListing,
       { selectedVariantsIds },
       channelId
     ) => ({

--- a/src/products/views/ProductUpdate/utils.ts
+++ b/src/products/views/ProductUpdate/utils.ts
@@ -5,7 +5,7 @@ import reduce from "lodash/reduce";
 import { initialChannelWithVariantData } from "./consts";
 import {
   ChannelsWithVariantsData,
-  channelVariantListing,
+  ChannelVariantListing,
   ChannelWithVariantData
 } from "./types";
 
@@ -24,7 +24,7 @@ export function createFromChannels<T>(
 
 export function createUpdatedChannels(
   channels: ChannelData[],
-  listing: channelVariantListing
+  listing: ChannelVariantListing
 ): ChannelData[] {
   return reduce(
     listing,
@@ -59,7 +59,7 @@ export const getChannelVariantToggleData = (
 
 export const areAllVariantsAtAllChannelsSelected = (
   variants: string[] = [],
-  channelsWithVariants: channelVariantListing = {}
+  channelsWithVariants: ChannelVariantListing = {}
 ) =>
   every(channelsWithVariants, channelWithVariantsData =>
     areAllChannelVariantsSelected(variants, channelWithVariantsData)
@@ -82,9 +82,9 @@ export const getTotalSelectedChannelsCount = (
   ).length;
 
 export const addAllVariantsToAllChannels = (
-  listings: channelVariantListing,
+  listings: ChannelVariantListing,
   variants: string[]
-): channelVariantListing => {
+): ChannelVariantListing => {
   const areAllChannelsSelected = areAllVariantsAtAllChannelsSelected(
     variants,
     listings
@@ -92,7 +92,7 @@ export const addAllVariantsToAllChannels = (
 
   const updatedListing = reduce(
     listings,
-    (result: channelVariantListing, _, channelId) => ({
+    (result: ChannelVariantListing, _, channelId) => ({
       ...result,
       [channelId]: getChannelVariantToggleData(variants, areAllChannelsSelected)
     }),
@@ -104,11 +104,11 @@ export const addAllVariantsToAllChannels = (
 
 export const channelVariantListingDiffToDict = (
   listing: ChannelsWithVariantsData
-): channelVariantListing =>
+): ChannelVariantListing =>
   reduce(
     listing,
     (
-      listingDict: channelVariantListing,
+      listingDict: ChannelVariantListing,
       { selectedVariantsIds },
       channelId
     ) => ({

--- a/src/products/views/ProductUpdate/utils.ts
+++ b/src/products/views/ProductUpdate/utils.ts
@@ -69,30 +69,27 @@ export const getChannelWithRemovedVariantData = ({
 });
 
 export const getChannelVariantToggleData = (
-  variants: ProductDetails_product_variants[],
+  variants: string[],
   isSelected: boolean
-): ChannelWithVariantData => {
-  const allProductVariantsIds = extractAllProductVariantsIds(variants);
-
-  return isSelected
+): ChannelWithVariantData =>
+  isSelected
     ? {
         selectedVariantsIds: [],
         variantsIdsToAdd: [],
-        variantsIdsToRemove: allProductVariantsIds
+        variantsIdsToRemove: variants
       }
     : {
-        selectedVariantsIds: allProductVariantsIds,
-        variantsIdsToAdd: allProductVariantsIds,
+        selectedVariantsIds: variants,
+        variantsIdsToAdd: variants,
         variantsIdsToRemove: []
       };
-};
 
 export const extractAllProductVariantsIds = (
   productVariants: ProductDetails_product_variants[] = []
 ) => productVariants.map(({ id }) => id);
 
 export const areAllVariantsAtAllChannelsSelected = (
-  variants: ProductDetails_product_variants[] = [],
+  variants: string[] = [],
   channelsWithVariants: ChannelsWithVariantsData = {}
 ) =>
   every(channelsWithVariants, channelWithVariantsData =>
@@ -100,7 +97,7 @@ export const areAllVariantsAtAllChannelsSelected = (
   );
 
 export const areAllChannelVariantsSelected = (
-  variants: ProductDetails_product_variants[] = [],
+  variants: string[] = [],
   { selectedVariantsIds }: Pick<ChannelWithVariantData, "selectedVariantsIds">
 ) => selectedVariantsIds.length === variants.length;
 

--- a/src/products/views/ProductUpdate/utils.ts
+++ b/src/products/views/ProductUpdate/utils.ts
@@ -7,11 +7,8 @@ import { ProductDetails_product_variants } from "@saleor/products/types/ProductD
 import every from "lodash/every";
 import reduce from "lodash/reduce";
 
-import {
-  ChannelsWithVariantsData,
-  ChannelWithVariantData,
-  initialChannelWithVariantData
-} from "./types";
+import { initialChannelWithVariantData } from "./consts";
+import { ChannelsWithVariantsData, ChannelWithVariantData } from "./types";
 
 export const getParsedChannelsWithVariantsDataFromChannels = (
   channels: ChannelData[]

--- a/src/products/views/ProductUpdate/utils.ts
+++ b/src/products/views/ProductUpdate/utils.ts
@@ -22,6 +22,24 @@ export function createFromChannels<T>(
   );
 }
 
+export function createUpdatedChannels(
+  channels: ChannelData[],
+  listing: channelVariantListing
+): ChannelData[] {
+  return reduce(
+    listing,
+    (acc, variantsIds, channelId) => [
+      ...acc,
+      {
+        id: channelId,
+        name: channels.find(channel => channel.id === channelId).name,
+        variantsIds
+      } as ChannelData
+    ],
+    []
+  );
+}
+
 export const getParsedChannelsWithVariantsDataFromChannels = (
   channels: ChannelData[]
 ): ChannelsWithVariantsData =>


### PR DESCRIPTION
I want to merge this change because it adds intermediate channel variant selection data state to channel availability dialog.

**PR intended to be tested with API branch:** 3.0

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
