### PR TITLE
Add saving and retrieving currency from LocalStorage in gift card create dialog

### DIFF
--- a/src/giftCards/GiftCardCreateDialog/GiftCardCreateDialog.tsx
+++ b/src/giftCards/GiftCardCreateDialog/GiftCardCreateDialog.tsx
@@ -27,10 +27,7 @@ const GiftCardCreateDialog: React.FC<DialogActionHandlersProps> = ({
   const intl = useIntl();
   const notify = useNotifier();
 
-  const {
-    data: channelCurrenciesData,
-    loading: loadingChannelCurrencies
-  } = useChannelCurrencies({});
+  const { loading: loadingChannelCurrencies } = useChannelCurrencies({});
 
   const [cardCode, setCardCode] = useState(null);
 
@@ -116,7 +113,6 @@ const GiftCardCreateDialog: React.FC<DialogActionHandlersProps> = ({
             />
           ) : (
             <GiftCardCreateDialogForm
-              channelCurrencies={channelCurrenciesData?.shop?.channelCurrencies}
               opts={createGiftCardOpts}
               onClose={handleClose}
               apiErrors={createGiftCardOpts?.data?.giftCardCreate?.errors}

--- a/src/giftCards/GiftCardCreateDialog/GiftCardCreateDialogMoneyInput.tsx
+++ b/src/giftCards/GiftCardCreateDialog/GiftCardCreateDialogMoneyInput.tsx
@@ -1,0 +1,87 @@
+import TextWithSelectField from "@saleor/components/TextWithSelectField";
+import { ChangeEvent } from "@saleor/hooks/useForm";
+import useLocalStorage from "@saleor/hooks/useLocalStorage";
+import { mapSingleValueNodeToChoice } from "@saleor/utils/maps";
+import * as React from "react";
+import { useEffect } from "react";
+import { useIntl } from "react-intl";
+
+import { getGiftCardErrorMessage } from "../GiftCardUpdate/messages";
+import { GiftCardCreateFormData } from "./GiftCardCreateDialogForm";
+import { giftCardCreateDialogMessages as messages } from "./messages";
+import { useChannelCurrencies } from "./queries";
+import { useGiftCardCreateDialogFormStyles as useStyles } from "./styles";
+import { GiftCardCreateFormCommonProps } from "./types";
+
+interface GiftCardCreateDialogMoneyInputProps
+  extends GiftCardCreateFormCommonProps {
+  set: (data: Partial<GiftCardCreateFormData>) => void;
+}
+
+const GiftCardCreateDialogMoneyInput: React.FC<GiftCardCreateDialogMoneyInputProps> = ({
+  errors,
+  data: { balanceAmount, balanceCurrency },
+  change,
+  set
+}) => {
+  const intl = useIntl();
+  const classes = useStyles({});
+
+  const { data: channelCurrenciesData } = useChannelCurrencies({});
+
+  const { channelCurrencies } = channelCurrenciesData?.shop;
+
+  const [savedCurrency, setCurrency] = useLocalStorage(
+    "giftCardCreateDialogCurrency",
+    undefined
+  );
+
+  const getInitialCurrency = () => {
+    if (
+      savedCurrency &&
+      !!channelCurrencies.find((currency: string) => currency === savedCurrency)
+    ) {
+      return savedCurrency;
+    }
+
+    return channelCurrencies[0];
+  };
+
+  useEffect(() => {
+    set({
+      balanceCurrency: getInitialCurrency()
+    });
+  }, []);
+
+  const handleInputChange = (event: ChangeEvent<any>) => {
+    if (event.target?.name === "balanceCurrency") {
+      setCurrency(event.target?.value);
+    }
+
+    change(event);
+  };
+
+  return (
+    <TextWithSelectField
+      isError={!!errors?.balance}
+      helperText={getGiftCardErrorMessage(errors?.balance, intl)}
+      change={handleInputChange}
+      choices={mapSingleValueNodeToChoice(channelCurrencies)}
+      containerClassName={classes.balanceContainer}
+      textFieldProps={{
+        type: "float",
+        label: intl.formatMessage(messages.amountLabel),
+        name: "balanceAmount",
+        value: balanceAmount,
+        minValue: 0
+      }}
+      selectFieldProps={{
+        name: "balanceCurrency",
+        value: balanceCurrency,
+        className: classes.currencySelectField
+      }}
+    />
+  );
+};
+
+export default GiftCardCreateDialogMoneyInput;

--- a/src/giftCards/GiftCardCreateDialog/GiftCardCreateExpirySelect/GiftCardCreateExpirySelect.tsx
+++ b/src/giftCards/GiftCardCreateDialog/GiftCardCreateExpirySelect/GiftCardCreateExpirySelect.tsx
@@ -3,14 +3,14 @@ import HorizontalSpacer from "@saleor/apps/components/HorizontalSpacer";
 import VerticalSpacer from "@saleor/apps/components/VerticalSpacer";
 import ControlledCheckbox from "@saleor/components/ControlledCheckbox";
 import RadioGroupField from "@saleor/components/RadioGroupField";
-import { GiftCardError } from "@saleor/fragments/types/GiftCardError";
 import TimePeriodField from "@saleor/giftCards/components/TimePeriodField";
-import { GiftCardExpiryType } from "@saleor/giftCards/GiftCardCreateDialog/types";
+import {
+  GiftCardCreateFormCommonProps,
+  GiftCardExpiryType
+} from "@saleor/giftCards/GiftCardCreateDialog/types";
 import { getExpiryPeriodTerminationDate } from "@saleor/giftCards/GiftCardCreateDialog/utils";
 import { getGiftCardErrorMessage } from "@saleor/giftCards/GiftCardUpdate/messages";
 import useCurrentDate from "@saleor/hooks/useCurrentDate";
-import { FormChange } from "@saleor/hooks/useForm";
-import { TimePeriodTypeEnum } from "@saleor/types/globalTypes";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import { MessageDescriptor, useIntl } from "react-intl";
@@ -34,25 +34,16 @@ const options: UntranslatedOption[] = [
   }
 ];
 
-interface GiftCardCreateExpirySelectProps {
-  change: FormChange;
-  expirySelected: boolean;
-  expiryPeriodType: TimePeriodTypeEnum;
-  expiryPeriodAmount: number;
-  expiryType: GiftCardExpiryType;
-  customOptions?: UntranslatedOption[];
-  errors?: Record<"expiryDate", GiftCardError>;
-  expiryDate?: string;
-}
-
-const GiftCardCreateExpirySelect: React.FC<GiftCardCreateExpirySelectProps> = ({
+const GiftCardCreateExpirySelect: React.FC<GiftCardCreateFormCommonProps> = ({
   errors,
   change,
-  expirySelected,
-  expiryPeriodType,
-  expiryPeriodAmount,
-  expiryType,
-  expiryDate
+  data: {
+    expirySelected,
+    expiryPeriodType,
+    expiryPeriodAmount,
+    expiryType,
+    expiryDate
+  }
 }) => {
   const intl = useIntl();
   const classes = useStyles({});

--- a/src/giftCards/GiftCardCreateDialog/types.ts
+++ b/src/giftCards/GiftCardCreateDialog/types.ts
@@ -10,29 +10,13 @@ export interface GiftCardCreateFormCustomer {
   email: string;
 }
 
-export interface GiftCardCommonFormData {
-  tag: string;
-  balanceAmount: number;
-  balanceCurrency: string;
-  expiryDate: string;
-}
-
 export type GiftCardCreateFormErrors = Record<
-  "tag" | "expiryDate" | "customer" | "currency" | "amount",
+  "tag" | "expiryDate" | "customer" | "currency" | "amount" | "balance",
   GiftCardError
->;
-
-export type GiftCardCreateInputData = Pick<
-  GiftCardCreateFormData,
-  | "expirySelected"
-  | "expiryDate"
-  | "expiryPeriodAmount"
-  | "expiryPeriodType"
-  | "expiryType"
 >;
 
 export interface GiftCardCreateFormCommonProps {
   change: FormChange;
   errors: GiftCardCreateFormErrors;
-  data: GiftCardCommonFormData;
+  data: GiftCardCreateFormData;
 }

--- a/src/giftCards/GiftCardUpdate/providers/GiftCardUpdateFormProvider/GiftCardUpdateFormProvider.tsx
+++ b/src/giftCards/GiftCardUpdate/providers/GiftCardUpdateFormProvider/GiftCardUpdateFormProvider.tsx
@@ -1,6 +1,5 @@
 import { MetadataFormData } from "@saleor/components/Metadata";
 import { GiftCardError } from "@saleor/fragments/types/GiftCardError";
-import { GiftCardCommonFormData } from "@saleor/giftCards/GiftCardCreateDialog/types";
 import { MutationResultWithOpts } from "@saleor/hooks/makeMutation";
 import useForm, { FormChange, UseFormResult } from "@saleor/hooks/useForm";
 import useNotifier from "@saleor/hooks/useNotifier";
@@ -18,7 +17,10 @@ import useMetadataChangeTrigger from "@saleor/utils/metadata/useMetadataChangeTr
 import React, { createContext } from "react";
 import { useIntl } from "react-intl";
 
-import { initialData as emptyFormData } from "../../../GiftCardCreateDialog/GiftCardCreateDialogForm";
+import {
+  GiftCardCreateFormData,
+  initialData as emptyFormData
+} from "../../../GiftCardCreateDialog/GiftCardCreateDialogForm";
 import { useGiftCardUpdateMutation } from "../../mutations";
 import { GiftCardUpdate } from "../../types/GiftCardUpdate";
 import useGiftCardDetails from "../GiftCardDetailsProvider/hooks/useGiftCardDetails";
@@ -28,7 +30,7 @@ interface GiftCardUpdateFormProviderProps {
 }
 
 export type GiftCardUpdateFormData = MetadataFormData &
-  Omit<GiftCardCommonFormData, "balanceAmount" | "balanceCurrency">;
+  Pick<GiftCardCreateFormData, "tag" | "expiryDate">;
 
 export interface GiftCardUpdateFormConsumerData
   extends GiftCardUpdateFormErrors {


### PR DESCRIPTION
I want to merge this change because it adds saving and retrieving currency from LocalStorage in gift card create dialog.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
