### PR TITLE
Add variants to sale view

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -789,6 +789,7 @@ input CatalogueInput {
   products: [ID]
   categories: [ID]
   collections: [ID]
+  variants: [ID]
 }
 
 type Category implements Node & ObjectWithMetadata {
@@ -5792,6 +5793,7 @@ type Sale implements Node & ObjectWithMetadata {
   categories(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  variants(before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   translation(languageCode: LanguageCodeEnum!): SaleTranslation
   channelListings: [SaleChannelListing!]
   discountValue: Float
@@ -5869,6 +5871,7 @@ input SaleInput {
   type: DiscountValueTypeEnum
   value: PositiveDecimal
   products: [ID]
+  variants: [ID]
   categories: [ID]
   collections: [ID]
   startDate: DateTime

--- a/src/components/AssignVariantDialog/AssignVariantDialog.tsx
+++ b/src/components/AssignVariantDialog/AssignVariantDialog.tsx
@@ -1,0 +1,222 @@
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TableBody,
+  TableCell,
+  TableRow,
+  TextField
+} from "@material-ui/core";
+import ConfirmButton, {
+  ConfirmButtonTransitionState
+} from "@saleor/components/ConfirmButton";
+import ResponsiveTable from "@saleor/components/ResponsiveTable";
+import TableCellAvatar from "@saleor/components/TableCellAvatar";
+import useSearchQuery from "@saleor/hooks/useSearchQuery";
+import { buttonMessages } from "@saleor/intl";
+import { makeStyles } from "@saleor/macaw-ui";
+import { maybe } from "@saleor/misc";
+import { SearchVariants_search_edges_node } from "@saleor/searches/types/SearchVariants";
+import useScrollableDialogStyle from "@saleor/styles/useScrollableDialogStyle";
+import { FetchMoreProps } from "@saleor/types";
+import React from "react";
+import InfiniteScroll from "react-infinite-scroll-component";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import Checkbox from "../Checkbox";
+
+export interface FormData {
+  variants: SearchVariants_search_edges_node[];
+  query: string;
+}
+
+const useStyles = makeStyles(
+  {
+    avatar: {
+      "&&:first-child": {
+        paddingLeft: 0
+      },
+      width: 72
+    },
+    checkboxCell: {
+      paddingLeft: 0,
+      width: 88
+    },
+    colName: {
+      paddingLeft: 0
+    }
+  },
+  { name: "AssignVariantDialog" }
+);
+
+export interface AssignVariantDialogProps extends FetchMoreProps {
+  confirmButtonState: ConfirmButtonTransitionState;
+  open: boolean;
+  variants: SearchVariants_search_edges_node[];
+  loading: boolean;
+  onClose: () => void;
+  onFetch: (value: string) => void;
+  onSubmit: (data: SearchVariants_search_edges_node[]) => void;
+}
+
+function handleVariantAssign(
+  variant: SearchVariants_search_edges_node,
+  isSelected: boolean,
+  selectedVariants: SearchVariants_search_edges_node[],
+  setSelectedVariants: (data: SearchVariants_search_edges_node[]) => void
+) {
+  if (isSelected) {
+    setSelectedVariants(
+      selectedVariants.filter(
+        selectedVariant => selectedVariant.id !== variant.id
+      )
+    );
+  } else {
+    setSelectedVariants([...selectedVariants, variant]);
+  }
+}
+
+const scrollableTargetId = "assignVariantScrollableDialog";
+
+const AssignVariantDialog: React.FC<AssignVariantDialogProps> = props => {
+  const {
+    confirmButtonState,
+    hasMore,
+    open,
+    loading,
+    variants,
+    onClose,
+    onFetch,
+    onFetchMore,
+    onSubmit
+  } = props;
+  const classes = useStyles(props);
+  const scrollableDialogClasses = useScrollableDialogStyle({});
+
+  const intl = useIntl();
+  const [query, onQueryChange] = useSearchQuery(onFetch);
+  const [selectedVariants, setSelectedVariants] = React.useState<
+    SearchVariants_search_edges_node[]
+  >([]);
+
+  const handleSubmit = () => onSubmit(selectedVariants);
+
+  return (
+    <Dialog
+      onClose={onClose}
+      open={open}
+      classes={{ paper: scrollableDialogClasses.dialog }}
+      fullWidth
+      maxWidth="sm"
+    >
+      <DialogTitle>
+        <FormattedMessage
+          defaultMessage="Assign Variant"
+          description="dialog header"
+        />
+      </DialogTitle>
+      <DialogContent className={scrollableDialogClasses.topArea}>
+        <TextField
+          name="query"
+          value={query}
+          onChange={onQueryChange}
+          label={intl.formatMessage({
+            defaultMessage: "Search Variants"
+          })}
+          placeholder={intl.formatMessage({
+            defaultMessage:
+              "Search by variant name, attribute, variant type etc..."
+          })}
+          fullWidth
+          InputProps={{
+            autoComplete: "off",
+            endAdornment: loading && <CircularProgress size={16} />
+          }}
+        />
+      </DialogContent>
+      <DialogContent
+        className={scrollableDialogClasses.scrollArea}
+        id={scrollableTargetId}
+      >
+        <InfiniteScroll
+          dataLength={variants?.length}
+          next={onFetchMore}
+          hasMore={hasMore}
+          scrollThreshold="100px"
+          loader={
+            <div className={scrollableDialogClasses.loadMoreLoaderContainer}>
+              <CircularProgress size={16} />
+            </div>
+          }
+          scrollableTarget={scrollableTargetId}
+        >
+          <ResponsiveTable key="table">
+            <TableBody>
+              {variants &&
+                variants.map(variant => {
+                  const isSelected = selectedVariants.some(
+                    selectedVariant => selectedVariant.id === variant.id
+                  );
+
+                  return (
+                    <TableRow
+                      key={variant.id}
+                      data-test-id="assign-variant-table-row"
+                    >
+                      <TableCellAvatar
+                        className={classes.avatar}
+                        thumbnail={maybe(() => variant.product.thumbnail.url)}
+                      />
+                      <TableCell className={classes.colName}>
+                        {variant.product.name}
+                      </TableCell>
+                      <TableCell>{variant.name}</TableCell>
+                      <TableCell
+                        padding="checkbox"
+                        className={classes.checkboxCell}
+                      >
+                        <Checkbox
+                          checked={isSelected}
+                          onChange={() =>
+                            handleVariantAssign(
+                              variant,
+                              isSelected,
+                              selectedVariants,
+                              setSelectedVariants
+                            )
+                          }
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+            </TableBody>
+          </ResponsiveTable>
+        </InfiniteScroll>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>
+          <FormattedMessage {...buttonMessages.back} />
+        </Button>
+        <ConfirmButton
+          data-test="submit"
+          transitionState={confirmButtonState}
+          color="primary"
+          variant="contained"
+          type="submit"
+          onClick={handleSubmit}
+        >
+          <FormattedMessage
+            defaultMessage="Assign variants"
+            description="button"
+          />
+        </ConfirmButton>
+      </DialogActions>
+    </Dialog>
+  );
+};
+AssignVariantDialog.displayName = "AssignVariantDialog";
+export default AssignVariantDialog;

--- a/src/components/AssignVariantDialog/index.ts
+++ b/src/components/AssignVariantDialog/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./AssignVariantDialog";
+export * from "./AssignVariantDialog";

--- a/src/discounts/components/DiscountVariants/DiscountVariants.tsx
+++ b/src/discounts/components/DiscountVariants/DiscountVariants.tsx
@@ -1,0 +1,222 @@
+import {
+  Button,
+  Card,
+  IconButton,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableRow
+} from "@material-ui/core";
+import DeleteIcon from "@material-ui/icons/Delete";
+import CardTitle from "@saleor/components/CardTitle";
+import Checkbox from "@saleor/components/Checkbox";
+import ResponsiveTable from "@saleor/components/ResponsiveTable";
+import Skeleton from "@saleor/components/Skeleton";
+import TableCellAvatar from "@saleor/components/TableCellAvatar";
+import { AVATAR_MARGIN } from "@saleor/components/TableCellAvatar/Avatar";
+import TableHead from "@saleor/components/TableHead";
+import TablePagination from "@saleor/components/TablePagination";
+import { makeStyles } from "@saleor/macaw-ui";
+import { mapEdgesToItems } from "@saleor/utils/maps";
+import React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { maybe, renderCollection } from "../../../misc";
+import { ListActions, ListProps } from "../../../types";
+import { SaleDetails_sale } from "../../types/SaleDetails";
+
+export interface SaleVariantsProps
+  extends Omit<ListProps, "onRowClick">,
+    ListActions {
+  discount: SaleDetails_sale;
+  onVariantAssign: () => void;
+  onRowClick: (productId: string, variantId: string) => () => void;
+  onVariantUnassign: (id: string) => void;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    colActions: {
+      "&:last-child": {
+        paddingRight: 0
+      },
+      width: `calc(76px + ${theme.spacing(0.5)})`
+    },
+    colProductName: {
+      paddingLeft: 0,
+      width: "auto"
+    },
+    colNameLabel: {
+      marginLeft: `calc(${AVATAR_MARGIN}px + ${theme.spacing(3)})`
+    },
+    colVariantName: {
+      width: 150
+    },
+    colType: {
+      width: 200
+    },
+    table: {
+      tableLayout: "fixed"
+    },
+    tableRow: {
+      cursor: "pointer"
+    }
+  }),
+  { name: "DiscountVariants" }
+);
+
+const numberOfColumns = 5;
+
+const DiscountVariants: React.FC<SaleVariantsProps> = props => {
+  const {
+    discount: sale,
+    disabled,
+    pageInfo,
+    onRowClick,
+    onPreviousPage,
+    onVariantAssign,
+    onVariantUnassign,
+    onNextPage,
+    isChecked,
+    selected,
+    toggle,
+    toggleAll,
+    toolbar
+  } = props;
+  const classes = useStyles(props);
+
+  const intl = useIntl();
+
+  return (
+    <Card>
+      <CardTitle
+        title={intl.formatMessage({
+          defaultMessage: "Eligible Variants",
+          description: "section header"
+        })}
+        toolbar={
+          <Button
+            color="primary"
+            onClick={onVariantAssign}
+            data-test-id="assign-variant"
+          >
+            <FormattedMessage
+              defaultMessage="Assign variants"
+              description="button"
+            />
+          </Button>
+        }
+      />
+      <ResponsiveTable>
+        <colgroup>
+          <col />
+          <col className={classes.colProductName} />
+          <col className={classes.colVariantName} />
+          <col className={classes.colType} />
+          <col className={classes.colActions} />
+        </colgroup>
+        <TableHead
+          colSpan={numberOfColumns}
+          selected={selected}
+          disabled={disabled}
+          items={mapEdgesToItems(sale?.variants)}
+          toggleAll={toggleAll}
+          toolbar={toolbar}
+        >
+          <TableCell className={classes.colProductName}>
+            <span className={classes.colNameLabel}>
+              <FormattedMessage defaultMessage="Product Name" />
+            </span>
+          </TableCell>
+          <TableCell className={classes.colVariantName}>
+            <FormattedMessage defaultMessage="Variant Name" />
+          </TableCell>
+          <TableCell className={classes.colType}>
+            <FormattedMessage defaultMessage="Product Type" />
+          </TableCell>
+          <TableCell className={classes.colActions} />
+        </TableHead>
+        <TableFooter>
+          <TableRow>
+            <TablePagination
+              colSpan={numberOfColumns}
+              hasNextPage={pageInfo && !disabled ? pageInfo.hasNextPage : false}
+              onNextPage={onNextPage}
+              hasPreviousPage={
+                pageInfo && !disabled ? pageInfo.hasPreviousPage : false
+              }
+              onPreviousPage={onPreviousPage}
+            />
+          </TableRow>
+        </TableFooter>
+        <TableBody>
+          {renderCollection(
+            mapEdgesToItems(sale?.variants),
+            variant => {
+              const isSelected = variant ? isChecked(variant.id) : false;
+
+              return (
+                <TableRow
+                  hover={!!variant}
+                  key={variant ? variant.id : "skeleton"}
+                  onClick={
+                    variant && onRowClick(variant.product.id, variant.id)
+                  }
+                  className={classes.tableRow}
+                  selected={isSelected}
+                >
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={isSelected}
+                      disabled={disabled}
+                      disableClickPropagation
+                      onChange={() => toggle(variant.id)}
+                    />
+                  </TableCell>
+                  <TableCellAvatar
+                    className={classes.colProductName}
+                    thumbnail={maybe(() => variant.product.thumbnail.url)}
+                  >
+                    {maybe<React.ReactNode>(
+                      () => variant.product.name,
+                      <Skeleton />
+                    )}
+                  </TableCellAvatar>
+                  <TableCell className={classes.colType}>
+                    {maybe<React.ReactNode>(() => variant.name, <Skeleton />)}
+                  </TableCell>
+                  <TableCell className={classes.colType}>
+                    {maybe<React.ReactNode>(
+                      () => variant.product.productType.name,
+                      <Skeleton />
+                    )}
+                  </TableCell>
+                  <TableCell className={classes.colActions}>
+                    <IconButton
+                      disabled={!variant || disabled}
+                      onClick={event => {
+                        event.stopPropagation();
+                        onVariantUnassign(variant.id);
+                      }}
+                    >
+                      <DeleteIcon color="primary" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              );
+            },
+            () => (
+              <TableRow>
+                <TableCell colSpan={numberOfColumns}>
+                  <FormattedMessage defaultMessage="No variants found" />
+                </TableCell>
+              </TableRow>
+            )
+          )}
+        </TableBody>
+      </ResponsiveTable>
+    </Card>
+  );
+};
+DiscountVariants.displayName = "DiscountVariants";
+export default DiscountVariants;

--- a/src/discounts/components/DiscountVariants/index.ts
+++ b/src/discounts/components/DiscountVariants/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./DiscountVariants";
+export * from "./DiscountVariants";

--- a/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
+++ b/src/discounts/components/SaleDetailsPage/SaleDetailsPage.tsx
@@ -30,6 +30,7 @@ import DiscountCategories from "../DiscountCategories";
 import DiscountCollections from "../DiscountCollections";
 import DiscountDates from "../DiscountDates";
 import DiscountProducts from "../DiscountProducts";
+import DiscountVariants from "../DiscountVariants";
 import SaleInfo from "../SaleInfo";
 import SaleSummary from "../SaleSummary";
 import SaleType from "../SaleType";
@@ -49,20 +50,27 @@ export interface SaleDetailsPageFormData extends MetadataFormData {
 export enum SaleDetailsPageTab {
   categories = "categories",
   collections = "collections",
-  products = "products"
+  products = "products",
+  variants = "variants"
 }
+
 export function saleDetailsPageTab(tab: string): SaleDetailsPageTab {
   return tab === SaleDetailsPageTab.products
     ? SaleDetailsPageTab.products
     : tab === SaleDetailsPageTab.collections
     ? SaleDetailsPageTab.collections
-    : SaleDetailsPageTab.categories;
+    : tab === SaleDetailsPageTab.categories
+    ? SaleDetailsPageTab.categories
+    : SaleDetailsPageTab.variants;
 }
 
 export interface SaleDetailsPageProps
   extends Pick<ListProps, Exclude<keyof ListProps, "onRowClick">>,
     TabListActions<
-      "categoryListToolbar" | "collectionListToolbar" | "productListToolbar"
+      | "categoryListToolbar"
+      | "collectionListToolbar"
+      | "productListToolbar"
+      | "variantListToolbar"
     >,
     ChannelProps {
   activeTab: SaleDetailsPageTab;
@@ -82,6 +90,9 @@ export interface SaleDetailsPageProps
   onProductAssign: () => void;
   onProductUnassign: (id: string) => void;
   onProductClick: (id: string) => () => void;
+  onVariantAssign: () => void;
+  onVariantUnassign: (id: string) => void;
+  onVariantClick: (productId: string, variantId: string) => () => void;
   onRemove: () => void;
   onSubmit: (data: SaleDetailsPageFormData) => void;
   onTabClick: (index: SaleDetailsPageTab) => void;
@@ -92,6 +103,7 @@ export interface SaleDetailsPageProps
 const CategoriesTab = Tab(SaleDetailsPageTab.categories);
 const CollectionsTab = Tab(SaleDetailsPageTab.collections);
 const ProductsTab = Tab(SaleDetailsPageTab.products);
+const VariantsTab = Tab(SaleDetailsPageTab.variants);
 
 const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
   activeTab,
@@ -120,9 +132,13 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
   onProductAssign,
   onProductUnassign,
   onProductClick,
+  onVariantAssign,
+  onVariantUnassign,
+  onVariantClick,
   categoryListToolbar,
   collectionListToolbar,
   productListToolbar,
+  variantListToolbar,
   isChecked,
   selected,
   selectedChannelId,
@@ -239,6 +255,25 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
                       }
                     )}
                   </ProductsTab>
+                  <VariantsTab
+                    testId="variants-tab"
+                    isActive={activeTab === SaleDetailsPageTab.variants}
+                    changeTab={onTabClick}
+                  >
+                    {intl.formatMessage(
+                      {
+                        defaultMessage: "Variants ({quantity})",
+                        description: "number of variants",
+                        id: "saleDetailsPageProductsQuantity"
+                      },
+                      {
+                        quantity: maybe(
+                          () => sale.variants.totalCount.toString(),
+                          "…"
+                        )
+                      }
+                    )}
+                  </VariantsTab>
                 </TabContainer>
                 <CardSpacer />
                 {activeTab === SaleDetailsPageTab.categories ? (
@@ -273,7 +308,7 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
                     toggleAll={toggleAll}
                     toolbar={collectionListToolbar}
                   />
-                ) : (
+                ) : activeTab === SaleDetailsPageTab.products ? (
                   <DiscountProducts
                     disabled={disabled}
                     onNextPage={onNextPage}
@@ -289,6 +324,22 @@ const SaleDetailsPage: React.FC<SaleDetailsPageProps> = ({
                     toggle={toggle}
                     toggleAll={toggleAll}
                     toolbar={productListToolbar}
+                  />
+                ) : (
+                  <DiscountVariants
+                    disabled={disabled}
+                    onNextPage={onNextPage}
+                    onPreviousPage={onPreviousPage}
+                    onVariantAssign={onVariantAssign}
+                    onVariantUnassign={onVariantUnassign}
+                    onRowClick={onVariantClick}
+                    pageInfo={pageInfo}
+                    discount={sale}
+                    isChecked={isChecked}
+                    selected={selected}
+                    toggle={toggle}
+                    toggleAll={toggleAll}
+                    toolbar={variantListToolbar}
                   />
                 )}
                 <CardSpacer />

--- a/src/discounts/fixtures.ts
+++ b/src/discounts/fixtures.ts
@@ -424,6 +424,147 @@ export const sale: SaleDetails_sale = {
     },
     totalCount: 4
   },
+  variants: {
+    edges: [
+      {
+        node: {
+          id: "UHJvZHVjdFZhcmlhbnQ6MzE0",
+          name: "XL",
+          product: {
+            id: "UHJvZHVjdDoxMTg=",
+            name: "White Hoodie",
+            thumbnail: {
+              url: placeholderImage,
+              __typename: "Image"
+            },
+            productType: {
+              id: "UHJvZHVjdFR5cGU6MTQ=",
+              name: "Top (clothing)",
+              __typename: "ProductType"
+            },
+            channelListings: [
+              {
+                isPublished: true,
+                publicationDate: "2020-01-01",
+                isAvailableForPurchase: true,
+                availableForPurchase: "2020-08-31",
+                visibleInListings: true,
+                channel: {
+                  id: "Q2hhbm5lbDox",
+                  name: "Channel-USD",
+                  currencyCode: "USD",
+                  __typename: "Channel"
+                },
+                __typename: "ProductChannelListing"
+              }
+            ],
+            __typename: "Product"
+          },
+          __typename: "ProductVariant"
+        },
+        __typename: "ProductVariantCountableEdge"
+      },
+      {
+        node: {
+          id: "UHJvZHVjdFZhcmlhbnQ6Mjc4",
+          name: "L",
+          product: {
+            id: "UHJvZHVjdDoxMTE=",
+            name: "T-shirt",
+            thumbnail: {
+              url: placeholderImage,
+              __typename: "Image"
+            },
+            productType: {
+              id: "UHJvZHVjdFR5cGU6MTQ=",
+              name: "Top (clothing)",
+              __typename: "ProductType"
+            },
+            channelListings: [
+              {
+                isPublished: true,
+                publicationDate: "2020-01-01",
+                isAvailableForPurchase: true,
+                availableForPurchase: "2020-08-31",
+                visibleInListings: true,
+                channel: {
+                  id: "Q2hhbm5lbDox",
+                  name: "Channel-USD",
+                  currencyCode: "USD",
+                  __typename: "Channel"
+                },
+                __typename: "ProductChannelListing"
+              }
+            ],
+            __typename: "Product"
+          },
+          __typename: "ProductVariant"
+        },
+        __typename: "ProductVariantCountableEdge"
+      },
+      {
+        node: {
+          id: "UHJvZHVjdFZhcmlhbnQ6MjUz",
+          name: "L",
+          product: {
+            id: "UHJvZHVjdDo4OQ==",
+            name: "Code Division T-shirt",
+            thumbnail: {
+              url: placeholderImage,
+              __typename: "Image"
+            },
+            productType: {
+              id: "UHJvZHVjdFR5cGU6MTQ=",
+              name: "Top (clothing)",
+              __typename: "ProductType"
+            },
+            channelListings: [
+              {
+                isPublished: true,
+                publicationDate: "2020-01-01",
+                isAvailableForPurchase: true,
+                availableForPurchase: "2020-08-31",
+                visibleInListings: true,
+                channel: {
+                  id: "Q2hhbm5lbDox",
+                  name: "Channel-USD",
+                  currencyCode: "USD",
+                  __typename: "Channel"
+                },
+                __typename: "ProductChannelListing"
+              },
+              {
+                isPublished: true,
+                publicationDate: "2020-01-01",
+                isAvailableForPurchase: true,
+                availableForPurchase: "2020-08-31",
+                visibleInListings: true,
+                channel: {
+                  id: "Q2hhbm5lbDoy",
+                  name: "Channel-PLN",
+                  currencyCode: "PLN",
+                  __typename: "Channel"
+                },
+                __typename: "ProductChannelListing"
+              }
+            ],
+            __typename: "Product"
+          },
+          __typename: "ProductVariant"
+        },
+        __typename: "ProductVariantCountableEdge"
+      }
+    ],
+    pageInfo: {
+      endCursor: "W251bGwsICIxMTgyMjM1OTEiXQ==",
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: "W251bGwsICIxMDQwNDk0NiJd",
+      __typename: "PageInfo"
+    },
+    totalCount: 3,
+    __typename: "ProductVariantCountableConnection"
+  },
   startDate: "2019-01-03",
   type: "PERCENTAGE" as SaleType
 };

--- a/src/discounts/types/SaleCataloguesAdd.ts
+++ b/src/discounts/types/SaleCataloguesAdd.ts
@@ -43,6 +43,70 @@ export interface SaleCataloguesAdd_saleCataloguesAdd_sale_channelListings {
   currency: string;
 }
 
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product_thumbnail {
+  __typename: "Image";
+  url: string;
+}
+
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product_productType {
+  __typename: "ProductType";
+  id: string;
+  name: string;
+}
+
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product_channelListings_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+  currencyCode: string;
+}
+
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product_channelListings {
+  __typename: "ProductChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  isAvailableForPurchase: boolean | null;
+  availableForPurchase: any | null;
+  visibleInListings: boolean;
+  channel: SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product_channelListings_channel;
+}
+
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product {
+  __typename: "Product";
+  id: string;
+  name: string;
+  thumbnail: SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product_thumbnail | null;
+  productType: SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product_productType;
+  channelListings: SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product_channelListings[] | null;
+}
+
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node {
+  __typename: "ProductVariant";
+  id: string;
+  name: string;
+  product: SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node_product;
+}
+
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges {
+  __typename: "ProductVariantCountableEdge";
+  node: SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges_node;
+}
+
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface SaleCataloguesAdd_saleCataloguesAdd_sale_variants {
+  __typename: "ProductVariantCountableConnection";
+  edges: SaleCataloguesAdd_saleCataloguesAdd_sale_variants_edges[];
+  pageInfo: SaleCataloguesAdd_saleCataloguesAdd_sale_variants_pageInfo;
+  totalCount: number | null;
+}
+
 export interface SaleCataloguesAdd_saleCataloguesAdd_sale_products_edges_node_productType {
   __typename: "ProductType";
   id: string;
@@ -174,6 +238,7 @@ export interface SaleCataloguesAdd_saleCataloguesAdd_sale {
   startDate: any;
   endDate: any | null;
   channelListings: SaleCataloguesAdd_saleCataloguesAdd_sale_channelListings[] | null;
+  variants: SaleCataloguesAdd_saleCataloguesAdd_sale_variants | null;
   products: SaleCataloguesAdd_saleCataloguesAdd_sale_products | null;
   categories: SaleCataloguesAdd_saleCataloguesAdd_sale_categories | null;
   collections: SaleCataloguesAdd_saleCataloguesAdd_sale_collections | null;

--- a/src/discounts/types/SaleCataloguesRemove.ts
+++ b/src/discounts/types/SaleCataloguesRemove.ts
@@ -43,6 +43,70 @@ export interface SaleCataloguesRemove_saleCataloguesRemove_sale_channelListings 
   currency: string;
 }
 
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product_thumbnail {
+  __typename: "Image";
+  url: string;
+}
+
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product_productType {
+  __typename: "ProductType";
+  id: string;
+  name: string;
+}
+
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product_channelListings_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+  currencyCode: string;
+}
+
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product_channelListings {
+  __typename: "ProductChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  isAvailableForPurchase: boolean | null;
+  availableForPurchase: any | null;
+  visibleInListings: boolean;
+  channel: SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product_channelListings_channel;
+}
+
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product {
+  __typename: "Product";
+  id: string;
+  name: string;
+  thumbnail: SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product_thumbnail | null;
+  productType: SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product_productType;
+  channelListings: SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product_channelListings[] | null;
+}
+
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node {
+  __typename: "ProductVariant";
+  id: string;
+  name: string;
+  product: SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node_product;
+}
+
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges {
+  __typename: "ProductVariantCountableEdge";
+  node: SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges_node;
+}
+
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface SaleCataloguesRemove_saleCataloguesRemove_sale_variants {
+  __typename: "ProductVariantCountableConnection";
+  edges: SaleCataloguesRemove_saleCataloguesRemove_sale_variants_edges[];
+  pageInfo: SaleCataloguesRemove_saleCataloguesRemove_sale_variants_pageInfo;
+  totalCount: number | null;
+}
+
 export interface SaleCataloguesRemove_saleCataloguesRemove_sale_products_edges_node_productType {
   __typename: "ProductType";
   id: string;
@@ -174,6 +238,7 @@ export interface SaleCataloguesRemove_saleCataloguesRemove_sale {
   startDate: any;
   endDate: any | null;
   channelListings: SaleCataloguesRemove_saleCataloguesRemove_sale_channelListings[] | null;
+  variants: SaleCataloguesRemove_saleCataloguesRemove_sale_variants | null;
   products: SaleCataloguesRemove_saleCataloguesRemove_sale_products | null;
   categories: SaleCataloguesRemove_saleCataloguesRemove_sale_categories | null;
   collections: SaleCataloguesRemove_saleCataloguesRemove_sale_collections | null;

--- a/src/discounts/types/SaleDetails.ts
+++ b/src/discounts/types/SaleDetails.ts
@@ -36,6 +36,70 @@ export interface SaleDetails_sale_channelListings {
   currency: string;
 }
 
+export interface SaleDetails_sale_variants_edges_node_product_thumbnail {
+  __typename: "Image";
+  url: string;
+}
+
+export interface SaleDetails_sale_variants_edges_node_product_productType {
+  __typename: "ProductType";
+  id: string;
+  name: string;
+}
+
+export interface SaleDetails_sale_variants_edges_node_product_channelListings_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+  currencyCode: string;
+}
+
+export interface SaleDetails_sale_variants_edges_node_product_channelListings {
+  __typename: "ProductChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  isAvailableForPurchase: boolean | null;
+  availableForPurchase: any | null;
+  visibleInListings: boolean;
+  channel: SaleDetails_sale_variants_edges_node_product_channelListings_channel;
+}
+
+export interface SaleDetails_sale_variants_edges_node_product {
+  __typename: "Product";
+  id: string;
+  name: string;
+  thumbnail: SaleDetails_sale_variants_edges_node_product_thumbnail | null;
+  productType: SaleDetails_sale_variants_edges_node_product_productType;
+  channelListings: SaleDetails_sale_variants_edges_node_product_channelListings[] | null;
+}
+
+export interface SaleDetails_sale_variants_edges_node {
+  __typename: "ProductVariant";
+  id: string;
+  name: string;
+  product: SaleDetails_sale_variants_edges_node_product;
+}
+
+export interface SaleDetails_sale_variants_edges {
+  __typename: "ProductVariantCountableEdge";
+  node: SaleDetails_sale_variants_edges_node;
+}
+
+export interface SaleDetails_sale_variants_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface SaleDetails_sale_variants {
+  __typename: "ProductVariantCountableConnection";
+  edges: SaleDetails_sale_variants_edges[];
+  pageInfo: SaleDetails_sale_variants_pageInfo;
+  totalCount: number | null;
+}
+
 export interface SaleDetails_sale_products_edges_node_productType {
   __typename: "ProductType";
   id: string;
@@ -167,6 +231,7 @@ export interface SaleDetails_sale {
   startDate: any;
   endDate: any | null;
   channelListings: SaleDetails_sale_channelListings[] | null;
+  variants: SaleDetails_sale_variants | null;
   products: SaleDetails_sale_products | null;
   categories: SaleDetails_sale_categories | null;
   collections: SaleDetails_sale_collections | null;

--- a/src/discounts/urls.ts
+++ b/src/discounts/urls.ts
@@ -53,9 +53,11 @@ export type SaleUrlDialog =
   | "assign-category"
   | "assign-collection"
   | "assign-product"
+  | "assign-variant"
   | "unassign-category"
   | "unassign-collection"
   | "unassign-product"
+  | "unassign-variant"
   | "remove"
   | ChannelsAction;
 export type SaleUrlQueryParams = Pagination &

--- a/src/fragments/discounts.ts
+++ b/src/fragments/discounts.ts
@@ -32,6 +32,32 @@ export const saleDetailsFragment = gql`
   ${saleFragment}
   fragment SaleDetailsFragment on Sale {
     ...SaleFragment
+    variants(after: $after, before: $before, first: $first, last: $last) {
+      edges {
+        node {
+          id
+          name
+          product {
+            id
+            name
+            thumbnail {
+              url
+            }
+            productType {
+              id
+              name
+            }
+            channelListings {
+              ...ChannelListingProductWithoutPricingFragment
+            }
+          }
+        }
+      }
+      pageInfo {
+        ...PageInfoFragment
+      }
+      totalCount
+    }
     products(after: $after, before: $before, first: $first, last: $last) {
       edges {
         node {

--- a/src/fragments/types/SaleDetailsFragment.ts
+++ b/src/fragments/types/SaleDetailsFragment.ts
@@ -36,6 +36,70 @@ export interface SaleDetailsFragment_channelListings {
   currency: string;
 }
 
+export interface SaleDetailsFragment_variants_edges_node_product_thumbnail {
+  __typename: "Image";
+  url: string;
+}
+
+export interface SaleDetailsFragment_variants_edges_node_product_productType {
+  __typename: "ProductType";
+  id: string;
+  name: string;
+}
+
+export interface SaleDetailsFragment_variants_edges_node_product_channelListings_channel {
+  __typename: "Channel";
+  id: string;
+  name: string;
+  currencyCode: string;
+}
+
+export interface SaleDetailsFragment_variants_edges_node_product_channelListings {
+  __typename: "ProductChannelListing";
+  isPublished: boolean;
+  publicationDate: any | null;
+  isAvailableForPurchase: boolean | null;
+  availableForPurchase: any | null;
+  visibleInListings: boolean;
+  channel: SaleDetailsFragment_variants_edges_node_product_channelListings_channel;
+}
+
+export interface SaleDetailsFragment_variants_edges_node_product {
+  __typename: "Product";
+  id: string;
+  name: string;
+  thumbnail: SaleDetailsFragment_variants_edges_node_product_thumbnail | null;
+  productType: SaleDetailsFragment_variants_edges_node_product_productType;
+  channelListings: SaleDetailsFragment_variants_edges_node_product_channelListings[] | null;
+}
+
+export interface SaleDetailsFragment_variants_edges_node {
+  __typename: "ProductVariant";
+  id: string;
+  name: string;
+  product: SaleDetailsFragment_variants_edges_node_product;
+}
+
+export interface SaleDetailsFragment_variants_edges {
+  __typename: "ProductVariantCountableEdge";
+  node: SaleDetailsFragment_variants_edges_node;
+}
+
+export interface SaleDetailsFragment_variants_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface SaleDetailsFragment_variants {
+  __typename: "ProductVariantCountableConnection";
+  edges: SaleDetailsFragment_variants_edges[];
+  pageInfo: SaleDetailsFragment_variants_pageInfo;
+  totalCount: number | null;
+}
+
 export interface SaleDetailsFragment_products_edges_node_productType {
   __typename: "ProductType";
   id: string;
@@ -167,6 +231,7 @@ export interface SaleDetailsFragment {
   startDate: any;
   endDate: any | null;
   channelListings: SaleDetailsFragment_channelListings[] | null;
+  variants: SaleDetailsFragment_variants | null;
   products: SaleDetailsFragment_products | null;
   categories: SaleDetailsFragment_categories | null;
   collections: SaleDetailsFragment_collections | null;

--- a/src/searches/types/SearchVariants.ts
+++ b/src/searches/types/SearchVariants.ts
@@ -1,0 +1,55 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SearchVariants
+// ====================================================
+
+export interface SearchVariants_search_edges_node_product_thumbnail {
+  __typename: "Image";
+  url: string;
+}
+
+export interface SearchVariants_search_edges_node_product {
+  __typename: "Product";
+  name: string;
+  thumbnail: SearchVariants_search_edges_node_product_thumbnail | null;
+}
+
+export interface SearchVariants_search_edges_node {
+  __typename: "ProductVariant";
+  id: string;
+  name: string;
+  product: SearchVariants_search_edges_node_product;
+}
+
+export interface SearchVariants_search_edges {
+  __typename: "ProductVariantCountableEdge";
+  node: SearchVariants_search_edges_node;
+}
+
+export interface SearchVariants_search_pageInfo {
+  __typename: "PageInfo";
+  endCursor: string | null;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  startCursor: string | null;
+}
+
+export interface SearchVariants_search {
+  __typename: "ProductVariantCountableConnection";
+  edges: SearchVariants_search_edges[];
+  pageInfo: SearchVariants_search_pageInfo;
+}
+
+export interface SearchVariants {
+  search: SearchVariants_search | null;
+}
+
+export interface SearchVariantsVariables {
+  after?: string | null;
+  first: number;
+  query: string;
+}

--- a/src/searches/useVariantSearch.ts
+++ b/src/searches/useVariantSearch.ts
@@ -1,0 +1,39 @@
+import { pageInfoFragment } from "@saleor/fragments/pageInfo";
+import makeTopLevelSearch from "@saleor/hooks/makeTopLevelSearch";
+import gql from "graphql-tag";
+
+import {
+  SearchVariants,
+  SearchVariantsVariables
+} from "./types/SearchVariants";
+
+export const searchVariants = gql`
+  ${pageInfoFragment}
+  query SearchVariants($after: String, $first: Int!, $query: String!) {
+    search: productVariants(
+      after: $after
+      first: $first
+      filter: { search: $query }
+    ) {
+      edges {
+        node {
+          id
+          name
+          product {
+            name
+            thumbnail {
+              url
+            }
+          }
+        }
+      }
+      pageInfo {
+        ...PageInfoFragment
+      }
+    }
+  }
+`;
+
+export default makeTopLevelSearch<SearchVariants, SearchVariantsVariables>(
+  searchVariants
+);

--- a/src/storybook/stories/discounts/SaleDetailsPage.tsx
+++ b/src/storybook/stories/discounts/SaleDetailsPage.tsx
@@ -36,6 +36,9 @@ const props: SaleDetailsPageProps = {
   onProductAssign: () => undefined,
   onProductClick: () => undefined,
   onProductUnassign: () => undefined,
+  onVariantAssign: () => undefined,
+  onVariantClick: () => undefined,
+  onVariantUnassign: () => undefined,
   onRemove: () => undefined,
   onSubmit: () => undefined,
   onTabClick: () => undefined,
@@ -45,6 +48,7 @@ const props: SaleDetailsPageProps = {
     hasPreviousPage: false
   },
   productListToolbar: null,
+  variantListToolbar: null,
   sale,
   saveButtonBarState: "default",
   selectedChannelId: "123",

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1989,6 +1989,7 @@ export interface CatalogueInput {
   products?: (string | null)[] | null;
   categories?: (string | null)[] | null;
   collections?: (string | null)[] | null;
+  variants?: (string | null)[] | null;
 }
 
 export interface CategoryFilterInput {
@@ -2633,6 +2634,7 @@ export interface SaleInput {
   type?: DiscountValueTypeEnum | null;
   value?: any | null;
   products?: (string | null)[] | null;
+  variants?: (string | null)[] | null;
   categories?: (string | null)[] | null;
   collections?: (string | null)[] | null;
   startDate?: any | null;


### PR DESCRIPTION
I want to merge this change because i need to add variants to sale page. Sale can be added per variant.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

Adding on sale view:

Variant table
![alt text](https://i.ibb.co/YLdJPhP/Screenshot-2021-09-17-at-12-26-49.png "Variant table")
Variant search
![alt text](https://i.ibb.co/7QRkZWh/Screenshot-2021-09-17-at-12-27-05.png "Variant search")

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [x] All visible strings are translated with proper context including data-formatting
3. [x] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
