### PR TITLE
Add page type and attributes permissions handling

### DIFF
--- a/cypress/Data/permissions.js
+++ b/cypress/Data/permissions.js
@@ -66,6 +66,13 @@ export const PERMISSIONS = {
       CONFIGURATION_SELECTORS.productTypes
     ]
   },
+  pageTypeAndAttribute: {
+    parent: configurationAsParent,
+    permissionSelectors: [
+      CONFIGURATION_SELECTORS.pageTypes,
+      CONFIGURATION_SELECTORS.attributes
+    ]
+  },
   settings: {
     parent: configurationAsParent,
     permissionSelectors: [

--- a/cypress/Data/permissionsUsers.js
+++ b/cypress/Data/permissionsUsers.js
@@ -33,9 +33,6 @@ export const PERMISSIONS_OPTIONS = {
     user: ONE_PERMISSION_USERS.page,
     permissions: [PERMISSIONS.page]
   },
-  pageTypeAndAttribute: {
-    user: ONE_PERMISSION_USERS.pageTypeAndAttribute
-  },
   plugin: {
     user: ONE_PERMISSION_USERS.plugin,
     permissions: [PERMISSIONS.plugin]
@@ -47,6 +44,10 @@ export const PERMISSIONS_OPTIONS = {
   productTypeAndAttribute: {
     user: ONE_PERMISSION_USERS.productTypeAndAttribute,
     permissions: [PERMISSIONS.productTypeAndAttribute]
+  },
+  pageTypeAndAttribute: {
+    user: ONE_PERMISSION_USERS.pageTypeAndAttribute,
+    permissions: [PERMISSIONS.pageTypeAndAttribute]
   },
   settings: {
     user: ONE_PERMISSION_USERS.settings,

--- a/src/auth/components/SectionRoute.tsx
+++ b/src/auth/components/SectionRoute.tsx
@@ -4,7 +4,7 @@ import { Route, RouteProps } from "react-router-dom";
 
 import NotFound from "../../NotFound";
 import { PermissionEnum } from "../../types/globalTypes";
-import { hasPermission } from "../misc";
+import { hasPermissions } from "../misc";
 
 interface SectionRouteProps extends RouteProps {
   permissions?: PermissionEnum[];
@@ -16,12 +16,10 @@ export const SectionRoute: React.FC<SectionRouteProps> = ({
 }) => {
   const { user } = useUser();
 
-  const hasPermissions =
-    !permissions ||
-    permissions
-      .map(permission => hasPermission(permission, user))
-      .reduce((prev, curr) => prev && curr);
-  return hasPermissions ? <Route {...props} /> : <NotFound />;
+  const hasSectionPermissions =
+    !permissions || hasPermissions(permissions, user);
+
+  return hasSectionPermissions ? <Route {...props} /> : <NotFound />;
 };
 SectionRoute.displayName = "Route";
 export default SectionRoute;

--- a/src/auth/components/SectionRoute.tsx
+++ b/src/auth/components/SectionRoute.tsx
@@ -4,22 +4,37 @@ import { Route, RouteProps } from "react-router-dom";
 
 import NotFound from "../../NotFound";
 import { PermissionEnum } from "../../types/globalTypes";
-import { hasPermissions } from "../misc";
+import { hasAllPermissions, hasAnyPermissions } from "../misc";
+
+type MatchPermissionType = "all" | "any";
 
 interface SectionRouteProps extends RouteProps {
   permissions?: PermissionEnum[];
+  matchPermission?: MatchPermissionType;
 }
+
+const matchAll = (match: MatchPermissionType) => match === "all";
 
 export const SectionRoute: React.FC<SectionRouteProps> = ({
   permissions,
+  matchPermission = "all",
   ...props
 }) => {
   const { user } = useUser();
 
-  const hasSectionPermissions =
-    !permissions || hasPermissions(permissions, user);
+  const hasSectionPermissions = () => {
+    if (!permissions) {
+      return true;
+    }
 
-  return hasSectionPermissions ? <Route {...props} /> : <NotFound />;
+    if (matchAll(matchPermission)) {
+      return hasAllPermissions(permissions, user);
+    }
+
+    return hasAnyPermissions(permissions, user);
+  };
+
+  return hasSectionPermissions() ? <Route {...props} /> : <NotFound />;
 };
 SectionRoute.displayName = "Route";
 export default SectionRoute;

--- a/src/auth/misc.ts
+++ b/src/auth/misc.ts
@@ -4,3 +4,6 @@ import { PermissionEnum } from "../types/globalTypes";
 
 export const hasPermission = (permission: PermissionEnum, user: User) =>
   user.userPermissions.map(perm => perm.code).includes(permission);
+
+export const hasPermissions = (permissions: PermissionEnum[], user: User) =>
+  permissions.some(permission => hasPermission(permission, user));

--- a/src/auth/misc.ts
+++ b/src/auth/misc.ts
@@ -5,5 +5,8 @@ import { PermissionEnum } from "../types/globalTypes";
 export const hasPermission = (permission: PermissionEnum, user: User) =>
   user.userPermissions.map(perm => perm.code).includes(permission);
 
-export const hasPermissions = (permissions: PermissionEnum[], user: User) =>
-  permissions.some(permission => hasPermission(permission, user));
+export const hasAnyPermissions = (permissions: PermissionEnum[], user: User) =>
+  permissions?.some(permission => hasPermission(permission, user)) || false;
+
+export const hasAllPermissions = (permissions: PermissionEnum[], user: User) =>
+  permissions?.every(permission => hasPermission(permission, user)) || false;

--- a/src/components/AppLayout/menuStructure.ts
+++ b/src/components/AppLayout/menuStructure.ts
@@ -6,11 +6,8 @@ import discountsIcon from "@assets/images/menu-discounts-icon.svg";
 import homeIcon from "@assets/images/menu-home-icon.svg";
 import ordersIcon from "@assets/images/menu-orders-icon.svg";
 import translationIcon from "@assets/images/menu-translation-icon.svg";
-import {
-  configurationMenuUrl,
-  createConfigurationMenu
-} from "@saleor/configuration";
-import { MenuItem } from "@saleor/configuration/ConfigurationPage";
+import { configurationMenuUrl } from "@saleor/configuration";
+import { getConfigMenuItemsPermissions } from "@saleor/configuration/utils";
 import { User } from "@saleor/fragments/types/User";
 import { giftCardsListUrl } from "@saleor/giftCards/urls";
 import { commonMessages, sectionNames } from "@saleor/intl";
@@ -33,8 +30,6 @@ interface FilterableMenuItem extends Omit<SidebarMenuItem, "children"> {
 }
 
 function createMenuStructure(intl: IntlShape, user: User): SidebarMenuItem[] {
-  const configurationMenu = createConfigurationMenu(intl);
-
   const menuItems: FilterableMenuItem[] = [
     {
       ariaLabel: "home",
@@ -152,12 +147,7 @@ function createMenuStructure(intl: IntlShape, user: User): SidebarMenuItem[] {
       ariaLabel: "configure",
       iconSrc: configurationIcon,
       label: intl.formatMessage(sectionNames.configuration),
-      permissions: configurationMenu
-        .reduce(
-          (sections, section) => [...sections, ...section.menuItems],
-          [] as MenuItem[]
-        )
-        .map(section => section.permission),
+      permissions: getConfigMenuItemsPermissions(intl),
       id: "configure",
       url: configurationMenuUrl
     }

--- a/src/configuration/ConfigurationPage.tsx
+++ b/src/configuration/ConfigurationPage.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { hasPermission } from "../auth/misc";
+import { hasPermissions } from "../auth/misc";
 import Container from "../components/Container";
 import PageHeader from "../components/PageHeader";
 import { PermissionEnum } from "../types/globalTypes";
@@ -14,7 +14,7 @@ import { PermissionEnum } from "../types/globalTypes";
 export interface MenuItem {
   description: string;
   icon: React.ReactElement<IconProps>;
-  permission: PermissionEnum;
+  permissions: PermissionEnum[];
   title: string;
   url?: string;
   testId?: string;
@@ -100,6 +100,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
   const classes = useStyles(props);
 
   const intl = useIntl();
+
   return (
     <Container>
       <PageHeader
@@ -109,7 +110,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
       {menus
         .filter(menu =>
           menu.menuItems.some(menuItem =>
-            hasPermission(menuItem.permission, user)
+            hasPermissions(menuItem.permissions, user)
           )
         )
         .map((menu, menuIndex) => (
@@ -119,7 +120,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
             </div>
             <div className={classes.configurationItem}>
               {menu.menuItems
-                .filter(menuItem => hasPermission(menuItem.permission, user))
+                .filter(menuItem => hasPermissions(menuItem.permissions, user))
                 .map((item, itemIndex) => (
                   <Card
                     className={item.url ? classes.card : classes.cardDisabled}

--- a/src/configuration/ConfigurationPage.tsx
+++ b/src/configuration/ConfigurationPage.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from "@saleor/macaw-ui";
 import React from "react";
 import { useIntl } from "react-intl";
 
-import { hasPermissions } from "../auth/misc";
+import { hasAnyPermissions } from "../auth/misc";
 import Container from "../components/Container";
 import PageHeader from "../components/PageHeader";
 import { PermissionEnum } from "../types/globalTypes";
@@ -110,7 +110,7 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
       {menus
         .filter(menu =>
           menu.menuItems.some(menuItem =>
-            hasPermissions(menuItem.permissions, user)
+            hasAnyPermissions(menuItem.permissions, user)
           )
         )
         .map((menu, menuIndex) => (
@@ -120,7 +120,9 @@ export const ConfigurationPage: React.FC<ConfigurationPageProps> = props => {
             </div>
             <div className={classes.configurationItem}>
               {menu.menuItems
-                .filter(menuItem => hasPermissions(menuItem.permissions, user))
+                .filter(menuItem =>
+                  hasAnyPermissions(menuItem.permissions, user)
+                )
                 .map((item, itemIndex) => (
                   <Card
                     className={item.url ? classes.card : classes.cardDisabled}

--- a/src/configuration/index.tsx
+++ b/src/configuration/index.tsx
@@ -48,7 +48,10 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuAttributes"
           }),
           icon: <Attributes fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+          permissions: [
+            PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+            PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES
+          ],
           title: intl.formatMessage(sectionNames.attributes),
           url: attributeListUrl(),
           testId: "configurationMenuAttributes"
@@ -59,39 +62,10 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuProductTypes"
           }),
           icon: <ProductTypes fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+          permissions: [PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES],
           title: intl.formatMessage(sectionNames.productTypes),
           url: productTypeListUrl(),
           testId: "configurationMenuProductTypes"
-        }
-      ]
-    },
-    {
-      label: intl.formatMessage({
-        defaultMessage: "Attributes and Page Types"
-      }),
-      menuItems: [
-        {
-          description: intl.formatMessage({
-            defaultMessage: "Determine attributes used to create page types",
-            id: "configurationMenuPageAttributes"
-          }),
-          icon: <ProductTypes fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
-          title: intl.formatMessage(sectionNames.attributes),
-          url: attributeListUrl(),
-          testId: "configurationMenuPageAttributes"
-        },
-        {
-          description: intl.formatMessage({
-            defaultMessage: "Define types of pages you create",
-            id: "configurationMenuPageTypes"
-          }),
-          icon: <Attributes fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
-          title: intl.formatMessage(sectionNames.pageTypes),
-          url: productTypeListUrl(),
-          testId: "configurationMenuPageTypes"
         }
       ]
     },
@@ -106,7 +80,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuTaxes"
           }),
           icon: <Taxes fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_SETTINGS,
+          permissions: [PermissionEnum.MANAGE_SETTINGS],
           title: intl.formatMessage(sectionNames.taxes),
           url: taxSection,
           testId: "configurationMenuTaxes"
@@ -124,7 +98,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuStaff"
           }),
           icon: <StaffMembers fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_STAFF,
+          permissions: [PermissionEnum.MANAGE_STAFF],
           title: intl.formatMessage(sectionNames.staff),
           url: staffListUrl(),
           testId: "configurationMenuStaff"
@@ -136,7 +110,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuPermissionGroups"
           }),
           icon: <PermissionGroups fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_STAFF,
+          permissions: [PermissionEnum.MANAGE_STAFF],
           title: intl.formatMessage(sectionNames.permissionGroups),
           url: permissionGroupListUrl(),
           testId: "configurationMenuPermissionGroups"
@@ -154,7 +128,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuShipping"
           }),
           icon: <ShippingMethods fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_SHIPPING,
+          permissions: [PermissionEnum.MANAGE_SHIPPING],
           title: intl.formatMessage(sectionNames.shipping),
           url: shippingZonesListUrl(),
           testId: "configurationMenuShipping"
@@ -165,7 +139,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuWarehouses"
           }),
           icon: <Warehouses fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PRODUCTS,
+          permissions: [PermissionEnum.MANAGE_PRODUCTS],
           title: intl.formatMessage(sectionNames.warehouses),
           url: warehouseSection,
           testId: "configurationMenuWarehouses"
@@ -183,7 +157,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuChannels"
           }),
           icon: <Channels fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_CHANNELS,
+          permissions: [PermissionEnum.MANAGE_CHANNELS],
           title: intl.formatMessage(sectionNames.channels),
           url: channelsListUrl(),
           testId: "configurationMenuChannels"
@@ -201,7 +175,10 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuPageTypes"
           }),
           icon: <PageTypes fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PAGES,
+          permissions: [
+            PermissionEnum.MANAGE_PAGES,
+            PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES
+          ],
           title: intl.formatMessage(sectionNames.pageTypes),
           url: pageTypeListUrl(),
           testId: "configurationMenuPageTypes"
@@ -212,7 +189,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuPages"
           }),
           icon: <Pages fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_PAGES,
+          permissions: [PermissionEnum.MANAGE_PAGES],
           title: intl.formatMessage(sectionNames.pages),
           url: pageListUrl(),
           testId: "configurationMenuPages"
@@ -230,7 +207,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuNavigation"
           }),
           icon: <Navigation fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_MENUS,
+          permissions: [PermissionEnum.MANAGE_MENUS],
           title: intl.formatMessage(sectionNames.navigation),
           url: menuListUrl(),
           testId: "configurationMenuNavigation"
@@ -241,7 +218,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
             id: "configurationMenuSiteSettings"
           }),
           icon: <SiteSettings fontSize="inherit" viewBox="0 0 44 44" />,
-          permission: PermissionEnum.MANAGE_SETTINGS,
+          permissions: [PermissionEnum.MANAGE_SETTINGS],
           title: intl.formatMessage(sectionNames.siteSettings),
           url: siteSettingsUrl(),
           testId: "configurationMenuSiteSettings"
@@ -258,7 +235,7 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
               preserveAspectRatio="xMinYMin meet"
             />
           ),
-          permission: PermissionEnum.MANAGE_PLUGINS,
+          permissions: [PermissionEnum.MANAGE_PLUGINS],
           title: intl.formatMessage(sectionNames.plugins),
           url: pluginListUrl(),
           testId: "configurationPluginsPages"

--- a/src/configuration/index.tsx
+++ b/src/configuration/index.tsx
@@ -68,6 +68,35 @@ export function createConfigurationMenu(intl: IntlShape): MenuSection[] {
     },
     {
       label: intl.formatMessage({
+        defaultMessage: "Attributes and Page Types"
+      }),
+      menuItems: [
+        {
+          description: intl.formatMessage({
+            defaultMessage: "Determine attributes used to create page types",
+            id: "configurationMenuPageAttributes"
+          }),
+          icon: <ProductTypes fontSize="inherit" viewBox="0 0 44 44" />,
+          permission: PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+          title: intl.formatMessage(sectionNames.attributes),
+          url: attributeListUrl(),
+          testId: "configurationMenuPageAttributes"
+        },
+        {
+          description: intl.formatMessage({
+            defaultMessage: "Define types of pages you create",
+            id: "configurationMenuPageTypes"
+          }),
+          icon: <Attributes fontSize="inherit" viewBox="0 0 44 44" />,
+          permission: PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+          title: intl.formatMessage(sectionNames.pageTypes),
+          url: productTypeListUrl(),
+          testId: "configurationMenuPageTypes"
+        }
+      ]
+    },
+    {
+      label: intl.formatMessage({
         defaultMessage: "Product Settings"
       }),
       menuItems: [

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -12,4 +12,4 @@ export const getConfigMenuItemsPermissions = (
         prev.concat(next.menuItems.map(menuItem => menuItem.permissions)),
       []
     )
-    .reduce((prev, next) => prev.concat(next), []);
+    .flat();

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -8,8 +8,10 @@ export const getConfigMenuItemsPermissions = (
 ): PermissionEnum[] =>
   createConfigurationMenu(intl)
     .reduce(
-      (prev, next) =>
-        prev.concat(next.menuItems.map(menuItem => menuItem.permissions)),
+      (prev, { menuItems }) => [
+        ...prev,
+        ...menuItems.map(({ permissions }) => permissions)
+      ],
       []
     )
     .flat();

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -1,0 +1,15 @@
+import { PermissionEnum } from "@saleor/types/globalTypes";
+import { IntlShape } from "react-intl";
+
+import { createConfigurationMenu } from ".";
+
+export const getConfigMenuItemsPermissions = (
+  intl: IntlShape
+): PermissionEnum[] =>
+  createConfigurationMenu(intl)
+    .reduce(
+      (prev, next) =>
+        prev.concat(next.menuItems.map(menuItem => menuItem.permissions)),
+      []
+    )
+    .reduce((prev, next) => prev.concat(next), []);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ import AuthProvider, { useAuth } from "./auth/AuthProvider";
 import LoginLoading from "./auth/components/LoginLoading/LoginLoading";
 import SectionRoute from "./auth/components/SectionRoute";
 import authLink from "./auth/link";
-import { hasPermission } from "./auth/misc";
+import { hasPermissions } from "./auth/misc";
 import CategorySection from "./categories";
 import ChannelsSection from "./channels";
 import { channelsSection } from "./channels/urls";
@@ -41,7 +41,8 @@ import MessageManagerProvider from "./components/messages";
 import { ShopProvider } from "./components/Shop";
 import { WindowTitle } from "./components/WindowTitle";
 import { API_URI, APP_MOUNT_URI, DEMO_MODE, GTM_ID } from "./config";
-import ConfigurationSection, { createConfigurationMenu } from "./configuration";
+import ConfigurationSection from "./configuration";
+import { getConfigMenuItemsPermissions } from "./configuration/utils";
 import AppStateProvider from "./containers/AppState";
 import BackgroundTasksProvider from "./containers/BackgroundTasks";
 import ServiceWorker from "./containers/ServiceWorker/ServiceWorker";
@@ -71,6 +72,7 @@ import TranslationsSection from "./translations";
 import { PermissionEnum } from "./types/globalTypes";
 import WarehouseSection from "./warehouses";
 import { warehouseSection } from "./warehouses/urls";
+
 if (process.env.GTM_ID) {
   TagManager.initialize({ gtmId: GTM_ID });
 }
@@ -155,31 +157,6 @@ const Routes: React.FC = () => {
     user
   } = useAuth();
 
-  console.log(user);
-
-  // {
-  //   createConfigurationMenu(intl).filter(menu =>
-  //     menu.menuItems.map(item => hasPermission(item.permission, user))
-  //   ).length > 0 && (
-  //     <SectionRoute
-  //       exact
-  //       path="/configuration"
-  //       component={ConfigurationSection}
-  //     />
-  //   );
-  // }
-
-  console.log("create config menu", createConfigurationMenu(intl));
-  console.log(user);
-  // console.log(
-  // createConfigurationMenu(intl).filter(menu => {
-  //   console.log("menu items", menu.menuItems);
-  //   console.log("user", user);
-
-  //   return menu.menuItems.map(item => hasPermission(item.permission, user));
-  // });
-  // );
-
   const { channel } = useAppChannel(false);
 
   const channelLoaded = typeof channel !== "undefined";
@@ -245,7 +222,10 @@ const Routes: React.FC = () => {
                 component={PageSection}
               />
               <SectionRoute
-                permissions={[PermissionEnum.MANAGE_PAGES]}
+                permissions={[
+                  PermissionEnum.MANAGE_PAGES,
+                  PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES
+                ]}
                 path="/page-types"
                 component={PageTypesSection}
               />
@@ -308,7 +288,8 @@ const Routes: React.FC = () => {
               />
               <SectionRoute
                 permissions={[
-                  PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES
+                  PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+                  PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES
                 ]}
                 path={attributeSection}
                 component={AttributeSection}
@@ -328,9 +309,7 @@ const Routes: React.FC = () => {
                 path={channelsSection}
                 component={ChannelsSection}
               />
-              {createConfigurationMenu(intl).filter(menu =>
-                menu.menuItems.map(item => hasPermission(item.permission, user))
-              ).length > 0 && (
+              {hasPermissions(getConfigMenuItemsPermissions(intl), user) && (
                 <SectionRoute
                   exact
                   path="/configuration"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -155,6 +155,31 @@ const Routes: React.FC = () => {
     user
   } = useAuth();
 
+  console.log(user);
+
+  // {
+  //   createConfigurationMenu(intl).filter(menu =>
+  //     menu.menuItems.map(item => hasPermission(item.permission, user))
+  //   ).length > 0 && (
+  //     <SectionRoute
+  //       exact
+  //       path="/configuration"
+  //       component={ConfigurationSection}
+  //     />
+  //   );
+  // }
+
+  console.log("create config menu", createConfigurationMenu(intl));
+  console.log(user);
+  // console.log(
+  // createConfigurationMenu(intl).filter(menu => {
+  //   console.log("menu items", menu.menuItems);
+  //   console.log("user", user);
+
+  //   return menu.menuItems.map(item => hasPermission(item.permission, user));
+  // });
+  // );
+
   const { channel } = useAppChannel(false);
 
   const channelLoaded = typeof channel !== "undefined";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ import AuthProvider, { useAuth } from "./auth/AuthProvider";
 import LoginLoading from "./auth/components/LoginLoading/LoginLoading";
 import SectionRoute from "./auth/components/SectionRoute";
 import authLink from "./auth/link";
-import { hasPermissions } from "./auth/misc";
+import { hasAnyPermissions } from "./auth/misc";
 import CategorySection from "./categories";
 import ChannelsSection from "./channels";
 import { channelsSection } from "./channels/urls";
@@ -228,6 +228,7 @@ const Routes: React.FC = () => {
                 ]}
                 path="/page-types"
                 component={PageTypesSection}
+                matchPermission="any"
               />
               <SectionRoute
                 permissions={[PermissionEnum.MANAGE_PLUGINS]}
@@ -293,6 +294,7 @@ const Routes: React.FC = () => {
                 ]}
                 path={attributeSection}
                 component={AttributeSection}
+                matchPermission="any"
               />
               <SectionRoute
                 permissions={[PermissionEnum.MANAGE_APPS]}
@@ -309,7 +311,7 @@ const Routes: React.FC = () => {
                 path={channelsSection}
                 component={ChannelsSection}
               />
-              {hasPermissions(getConfigMenuItemsPermissions(intl), user) && (
+              {hasAnyPermissions(getConfigMenuItemsPermissions(intl), user) && (
                 <SectionRoute
                   exact
                   path="/configuration"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,6 @@ import AuthProvider, { useAuth } from "./auth/AuthProvider";
 import LoginLoading from "./auth/components/LoginLoading/LoginLoading";
 import SectionRoute from "./auth/components/SectionRoute";
 import authLink from "./auth/link";
-import { hasAnyPermissions } from "./auth/misc";
 import CategorySection from "./categories";
 import ChannelsSection from "./channels";
 import { channelsSection } from "./channels/urls";
@@ -153,8 +152,7 @@ const Routes: React.FC = () => {
     hasToken,
     isAuthenticated,
     tokenAuthLoading,
-    tokenVerifyLoading,
-    user
+    tokenVerifyLoading
   } = useAuth();
 
   const { channel } = useAppChannel(false);
@@ -311,13 +309,13 @@ const Routes: React.FC = () => {
                 path={channelsSection}
                 component={ChannelsSection}
               />
-              {hasAnyPermissions(getConfigMenuItemsPermissions(intl), user) && (
-                <SectionRoute
-                  exact
-                  path="/configuration"
-                  component={ConfigurationSection}
-                />
-              )}
+              <SectionRoute
+                matchPermission="any"
+                permissions={getConfigMenuItemsPermissions(intl)}
+                exact
+                path="/configuration"
+                component={ConfigurationSection}
+              />
               <Route component={NotFound} />
             </Switch>
           </ErrorBoundary>


### PR DESCRIPTION
I want to merge this change because I wanted to add handling for missing permissions for page type and attributes. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
