### PR TITLE
Fetch shop data after user is authenticated

### DIFF
--- a/src/components/Shop/index.tsx
+++ b/src/components/Shop/index.tsx
@@ -2,6 +2,7 @@ import appleTouchIcon from "@assets/favicons/apple-touch-icon.png";
 import favicon16 from "@assets/favicons/favicon-16x16.png";
 import favicon32 from "@assets/favicons/favicon-32x32.png";
 import safariPinnedTab from "@assets/favicons/safari-pinned-tab.svg";
+import { useAuth } from "@saleor/auth/AuthProvider";
 import React from "react";
 import Helmet from "react-helmet";
 
@@ -12,22 +13,31 @@ type ShopContext = ShopInfo_shop;
 
 export const ShopContext = React.createContext<ShopContext>(undefined);
 
-export const ShopProvider: React.FC = ({ children }) => (
-  <TypedShopInfoQuery>
-    {({ data }) => (
-      <>
-        <Helmet>
-          <link rel="apple-touch-icon" sizes="180x180" href={appleTouchIcon} />
-          <link rel="icon" type="image/png" sizes="32x32" href={favicon32} />
-          <link rel="icon" type="image/png" sizes="16x16" href={favicon16} />
-          <link rel="mask-icon" href={safariPinnedTab} />
-        </Helmet>
-        <ShopContext.Provider value={data ? data.shop : undefined}>
-          {children}
-        </ShopContext.Provider>
-      </>
-    )}
-  </TypedShopInfoQuery>
-);
+export const ShopProvider: React.FC = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+
+  return (
+    <TypedShopInfoQuery skip={!isAuthenticated}>
+      {({ data }) => (
+        <>
+          <Helmet>
+            <link
+              rel="apple-touch-icon"
+              sizes="180x180"
+              href={appleTouchIcon}
+            />
+            <link rel="icon" type="image/png" sizes="32x32" href={favicon32} />
+            <link rel="icon" type="image/png" sizes="16x16" href={favicon16} />
+            <link rel="mask-icon" href={safariPinnedTab} />
+          </Helmet>
+          <ShopContext.Provider value={data ? data.shop : undefined}>
+            {children}
+          </ShopContext.Provider>
+        </>
+      )}
+    </TypedShopInfoQuery>
+  );
+};
+
 export const Shop = ShopContext.Consumer;
 export default Shop;

--- a/src/components/Shop/query.ts
+++ b/src/components/Shop/query.ts
@@ -13,7 +13,6 @@ const shopInfo = gql`
         country
         code
       }
-      channelCurrencies
       defaultCountry {
         code
         country
@@ -35,6 +34,7 @@ const shopInfo = gql`
         code
         name
       }
+      version
     }
   }
 `;

--- a/src/components/Shop/types/ShopInfo.ts
+++ b/src/components/Shop/types/ShopInfo.ts
@@ -42,7 +42,6 @@ export interface ShopInfo_shop_permissions {
 export interface ShopInfo_shop {
   __typename: "Shop";
   countries: ShopInfo_shop_countries[];
-  channelCurrencies: string[];
   defaultCountry: ShopInfo_shop_defaultCountry | null;
   defaultWeightUnit: WeightUnitsEnum | null;
   displayGrossPrices: boolean;
@@ -52,6 +51,7 @@ export interface ShopInfo_shop {
   name: string;
   trackInventoryByDefault: boolean | null;
   permissions: (ShopInfo_shop_permissions | null)[];
+  version: string;
 }
 
 export interface ShopInfo {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -125,15 +125,15 @@ const App: React.FC = () => (
               <ServiceWorker />
               <BackgroundTasksProvider>
                 <AppStateProvider>
-                  <ShopProvider>
-                    <AuthProvider>
+                  <AuthProvider>
+                    <ShopProvider>
                       <AppChannelProvider>
                         <ExternalAppProvider>
                           <Routes />
                         </ExternalAppProvider>
                       </AppChannelProvider>
-                    </AuthProvider>
-                  </ShopProvider>
+                    </ShopProvider>
+                  </AuthProvider>
                 </AppStateProvider>
               </BackgroundTasksProvider>
             </MessageManagerProvider>

--- a/src/siteSettings/mutations.ts
+++ b/src/siteSettings/mutations.ts
@@ -1,4 +1,3 @@
-import { IS_CLOUD_INSTANCE } from "@saleor/config";
 import { fragmentAddress } from "@saleor/fragments/address";
 import { shopErrorFragment } from "@saleor/fragments/errors";
 import { shopFragment } from "@saleor/fragments/shop";
@@ -18,6 +17,7 @@ const shopSettingsUpdate = gql`
     $shopDomainInput: SiteDomainInput!
     $shopSettingsInput: ShopSettingsInput!
     $addressInput: AddressInput
+    $isCloudInstance: Boolean!
   ) {
     shopSettingsUpdate(input: $shopSettingsInput) {
       errors {
@@ -27,7 +27,7 @@ const shopSettingsUpdate = gql`
         ...ShopFragment
       }
     }
-    shopDomainUpdate(input: $shopDomainInput) @skip(if: ${IS_CLOUD_INSTANCE}) {
+    shopDomainUpdate(input: $shopDomainInput) @skip(if: $isCloudInstance) {
       errors {
         ...ShopErrorFragment
       }

--- a/src/siteSettings/types/ShopSettingsUpdate.ts
+++ b/src/siteSettings/types/ShopSettingsUpdate.ts
@@ -138,4 +138,5 @@ export interface ShopSettingsUpdateVariables {
   shopDomainInput: SiteDomainInput;
   shopSettingsInput: ShopSettingsInput;
   addressInput?: AddressInput | null;
+  isCloudInstance: boolean;
 }

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -1,4 +1,5 @@
 import { WindowTitle } from "@saleor/components/WindowTitle";
+import { IS_CLOUD_INSTANCE } from "@saleor/config";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import { commonMessages, sectionNames } from "@saleor/intl";
@@ -80,7 +81,8 @@ export const SiteSettings: React.FC<SiteSettingsProps> = () => {
                   },
                   shopSettingsInput: {
                     description: data.description
-                  }
+                  },
+                  isCloudInstance: IS_CLOUD_INSTANCE
                 }
               });
 


### PR DESCRIPTION
I want to merge this change because it:
1. Gets rid off the unused `channelCurrencies` field
2. Delays the query after the user is authenticated, which allows to include staff-only fields (like `version`)

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
