### PR TITLE
Change values in create sale page when percentage/fixed amount is switched

### DIFF
--- a/src/discounts/components/SaleValue/SaleValue.tsx
+++ b/src/discounts/components/SaleValue/SaleValue.tsx
@@ -4,7 +4,6 @@ import {
   TableBody,
   TableCell,
   TableRow,
-  TextField,
   Typography
 } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
@@ -13,22 +12,21 @@ import Skeleton from "@saleor/components/Skeleton";
 import TableHead from "@saleor/components/TableHead";
 import { DiscountErrorFragment } from "@saleor/fragments/types/DiscountErrorFragment";
 import { renderCollection } from "@saleor/misc";
-import { SaleType } from "@saleor/types/globalTypes";
 import { getFormErrors } from "@saleor/utils/errors";
 import getDiscountErrorMessage from "@saleor/utils/errors/discounts";
 import * as React from "react";
-import { useEffect } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { SaleDetailsPageFormData } from "../SaleDetailsPage";
 import SaleValueTextField from "./SaleValueTextField";
 import { useStyles } from "./styles";
+import { SaleValueInputChangeType } from "./types";
 
 export interface SaleValueProps {
   data: SaleDetailsPageFormData;
   disabled: boolean;
   errors: DiscountErrorFragment[];
-  onChange: (channelId: string, discountValue: string) => void;
+  onChange: SaleValueInputChangeType;
 }
 
 const numberOfColumns = 2;
@@ -43,17 +41,6 @@ const SaleValue: React.FC<SaleValueProps> = ({
   const intl = useIntl();
   const classes = useStyles({});
   const formErrors = getFormErrors(["value"], errors);
-
-  // useEffect(() => {
-  //   // console.log(type);
-  //   if (type === SaleType.FIXED) {
-  //     // console.log(data);
-  //     data.channelListings.forEach(listing => {
-  //       console.log("Bonjourrrr", listing.id);
-  //       onChange(listing.id, "0");
-  //     });
-  //   }
-  // }, [type]);
 
   return (
     <Card>
@@ -122,38 +109,6 @@ const SaleValue: React.FC<SaleValueProps> = ({
                             onChange={onChange}
                           />
                         ) : (
-                          // <TextField
-                          //   disabled={disabled}
-                          //   helperText={
-                          //     error
-                          //       ? getDiscountErrorMessage(
-                          //           formErrors.value,
-                          //           intl
-                          //         )
-                          //       : ""
-                          //   }
-                          //   name="value"
-                          //   onChange={e => {
-                          //     console.info(listing.id, e.target.value);
-                          //     onChange(listing.id, e.target.value);
-                          //   }}
-                          //   label={intl.formatMessage({
-                          //     defaultMessage: "Discount Value",
-                          //     description: "sale discount"
-                          //   })}
-                          //   value={listing.discountValue || ""}
-                          //   type="number"
-                          //   fullWidth
-                          //   inputProps={{
-                          //     min: 0
-                          //   }}
-                          //   InputProps={{
-                          //     endAdornment:
-                          //       data.type === SaleType.FIXED
-                          //         ? listing.currency
-                          //         : "%"
-                          //   }}
-                          // />
                           <Skeleton />
                         )}
                       </TableCell>

--- a/src/discounts/components/SaleValue/SaleValue.tsx
+++ b/src/discounts/components/SaleValue/SaleValue.tsx
@@ -16,10 +16,12 @@ import { renderCollection } from "@saleor/misc";
 import { SaleType } from "@saleor/types/globalTypes";
 import { getFormErrors } from "@saleor/utils/errors";
 import getDiscountErrorMessage from "@saleor/utils/errors/discounts";
-import React from "react";
+import * as React from "react";
+import { useEffect } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { SaleDetailsPageFormData } from "../SaleDetailsPage";
+import SaleValueTextField from "./SaleValueTextField";
 import { useStyles } from "./styles";
 
 export interface SaleValueProps {
@@ -37,9 +39,21 @@ const SaleValue: React.FC<SaleValueProps> = ({
   errors,
   onChange
 }) => {
+  const { type } = data;
   const intl = useIntl();
   const classes = useStyles({});
   const formErrors = getFormErrors(["value"], errors);
+
+  // useEffect(() => {
+  //   // console.log(type);
+  //   if (type === SaleType.FIXED) {
+  //     // console.log(data);
+  //     data.channelListings.forEach(listing => {
+  //       console.log("Bonjourrrr", listing.id);
+  //       onChange(listing.id, "0");
+  //     });
+  //   }
+  // }, [type]);
 
   return (
     <Card>
@@ -93,8 +107,8 @@ const SaleValue: React.FC<SaleValueProps> = ({
                       </TableCell>
                       <TableCell>
                         {listing ? (
-                          <TextField
-                            disabled={disabled}
+                          <SaleValueTextField
+                            dataType={type}
                             helperText={
                               error
                                 ? getDiscountErrorMessage(
@@ -103,26 +117,43 @@ const SaleValue: React.FC<SaleValueProps> = ({
                                   )
                                 : ""
                             }
-                            name="value"
-                            onChange={e => onChange(listing.id, e.target.value)}
-                            label={intl.formatMessage({
-                              defaultMessage: "Discount Value",
-                              description: "sale discount"
-                            })}
-                            value={listing.discountValue || ""}
-                            type="number"
-                            fullWidth
-                            inputProps={{
-                              min: 0
-                            }}
-                            InputProps={{
-                              endAdornment:
-                                data.type === SaleType.FIXED
-                                  ? listing.currency
-                                  : "%"
-                            }}
+                            disabled={disabled}
+                            listing={listing}
+                            onChange={onChange}
                           />
                         ) : (
+                          // <TextField
+                          //   disabled={disabled}
+                          //   helperText={
+                          //     error
+                          //       ? getDiscountErrorMessage(
+                          //           formErrors.value,
+                          //           intl
+                          //         )
+                          //       : ""
+                          //   }
+                          //   name="value"
+                          //   onChange={e => {
+                          //     console.info(listing.id, e.target.value);
+                          //     onChange(listing.id, e.target.value);
+                          //   }}
+                          //   label={intl.formatMessage({
+                          //     defaultMessage: "Discount Value",
+                          //     description: "sale discount"
+                          //   })}
+                          //   value={listing.discountValue || ""}
+                          //   type="number"
+                          //   fullWidth
+                          //   inputProps={{
+                          //     min: 0
+                          //   }}
+                          //   InputProps={{
+                          //     endAdornment:
+                          //       data.type === SaleType.FIXED
+                          //         ? listing.currency
+                          //         : "%"
+                          //   }}
+                          // />
                           <Skeleton />
                         )}
                       </TableCell>

--- a/src/discounts/components/SaleValue/SaleValueTextField.tsx
+++ b/src/discounts/components/SaleValue/SaleValueTextField.tsx
@@ -1,0 +1,77 @@
+import { TextField } from "@material-ui/core";
+import { ChannelSaleData } from "@saleor/channels/utils";
+import { SaleType } from "@saleor/types/globalTypes";
+import React from "react";
+import { useState, useEffect } from "react";
+import { useIntl } from "react-intl";
+
+interface SaleValueTextFieldProps {
+  dataType: SaleType;
+  helperText: string;
+  disabled: boolean;
+  listing: ChannelSaleData;
+  onChange: (channelId: string, discountValue: string) => void; // to extract
+}
+
+const SaleValueTextField: React.FC<SaleValueTextFieldProps> = ({
+  dataType,
+  helperText,
+  disabled,
+  listing,
+  onChange
+}) => {
+  const intl = useIntl();
+
+  const [fixedValue, setFixedValue] = useState("");
+  const [percentageValue, setPercentageValue] = useState("");
+
+  const handleChange = (value: string) => {
+    onChange(listing.id, value);
+  };
+
+  const setCurrentValue = (value: string) => {
+    dataType === SaleType.PERCENTAGE
+      ? setPercentageValue(value)
+      : setFixedValue(value);
+  };
+
+  useEffect(() => {
+    console.log(dataType);
+    if (dataType === SaleType.PERCENTAGE) {
+      handleChange(percentageValue);
+    } else {
+      handleChange(fixedValue);
+    }
+  }, [dataType]);
+
+  const getTextFieldValue = () =>
+    dataType === SaleType.PERCENTAGE ? percentageValue : fixedValue;
+
+  return (
+    <TextField
+      disabled={disabled}
+      helperText={helperText || ""}
+      name="value"
+      onChange={e => {
+        // console.info(listing.id, e.target.value);
+        handleChange(e.target.value);
+        setCurrentValue(e.target.value);
+      }}
+      label={intl.formatMessage({
+        defaultMessage: "Discount Value",
+        description: "sale discount"
+      })}
+      value={getTextFieldValue() || ""}
+      type="number"
+      fullWidth
+      inputProps={{
+        min: 0
+      }}
+      InputProps={{
+        endAdornment: dataType === SaleType.FIXED ? listing.currency : "%"
+      }}
+    />
+  );
+};
+
+export default SaleValueTextField;

--- a/src/discounts/components/SaleValue/SaleValueTextField.tsx
+++ b/src/discounts/components/SaleValue/SaleValueTextField.tsx
@@ -2,15 +2,17 @@ import { TextField } from "@material-ui/core";
 import { ChannelSaleData } from "@saleor/channels/utils";
 import { SaleType } from "@saleor/types/globalTypes";
 import React from "react";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 
+import { SaleValueInputChangeType } from "./types";
+
 interface SaleValueTextFieldProps {
-  dataType: SaleType;
+  dataType: keyof typeof SaleType;
   helperText: string;
   disabled: boolean;
   listing: ChannelSaleData;
-  onChange: (channelId: string, discountValue: string) => void; // to extract
+  onChange: SaleValueInputChangeType;
 }
 
 const SaleValueTextField: React.FC<SaleValueTextFieldProps> = ({
@@ -22,21 +24,26 @@ const SaleValueTextField: React.FC<SaleValueTextFieldProps> = ({
 }) => {
   const intl = useIntl();
 
-  const [fixedValue, setFixedValue] = useState("");
-  const [percentageValue, setPercentageValue] = useState("");
+  const [fixedValue, setFixedValue] = useState(
+    dataType === SaleType.FIXED ? listing.discountValue : ""
+  );
+  const [percentageValue, setPercentageValue] = useState(
+    dataType === SaleType.PERCENTAGE ? listing.discountValue : ""
+  );
 
   const handleChange = (value: string) => {
     onChange(listing.id, value);
   };
 
   const setCurrentValue = (value: string) => {
-    dataType === SaleType.PERCENTAGE
-      ? setPercentageValue(value)
-      : setFixedValue(value);
+    if (dataType === SaleType.PERCENTAGE) {
+      setPercentageValue(value);
+    } else {
+      setFixedValue(value);
+    }
   };
 
   useEffect(() => {
-    console.log(dataType);
     if (dataType === SaleType.PERCENTAGE) {
       handleChange(percentageValue);
     } else {
@@ -53,7 +60,6 @@ const SaleValueTextField: React.FC<SaleValueTextFieldProps> = ({
       helperText={helperText || ""}
       name="value"
       onChange={e => {
-        // console.info(listing.id, e.target.value);
         handleChange(e.target.value);
         setCurrentValue(e.target.value);
       }}
@@ -61,7 +67,7 @@ const SaleValueTextField: React.FC<SaleValueTextFieldProps> = ({
         defaultMessage: "Discount Value",
         description: "sale discount"
       })}
-      value={getTextFieldValue() || ""}
+      value={getTextFieldValue()}
       type="number"
       fullWidth
       inputProps={{

--- a/src/discounts/components/SaleValue/SaleValueTextField.tsx
+++ b/src/discounts/components/SaleValue/SaleValueTextField.tsx
@@ -24,12 +24,8 @@ const SaleValueTextField: React.FC<SaleValueTextFieldProps> = ({
 }) => {
   const intl = useIntl();
 
-  const [fixedValue, setFixedValue] = useState(
-    dataType === SaleType.FIXED ? listing.discountValue : ""
-  );
-  const [percentageValue, setPercentageValue] = useState(
-    dataType === SaleType.PERCENTAGE ? listing.discountValue : ""
-  );
+  const [fixedValue, setFixedValue] = useState("");
+  const [percentageValue, setPercentageValue] = useState("");
 
   const handleChange = (value: string) => {
     onChange(listing.id, value);
@@ -42,6 +38,10 @@ const SaleValueTextField: React.FC<SaleValueTextFieldProps> = ({
       setFixedValue(value);
     }
   };
+
+  useEffect(() => {
+    setCurrentValue(listing.discountValue);
+  }, []);
 
   useEffect(() => {
     if (dataType === SaleType.PERCENTAGE) {

--- a/src/discounts/components/SaleValue/SaleValueTextField.tsx
+++ b/src/discounts/components/SaleValue/SaleValueTextField.tsx
@@ -44,11 +44,7 @@ const SaleValueTextField: React.FC<SaleValueTextFieldProps> = ({
   }, []);
 
   useEffect(() => {
-    if (dataType === SaleType.PERCENTAGE) {
-      handleChange(percentageValue);
-    } else {
-      handleChange(fixedValue);
-    }
+    handleChange(getTextFieldValue());
   }, [dataType]);
 
   const getTextFieldValue = () =>

--- a/src/discounts/components/SaleValue/types.ts
+++ b/src/discounts/components/SaleValue/types.ts
@@ -1,0 +1,4 @@
+export type SaleValueInputChangeType = (
+  channelId: string,
+  discountValue: string
+) => void;

--- a/src/discounts/handlers.ts
+++ b/src/discounts/handlers.ts
@@ -74,12 +74,10 @@ export function createSaleChannelsChangeHandler(
   triggerChange: () => void
 ) {
   return (id: string, discountValue: string) => {
-    console.info("createSaleChannelsChangeHandler", { id, discountValue });
     const channelIndex = channelListings.findIndex(
       channel => channel.id === id
     );
     const channel = channelListings[channelIndex];
-    console.info(channel);
 
     const updatedChannels = [
       ...channelListings.slice(0, channelIndex),
@@ -89,7 +87,6 @@ export function createSaleChannelsChangeHandler(
       },
       ...channelListings.slice(channelIndex + 1)
     ];
-    console.log(updatedChannels);
     updateChannels(updatedChannels);
     triggerChange();
   };
@@ -132,7 +129,7 @@ export const getSaleChannelsVariables = (
   formData: SaleDetailsPageFormData,
   prevChannels?: ChannelSaleData[]
 ) => {
-  const initialIds = prevChannels.map(channel => channel.id);
+  const initialIds = prevChannels?.map(channel => channel.id) || [];
   const modifiedIds = formData.channelListings.map(channel => channel.id);
 
   const idsDiff = arrayDiff(initialIds, modifiedIds);

--- a/src/discounts/handlers.ts
+++ b/src/discounts/handlers.ts
@@ -74,10 +74,12 @@ export function createSaleChannelsChangeHandler(
   triggerChange: () => void
 ) {
   return (id: string, discountValue: string) => {
+    console.info("createSaleChannelsChangeHandler", { id, discountValue });
     const channelIndex = channelListings.findIndex(
       channel => channel.id === id
     );
     const channel = channelListings[channelIndex];
+    console.info(channel);
 
     const updatedChannels = [
       ...channelListings.slice(0, channelIndex),
@@ -87,6 +89,7 @@ export function createSaleChannelsChangeHandler(
       },
       ...channelListings.slice(channelIndex + 1)
     ];
+    console.log(updatedChannels);
     updateChannels(updatedChannels);
     triggerChange();
   };

--- a/src/hooks/useStateFromProps.ts
+++ b/src/hooks/useStateFromProps.ts
@@ -17,7 +17,10 @@ function useStateFromProps<T>(
   }
 
   const { mergeFunc, onRefresh } = opts;
+  console.info(prevData);
+  console.info(data);
   const shouldUpdate = !isEqual(prevData, data);
+  console.info(shouldUpdate);
 
   if (shouldUpdate) {
     const newData =

--- a/src/hooks/useStateFromProps.ts
+++ b/src/hooks/useStateFromProps.ts
@@ -17,10 +17,7 @@ function useStateFromProps<T>(
   }
 
   const { mergeFunc, onRefresh } = opts;
-  console.info(prevData);
-  console.info(data);
   const shouldUpdate = !isEqual(prevData, data);
-  console.info(shouldUpdate);
 
   if (shouldUpdate) {
     const newData =


### PR DESCRIPTION
I want to merge this change because I want to fix a bug in sale create page where values don't change when percentage/fixed amount is switched.  

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
