### PR TITLE
Make domain field readonly for cloud instances

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -25,6 +25,7 @@ jobs:
       ENVIRONMENT: ${{ github.event.inputs.service_name }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      IS_CLOUD_INSTANCE: true
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -24,6 +24,7 @@ jobs:
       SENTRY_URL_PREFIX: "~/dashboard/static"
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      IS_CLOUD_INSTANCE: true
     steps:
       - name: Set env variables
         run: |

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -62,6 +62,7 @@ jobs:
           API_URI: ${{ steps.api_uri.outputs.custom_api_uri || 'https://qa.staging.saleor.cloud/graphql/' }}
           APP_MOUNT_URI: /
           STATIC_URL: /
+          IS_CLOUD_INSTANCE: true
         run: |
           npm run build
 

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -6476,14 +6476,14 @@
   "src_dot_siteSettings_dot_components_dot_SiteSettingsDetails_dot_1008586926": {
     "string": "Name of your store is shown on tab in web browser"
   },
-  "src_dot_siteSettings_dot_components_dot_SiteSettingsDetails_dot_1987367127": {
-    "string": "Store Description"
+  "src_dot_siteSettings_dot_components_dot_SiteSettingsDetails_dot_1170194728": {
+    "string": "Store domain"
   },
   "src_dot_siteSettings_dot_components_dot_SiteSettingsDetails_dot_2286355060": {
     "string": "Name of your store"
   },
-  "src_dot_siteSettings_dot_components_dot_SiteSettingsDetails_dot_3808773492": {
-    "string": "URL of your online store"
+  "src_dot_siteSettings_dot_components_dot_SiteSettingsDetails_dot_3868874271": {
+    "string": "Store description"
   },
   "src_dot_siteSettings_dot_components_dot_SiteSettingsDetails_dot_529433178": {
     "string": "Store description is shown on taskbar after your store name"

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export const APP_MOUNT_URI = process.env.APP_MOUNT_URI;
 export const APP_DEFAULT_URI = "/";
 export const API_URI = process.env.API_URI;
 export const SW_INTERVAL = parseInt(process.env.SW_INTERVAL, 0);
+export const IS_CLOUD_INSTANCE = process.env.IS_CLOUD_INSTANCE === "true";
 
 export const DEFAULT_INITIAL_SEARCH_DATA: SearchVariables = {
   after: null,

--- a/src/siteSettings/components/SiteSettingsDetails/SiteSettingsDetails.tsx
+++ b/src/siteSettings/components/SiteSettingsDetails/SiteSettingsDetails.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, TextField } from "@material-ui/core";
 import CardTitle from "@saleor/components/CardTitle";
 import FormSpacer from "@saleor/components/FormSpacer";
+import { IS_CLOUD_INSTANCE } from "@saleor/config";
 import { ShopErrorFragment } from "@saleor/fragments/types/ShopErrorFragment";
 import { commonMessages } from "@saleor/intl";
 import { getFormErrors } from "@saleor/utils/errors";
@@ -63,12 +64,13 @@ const SiteSettingsDetails: React.FC<SiteSettingsDetailsProps> = ({
           fullWidth
           name="domain"
           label={intl.formatMessage({
-            defaultMessage: "URL of your online store"
+            defaultMessage: "Store domain"
           })}
           helperText={getShopErrorMessage(formErrors.domain, intl)}
           value={data.domain}
           onChange={onChange}
           InputProps={{
+            readOnly: IS_CLOUD_INSTANCE,
             inputProps: {
               autoComplete: "none"
             }
@@ -81,7 +83,7 @@ const SiteSettingsDetails: React.FC<SiteSettingsDetailsProps> = ({
           fullWidth
           name="description"
           label={intl.formatMessage({
-            defaultMessage: "Store Description"
+            defaultMessage: "Store description"
           })}
           helperText={
             getShopErrorMessage(formErrors.description, intl) ||

--- a/src/siteSettings/mutations.ts
+++ b/src/siteSettings/mutations.ts
@@ -17,6 +17,7 @@ const shopSettingsUpdate = gql`
     $shopDomainInput: SiteDomainInput!
     $shopSettingsInput: ShopSettingsInput!
     $addressInput: AddressInput
+    $isCloudInstance: Boolean!
   ) {
     shopSettingsUpdate(input: $shopSettingsInput) {
       errors {
@@ -26,7 +27,7 @@ const shopSettingsUpdate = gql`
         ...ShopFragment
       }
     }
-    shopDomainUpdate(input: $shopDomainInput) {
+    shopDomainUpdate(input: $shopDomainInput) @skip(if: $isCloudInstance) {
       errors {
         ...ShopErrorFragment
       }

--- a/src/siteSettings/types/ShopSettingsUpdate.ts
+++ b/src/siteSettings/types/ShopSettingsUpdate.ts
@@ -138,4 +138,5 @@ export interface ShopSettingsUpdateVariables {
   shopDomainInput: SiteDomainInput;
   shopSettingsInput: ShopSettingsInput;
   addressInput?: AddressInput | null;
+  isCloudInstance: boolean;
 }

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -1,4 +1,5 @@
 import { WindowTitle } from "@saleor/components/WindowTitle";
+import { IS_CLOUD_INSTANCE } from "@saleor/config";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import { commonMessages, sectionNames } from "@saleor/intl";
@@ -28,9 +29,11 @@ export const SiteSettings: React.FC<SiteSettingsProps> = () => {
 
   const handleSiteSettingsSuccess = (data: ShopSettingsUpdate) => {
     if (
-      data.shopDomainUpdate.errors.length === 0 &&
-      data.shopSettingsUpdate.errors.length === 0 &&
-      data.shopAddressUpdate.errors.length === 0
+      [
+        ...data.shopAddressUpdate.errors,
+        ...data.shopSettingsUpdate.errors,
+        ...(data.shopDomainUpdate?.errors || [])
+      ].length === 0
     ) {
       notify({
         status: "success",
@@ -45,7 +48,7 @@ export const SiteSettings: React.FC<SiteSettingsProps> = () => {
         <TypedShopSettingsUpdate onCompleted={handleSiteSettingsSuccess}>
           {(updateShopSettings, updateShopSettingsOpts) => {
             const errors = [
-              ...(updateShopSettingsOpts.data?.shopDomainUpdate.errors || []),
+              ...(updateShopSettingsOpts.data?.shopDomainUpdate?.errors || []),
               ...(updateShopSettingsOpts.data?.shopSettingsUpdate.errors || []),
               ...(updateShopSettingsOpts.data?.shopAddressUpdate.errors || [])
             ];
@@ -78,13 +81,14 @@ export const SiteSettings: React.FC<SiteSettingsProps> = () => {
                   },
                   shopSettingsInput: {
                     description: data.description
-                  }
+                  },
+                  isCloudInstance: IS_CLOUD_INSTANCE
                 }
               });
 
               return [
                 ...result.data.shopAddressUpdate.errors,
-                ...result.data.shopDomainUpdate.errors,
+                ...(result.data.shopDomainUpdate?.errors || []),
                 ...result.data.shopSettingsUpdate.errors
               ];
             };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,8 @@ const environmentPlugin = new webpack.EnvironmentPlugin({
   ENVIRONMENT: "",
   GTM_ID: "",
   SENTRY_DSN: "",
-  SW_INTERVAL: "300" // Fetch SW every 300 seconds
+  SW_INTERVAL: "300", // Fetch SW every 300 seconds
+  IS_CLOUD_INSTANCE: false
 });
 
 const dashboardBuildPath = "build/dashboard/";


### PR DESCRIPTION
I want to merge this change because it disables shop domain changes on cloud instances. This change already exists in master branch and was done in #1385 

<!-- Please mention all relevant issue numbers. -->
SALEOR-1273

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
