### PR TITLE
Fix an issue where adornment can't be clicked in multi-select input fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6597,15 +6597,6 @@
         "@types/react": "*"
       }
     },
-    "@types/react-responsive": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-responsive/-/react-responsive-3.0.3.tgz",
-      "integrity": "sha512-paTAvXIFgv/jG60d7WSV0+yWCjqJ05cG+KOV48SiqYGjGi9kFdss9QnVTTLnFJmbUwWnoM+VD1Iyay1JBy/HPQ==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/react-router": {
       "version": "5.1.13",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.13.tgz",
@@ -12127,11 +12118,6 @@
           "dev": true
         }
       }
-    },
-    "css-mediaquery": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
     },
     "css-select": {
       "version": "2.1.0",
@@ -21195,14 +21181,6 @@
         }
       }
     },
-    "matchmediaquery": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
-      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
-      "requires": {
-        "css-mediaquery": "^0.1.2"
-      }
-    },
     "math-random": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
@@ -24711,16 +24689,6 @@
       "requires": {
         "@babel/runtime": "^7.9.2",
         "react-popper": "^1.3.7"
-      }
-    },
-    "react-responsive": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-7.0.0.tgz",
-      "integrity": "sha512-RukaKD+UI/MIR+P8eUgVGURfiCafRvvcVnq41scT0eEQWHwDGliH/OAlrwIr1oyz8aKLGroZa+U8mTZV5ihPfA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.0",
-        "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1"
       }
     },
     "react-router": {

--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
@@ -66,7 +66,9 @@ const useStyles = makeStyles(
     },
     adornment: {
       display: "flex",
-      alignItems: "center"
+      alignItems: "center",
+      userSelect: "none",
+      cursor: "pointer"
     }
   }),
   { name: "MultiAutocompleteSelectField" }
@@ -179,15 +181,34 @@ const MultiAutocompleteSelectFieldComponent: React.FC<MultiAutocompleteSelectFie
                         placeholder
                       }),
                       endAdornment: (
-                        <div className={classes.adornment}>
+                        <div
+                          className={classes.adornment}
+                          // onClick={() => {
+                          // console.info("bonjour");
+                          // if (!isOpen) {
+                          //   if (fetchOnFocus && !!!choices.length) {
+                          //     fetchChoices(inputValue);
+                          //   }
+                          //   if (choices.length > 0) {
+                          //     toggleMenu();
+                          //   }
+                          // }
+                          // }}
+                        >
                           {endAdornment}
-                          <ArrowDropdownIcon onClick={() => toggleMenu()} />
+                          <ArrowDropdownIcon />
                         </div>
                       ),
                       id: undefined,
                       onBlur,
-                      onClick: toggleMenu,
+                      onClick: (e: any) => {
+                        console.log(e);
+                        if (!isOpen) {
+                          toggleMenu();
+                        }
+                      },
                       onFocus: () => {
+                        console.log("on focus");
                         if (fetchOnFocus) {
                           fetchChoices(inputValue);
                         }

--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
@@ -68,7 +68,10 @@ const useStyles = makeStyles(
       display: "flex",
       alignItems: "center",
       userSelect: "none",
-      cursor: "pointer"
+      cursor: "pointer",
+      "&:active": {
+        pointerEvents: "none"
+      }
     }
   }),
   { name: "MultiAutocompleteSelectField" }
@@ -181,34 +184,15 @@ const MultiAutocompleteSelectFieldComponent: React.FC<MultiAutocompleteSelectFie
                         placeholder
                       }),
                       endAdornment: (
-                        <div
-                          className={classes.adornment}
-                          // onClick={() => {
-                          // console.info("bonjour");
-                          // if (!isOpen) {
-                          //   if (fetchOnFocus && !!!choices.length) {
-                          //     fetchChoices(inputValue);
-                          //   }
-                          //   if (choices.length > 0) {
-                          //     toggleMenu();
-                          //   }
-                          // }
-                          // }}
-                        >
+                        <div className={classes.adornment}>
                           {endAdornment}
                           <ArrowDropdownIcon />
                         </div>
                       ),
                       id: undefined,
                       onBlur,
-                      onClick: (e: any) => {
-                        console.log(e);
-                        if (!isOpen) {
-                          toggleMenu();
-                        }
-                      },
+                      onClick: toggleMenu,
                       onFocus: () => {
-                        console.log("on focus");
                         if (fetchOnFocus) {
                           fetchChoices(inputValue);
                         }

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -23,6 +23,12 @@ const useStyles = makeStyles(
     },
     nakedInput: {
       padding: theme.spacing(2, 3)
+    },
+    adornment: {
+      cursor: "pointer",
+      "&:active": {
+        pointerEvents: "none"
+      }
     }
   }),
   { name: "SingleAutocompleteSelectField" }
@@ -174,7 +180,7 @@ const SingleAutocompleteSelectFieldComponent: React.FC<SingleAutocompleteSelectF
                 placeholder
               }),
               endAdornment: (
-                <div>
+                <div className={classes.adornment}>
                   <ArrowDropdownIcon />
                 </div>
               ),


### PR DESCRIPTION
I want to merge this change because I want to fix an issue where adornment can't be clicked in multi-select input fields. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
