### PR TITLE
Update dashboard to work without SKU

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -418,6 +418,10 @@
     "context": "product field",
     "string": "Type"
   },
+  "productExportFieldVariantId": {
+    "context": "product field",
+    "string": "Export Variant ID"
+  },
   "productExportFieldVariantImages": {
     "context": "product field",
     "string": "Variant Images"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6602,15 +6602,6 @@
         "@types/react": "*"
       }
     },
-    "@types/react-responsive": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-responsive/-/react-responsive-3.0.3.tgz",
-      "integrity": "sha512-paTAvXIFgv/jG60d7WSV0+yWCjqJ05cG+KOV48SiqYGjGi9kFdss9QnVTTLnFJmbUwWnoM+VD1Iyay1JBy/HPQ==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "@types/react-router": {
       "version": "5.1.13",
       "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.13.tgz",
@@ -12131,11 +12122,6 @@
           "dev": true
         }
       }
-    },
-    "css-mediaquery": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
     },
     "css-select": {
       "version": "2.1.0",
@@ -21202,14 +21188,6 @@
         }
       }
     },
-    "matchmediaquery": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
-      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
-      "requires": {
-        "css-mediaquery": "^0.1.2"
-      }
-    },
     "math-random": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
@@ -24718,16 +24696,6 @@
       "requires": {
         "@babel/runtime": "^7.9.2",
         "react-popper": "^1.3.7"
-      }
-    },
-    "react-responsive": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-7.0.0.tgz",
-      "integrity": "sha512-RukaKD+UI/MIR+P8eUgVGURfiCafRvvcVnq41scT0eEQWHwDGliH/OAlrwIr1oyz8aKLGroZa+U8mTZV5ihPfA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.0",
-        "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1"
       }
     },
     "react-router": {

--- a/schema.graphql
+++ b/schema.graphql
@@ -5319,6 +5319,7 @@ enum ProductFieldEnum {
   COLLECTIONS
   CHARGE_TAXES
   PRODUCT_MEDIA
+  VARIANT_ID
   VARIANT_SKU
   VARIANT_WEIGHT
   VARIANT_MEDIA
@@ -5606,7 +5607,7 @@ type ProductUpdate {
 type ProductVariant implements Node & ObjectWithMetadata {
   id: ID!
   name: String!
-  sku: String!
+  sku: String
   product: Product!
   trackInventory: Boolean!
   weight: Weight
@@ -5636,7 +5637,7 @@ type ProductVariantBulkCreate {
 
 input ProductVariantBulkCreateInput {
   attributes: [BulkAttributeValueInput!]!
-  sku: String!
+  sku: String
   trackInventory: Boolean
   weight: WeightScalar
   stocks: [StockInput!]

--- a/schema.graphql
+++ b/schema.graphql
@@ -4355,7 +4355,8 @@ type OrderLine implements Node {
   id: ID!
   productName: String!
   variantName: String!
-  productSku: String!
+  productSku: String
+  productVariantId: String
   isShippingRequired: Boolean!
   quantity: Int!
   quantityFulfilled: Int!

--- a/src/fragments/types/FulfillmentFragment.ts
+++ b/src/fragments/types/FulfillmentFragment.ts
@@ -69,7 +69,7 @@ export interface FulfillmentFragment_lines_orderLine {
   isShippingRequired: boolean;
   variant: FulfillmentFragment_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/fragments/types/OrderDetailsFragment.ts
+++ b/src/fragments/types/OrderDetailsFragment.ts
@@ -266,7 +266,7 @@ export interface OrderDetailsFragment_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: OrderDetailsFragment_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -362,7 +362,7 @@ export interface OrderDetailsFragment_lines {
   isShippingRequired: boolean;
   variant: OrderDetailsFragment_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/fragments/types/OrderLineFragment.ts
+++ b/src/fragments/types/OrderLineFragment.ts
@@ -69,7 +69,7 @@ export interface OrderLineFragment {
   isShippingRequired: boolean;
   variant: OrderLineFragment_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/fragments/types/Product.ts
+++ b/src/fragments/types/Product.ts
@@ -289,7 +289,7 @@ export interface Product_variants_channelListings {
 export interface Product_variants {
   __typename: "ProductVariant";
   id: string;
-  sku: string;
+  sku: string | null;
   name: string;
   margin: number | null;
   media: Product_variants_media[] | null;

--- a/src/fragments/types/ProductVariant.ts
+++ b/src/fragments/types/ProductVariant.ts
@@ -265,7 +265,7 @@ export interface ProductVariant_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: ProductVariant_product_variants_media[] | null;
 }
 
@@ -337,7 +337,7 @@ export interface ProductVariant {
   name: string;
   product: ProductVariant_product;
   channelListings: ProductVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (ProductVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: ProductVariant_weight | null;

--- a/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
+++ b/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
@@ -352,15 +352,17 @@ const OrderProductAddDialog: React.FC<OrderProductAddDialogProps> = props => {
                           </TableCell>
                           <TableCell className={classes.colName}>
                             <div>{variant.name}</div>
-                            <div className={classes.grayText}>
-                              <FormattedMessage
-                                defaultMessage="SKU {sku}"
-                                description="variant sku"
-                                values={{
-                                  sku: variant.sku
-                                }}
-                              />
-                            </div>
+                            {variant.sku && (
+                              <div className={classes.grayText}>
+                                <FormattedMessage
+                                  defaultMessage="SKU {sku}"
+                                  description="variant sku"
+                                  values={{
+                                    sku: variant.sku
+                                  }}
+                                />
+                              </div>
+                            )}
                           </TableCell>
                           <TableCell className={classes.textRight}>
                             {variant?.channelListings[0]?.price && (

--- a/src/orders/components/OrderProductsCardElements/OrderProductsTableRow.tsx
+++ b/src/orders/components/OrderProductsCardElements/OrderProductsTableRow.tsx
@@ -96,7 +96,7 @@ const TableLine: React.FC<TableLineProps> = ({
         {maybe(() => line.orderLine.productName) || <Skeleton />}
       </TableCellAvatar>
       <TableCell className={classes.colSku}>
-        {line?.orderLine.productSku || <Skeleton />}
+        {line?.orderLine ? line.orderLine.productSku : <Skeleton />}
       </TableCell>
       <TableCell className={classes.colQuantity}>
         {quantityToDisplay || <Skeleton />}

--- a/src/orders/types/FulfillOrder.ts
+++ b/src/orders/types/FulfillOrder.ts
@@ -275,7 +275,7 @@ export interface FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: FulfillOrder_orderFulfill_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -371,7 +371,7 @@ export interface FulfillOrder_orderFulfill_order_lines {
   isShippingRequired: boolean;
   variant: FulfillOrder_orderFulfill_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderCancel.ts
+++ b/src/orders/types/OrderCancel.ts
@@ -273,7 +273,7 @@ export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderCancel_orderCancel_order_lines {
   isShippingRequired: boolean;
   variant: OrderCancel_orderCancel_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderCapture.ts
+++ b/src/orders/types/OrderCapture.ts
@@ -273,7 +273,7 @@ export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderCapture_orderCapture_order_lines {
   isShippingRequired: boolean;
   variant: OrderCapture_orderCapture_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderConfirm.ts
+++ b/src/orders/types/OrderConfirm.ts
@@ -273,7 +273,7 @@ export interface OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: OrderConfirm_orderConfirm_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderConfirm_orderConfirm_order_lines {
   isShippingRequired: boolean;
   variant: OrderConfirm_orderConfirm_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderDetails.ts
+++ b/src/orders/types/OrderDetails.ts
@@ -266,7 +266,7 @@ export interface OrderDetails_order_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: OrderDetails_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -362,7 +362,7 @@ export interface OrderDetails_order_lines {
   isShippingRequired: boolean;
   variant: OrderDetails_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderDiscountAdd.ts
+++ b/src/orders/types/OrderDiscountAdd.ts
@@ -273,7 +273,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orde
   isShippingRequired: boolean;
   variant: OrderDiscountAdd_orderDiscountAdd_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderDiscountAdd_orderDiscountAdd_order_lines {
   isShippingRequired: boolean;
   variant: OrderDiscountAdd_orderDiscountAdd_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderDiscountDelete.ts
+++ b/src/orders/types/OrderDiscountDelete.ts
@@ -273,7 +273,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_fulfillments_line
   isShippingRequired: boolean;
   variant: OrderDiscountDelete_orderDiscountDelete_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderDiscountDelete_orderDiscountDelete_order_lines {
   isShippingRequired: boolean;
   variant: OrderDiscountDelete_orderDiscountDelete_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderDiscountUpdate.ts
+++ b/src/orders/types/OrderDiscountUpdate.ts
@@ -273,7 +273,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_line
   isShippingRequired: boolean;
   variant: OrderDiscountUpdate_orderDiscountUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderDiscountUpdate_orderDiscountUpdate_order_lines {
   isShippingRequired: boolean;
   variant: OrderDiscountUpdate_orderDiscountUpdate_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderDraftCancel.ts
+++ b/src/orders/types/OrderDraftCancel.ts
@@ -273,7 +273,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orde
   isShippingRequired: boolean;
   variant: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderDraftCancel_draftOrderDelete_order_lines {
   isShippingRequired: boolean;
   variant: OrderDraftCancel_draftOrderDelete_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderDraftFinalize.ts
+++ b/src/orders/types/OrderDraftFinalize.ts
@@ -273,7 +273,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_
   isShippingRequired: boolean;
   variant: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderDraftFinalize_draftOrderComplete_order_lines {
   isShippingRequired: boolean;
   variant: OrderDraftFinalize_draftOrderComplete_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderDraftUpdate.ts
+++ b/src/orders/types/OrderDraftUpdate.ts
@@ -273,7 +273,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orde
   isShippingRequired: boolean;
   variant: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_lines {
   isShippingRequired: boolean;
   variant: OrderDraftUpdate_draftOrderUpdate_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderFulfillData.ts
+++ b/src/orders/types/OrderFulfillData.ts
@@ -62,7 +62,7 @@ export interface OrderFulfillData_order_lines_variant {
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   attributes: OrderFulfillData_order_lines_variant_attributes[];
   stocks: (OrderFulfillData_order_lines_variant_stocks | null)[] | null;
   trackInventory: boolean;

--- a/src/orders/types/OrderFulfillmentApprove.ts
+++ b/src/orders/types/OrderFulfillmentApprove.ts
@@ -273,7 +273,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillme
   isShippingRequired: boolean;
   variant: OrderFulfillmentApprove_orderFulfillmentApprove_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderFulfillmentApprove_orderFulfillmentApprove_order_lines {
   isShippingRequired: boolean;
   variant: OrderFulfillmentApprove_orderFulfillmentApprove_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderFulfillmentCancel.ts
+++ b/src/orders/types/OrderFulfillmentCancel.ts
@@ -273,7 +273,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillment
   isShippingRequired: boolean;
   variant: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_lines {
   isShippingRequired: boolean;
   variant: OrderFulfillmentCancel_orderFulfillmentCancel_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderFulfillmentRefundProducts.ts
+++ b/src/orders/types/OrderFulfillmentRefundProducts.ts
@@ -76,7 +76,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_f
   isShippingRequired: boolean;
   variant: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_fulfillment_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   isShippingRequired: boolean;
   variant: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -465,7 +465,7 @@ export interface OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_o
   isShippingRequired: boolean;
   variant: OrderFulfillmentRefundProducts_orderFulfillmentRefundProducts_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/src/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -273,7 +273,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   isShippingRequired: boolean;
   variant: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   isShippingRequired: boolean;
   variant: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderLineDelete.ts
+++ b/src/orders/types/OrderLineDelete.ts
@@ -273,7 +273,7 @@ export interface OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderL
   isShippingRequired: boolean;
   variant: OrderLineDelete_orderLineDelete_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderLineDelete_orderLineDelete_order_lines {
   isShippingRequired: boolean;
   variant: OrderLineDelete_orderLineDelete_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderLineDiscountRemove.ts
+++ b/src/orders/types/OrderLineDiscountRemove.ts
@@ -273,7 +273,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillme
   isShippingRequired: boolean;
   variant: OrderLineDiscountRemove_orderLineDiscountRemove_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderLineDiscountRemove_orderLineDiscountRemove_order_lines {
   isShippingRequired: boolean;
   variant: OrderLineDiscountRemove_orderLineDiscountRemove_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderLineDiscountUpdate.ts
+++ b/src/orders/types/OrderLineDiscountUpdate.ts
@@ -273,7 +273,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillme
   isShippingRequired: boolean;
   variant: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines {
   isShippingRequired: boolean;
   variant: OrderLineDiscountUpdate_orderLineDiscountUpdate_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderLineUpdate.ts
+++ b/src/orders/types/OrderLineUpdate.ts
@@ -273,7 +273,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderL
   isShippingRequired: boolean;
   variant: OrderLineUpdate_orderLineUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderLineUpdate_orderLineUpdate_order_lines {
   isShippingRequired: boolean;
   variant: OrderLineUpdate_orderLineUpdate_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderLinesAdd.ts
+++ b/src/orders/types/OrderLinesAdd.ts
@@ -273,7 +273,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLi
   isShippingRequired: boolean;
   variant: OrderLinesAdd_orderLinesCreate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderLinesAdd_orderLinesCreate_order_lines {
   isShippingRequired: boolean;
   variant: OrderLinesAdd_orderLinesCreate_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderMarkAsPaid.ts
+++ b/src/orders/types/OrderMarkAsPaid.ts
@@ -273,7 +273,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderL
   isShippingRequired: boolean;
   variant: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_lines {
   isShippingRequired: boolean;
   variant: OrderMarkAsPaid_orderMarkAsPaid_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderRefund.ts
+++ b/src/orders/types/OrderRefund.ts
@@ -273,7 +273,7 @@ export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderRefund_orderRefund_order_lines {
   isShippingRequired: boolean;
   variant: OrderRefund_orderRefund_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderShippingMethodUpdate.ts
+++ b/src/orders/types/OrderShippingMethodUpdate.ts
@@ -335,7 +335,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillment
   isShippingRequired: boolean;
   variant: OrderShippingMethodUpdate_orderUpdateShipping_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -431,7 +431,7 @@ export interface OrderShippingMethodUpdate_orderUpdateShipping_order_lines {
   isShippingRequired: boolean;
   variant: OrderShippingMethodUpdate_orderUpdateShipping_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderUpdate.ts
+++ b/src/orders/types/OrderUpdate.ts
@@ -273,7 +273,7 @@ export interface OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: OrderUpdate_orderUpdate_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderUpdate_orderUpdate_order_lines {
   isShippingRequired: boolean;
   variant: OrderUpdate_orderUpdate_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/OrderVoid.ts
+++ b/src/orders/types/OrderVoid.ts
@@ -273,7 +273,7 @@ export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine {
   isShippingRequired: boolean;
   variant: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;
@@ -369,7 +369,7 @@ export interface OrderVoid_orderVoid_order_lines {
   isShippingRequired: boolean;
   variant: OrderVoid_orderVoid_order_lines_variant | null;
   productName: string;
-  productSku: string;
+  productSku: string | null;
   quantity: number;
   quantityFulfilled: number;
   quantityToFulfill: number;

--- a/src/orders/types/SearchOrderVariant.ts
+++ b/src/orders/types/SearchOrderVariant.ts
@@ -36,7 +36,7 @@ export interface SearchOrderVariant_search_edges_node_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   channelListings: SearchOrderVariant_search_edges_node_variants_channelListings[] | null;
 }
 

--- a/src/products/components/ProductCreatePage/form.tsx
+++ b/src/products/components/ProductCreatePage/form.tsx
@@ -307,11 +307,10 @@ function useProductCreateForm(
 
   const disabled =
     !opts.selectedProductType?.hasVariants &&
-    (!data.sku ||
-      data.channelListings.some(
-        channel =>
-          validatePrice(channel.price) || validateCostPrice(channel.costPrice)
-      ) ||
+    (data.channelListings.some(
+      channel =>
+        validatePrice(channel.price) || validateCostPrice(channel.costPrice)
+    ) ||
       !data.category);
 
   return {

--- a/src/products/components/ProductExportDialog/ProductExportDialogInfo.tsx
+++ b/src/products/components/ProductExportDialog/ProductExportDialogInfo.tsx
@@ -36,6 +36,7 @@ const maxChips = 4;
 
 const inventoryFields = [
   ProductFieldEnum.PRODUCT_WEIGHT,
+  ProductFieldEnum.VARIANT_ID,
   ProductFieldEnum.VARIANT_SKU,
   ProductFieldEnum.VARIANT_WEIGHT
 ];

--- a/src/products/components/ProductExportDialog/messages.ts
+++ b/src/products/components/ProductExportDialog/messages.ts
@@ -50,6 +50,11 @@ function useProductExportFieldMessages() {
       description: "product field",
       id: "productExportFieldVariantImages"
     }),
+    [ProductFieldEnum.VARIANT_ID]: intl.formatMessage({
+      defaultMessage: "Export Variant ID",
+      description: "product field",
+      id: "productExportFieldVariantId"
+    }),
     [ProductFieldEnum.VARIANT_SKU]: intl.formatMessage({
       defaultMessage: "Export Variant SKU",
       description: "product field",

--- a/src/products/components/ProductStocks/ProductStocks.tsx
+++ b/src/products/components/ProductStocks/ProductStocks.tsx
@@ -158,7 +158,6 @@ const ProductStocks: React.FC<ProductStocksProps> = ({
               defaultMessage: "SKU (Stock Keeping Unit)"
             })}
             name="sku"
-            required
             onChange={onFormDataChange}
             value={data.sku}
           />

--- a/src/products/components/ProductUpdatePage/form.tsx
+++ b/src/products/components/ProductUpdatePage/form.tsx
@@ -353,11 +353,10 @@ function useProductUpdateForm(
 
   const disabled =
     !opts.hasVariants &&
-    (!data.sku ||
-      data.channelListings.some(
-        channel =>
-          validatePrice(channel.price) || validateCostPrice(channel.costPrice)
-      ));
+    data.channelListings.some(
+      channel =>
+        validatePrice(channel.price) || validateCostPrice(channel.costPrice)
+    );
 
   return {
     change: handleChange,

--- a/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorPage.tsx
+++ b/src/products/components/ProductVariantCreatorPage/ProductVariantCreatorPage.tsx
@@ -82,10 +82,8 @@ function canHitNext(
 
       return true;
     case ProductVariantCreatorStep.summary:
-      return !data.variants.some(
-        variant =>
-          variant.sku === "" ||
-          variant.channelListings.some(channel => validatePrice(channel.price))
+      return !data.variants.some(variant =>
+        variant.channelListings.some(channel => validatePrice(channel.price))
       );
 
     default:

--- a/src/products/types/ProductDetails.ts
+++ b/src/products/types/ProductDetails.ts
@@ -289,7 +289,7 @@ export interface ProductDetails_product_variants_channelListings {
 export interface ProductDetails_product_variants {
   __typename: "ProductVariant";
   id: string;
-  sku: string;
+  sku: string | null;
   name: string;
   margin: number | null;
   media: ProductDetails_product_variants_media[] | null;

--- a/src/products/types/ProductUpdate.ts
+++ b/src/products/types/ProductUpdate.ts
@@ -296,7 +296,7 @@ export interface ProductUpdate_productUpdate_product_variants_channelListings {
 export interface ProductUpdate_productUpdate_product_variants {
   __typename: "ProductVariant";
   id: string;
-  sku: string;
+  sku: string | null;
   name: string;
   margin: number | null;
   media: ProductUpdate_productUpdate_product_variants_media[] | null;

--- a/src/products/types/ProductVariantCreateData.ts
+++ b/src/products/types/ProductVariantCreateData.ts
@@ -155,7 +155,7 @@ export interface ProductVariantCreateData_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: ProductVariantCreateData_product_variants_media[] | null;
 }
 

--- a/src/products/types/ProductVariantDetails.ts
+++ b/src/products/types/ProductVariantDetails.ts
@@ -265,7 +265,7 @@ export interface ProductVariantDetails_productVariant_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: ProductVariantDetails_productVariant_product_variants_media[] | null;
 }
 
@@ -337,7 +337,7 @@ export interface ProductVariantDetails_productVariant {
   name: string;
   product: ProductVariantDetails_productVariant_product;
   channelListings: ProductVariantDetails_productVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (ProductVariantDetails_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: ProductVariantDetails_productVariant_weight | null;

--- a/src/products/types/SimpleProductUpdate.ts
+++ b/src/products/types/SimpleProductUpdate.ts
@@ -296,7 +296,7 @@ export interface SimpleProductUpdate_productUpdate_product_variants_channelListi
 export interface SimpleProductUpdate_productUpdate_product_variants {
   __typename: "ProductVariant";
   id: string;
-  sku: string;
+  sku: string | null;
   name: string;
   margin: number | null;
   media: SimpleProductUpdate_productUpdate_product_variants_media[] | null;
@@ -611,7 +611,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant_product
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: SimpleProductUpdate_productVariantUpdate_productVariant_product_variants_media[] | null;
 }
 
@@ -683,7 +683,7 @@ export interface SimpleProductUpdate_productVariantUpdate_productVariant {
   name: string;
   product: SimpleProductUpdate_productVariantUpdate_productVariant_product;
   channelListings: SimpleProductUpdate_productVariantUpdate_productVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (SimpleProductUpdate_productVariantUpdate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: SimpleProductUpdate_productVariantUpdate_productVariant_weight | null;
@@ -958,7 +958,7 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant_p
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: SimpleProductUpdate_productVariantStocksCreate_productVariant_product_variants_media[] | null;
 }
 
@@ -1030,7 +1030,7 @@ export interface SimpleProductUpdate_productVariantStocksCreate_productVariant {
   name: string;
   product: SimpleProductUpdate_productVariantStocksCreate_productVariant_product;
   channelListings: SimpleProductUpdate_productVariantStocksCreate_productVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (SimpleProductUpdate_productVariantStocksCreate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: SimpleProductUpdate_productVariantStocksCreate_productVariant_weight | null;
@@ -1304,7 +1304,7 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant_p
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: SimpleProductUpdate_productVariantStocksDelete_productVariant_product_variants_media[] | null;
 }
 
@@ -1376,7 +1376,7 @@ export interface SimpleProductUpdate_productVariantStocksDelete_productVariant {
   name: string;
   product: SimpleProductUpdate_productVariantStocksDelete_productVariant_product;
   channelListings: SimpleProductUpdate_productVariantStocksDelete_productVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (SimpleProductUpdate_productVariantStocksDelete_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: SimpleProductUpdate_productVariantStocksDelete_productVariant_weight | null;
@@ -1651,7 +1651,7 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant_p
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product_variants_media[] | null;
 }
 
@@ -1723,7 +1723,7 @@ export interface SimpleProductUpdate_productVariantStocksUpdate_productVariant {
   name: string;
   product: SimpleProductUpdate_productVariantStocksUpdate_productVariant_product;
   channelListings: SimpleProductUpdate_productVariantStocksUpdate_productVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (SimpleProductUpdate_productVariantStocksUpdate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: SimpleProductUpdate_productVariantStocksUpdate_productVariant_weight | null;

--- a/src/products/types/VariantCreate.ts
+++ b/src/products/types/VariantCreate.ts
@@ -272,7 +272,7 @@ export interface VariantCreate_productVariantCreate_productVariant_product_varia
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: VariantCreate_productVariantCreate_productVariant_product_variants_media[] | null;
 }
 
@@ -344,7 +344,7 @@ export interface VariantCreate_productVariantCreate_productVariant {
   name: string;
   product: VariantCreate_productVariantCreate_productVariant_product;
   channelListings: VariantCreate_productVariantCreate_productVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (VariantCreate_productVariantCreate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: VariantCreate_productVariantCreate_productVariant_weight | null;

--- a/src/products/types/VariantMediaAssign.ts
+++ b/src/products/types/VariantMediaAssign.ts
@@ -49,7 +49,7 @@ export interface VariantMediaAssign_variantMediaAssign_productVariant_product_va
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: VariantMediaAssign_variantMediaAssign_productVariant_product_variants_media[] | null;
 }
 

--- a/src/products/types/VariantMediaUnassign.ts
+++ b/src/products/types/VariantMediaUnassign.ts
@@ -49,7 +49,7 @@ export interface VariantMediaUnassign_variantMediaUnassign_productVariant_produc
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: VariantMediaUnassign_variantMediaUnassign_productVariant_product_variants_media[] | null;
 }
 

--- a/src/products/types/VariantUpdate.ts
+++ b/src/products/types/VariantUpdate.ts
@@ -272,7 +272,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product_varia
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: VariantUpdate_productVariantUpdate_productVariant_product_variants_media[] | null;
 }
 
@@ -344,7 +344,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant {
   name: string;
   product: VariantUpdate_productVariantUpdate_productVariant_product;
   channelListings: VariantUpdate_productVariantUpdate_productVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (VariantUpdate_productVariantUpdate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: VariantUpdate_productVariantUpdate_productVariant_weight | null;
@@ -619,7 +619,7 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant_product
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
   media: VariantUpdate_productVariantStocksUpdate_productVariant_product_variants_media[] | null;
 }
 
@@ -691,7 +691,7 @@ export interface VariantUpdate_productVariantStocksUpdate_productVariant {
   name: string;
   product: VariantUpdate_productVariantStocksUpdate_productVariant_product;
   channelListings: VariantUpdate_productVariantStocksUpdate_productVariant_channelListings[] | null;
-  sku: string;
+  sku: string | null;
   stocks: (VariantUpdate_productVariantStocksUpdate_productVariant_stocks | null)[] | null;
   trackInventory: boolean;
   weight: VariantUpdate_productVariantStocksUpdate_productVariant_weight | null;

--- a/src/translations/types/ProductVariantList.ts
+++ b/src/translations/types/ProductVariantList.ts
@@ -11,7 +11,7 @@ export interface ProductVariantList_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
-  sku: string;
+  sku: string | null;
 }
 
 export interface ProductVariantList_product {

--- a/src/types/globalTypes.ts
+++ b/src/types/globalTypes.ts
@@ -1645,6 +1645,7 @@ export enum ProductFieldEnum {
   PRODUCT_MEDIA = "PRODUCT_MEDIA",
   PRODUCT_TYPE = "PRODUCT_TYPE",
   PRODUCT_WEIGHT = "PRODUCT_WEIGHT",
+  VARIANT_ID = "VARIANT_ID",
   VARIANT_MEDIA = "VARIANT_MEDIA",
   VARIANT_SKU = "VARIANT_SKU",
   VARIANT_WEIGHT = "VARIANT_WEIGHT",
@@ -2611,7 +2612,7 @@ export interface ProductTypeSortingInput {
 
 export interface ProductVariantBulkCreateInput {
   attributes: BulkAttributeValueInput[];
-  sku: string;
+  sku?: string | null;
   trackInventory?: boolean | null;
   weight?: any | null;
   stocks?: StockInput[] | null;


### PR DESCRIPTION
I want to merge this change because... it:
- updates dashboard to work without SKU
- allow to export variant ID in products export

Backend: https://github.com/mirumee/saleor/pull/7633

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  --> feature/empty-sku

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
<img width="648" alt="Zrzut ekranu 2021-09-27 o 20 57 10" src="https://user-images.githubusercontent.com/9825562/134968664-d0d48eea-f48a-44e5-a20b-5e56352b8df7.png">
<img width="632" alt="Zrzut ekranu 2021-09-27 o 15 30 25" src="https://user-images.githubusercontent.com/9825562/134968676-4e5156e9-248b-4cc2-ae05-e1d1bb311855.png">

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://feature-empty-sku.api.saleor.rocks/graphql/
