### PR TITLE
Fix an issue where adornment can't be clicked in multi-select input fields - 3.0

### DIFF
--- a/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
+++ b/src/components/MultiAutocompleteSelectField/MultiAutocompleteSelectField.tsx
@@ -66,7 +66,12 @@ const useStyles = makeStyles(
     },
     adornment: {
       display: "flex",
-      alignItems: "center"
+      alignItems: "center",
+      userSelect: "none",
+      cursor: "pointer",
+      "&:active": {
+        pointerEvents: "none"
+      }
     }
   }),
   { name: "MultiAutocompleteSelectField" }
@@ -181,7 +186,7 @@ const MultiAutocompleteSelectFieldComponent: React.FC<MultiAutocompleteSelectFie
                       endAdornment: (
                         <div className={classes.adornment}>
                           {endAdornment}
-                          <ArrowDropdownIcon onClick={() => toggleMenu()} />
+                          <ArrowDropdownIcon />
                         </div>
                       ),
                       id: undefined,

--- a/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
+++ b/src/components/SingleAutocompleteSelectField/SingleAutocompleteSelectField.tsx
@@ -23,6 +23,12 @@ const useStyles = makeStyles(
     },
     nakedInput: {
       padding: theme.spacing(2, 3)
+    },
+    adornment: {
+      cursor: "pointer",
+      "&:active": {
+        pointerEvents: "none"
+      }
     }
   }),
   { name: "SingleAutocompleteSelectField" }
@@ -174,7 +180,7 @@ const SingleAutocompleteSelectFieldComponent: React.FC<SingleAutocompleteSelectF
                 placeholder
               }),
               endAdornment: (
-                <div>
+                <div className={classes.adornment}>
                   <ArrowDropdownIcon />
                 </div>
               ),


### PR DESCRIPTION
I want to merge this change because I want to fix an issue where adornment can't be clicked in multi-select input fields.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
