### PR TITLE
Invalidate second production cloudfront

### DIFF
--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -43,6 +43,7 @@ jobs:
           elif [[ "$REGION" == "eu" ]]; then
             BUCKET=${{ secrets.AWS_PROD_EU_DEPLOYMENT_BUCKET }}
             CF_ID=${{ secrets.AWS_PROD_EU_CF_DIST_ID }}
+            CF_2_ID=${{ secrets.AWS_PROD_EU_CF_2_DIST_ID }}
           else
             echo "Unknown region provided"
             exit 1
@@ -51,3 +52,6 @@ jobs:
           aws s3 sync build/dashboard s3://${BUCKET}/${ENVIRONMENT}/static/
           aws s3 cp build/dashboard/index.html s3://${BUCKET}/${ENVIRONMENT}/
           aws cloudfront create-invalidation --distribution-id ${CF_ID} --paths "/dashboard*"
+          if [[ -n "$CF_2_ID" ]]; then
+            aws cloudfront create-invalidation --distribution-id ${CF_2_ID} --paths "/dashboard*"
+          fi


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
