### PR TITLE
Add metadata input filtering before create/update

### DIFF
--- a/src/utils/handlers/filterMetadataArray.ts
+++ b/src/utils/handlers/filterMetadataArray.ts
@@ -1,0 +1,4 @@
+import { MetadataInput } from "@saleor/types/globalTypes";
+
+export const filterMetadataArray = (metadataInputs: MetadataInput[]) =>
+  metadataInputs.filter(input => !!input.key);

--- a/src/utils/handlers/metadataCreateHandler.ts
+++ b/src/utils/handlers/metadataCreateHandler.ts
@@ -9,6 +9,7 @@ import {
   UpdatePrivateMetadata,
   UpdatePrivateMetadataVariables
 } from "../metadata/types/UpdatePrivateMetadata";
+import { filterMetadataArray } from "./filterMetadataArray";
 
 function createMetadataCreateHandler<T extends MetadataFormData>(
   create: (data: T) => Promise<string>,
@@ -29,7 +30,7 @@ function createMetadataCreateHandler<T extends MetadataFormData>(
       const updateMetaResult = await setMetadata({
         variables: {
           id,
-          input: data.metadata,
+          input: filterMetadataArray(data.metadata),
           keysToDelete: []
         }
       });
@@ -47,7 +48,7 @@ function createMetadataCreateHandler<T extends MetadataFormData>(
       const updatePrivateMetaResult = await setPrivateMetadata({
         variables: {
           id,
-          input: data.privateMetadata,
+          input: filterMetadataArray(data.privateMetadata),
           keysToDelete: []
         }
       });

--- a/src/utils/handlers/metadataUpdateHandler.ts
+++ b/src/utils/handlers/metadataUpdateHandler.ts
@@ -12,6 +12,7 @@ import {
   UpdatePrivateMetadata,
   UpdatePrivateMetadataVariables
 } from "../metadata/types/UpdatePrivateMetadata";
+import { filterMetadataArray } from "./filterMetadataArray";
 
 interface ObjectWithMetadata {
   id: string;
@@ -47,9 +48,10 @@ function createMetadataUpdateHandler<TData extends MetadataFormData, TError>(
 
         const updateMetaResult = await updateMetadata({
           id: initial.id,
-          input: data.metadata,
+          input: filterMetadataArray(data.metadata),
           keysToDelete: keyDiff.removed
         });
+
         const updateMetaErrors = [
           ...(updateMetaResult.data.deleteMetadata.errors || []),
           ...(updateMetaResult.data.updateMetadata.errors || [])
@@ -68,7 +70,7 @@ function createMetadataUpdateHandler<TData extends MetadataFormData, TError>(
 
         const updatePrivateMetaResult = await updatePrivateMetadata({
           id: initial.id,
-          input: data.privateMetadata,
+          input: filterMetadataArray(data.privateMetadata),
           keysToDelete: keyDiff.removed
         });
 


### PR DESCRIPTION
I want to merge this change because I want to fix an issue where empty metadata input fields cause an error.

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
