### PR TITLE
Hide refund table if lines is empty

### DIFF
--- a/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
@@ -112,24 +112,27 @@ const OrderRefundPage: React.FC<OrderReturnPageProps> = props => {
                 )}
                 {renderCollection(
                   getFulfilledFulfillemnts(order),
-                  ({ id, lines }) => (
-                    <React.Fragment key={id}>
-                      <ItemsCard
-                        errors={errors}
-                        order={order}
-                        fulfilmentId={id}
-                        lines={getParsedLines(lines)}
-                        itemsQuantities={data.fulfilledItemsQuantities}
-                        itemsSelections={data.itemsToBeReplaced}
-                        onChangeQuantity={handlers.changeFulfiledItemsQuantity}
-                        onSetMaxQuantity={handlers.handleSetMaximalItemsQuantities(
-                          id
-                        )}
-                        onChangeSelected={handlers.changeItemsToBeReplaced}
-                      />
-                      <CardSpacer />
-                    </React.Fragment>
-                  )
+                  ({ id, lines }) =>
+                    !!lines.length && (
+                      <React.Fragment key={id}>
+                        <ItemsCard
+                          errors={errors}
+                          order={order}
+                          fulfilmentId={id}
+                          lines={getParsedLines(lines)}
+                          itemsQuantities={data.fulfilledItemsQuantities}
+                          itemsSelections={data.itemsToBeReplaced}
+                          onChangeQuantity={
+                            handlers.changeFulfiledItemsQuantity
+                          }
+                          onSetMaxQuantity={handlers.handleSetMaximalItemsQuantities(
+                            id
+                          )}
+                          onChangeSelected={handlers.changeItemsToBeReplaced}
+                        />
+                        <CardSpacer />
+                      </React.Fragment>
+                    )
                 )}
               </div>
               <div>


### PR DESCRIPTION
I want to merge this change because it fixes refund table that appears to load indefinitely when lines array is empty. 

<!-- Please mention all relevant issue numbers. -->

**PR intended to be tested with API branch:** <!-- For example: feature/warehouses  -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] This code contains UI changes
2. [ ] All visible strings are translated with proper context including data-formatting
3. [ ] Attributes `[data-test-id]` are added for new elements
4. [ ] Changes are mentioned in the changelog
5. [ ] The changes are tested in different browsers and in light/dark mode

### Test environment config

<!-- Do not remove this section. It is required to properly setup test deployment instance.
Modify API_URI if you want test instance to use custom backend. CYPRESS_API_URI is optional, use when necessary. -->

API_URI=https://master.staging.saleor.cloud/graphql/
