### PR TITLE
Refactor onShowMetadata to onOrderLineShowMetadata and remove barrel files

### DIFF
--- a/src/orders/components/OrderDetailsDatagrid/OrderDetailsDatagrid.tsx
+++ b/src/orders/components/OrderDetailsDatagrid/OrderDetailsDatagrid.tsx
@@ -22,14 +22,14 @@ import { messages } from "./messages";
 interface OrderDetailsDatagridProps {
   lines: OrderLineFragment[];
   loading: boolean;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
   enableVerticalBorder?: boolean;
 }
 
 export const OrderDetailsDatagrid = ({
   lines,
   loading,
-  onShowMetadata,
+  onOrderLineShowMetadata,
   enableVerticalBorder = true,
 }: OrderDetailsDatagridProps) => {
   const intl = useIntl();
@@ -56,7 +56,7 @@ export const OrderDetailsDatagrid = ({
       columns: visibleColumns,
       data: lines,
       loading,
-      onShowMetadata,
+      onOrderLineShowMetadata,
       intl,
     }),
     [intl, visibleColumns, loading],

--- a/src/orders/components/OrderDetailsDatagrid/datagrid.ts
+++ b/src/orders/components/OrderDetailsDatagrid/datagrid.ts
@@ -65,11 +65,11 @@ interface GetCellContentProps {
   data: OrderLineFragment[];
   loading: boolean;
   intl: IntlShape;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
 }
 
 export const createGetCellContent =
-  ({ columns, data, loading, onShowMetadata, intl }: GetCellContentProps) =>
+  ({ columns, data, loading, onOrderLineShowMetadata, intl }: GetCellContentProps) =>
   ([column, row]: Item, { added, removed }: GetCellContentOpts): GridCell => {
     if (loading) {
       return loadingCell();
@@ -115,7 +115,7 @@ export const createGetCellContent =
         });
       case "metadata":
         return buttonCell(intl.formatMessage(commonMessages.viewMetadata), () => {
-          onShowMetadata(rowData.id);
+          onOrderLineShowMetadata(rowData.id);
         });
 
       default:

--- a/src/orders/components/OrderDetailsDatagrid/index.ts
+++ b/src/orders/components/OrderDetailsDatagrid/index.ts
@@ -1,1 +1,0 @@
-export * from "./OrderDetailsDatagrid";

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -33,12 +33,12 @@ import OrderChannelSectionCard from "../OrderChannelSectionCard";
 import OrderCustomer from "../OrderCustomer";
 import OrderCustomerNote from "../OrderCustomerNote";
 import OrderDraftDetails from "../OrderDraftDetails/OrderDraftDetails";
-import { FormData as OrderDraftDetailsProductsFormData } from "../OrderDraftDetailsProducts";
-import OrderFulfilledProductsCard from "../OrderFulfilledProductsCard";
+import { FormData as OrderDraftDetailsProductsFormData } from "../OrderDraftDetailsProducts/OrderDraftDetailsProducts";
+import OrderFulfilledProductsCard from "../OrderFulfilledProductsCard/OrderFulfilledProductsCard";
 import OrderHistory, { FormData as HistoryFormData } from "../OrderHistory";
 import OrderInvoiceList from "../OrderInvoiceList";
 import { OrderPaymentOrTransaction } from "../OrderPaymentOrTransaction/OrderPaymentOrTransaction";
-import OrderUnfulfilledProductsCard from "../OrderUnfulfilledProductsCard";
+import OrderUnfulfilledProductsCard from "../OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard";
 import { messages } from "./messages";
 import Title from "./Title";
 import {
@@ -65,7 +65,7 @@ interface OrderDetailsPageProps {
   onBillingAddressEdit: () => any;
   onFulfillmentApprove: (id: string) => any;
   onFulfillmentCancel: (id: string) => any;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
   onFulfillmentTrackingNumberUpdate: (id: string) => any;
   onOrderFulfill: () => any;
   onProductClick?: (id: string) => any;
@@ -120,7 +120,7 @@ const OrderDetailsPage = (props: OrderDetailsPageProps) => {
     onShippingMethodEdit,
     onTransactionAction,
     onAddManualTransaction,
-    onShowMetadata,
+    onOrderLineShowMetadata,
     onMarkAsPaid,
     onRefundAdd,
     onSubmit,
@@ -216,7 +216,7 @@ const OrderDetailsPage = (props: OrderDetailsPageProps) => {
                   lines={unfulfilled}
                   onFulfill={onOrderFulfill}
                   loading={loading}
-                  onShowMetadata={onShowMetadata}
+                  onOrderLineShowMetadata={onOrderLineShowMetadata}
                 />
               ) : (
                 <>
@@ -224,7 +224,7 @@ const OrderDetailsPage = (props: OrderDetailsPageProps) => {
                     order={order}
                     errors={errors}
                     loading={loading}
-                    onShowMetadata={onShowMetadata}
+                    onOrderLineShowMetadata={onOrderLineShowMetadata}
                     onOrderLineAdd={onOrderLineAdd}
                     onOrderLineChange={onOrderLineChange}
                     onOrderLineRemove={onOrderLineRemove}
@@ -240,7 +240,7 @@ const OrderDetailsPage = (props: OrderDetailsPageProps) => {
                   fulfillment={fulfillment}
                   fulfillmentAllowUnpaid={shop?.fulfillmentAllowUnpaid}
                   order={order}
-                  onShowMetadata={onShowMetadata}
+                  onOrderLineShowMetadata={onOrderLineShowMetadata}
                   onOrderFulfillmentCancel={() => onFulfillmentCancel(fulfillment.id)}
                   onTrackingCodeAdd={() => onFulfillmentTrackingNumberUpdate(fulfillment.id)}
                   onOrderFulfillmentApprove={() => onFulfillmentApprove(fulfillment.id)}

--- a/src/orders/components/OrderDetailsPage/index.ts
+++ b/src/orders/components/OrderDetailsPage/index.ts
@@ -1,2 +1,0 @@
-export { default } from "./OrderDetailsPage";
-export * from "./OrderDetailsPage";

--- a/src/orders/components/OrderDraftDetails/OrderDraftDetails.tsx
+++ b/src/orders/components/OrderDraftDetails/OrderDraftDetails.tsx
@@ -14,7 +14,7 @@ import { Button } from "@saleor/macaw-ui-next";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { maybe } from "../../../misc";
-import OrderDraftDetailsProducts from "../OrderDraftDetailsProducts";
+import OrderDraftDetailsProducts from "../OrderDraftDetailsProducts/OrderDraftDetailsProducts";
 import OrderDraftDetailsSummary from "../OrderDraftDetailsSummary";
 
 interface OrderDraftDetailsProps {
@@ -26,7 +26,7 @@ interface OrderDraftDetailsProps {
   onOrderLineChange: (id: string, data: OrderLineInput) => void;
   onOrderLineRemove: (id: string) => void;
   onShippingMethodEdit: () => void;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
 }
 
 const OrderDraftDetails = ({
@@ -38,7 +38,7 @@ const OrderDraftDetails = ({
   onOrderLineChange,
   onOrderLineRemove,
   onShippingMethodEdit,
-  onShowMetadata,
+  onOrderLineShowMetadata,
 }: OrderDraftDetailsProps) => {
   const intl = useIntl();
   const isChannelActive = order?.channel.isActive;
@@ -68,7 +68,7 @@ const OrderDraftDetails = ({
         loading={loading}
         onOrderLineChange={onOrderLineChange}
         onOrderLineRemove={onOrderLineRemove}
-        onShowMetadata={onShowMetadata}
+        onOrderLineShowMetadata={onOrderLineShowMetadata}
       />
       {maybe(() => order.lines.length) !== 0 && (
         <DashboardCard.Content>

--- a/src/orders/components/OrderDraftDetailsDatagrid/OrderDraftDetailsDatagrid.tsx
+++ b/src/orders/components/OrderDraftDetailsDatagrid/OrderDraftDetailsDatagrid.tsx
@@ -27,7 +27,7 @@ interface OrderDraftDetailsDatagridProps {
   errors: OrderErrorFragment[];
   onOrderLineChange: (id: string, data: FormData) => void;
   onOrderLineRemove: (id: string) => void;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
 }
 
 export const OrderDraftDetailsDatagrid = ({
@@ -35,7 +35,7 @@ export const OrderDraftDetailsDatagrid = ({
   errors,
   onOrderLineChange,
   onOrderLineRemove,
-  onShowMetadata,
+  onOrderLineShowMetadata,
 }: OrderDraftDetailsDatagridProps) => {
   const intl = useIntl();
   const datagrid = useDatagridChangeState();
@@ -64,7 +64,7 @@ export const OrderDraftDetailsDatagrid = ({
     columns: visibleColumns,
     lines,
     errors,
-    onShowMetadata,
+    onOrderLineShowMetadata,
   });
   const getMenuItems = useCallback(
     index => [

--- a/src/orders/components/OrderDraftDetailsDatagrid/datagrid.ts
+++ b/src/orders/components/OrderDraftDetailsDatagrid/datagrid.ts
@@ -80,14 +80,14 @@ interface GetCellContentProps {
   columns: AvailableColumn[];
   lines: OrderDetailsFragment["lines"];
   errors: OrderErrorFragment[];
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
 }
 
 export const useGetCellContent = ({
   columns,
   lines,
   errors,
-  onShowMetadata,
+  onOrderLineShowMetadata,
 }: GetCellContentProps) => {
   const intl = useIntl();
   const { theme } = useTheme();
@@ -162,7 +162,7 @@ export const useGetCellContent = ({
         });
       case "metadata":
         return buttonCell(intl.formatMessage(commonMessages.viewMetadata), () => {
-          onShowMetadata(rowData.id);
+          onOrderLineShowMetadata(rowData.id);
         });
 
       default:

--- a/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
+++ b/src/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
@@ -23,7 +23,7 @@ interface OrderDraftDetailsProductsProps {
   loading: boolean;
   onOrderLineChange: (id: string, data: FormData) => void;
   onOrderLineRemove: (id: string) => void;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
 }
 
 const OrderDraftDetailsProducts = ({
@@ -32,7 +32,7 @@ const OrderDraftDetailsProducts = ({
   loading,
   onOrderLineChange,
   onOrderLineRemove,
-  onShowMetadata,
+  onOrderLineShowMetadata,
 }: OrderDraftDetailsProductsProps) => {
   const classes = useStyles();
   const lines = order?.lines ?? [];
@@ -49,7 +49,7 @@ const OrderDraftDetailsProducts = ({
       onOrderLineRemove={onOrderLineRemove}
       onOrderLineChange={onOrderLineChange}
       errors={formErrors}
-      onShowMetadata={onShowMetadata}
+      onOrderLineShowMetadata={onOrderLineShowMetadata}
     />
   );
 };

--- a/src/orders/components/OrderDraftDetailsProducts/index.ts
+++ b/src/orders/components/OrderDraftDetailsProducts/index.ts
@@ -1,2 +1,0 @@
-export { default } from "./OrderDraftDetailsProducts";
-export * from "./OrderDraftDetailsProducts";

--- a/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
@@ -55,7 +55,7 @@ interface OrderDraftPageProps extends FetchMoreProps {
   onShippingAddressEdit: () => void;
   onShippingMethodEdit: () => void;
   onProfileView: () => void;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
 }
 
 const draftOrderListUrl = orderDraftListUrl();
@@ -80,7 +80,7 @@ const OrderDraftPage = (props: OrderDraftPageProps) => {
     onShippingAddressEdit,
     onShippingMethodEdit,
     onProfileView,
-    onShowMetadata,
+    onOrderLineShowMetadata,
     order,
     channelUsabilityData,
     users,
@@ -147,7 +147,7 @@ const OrderDraftPage = (props: OrderDraftPageProps) => {
           onOrderLineChange={onOrderLineChange}
           onOrderLineRemove={onOrderLineRemove}
           onShippingMethodEdit={onShippingMethodEdit}
-          onShowMetadata={onShowMetadata}
+          onOrderLineShowMetadata={onOrderLineShowMetadata}
         />
         <OrderHistory
           history={order?.events}

--- a/src/orders/components/OrderDraftPage/index.ts
+++ b/src/orders/components/OrderDraftPage/index.ts
@@ -1,2 +1,0 @@
-export { default } from "./OrderDraftPage";
-export * from "./OrderDraftPage";

--- a/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
+++ b/src/orders/components/OrderFulfilledProductsCard/OrderFulfilledProductsCard.tsx
@@ -7,7 +7,7 @@ import { Box, Button, Divider, TrashBinIcon } from "@saleor/macaw-ui-next";
 import { PropsWithChildren } from "react";
 
 import OrderCardTitle from "../OrderCardTitle";
-import { OrderDetailsDatagrid } from "../OrderDetailsDatagrid";
+import { OrderDetailsDatagrid } from "../OrderDetailsDatagrid/OrderDetailsDatagrid";
 import ActionButtons from "./ActionButtons";
 import ExtraInfoLines from "./ExtraInfoLines";
 
@@ -19,7 +19,7 @@ interface OrderFulfilledProductsCardProps {
   onOrderFulfillmentCancel: () => void;
   onTrackingCodeAdd: () => void;
   dataTestId?: string;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
 }
 
 const statusesToMergeLines = [
@@ -46,7 +46,7 @@ const OrderFulfilledProductsCard = (props: PropsWithChildren<OrderFulfilledProdu
     onOrderFulfillmentApprove,
     onOrderFulfillmentCancel,
     onTrackingCodeAdd,
-    onShowMetadata,
+    onOrderLineShowMetadata,
     dataTestId,
   } = props;
 
@@ -94,7 +94,11 @@ const OrderFulfilledProductsCard = (props: PropsWithChildren<OrderFulfilledProdu
         }
       />
       <DashboardCard.Content paddingX={0}>
-        <OrderDetailsDatagrid lines={getLines()} loading={false} onShowMetadata={onShowMetadata} />
+        <OrderDetailsDatagrid
+          lines={getLines()}
+          loading={false}
+          onOrderLineShowMetadata={onOrderLineShowMetadata}
+        />
         <ExtraInfoLines fulfillment={fulfillment} />
       </DashboardCard.Content>
       {props.children}

--- a/src/orders/components/OrderFulfilledProductsCard/index.ts
+++ b/src/orders/components/OrderFulfilledProductsCard/index.ts
@@ -1,2 +1,0 @@
-export { default } from "./OrderFulfilledProductsCard";
-export * from "./OrderFulfilledProductsCard";

--- a/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
+++ b/src/orders/components/OrderUnfulfilledProductsCard/OrderUnfulfilledProductsCard.tsx
@@ -6,7 +6,7 @@ import { Button, Text } from "@saleor/macaw-ui-next";
 import { FormattedMessage } from "react-intl";
 
 import OrderCardTitle from "../OrderCardTitle";
-import { OrderDetailsDatagrid } from "../OrderDetailsDatagrid";
+import { OrderDetailsDatagrid } from "../OrderDetailsDatagrid/OrderDetailsDatagrid";
 import { useStyles } from "./styles";
 import { toLineWithUnfulfilledQuantity } from "./utils";
 
@@ -16,13 +16,13 @@ interface OrderUnfulfilledProductsCardProps {
   lines: OrderLineFragment[];
   onFulfill: () => void;
   loading: boolean;
-  onShowMetadata: (id: string) => void;
+  onOrderLineShowMetadata: (id: string) => void;
 }
 
 const OrderUnfulfilledProductsCard = ({
   showFulfillmentAction,
   notAllowedToFulfillUnpaid,
-  onShowMetadata,
+  onOrderLineShowMetadata,
   lines,
   onFulfill,
   loading,
@@ -41,7 +41,7 @@ const OrderUnfulfilledProductsCard = ({
           <OrderDetailsDatagrid
             lines={toLineWithUnfulfilledQuantity(lines)}
             loading={loading}
-            onShowMetadata={onShowMetadata}
+            onOrderLineShowMetadata={onOrderLineShowMetadata}
           />
           {showFulfillmentAction && (
             <DashboardCard.BottomActions justifyContent="flex-end">

--- a/src/orders/components/OrderUnfulfilledProductsCard/index.ts
+++ b/src/orders/components/OrderUnfulfilledProductsCard/index.ts
@@ -1,2 +1,0 @@
-export { default } from "./OrderUnfulfilledProductsCard";
-export * from "./OrderUnfulfilledProductsCard";

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -41,7 +41,7 @@ import { extractMutationErrors, getStringOrPlaceholder } from "../../../../misc"
 import { productUrl } from "../../../../products/urls";
 import OrderAddressFields from "../../../components/OrderAddressFields/OrderAddressFields";
 import OrderDraftCancelDialog from "../../../components/OrderDraftCancelDialog/OrderDraftCancelDialog";
-import OrderDraftPage from "../../../components/OrderDraftPage";
+import OrderDraftPage from "../../../components/OrderDraftPage/OrderDraftPage";
 import OrderProductAddDialog from "../../../components/OrderProductAddDialog";
 import OrderShippingMethodEditDialog from "../../../components/OrderShippingMethodEditDialog";
 import { orderDraftListUrl, OrderUrlDialog, OrderUrlQueryParams } from "../../../urls";
@@ -227,7 +227,7 @@ export const OrderDraftDetails = ({
             onDraftFinalize={() => orderDraftFinalize.mutate({ id })}
             onDraftRemove={() => openModal("cancel")}
             onOrderLineAdd={() => openModal("add-order-line")}
-            onShowMetadata={id => openModal("view-metadata", { id })}
+            onOrderLineShowMetadata={id => openModal("view-metadata", { id })}
             order={order}
             channelUsabilityData={channelUsabilityData}
             onProductClick={id => () => navigate(productUrl(encodeURIComponent(id)))}

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -51,7 +51,7 @@ import { customerUrl } from "../../../../customers/urls";
 import { productUrl } from "../../../../products/urls";
 import OrderAddressFields from "../../../components/OrderAddressFields/OrderAddressFields";
 import OrderCancelDialog from "../../../components/OrderCancelDialog";
-import OrderDetailsPage from "../../../components/OrderDetailsPage";
+import OrderDetailsPage from "../../../components/OrderDetailsPage/OrderDetailsPage";
 import OrderFulfillmentCancelDialog from "../../../components/OrderFulfillmentCancelDialog";
 import OrderFulfillmentTrackingDialog from "../../../components/OrderFulfillmentTrackingDialog";
 import OrderMarkAsPaidDialog from "../../../components/OrderMarkAsPaidDialog/OrderMarkAsPaidDialog";
@@ -225,7 +225,7 @@ export const OrderNormalDetails = ({
         )}
         shippingMethods={data?.order?.shippingMethods || []}
         onOrderCancel={() => openModal("cancel")}
-        onShowMetadata={id => openModal("view-metadata", { id })}
+        onOrderLineShowMetadata={id => openModal("view-metadata", { id })}
         onTransactionAction={(id, action) =>
           openModal("transaction-action", {
             type: action,

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -45,7 +45,7 @@ import {
 import { productUrl } from "../../../../products/urls";
 import OrderAddressFields from "../../../components/OrderAddressFields/OrderAddressFields";
 import OrderCancelDialog from "../../../components/OrderCancelDialog";
-import OrderDetailsPage from "../../../components/OrderDetailsPage";
+import OrderDetailsPage from "../../../components/OrderDetailsPage/OrderDetailsPage";
 import OrderFulfillmentCancelDialog from "../../../components/OrderFulfillmentCancelDialog";
 import OrderFulfillmentTrackingDialog from "../../../components/OrderFulfillmentTrackingDialog";
 import OrderMarkAsPaidDialog from "../../../components/OrderMarkAsPaidDialog/OrderMarkAsPaidDialog";
@@ -227,7 +227,7 @@ export const OrderUnconfirmedDetails = ({
             }
             onOrderLineRemove={id => orderLineDelete.mutate({ id })}
             onShippingMethodEdit={() => openModal("edit-shipping")}
-            onShowMetadata={id => openModal("view-metadata", { id })}
+            onOrderLineShowMetadata={id => openModal("view-metadata", { id })}
             saveButtonBarState={getMutationState(
               updateMetadataOpts.called || updatePrivateMetadataOpts.called,
               updateMetadataOpts.loading || updatePrivateMetadataOpts.loading,


### PR DESCRIPTION
## Summary

- Renamed `onShowMetadata` → `onOrderLineShowMetadata` across 13 files
- Removed 6 barrel files (index.ts) from order components  
- Updated 7 import statements to use direct component paths

## Changes

### Prop/Function Rename
The handler `onShowMetadata` has been renamed to `onOrderLineShowMetadata` for better clarity. The new name explicitly indicates this handler shows metadata for order lines specifically, not for the entire order.

**Files changed (13):**
- View layer (3): OrderDraftDetails, OrderNormalDetails, OrderUnconfirmedDetails
- Page components (2): OrderDetailsPage, OrderDraftPage
- Card components (3): OrderUnfulfilledProductsCard, OrderFulfilledProductsCard, OrderDraftDetailsProducts
- Draft details (1): OrderDraftDetails
- Datagrid (4): OrderDetailsDatagrid (x2), OrderDraftDetailsDatagrid (x2)

### Barrel File Removal
Removed barrel files (index.ts) and updated imports to use direct paths for better code clarity and explicit imports.

**Files removed (6):**
- OrderDetailsPage/index.ts
- OrderDraftPage/index.ts
- OrderUnfulfilledProductsCard/index.ts
- OrderFulfilledProductsCard/index.ts
- OrderDraftDetailsProducts/index.ts
- OrderDetailsDatagrid/index.ts

**Import updates (7 files):**
- OrderDetailsPage.tsx (3 imports)
- OrderDraftDetails.tsx (1 import)
- OrderFulfilledProductsCard.tsx (1 import)
- OrderUnfulfilledProductsCard.tsx (1 import)
- views: OrderDraftDetails, OrderNormalDetails, OrderUnconfirmedDetails (1 each)

## Test plan
- [ ] Type checking passes (`npm run check-types`)
- [ ] View order details page
- [ ] Click "View Metadata" button in order lines table
- [ ] Verify metadata modal opens correctly