### PR TITLE
Increase extension name display width

### DIFF
--- a/.changeset/extension-name-width.md
+++ b/.changeset/extension-name-width.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Increase extension name display width in InstalledExtensionsList from 200px to 400px to improve readability for extensions with longer names

--- a/src/extensions/views/InstalledExtensions/components/InstalledExtensionsList/InstalledExtensionsList.tsx
+++ b/src/extensions/views/InstalledExtensions/components/InstalledExtensionsList/InstalledExtensionsList.tsx
@@ -108,7 +108,7 @@ export const InstalledExtensionsList = ({
                     <Text
                       size={4}
                       fontWeight="bold"
-                      __maxWidth="200px"
+                      __maxWidth="400px"
                       overflow="hidden"
                       textOverflow="ellipsis"
                       whiteSpace="nowrap"


### PR DESCRIPTION
## Summary
- Increased extension name max width from 200px to 400px in InstalledExtensionsList

## Context
This UI enhancement improves readability by allowing more characters to display before truncation. Extensions with longer names will now be more readable in the installed extensions list.

## Changes
- Modified `InstalledExtensionsList.tsx` to increase `__maxWidth` CSS property from `200px` to `400px`

## Screenshots
N/A - minor CSS adjustment to text container width