### PR TITLE
Enable TypeScript strict mode for ChannelsListPage

### DIFF
--- a/src/channels/pages/ChannelsListPage/ChannelsListPage.tsx
+++ b/src/channels/pages/ChannelsListPage/ChannelsListPage.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { channelAddUrl, channelUrl } from "@dashboard/channels/urls";
 import { LimitsInfo } from "@dashboard/components/AppLayout/LimitsInfo";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
@@ -112,7 +111,7 @@ const ChannelsListPage = ({ channelsList, limits, onRemove }: ChannelsListPagePr
                     <span data-test-id="name">{channel?.name || <Skeleton />}</span>
                   </TableCell>
                   <TableCell className={classes.colAction}>
-                    {channelsList?.length > 1 && (
+                    {channelsList && channelsList.length > 1 && (
                       <TableButtonWrapper>
                         <Button
                           variant="secondary"


### PR DESCRIPTION
## Summary

- Removed `@ts-strict-ignore` directive from ChannelsListPage component
- Fixed type safety issue with nullable array length check to ensure TypeScript strict mode compatibility

## Changes

**Before:**
```typescript
{channelsList?.length > 1 && (
```

**After:**
```typescript
{channelsList && channelsList.length > 1 && (
```

The optional chaining operator `?.` returns `number | undefined`, and comparing `undefined > 1` is not valid in strict TypeScript mode. The fix explicitly checks that `channelsList` exists before accessing its `length` property.

## Test plan

- [x] TypeScript type checking passes (`pnpm run check-types`)
- [x] Pre-commit hooks pass (ESLint, Prettier)
- [ ] Verify the channels list page renders correctly
- [ ] Verify the delete button shows only when there are multiple channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)