### PR TITLE
Fix DataGrid row checkbox visibility

### DIFF
--- a/.changeset/fix-datagrid-checkbox-visibility.md
+++ b/.changeset/fix-datagrid-checkbox-visibility.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix row checkbox visibility in DataGrid by overriding rowMarkerTheme accentColor. Previously, checked row checkboxes had light gray background with white checkmark, making them invisible. Now they use dark text color for background, matching header checkbox appearance.

--- a/src/components/Datagrid/Datagrid.tsx
+++ b/src/components/Datagrid/Datagrid.tsx
@@ -143,6 +143,12 @@ const Datagrid = ({
   const classes = useStyles({ actionButtonPosition });
   const { themeValues, theme } = useTheme();
   const datagridTheme = useDatagridTheme(readonly, readonly);
+  const rowMarkerTheme = useMemo(
+    () => ({
+      accentColor: themeValues.colors.text.default1,
+    }),
+    [themeValues],
+  );
   const editor = useRef<DataEditorRef | null>(null);
   const customRenderers = useCustomCellRenderers();
   const { scrolledToRight } = useScrollRight();
@@ -477,6 +483,7 @@ const Datagrid = ({
                     headerIcons={headerIcons}
                     drawHeader={drawHeader}
                     theme={datagridTheme}
+                    rowMarkerTheme={rowMarkerTheme}
                     className={classes.datagrid}
                     getCellContent={handleGetCellContent}
                     onCellEdited={handleOnCellEdited}


### PR DESCRIPTION

![2025-11-19 at 14 06 45 - CleanShot@2x](https://github.com/user-attachments/assets/e35bbc37-9508-487a-a6ca-80f4fda1fb4c)

## Summary
- Fixed row checkbox visibility in DataGrid where white checkmarks on light gray background were invisible
- Added `rowMarkerTheme` override to use dark text color for checkbox background
- Row checkboxes now match header checkbox appearance

## Root Cause
The glide-data-grid library uses `theme.accentColor` for row marker checkboxes (when `highlighted=true`), but our theme had `accentColor` set to light gray `background.default2`, causing white checkmarks to be invisible.

## Solution
Override `accentColor` specifically for row markers using the `rowMarkerTheme` prop, setting it to `text.default1` (dark) to match header checkbox appearance.

## Test Plan
- [ ] Verify row checkboxes show dark background when checked
- [ ] Verify checkmarks are visible
- [ ] Verify header checkbox still works correctly