### PR TITLE
Implement page-based code splitting

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,30 +9,25 @@ import { PermissionEnum } from "@dashboard/graphql";
 import useAppState from "@dashboard/hooks/useAppState";
 import { pageListPath } from "@dashboard/modeling/urls";
 import { modelTypesPath } from "@dashboard/modelTypes/urls";
-import { RefundsSettingsRoute } from "@dashboard/refundsSettings/route";
 import { refundsSettingsPath } from "@dashboard/refundsSettings/urls";
 import { structuresListPath } from "@dashboard/structures/urls";
 import { ThemeProvider } from "@dashboard/theme";
 import { OnboardingProvider } from "@dashboard/welcomePage/WelcomePageOnboarding/onboardingContext";
 import { ThemeProvider as LegacyThemeProvider } from "@saleor/macaw-ui";
 import { SaleorProvider } from "@saleor/sdk";
+import { lazy, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "react-error-boundary";
 import TagManager from "react-gtm-module";
 import { useIntl } from "react-intl";
 import { Redirect, Switch } from "react-router-dom";
 
-import AttributeSection from "./attributes";
 import { attributeSection } from "./attributes/urls";
-import Auth from "./auth";
 import AuthProvider from "./auth/AuthProvider";
 import LoginLoading from "./auth/components/LoginLoading/LoginLoading";
 import SectionRoute from "./auth/components/SectionRoute";
 import { useAuthRedirection } from "./auth/hooks/useAuthRedirection";
-import CategorySection from "./categories";
-import ChannelsSection from "./channels";
 import { channelsSection } from "./channels/urls";
-import CollectionSection from "./collections";
 import AppLayout from "./components/AppLayout";
 import useAppChannel, { AppChannelProvider } from "./components/AppLayout/AppChannelContext";
 import { DateProvider } from "./components/Date";
@@ -48,38 +43,52 @@ import { SavebarRefProvider } from "./components/Savebar/SavebarRefContext";
 import { ShopProvider } from "./components/Shop";
 import { WindowTitle } from "./components/WindowTitle";
 import { GTM_ID } from "./config";
-import ConfigurationSection from "./configuration";
 import { getConfigMenuItemsPermissions } from "./configuration/utils";
 import AppStateProvider from "./containers/AppState";
 import BackgroundTasksProvider from "./containers/BackgroundTasks";
-import { CustomerSection } from "./customers";
-import DiscountSection from "./discounts";
-import { ExtensionsSection } from "./extensions";
 import { FeatureFlagsProviderWithUser } from "./featureFlags/FeatureFlagsProvider";
-import GiftCardSection from "./giftCards";
 import { giftCardsSectionUrlName } from "./giftCards/urls";
 import { apolloClient, saleorClient } from "./graphql/client";
 import { useLocationState } from "./hooks/useLocationState";
 import { commonMessages } from "./intl";
-import PageSection from "./modeling";
-import PageTypesSection from "./modelTypes";
 import { NotFound } from "./NotFound";
-import OrdersSection from "./orders";
-import PermissionGroupSection from "./permissionGroups";
-import ProductSection from "./products";
-import ProductTypesSection from "./productTypes";
-import SearchSection from "./search";
 import errorTracker from "./services/errorTracking";
-import ShippingSection from "./shipping";
-import SiteSettingsSection from "./siteSettings";
-import StaffSection from "./staff";
-import NavigationSection from "./structures";
-import TaxesSection from "./taxes";
 import { paletteOverrides, themeOverrides } from "./themeOverrides";
-import TranslationsSection from "./translations";
-import WarehouseSection from "./warehouses";
 import { warehouseSection } from "./warehouses/urls";
-import { WelcomePage } from "./welcomePage";
+
+// Lazy-loaded page sections for code splitting
+const AttributeSection = lazy(() => import("./attributes"));
+const Auth = lazy(() => import("./auth"));
+const CategorySection = lazy(() => import("./categories"));
+const ChannelsSection = lazy(() => import("./channels"));
+const CollectionSection = lazy(() => import("./collections"));
+const CustomerSection = lazy(() =>
+  import("./customers").then(m => ({ default: m.CustomerSection })),
+);
+const DiscountSection = lazy(() => import("./discounts"));
+const ExtensionsSection = lazy(() =>
+  import("./extensions").then(m => ({ default: m.ExtensionsSection })),
+);
+const GiftCardSection = lazy(() => import("./giftCards"));
+const PageSection = lazy(() => import("./modeling"));
+const PageTypesSection = lazy(() => import("./modelTypes"));
+const OrdersSection = lazy(() => import("./orders"));
+const PermissionGroupSection = lazy(() => import("./permissionGroups"));
+const ProductSection = lazy(() => import("./products"));
+const ProductTypesSection = lazy(() => import("./productTypes"));
+const SearchSection = lazy(() => import("./search"));
+const ShippingSection = lazy(() => import("./shipping"));
+const SiteSettingsSection = lazy(() => import("./siteSettings"));
+const StaffSection = lazy(() => import("./staff"));
+const NavigationSection = lazy(() => import("./structures"));
+const TaxesSection = lazy(() => import("./taxes"));
+const TranslationsSection = lazy(() => import("./translations"));
+const WarehouseSection = lazy(() => import("./warehouses"));
+const ConfigurationSection = lazy(() => import("./configuration"));
+const WelcomePage = lazy(() => import("./welcomePage").then(m => ({ default: m.WelcomePage })));
+const RefundsSettingsRoute = lazy(() =>
+  import("./refundsSettings/route").then(m => ({ default: m.RefundsSettingsRoute })),
+);
 
 if (GTM_ID) {
   TagManager.initialize({ gtmId: GTM_ID });
@@ -182,149 +191,153 @@ const Routes = () => {
                 <ErrorPage onBack={resetErrorBoundary} onRefresh={() => window.location.reload()} />
               )}
             >
-              <Switch>
-                {legacyRedirects}
-                <SectionRoute exact path="/" component={WelcomePage} />
-                <SectionRoute
-                  permissions={[
-                    PermissionEnum.MANAGE_PRODUCTS,
-                    PermissionEnum.MANAGE_ORDERS,
-                    PermissionEnum.MANAGE_PAGES,
-                    PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-                  ]}
-                  matchPermission="any"
-                  path="/search"
-                  component={SearchSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_PRODUCTS]}
-                  path="/categories"
-                  component={CategorySection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_PRODUCTS]}
-                  path="/collections"
-                  component={CollectionSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_USERS]}
-                  path="/customers"
-                  component={CustomerSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_GIFT_CARD]}
-                  path={giftCardsSectionUrlName}
-                  component={GiftCardSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_DISCOUNTS]}
-                  path="/discounts"
-                  component={DiscountSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_PAGES]}
-                  path={pageListPath}
-                  component={PageSection}
-                />
-                <SectionRoute
-                  permissions={[
-                    PermissionEnum.MANAGE_PAGES,
-                    PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
-                  ]}
-                  path={modelTypesPath}
-                  component={PageTypesSection}
-                  matchPermission="any"
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_ORDERS]}
-                  path="/orders"
-                  component={OrdersSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_PRODUCTS]}
-                  path="/products"
-                  component={ProductSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES]}
-                  path="/product-types"
-                  component={ProductTypesSection}
-                />
-                <SectionRoute path="/staff" component={StaffSection} />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_STAFF]}
-                  path="/permission-groups"
-                  component={PermissionGroupSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_SETTINGS]}
-                  path="/site-settings"
-                  component={SiteSettingsSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_SETTINGS]}
-                  path={refundsSettingsPath}
-                  component={RefundsSettingsRoute}
-                />
-                <SectionRoute path="/taxes" component={TaxesSection} />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_SHIPPING]}
-                  path="/shipping"
-                  component={ShippingSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_TRANSLATIONS]}
-                  path="/translations"
-                  component={TranslationsSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_MENUS]}
-                  path={structuresListPath}
-                  component={NavigationSection}
-                />
-                <SectionRoute
-                  permissions={[
-                    PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
-                    PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
-                  ]}
-                  path={attributeSection}
-                  component={AttributeSection}
-                  matchPermission="any"
-                />
-                <SectionRoute
-                  permissions={[]}
-                  path={extensionsSection}
-                  component={ExtensionsSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_PRODUCTS]}
-                  path={warehouseSection}
-                  component={WarehouseSection}
-                />
-                <SectionRoute
-                  permissions={[PermissionEnum.MANAGE_CHANNELS]}
-                  path={channelsSection}
-                  component={ChannelsSection}
-                />
-                <SectionRoute
-                  matchPermission="any"
-                  permissions={getConfigMenuItemsPermissions(intl)}
-                  exact
-                  path="/configuration"
-                  component={ConfigurationSection}
-                />
-                <Redirect to={ExtensionsPaths.installedExtensions} path={"/apps"} />
-                <Redirect to={ExtensionsPaths.installedExtensions} path="/custom-apps/" />
-                <Redirect to={ExtensionsPaths.installedExtensions} path="/plugins" />
-                <Route component={NotFound} />
-              </Switch>
+              <Suspense fallback={<LoginLoading />}>
+                <Switch>
+                  {legacyRedirects}
+                  <SectionRoute exact path="/" component={WelcomePage} />
+                  <SectionRoute
+                    permissions={[
+                      PermissionEnum.MANAGE_PRODUCTS,
+                      PermissionEnum.MANAGE_ORDERS,
+                      PermissionEnum.MANAGE_PAGES,
+                      PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+                    ]}
+                    matchPermission="any"
+                    path="/search"
+                    component={SearchSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_PRODUCTS]}
+                    path="/categories"
+                    component={CategorySection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_PRODUCTS]}
+                    path="/collections"
+                    component={CollectionSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_USERS]}
+                    path="/customers"
+                    component={CustomerSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_GIFT_CARD]}
+                    path={giftCardsSectionUrlName}
+                    component={GiftCardSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_DISCOUNTS]}
+                    path="/discounts"
+                    component={DiscountSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_PAGES]}
+                    path={pageListPath}
+                    component={PageSection}
+                  />
+                  <SectionRoute
+                    permissions={[
+                      PermissionEnum.MANAGE_PAGES,
+                      PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+                    ]}
+                    path={modelTypesPath}
+                    component={PageTypesSection}
+                    matchPermission="any"
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_ORDERS]}
+                    path="/orders"
+                    component={OrdersSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_PRODUCTS]}
+                    path="/products"
+                    component={ProductSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES]}
+                    path="/product-types"
+                    component={ProductTypesSection}
+                  />
+                  <SectionRoute path="/staff" component={StaffSection} />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_STAFF]}
+                    path="/permission-groups"
+                    component={PermissionGroupSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_SETTINGS]}
+                    path="/site-settings"
+                    component={SiteSettingsSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_SETTINGS]}
+                    path={refundsSettingsPath}
+                    component={RefundsSettingsRoute}
+                  />
+                  <SectionRoute path="/taxes" component={TaxesSection} />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_SHIPPING]}
+                    path="/shipping"
+                    component={ShippingSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_TRANSLATIONS]}
+                    path="/translations"
+                    component={TranslationsSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_MENUS]}
+                    path={structuresListPath}
+                    component={NavigationSection}
+                  />
+                  <SectionRoute
+                    permissions={[
+                      PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+                      PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+                    ]}
+                    path={attributeSection}
+                    component={AttributeSection}
+                    matchPermission="any"
+                  />
+                  <SectionRoute
+                    permissions={[]}
+                    path={extensionsSection}
+                    component={ExtensionsSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_PRODUCTS]}
+                    path={warehouseSection}
+                    component={WarehouseSection}
+                  />
+                  <SectionRoute
+                    permissions={[PermissionEnum.MANAGE_CHANNELS]}
+                    path={channelsSection}
+                    component={ChannelsSection}
+                  />
+                  <SectionRoute
+                    matchPermission="any"
+                    permissions={getConfigMenuItemsPermissions(intl)}
+                    exact
+                    path="/configuration"
+                    component={ConfigurationSection}
+                  />
+                  <Redirect to={ExtensionsPaths.installedExtensions} path={"/apps"} />
+                  <Redirect to={ExtensionsPaths.installedExtensions} path="/custom-apps/" />
+                  <Redirect to={ExtensionsPaths.installedExtensions} path="/plugins" />
+                  <Route component={NotFound} />
+                </Switch>
+              </Suspense>
             </ErrorBoundary>
           </AppLayout>
         </AppExtensionPopupProvider>
       ) : homePageLoading ? (
         <LoginLoading />
       ) : (
-        <Auth />
+        <Suspense fallback={<LoginLoading />}>
+          <Auth />
+        </Suspense>
       )}
     </>
   );


### PR DESCRIPTION
This change introduces lazy loading for all page sections using React.lazy() and Suspense to enable automatic code splitting. This results in:
- Smaller initial bundle size
- Faster initial page load
- Separate chunks per page that are loaded on-demand
- Better caching as individual page updates don't invalidate other page chunks

All major page sections (products, orders, customers, etc.) are now dynamically imported and wrapped in Suspense boundaries with LoginLoading as the fallback.

I have briefly tested the performance and found approx 50-100ms faster initial script evaluation, which makes sense because some of js is not loaded
