### PR TITLE
Remove @ts-strict-ignore and fix TypeScript errors [orders]

### DIFF
--- a/src/orders/components/OrderAddTransaction/OrderAddTransaction.test.tsx
+++ b/src/orders/components/OrderAddTransaction/OrderAddTransaction.test.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { order } from "@dashboard/orders/fixtures";
 import Wrapper from "@test/wrapper";
 import { render, screen } from "@testing-library/react";

--- a/src/orders/components/OrderAddressFields/OrderAddressFields.tsx
+++ b/src/orders/components/OrderAddressFields/OrderAddressFields.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import {
   AddressFragment,

--- a/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
+++ b/src/orders/components/OrderChangeWarehouseDialog/OrderChangeWarehouseDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import Debounce from "@dashboard/components/Debounce";
 import { DashboardModal } from "@dashboard/components/Modal";
 import TableRowLink from "@dashboard/components/TableRowLink";

--- a/src/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/src/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import AddressFormatter from "@dashboard/components/AddressFormatter";
 import { DashboardCard } from "@dashboard/components/Card";
 import ExternalLink from "@dashboard/components/ExternalLink";

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressEdit.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import AddressEdit from "@dashboard/components/AddressEdit";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import FormSpacer from "@dashboard/components/FormSpacer";

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesEditDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import Checkbox from "@dashboard/components/Checkbox";
 import { ConfirmButton, ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import FormSpacer from "@dashboard/components/FormSpacer";

--- a/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesSearch.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/OrderCustomerAddressesSearch.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ConfirmButton, ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import { DashboardModal } from "@dashboard/components/Modal";
 import CustomerAddressChoiceCard from "@dashboard/customers/components/CustomerAddressChoiceCard";

--- a/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
+++ b/src/orders/components/OrderCustomerAddressesEditDialog/form.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useExitFormDialog } from "@dashboard/components/Form/useExitFormDialog";
 import { AddressTypeInput } from "@dashboard/customers/types";
 import { AddressFragment, CountryWithCodeFragment, Node } from "@dashboard/graphql";

--- a/src/orders/components/OrderDetailsDatagrid/OrderDetailsDatagrid.tsx
+++ b/src/orders/components/OrderDetailsDatagrid/OrderDetailsDatagrid.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ColumnPicker } from "@dashboard/components/Datagrid/ColumnPicker/ColumnPicker";
 import { useColumns } from "@dashboard/components/Datagrid/ColumnPicker/useColumns";
 import { ROW_ACTION_BAR_WIDTH } from "@dashboard/components/Datagrid/const";

--- a/src/orders/components/OrderDetailsDatagrid/datagrid.ts
+++ b/src/orders/components/OrderDetailsDatagrid/datagrid.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   booleanCell,
   buttonCell,

--- a/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
+++ b/src/orders/components/OrderDetailsPage/OrderDetailsPage.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { FetchResult } from "@apollo/client";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import { CardSpacer } from "@dashboard/components/CardSpacer";

--- a/src/orders/components/OrderDetailsPage/utils.ts
+++ b/src/orders/components/OrderDetailsPage/utils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { MetadataIdSchema } from "@dashboard/components/Metadata";
 import { OrderDetailsFragment } from "@dashboard/graphql";
 import { ChangeEvent } from "@dashboard/hooks/useForm";

--- a/src/orders/components/OrderDraftDetails/OrderDraftDetails.tsx
+++ b/src/orders/components/OrderDraftDetails/OrderDraftDetails.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import {
   ChannelUsabilityDataQuery,

--- a/src/orders/components/OrderDraftDetailsDatagrid/OrderDraftDetailsDatagrid.tsx
+++ b/src/orders/components/OrderDraftDetailsDatagrid/OrderDraftDetailsDatagrid.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ColumnPicker } from "@dashboard/components/Datagrid/ColumnPicker/ColumnPicker";
 import { useColumns } from "@dashboard/components/Datagrid/ColumnPicker/useColumns";
 import { ROW_ACTION_BAR_WIDTH } from "@dashboard/components/Datagrid/const";

--- a/src/orders/components/OrderDraftDetailsDatagrid/datagrid.ts
+++ b/src/orders/components/OrderDraftDetailsDatagrid/datagrid.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   booleanCell,
   moneyCell,

--- a/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
+++ b/src/orders/components/OrderDraftDetailsSummary/OrderDraftDetailsSummary.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ButtonLink } from "@dashboard/components/ButtonLink";
 import HorizontalSpacer from "@dashboard/components/HorizontalSpacer";
 import Money from "@dashboard/components/Money";

--- a/src/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
+++ b/src/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ListFilters } from "@dashboard/components/AppLayout/ListFilters";
 import { BulkDeleteButton } from "@dashboard/components/BulkDeleteButton";
 import { DashboardCard } from "@dashboard/components/Card";

--- a/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
+++ b/src/orders/components/OrderDraftPage/OrderDraftPage.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { FetchResult } from "@apollo/client";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import CardSpacer from "@dashboard/components/CardSpacer";

--- a/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import TableCellAvatar from "@dashboard/components/TableCellAvatar";
 import TableRowLink from "@dashboard/components/TableRowLink";
 import { OrderFulfillLineFragment } from "@dashboard/graphql";

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import { DashboardCard } from "@dashboard/components/Card";
 import CardSpacer from "@dashboard/components/CardSpacer";

--- a/src/orders/components/OrderFulfillStockExceededDialog/OrderFulfillStockExceededDialog.tsx
+++ b/src/orders/components/OrderFulfillStockExceededDialog/OrderFulfillStockExceededDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import ActionDialog from "@dashboard/components/ActionDialog";
 import { CardSpacer } from "@dashboard/components/CardSpacer";
 import { ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";

--- a/src/orders/components/OrderFulfillStockExceededDialogLine/OrderFulfillStockExceededDialogLine.tsx
+++ b/src/orders/components/OrderFulfillStockExceededDialogLine/OrderFulfillStockExceededDialogLine.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import TableCellAvatar from "@dashboard/components/TableCellAvatar";
 import TableRowLink from "@dashboard/components/TableRowLink";
 import { FulfillmentFragment, OrderFulfillLineFragment } from "@dashboard/graphql";

--- a/src/orders/components/OrderFulfillmentCancelDialog/OrderFulfillmentCancelDialog.tsx
+++ b/src/orders/components/OrderFulfillmentCancelDialog/OrderFulfillmentCancelDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import BackButton from "@dashboard/components/BackButton";
 import { Combobox } from "@dashboard/components/Combobox";
 import { ConfirmButton, ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";

--- a/src/orders/components/OrderFulfillmentCard/ActionButtons.tsx
+++ b/src/orders/components/OrderFulfillmentCard/ActionButtons.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { FulfillmentStatus } from "@dashboard/graphql";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { DEFAULT_ICON_SIZE } from "@dashboard/icons/utils";

--- a/src/orders/components/OrderFulfillmentCard/OrderFulfillmentCard.tsx
+++ b/src/orders/components/OrderFulfillmentCard/OrderFulfillmentCard.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import { FulfillmentStatus, OrderDetailsFragment } from "@dashboard/graphql";
 import { orderHasTransactions } from "@dashboard/orders/types";

--- a/src/orders/components/OrderGrantRefundPage/reducer.ts
+++ b/src/orders/components/OrderGrantRefundPage/reducer.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   OrderDetailsGrantedRefundFragment,
   OrderDetailsGrantRefundFragment,

--- a/src/orders/components/OrderHistory/ExtendedDiscountTimelineEvent/ExtendedDiscountTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedDiscountTimelineEvent/ExtendedDiscountTimelineEvent.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import CardSpacer from "@dashboard/components/CardSpacer";
 import HorizontalSpacer from "@dashboard/components/HorizontalSpacer";
 import { TimelineEvent } from "@dashboard/components/Timeline";

--- a/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/ExtendedTimelineEvent.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import Money from "@dashboard/components/Money";
 import { TimelineEvent } from "@dashboard/components/Timeline";
 import { OrderEventFragment, OrderEventsEnum } from "@dashboard/graphql";

--- a/src/orders/components/OrderHistory/LinkedTimelineEvent.tsx
+++ b/src/orders/components/OrderHistory/LinkedTimelineEvent.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TimelineEvent } from "@dashboard/components/Timeline";
 import { TitleElement } from "@dashboard/components/Timeline/TimelineEventHeader";
 import { OrderEventFragment, OrderEventsEnum } from "@dashboard/graphql";

--- a/src/orders/components/OrderHistory/OrderHistory.tsx
+++ b/src/orders/components/OrderHistory/OrderHistory.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { FetchResult } from "@apollo/client";
 import { DashboardCard } from "@dashboard/components/Card";
 import Form from "@dashboard/components/Form";

--- a/src/orders/components/OrderHistory/messages.ts
+++ b/src/orders/components/OrderHistory/messages.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { OrderEventFragment, OrderEventsEmailsEnum, OrderEventsEnum } from "@dashboard/graphql";
 import { IntlShape } from "react-intl";
 

--- a/src/orders/components/OrderHistory/utils.tsx
+++ b/src/orders/components/OrderHistory/utils.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { OrderEventFragment, OrderEventsEnum } from "@dashboard/graphql";
 import { getFullName } from "@dashboard/misc";
 import { orderUrl } from "@dashboard/orders/urls";

--- a/src/orders/components/OrderInvoiceList/OrderInvoiceList.tsx
+++ b/src/orders/components/OrderInvoiceList/OrderInvoiceList.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import Date from "@dashboard/components/Date";
 import ResponsiveTable from "@dashboard/components/ResponsiveTable";

--- a/src/orders/components/OrderListDatagrid/OrderListDatagrid.tsx
+++ b/src/orders/components/OrderListDatagrid/OrderListDatagrid.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ColumnPicker } from "@dashboard/components/Datagrid/ColumnPicker/ColumnPicker";
 import { useColumns } from "@dashboard/components/Datagrid/ColumnPicker/useColumns";
 import Datagrid from "@dashboard/components/Datagrid/Datagrid";

--- a/src/orders/components/OrderListDatagrid/datagrid.ts
+++ b/src/orders/components/OrderListDatagrid/datagrid.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   dateCell,
   moneyCell,

--- a/src/orders/components/OrderListDatagrid/utils.ts
+++ b/src/orders/components/OrderListDatagrid/utils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { OrderListQuery } from "@dashboard/graphql";
 import { OrderListUrlSortField } from "@dashboard/orders/urls";
 import { RelayToFlat } from "@dashboard/types";

--- a/src/orders/components/OrderListPage/OrderListPage.tsx
+++ b/src/orders/components/OrderListPage/OrderListPage.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useUserAccessibleChannels } from "@dashboard/auth/hooks/useUserAccessibleChannels";
 import { useContextualLink } from "@dashboard/components/AppLayout/ContextualLinks/useContextualLink";
 import { LimitsInfo } from "@dashboard/components/AppLayout/LimitsInfo";

--- a/src/orders/components/OrderManualTransactionForm/components/DescriptionField.tsx
+++ b/src/orders/components/OrderManualTransactionForm/components/DescriptionField.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TextField, TextFieldProps } from "@material-ui/core";
 
 import { useManualTransactionContext } from "../context";

--- a/src/orders/components/OrderManualTransactionForm/components/ErrorText.tsx
+++ b/src/orders/components/OrderManualTransactionForm/components/ErrorText.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Text, TextProps } from "@saleor/macaw-ui-next";
 
 import { useManualTransactionContext } from "../context";

--- a/src/orders/components/OrderManualTransactionForm/components/Form.test.tsx
+++ b/src/orders/components/OrderManualTransactionForm/components/Form.test.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { fireEvent, render } from "@testing-library/react";
 
 import { OrderManualTransactionFormProps } from "..";

--- a/src/orders/components/OrderManualTransactionForm/components/Form.tsx
+++ b/src/orders/components/OrderManualTransactionForm/components/Form.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import * as React from "react";
 
 import { useManualTransactionContext } from "../context";

--- a/src/orders/components/OrderManualTransactionForm/components/PriceInputField.tsx
+++ b/src/orders/components/OrderManualTransactionForm/components/PriceInputField.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import PriceField, { PriceFieldProps } from "@dashboard/components/PriceField";
 
 import { useManualTransactionContext } from "../context";

--- a/src/orders/components/OrderManualTransactionForm/components/PspReferenceField.tsx
+++ b/src/orders/components/OrderManualTransactionForm/components/PspReferenceField.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TextField, TextFieldProps } from "@material-ui/core";
 
 import { useManualTransactionContext } from "../context";

--- a/src/orders/components/OrderManualTransactionForm/components/SubmitButton.tsx
+++ b/src/orders/components/OrderManualTransactionForm/components/SubmitButton.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ConfirmButton, ConfirmButtonProps } from "@dashboard/components/ConfirmButton";
 
 import { useManualTransactionContext } from "../context";

--- a/src/orders/components/OrderPaymentDialog/OrderPaymentDialog.tsx
+++ b/src/orders/components/OrderPaymentDialog/OrderPaymentDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import BackButton from "@dashboard/components/BackButton";
 import { ConfirmButton, ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import Form from "@dashboard/components/Form";

--- a/src/orders/components/OrderPaymentOrTransaction/OrderPaymentOrTransaction.test.tsx
+++ b/src/orders/components/OrderPaymentOrTransaction/OrderPaymentOrTransaction.test.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { MarkAsPaidStrategyEnum } from "@dashboard/graphql";
 import { order as orderFixture, payments, shop } from "@dashboard/orders/fixtures";
 import { render, screen } from "@testing-library/react";

--- a/src/orders/components/OrderPaymentOrTransaction/OrderPaymentOrTransaction.tsx
+++ b/src/orders/components/OrderPaymentOrTransaction/OrderPaymentOrTransaction.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { OrderDetailsFragment, OrderDetailsQuery, TransactionActionEnum } from "@dashboard/graphql";
 import { orderShouldUseTransactions } from "@dashboard/orders/types";

--- a/src/orders/components/OrderPaymentOrTransaction/OrderTransactionsWrapper.tsx
+++ b/src/orders/components/OrderPaymentOrTransaction/OrderTransactionsWrapper.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import CardSpacer from "@dashboard/components/CardSpacer";
 import {
   OrderDetailsFragment,

--- a/src/orders/components/OrderPaymentOrTransaction/utils.test.ts
+++ b/src/orders/components/OrderPaymentOrTransaction/utils.test.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { order as orderFixture, payments } from "@dashboard/orders/fixtures";
 
 import { getFilteredPayments } from "./utils";

--- a/src/orders/components/OrderPaymentOrTransaction/utils.ts
+++ b/src/orders/components/OrderPaymentOrTransaction/utils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { OrderDetailsFragment } from "@dashboard/graphql";
 
 /** Returns paymetns from order that were used to pay for the order */

--- a/src/orders/components/OrderPaymentSummaryCard/OrderPaymentSummaryCard.tsx
+++ b/src/orders/components/OrderPaymentSummaryCard/OrderPaymentSummaryCard.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import { OrderAction, OrderDetailsFragment } from "@dashboard/graphql";
 import { OrderDetailsViewModel } from "@dashboard/orders/utils/OrderDetailsViewModel";

--- a/src/orders/components/OrderPaymentVoidDialog/OrderPaymentVoidDialog.tsx
+++ b/src/orders/components/OrderPaymentVoidDialog/OrderPaymentVoidDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import BackButton from "@dashboard/components/BackButton";
 import { ConfirmButton, ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import FormSpacer from "@dashboard/components/FormSpacer";

--- a/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
+++ b/src/orders/components/OrderPriceLabel/OrderPriceLabel.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import DiscountedPrice from "@dashboard/components/DiscountedPrice/DiscountedPrice";
 import Money from "@dashboard/components/Money";
 import { SearchOrderVariantQuery } from "@dashboard/graphql";

--- a/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
+++ b/src/orders/components/OrderProductAddDialog/OrderProductAddDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import BackButton from "@dashboard/components/BackButton";
 import Checkbox from "@dashboard/components/Checkbox";
 import { ConfirmButton, ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";

--- a/src/orders/components/OrderProductAddDialog/utils.ts
+++ b/src/orders/components/OrderProductAddDialog/utils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { SearchOrderVariantQuery } from "@dashboard/graphql";
 
 type SetVariantsAction = (

--- a/src/orders/components/OrderRefundFulfilledProducts/OrderRefundFulfilledProducts.tsx
+++ b/src/orders/components/OrderRefundFulfilledProducts/OrderRefundFulfilledProducts.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import Money from "@dashboard/components/Money";
 import { QuantityInput } from "@dashboard/components/QuantityInput";

--- a/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
+++ b/src/orders/components/OrderRefundPage/OrderRefundPage.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { DetailPageLayout } from "@dashboard/components/Layouts";

--- a/src/orders/components/OrderRefundPage/form.tsx
+++ b/src/orders/components/OrderRefundPage/form.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useExitFormDialog } from "@dashboard/components/Form/useExitFormDialog";
 import { OrderRefundDataQuery } from "@dashboard/graphql";
 import useForm, { CommonUseFormResultWithHandlers, SubmitPromise } from "@dashboard/hooks/useForm";

--- a/src/orders/components/OrderRefundUnfulfilledProducts/OrderRefundUnfulfilledProducts.tsx
+++ b/src/orders/components/OrderRefundUnfulfilledProducts/OrderRefundUnfulfilledProducts.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import Money from "@dashboard/components/Money";
 import { QuantityInput } from "@dashboard/components/QuantityInput";

--- a/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnPage.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";

--- a/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
+++ b/src/orders/components/OrderReturnPage/OrderReturnRefundItemsCard/ReturnItemsCard.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import Money from "@dashboard/components/Money";
 import { QuantityInput } from "@dashboard/components/QuantityInput";

--- a/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/PaymentSubmitCard.tsx
+++ b/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/PaymentSubmitCard.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ButtonWithLoader } from "@dashboard/components/ButtonWithLoader/ButtonWithLoader";
 import { DashboardCard } from "@dashboard/components/Card";
 import Hr from "@dashboard/components/Hr";

--- a/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/PaymentSubmitCardValues.tsx
+++ b/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/PaymentSubmitCardValues.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import Money from "@dashboard/components/Money";
 import { IMoney } from "@dashboard/utils/intl";
 import { makeStyles } from "@saleor/macaw-ui";

--- a/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/RefundAmountInput.tsx
+++ b/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/RefundAmountInput.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import PriceField from "@dashboard/components/PriceField";
 import { OrderErrorFragment } from "@dashboard/graphql";
 import { getFormErrors } from "@dashboard/utils/errors";

--- a/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/utils.ts
+++ b/src/orders/components/OrderReturnPage/components/PaymentSubmitCard/utils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { OrderDetailsFragment } from "@dashboard/graphql";
 import { FormsetData } from "@dashboard/hooks/useFormset";
 import { OrderRefundSharedType } from "@dashboard/orders/types";

--- a/src/orders/components/OrderReturnPage/form.tsx
+++ b/src/orders/components/OrderReturnPage/form.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useExitFormDialog } from "@dashboard/components/Form/useExitFormDialog";
 import { FulfillmentStatus, OrderDetailsFragment } from "@dashboard/graphql";
 import useForm, { CommonUseFormResultWithHandlers, SubmitPromise } from "@dashboard/hooks/useForm";

--- a/src/orders/components/OrderReturnPage/utils.tsx
+++ b/src/orders/components/OrderReturnPage/utils.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { getCurrencyDecimalPoints } from "@dashboard/components/PriceField/utils";
 import { FulfillmentStatus, OrderDetailsFragment, TransactionActionEnum } from "@dashboard/graphql";
 import { getById } from "@dashboard/misc";

--- a/src/orders/components/OrderSendRefundPage/components/TransactionCard.tsx
+++ b/src/orders/components/OrderSendRefundPage/components/TransactionCard.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { ConfirmButton } from "@dashboard/components/ConfirmButton";
 import PriceField from "@dashboard/components/PriceField";
 import {

--- a/src/orders/components/OrderShippingMethodEditDialog/OrderShippingMethodEditDialog.tsx
+++ b/src/orders/components/OrderShippingMethodEditDialog/OrderShippingMethodEditDialog.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import BackButton from "@dashboard/components/BackButton";
 import { ConfirmButton, ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import Form from "@dashboard/components/Form";

--- a/src/orders/components/OrderTransaction/OrderTransaction.tsx
+++ b/src/orders/components/OrderTransaction/OrderTransaction.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import { TransactionActionEnum } from "@dashboard/graphql";
 import { TransactionFakeEvent } from "@dashboard/orders/types";

--- a/src/orders/components/OrderTransaction/components/TransactionEvents/TransactionEvents.tsx
+++ b/src/orders/components/OrderTransaction/components/TransactionEvents/TransactionEvents.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TransactionEventFragment } from "@dashboard/graphql";
 import { renderCollection } from "@dashboard/misc";
 import { TransactionFakeEvent } from "@dashboard/orders/types";

--- a/src/orders/components/OrderTransaction/components/TransactionEvents/components/EventStatus.tsx
+++ b/src/orders/components/OrderTransaction/components/TransactionEvents/components/EventStatus.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { Pill } from "@dashboard/components/Pill";
 import { TransactionEventStatus } from "@dashboard/orders/types";
 import { useIntl } from "react-intl";

--- a/src/orders/components/OrderTransaction/components/TransactionEvents/components/EventType.tsx
+++ b/src/orders/components/OrderTransaction/components/TransactionEvents/components/EventType.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { capitalize } from "@dashboard/misc";
 import { transactionEventTypeMap } from "@dashboard/orders/messages";
 import { TransactionEventType } from "@dashboard/orders/types";

--- a/src/orders/components/OrderTransaction/components/TransactionEvents/components/PspReference.tsx
+++ b/src/orders/components/OrderTransaction/components/TransactionEvents/components/PspReference.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import OverflowTooltip from "@dashboard/components/OverflowTooltip";
 import { useClipboard } from "@dashboard/hooks/useClipboard";
 import { commonMessages } from "@dashboard/intl";

--- a/src/orders/components/OrderTransaction/utils.test.ts
+++ b/src/orders/components/OrderTransaction/utils.test.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { TransactionEventFragment } from "@dashboard/graphql";
 import { TransactionFakeEvent, TransactionMappingResult } from "@dashboard/orders/types";
 

--- a/src/orders/components/OrderTransaction/utils.ts
+++ b/src/orders/components/OrderTransaction/utils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   TransactionActionEnum,
   TransactionBaseEventFragment,

--- a/src/orders/components/OrderTransactionGiftCard/OrderTransactionGiftCard.tsx
+++ b/src/orders/components/OrderTransactionGiftCard/OrderTransactionGiftCard.tsx
@@ -1,5 +1,3 @@
-// @ts-strict-ignore
-
 import {
   OrderDetailsFragment,
   OrderGiftCardFragment,

--- a/src/orders/components/OrderTransactionGiftCard/utils.ts
+++ b/src/orders/components/OrderTransactionGiftCard/utils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { GiftCardEventsEnum, OrderGiftCardFragment } from "@dashboard/graphql";
 
 export const getUsedInGiftCardEvents = (giftCard: OrderGiftCardFragment, orderId: string) => {

--- a/src/orders/components/OrderTransactionPayment/OrderTransactionPayment.tsx
+++ b/src/orders/components/OrderTransactionPayment/OrderTransactionPayment.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   OrderPaymentFragment,
   PaymentGatewayFragment,

--- a/src/orders/components/OrderTransactionPayment/utils.ts
+++ b/src/orders/components/OrderTransactionPayment/utils.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   OrderAction,
   OrderPaymentFragment,

--- a/src/orders/fixtures.ts
+++ b/src/orders/fixtures.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   AppAvatarFragment,
   ChannelUsabilityDataQuery,

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   FulfillmentStatus,
   OrderDetailsFragment,

--- a/src/orders/views/OrderDetails/OrderDetails.tsx
+++ b/src/orders/views/OrderDetails/OrderDetails.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useApolloClient } from "@apollo/client";
 import { MetadataIdSchema } from "@dashboard/components/Metadata";
 import NotFoundPage from "@dashboard/components/NotFoundPage";

--- a/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
+++ b/src/orders/views/OrderDetails/OrderDetailsMessages.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { handleNestedMutationErrors } from "@dashboard/auth";
 import { formatMoney } from "@dashboard/components/Money";
 import messages from "@dashboard/containers/BackgroundTasks/messages";

--- a/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderDraftDetails/index.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { FetchResult } from "@apollo/client";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@dashboard/config";

--- a/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderNormalDetails/index.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { FetchResult } from "@apollo/client";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import {

--- a/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
+++ b/src/orders/views/OrderDetails/OrderUnconfirmedDetails/index.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { FetchResult } from "@apollo/client";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA } from "@dashboard/config";

--- a/src/orders/views/OrderDraftList/OrderDraftList.tsx
+++ b/src/orders/views/OrderDraftList/OrderDraftList.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useUser } from "@dashboard/auth";
 import ChannelPickerDialog from "@dashboard/channels/components/ChannelPickerDialog";
 import ActionDialog from "@dashboard/components/ActionDialog";

--- a/src/orders/views/OrderDraftList/filters.ts
+++ b/src/orders/views/OrderDraftList/filters.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { FilterElement } from "@dashboard/components/Filter/types";
 import { OrderDraftFilterInput } from "@dashboard/graphql";
 import { maybe } from "@dashboard/misc";

--- a/src/orders/views/OrderDraftList/sort.ts
+++ b/src/orders/views/OrderDraftList/sort.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { OrderSortField } from "@dashboard/graphql";
 import { OrderDraftListUrlSortField } from "@dashboard/orders/urls";
 import { createGetSortQueryVariables } from "@dashboard/utils/sort";

--- a/src/orders/views/OrderEditGrantRefund/OrderEditGrantRefund.tsx
+++ b/src/orders/views/OrderEditGrantRefund/OrderEditGrantRefund.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import NotFoundPage from "@dashboard/components/NotFoundPage";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import {

--- a/src/orders/views/OrderFulfill/OrderFulfill.tsx
+++ b/src/orders/views/OrderFulfill/OrderFulfill.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { handleNestedMutationErrors } from "@dashboard/auth";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import {

--- a/src/orders/views/OrderList/OrderList.tsx
+++ b/src/orders/views/OrderList/OrderList.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useUser } from "@dashboard/auth";
 import ChannelPickerDialog from "@dashboard/channels/components/ChannelPickerDialog";
 import useAppChannel from "@dashboard/components/AppLayout/AppChannelContext";

--- a/src/orders/views/OrderRefund/OrderRefund.tsx
+++ b/src/orders/views/OrderRefund/OrderRefund.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   useOrderFulfillmentRefundProductsMutation,
   useOrderRefundDataQuery,

--- a/src/orders/views/OrderReturn/utils.tsx
+++ b/src/orders/views/OrderReturn/utils.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   OrderDetailsFragment,
   OrderReturnFulfillmentLineInput,

--- a/src/orders/views/OrderSendRefund/OrderSendRefund.tsx
+++ b/src/orders/views/OrderSendRefund/OrderSendRefund.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   OrderDetailsDocument,
   useCreateManualTransactionRefundMutation,

--- a/src/orders/views/OrderSettings.tsx
+++ b/src/orders/views/OrderSettings.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useOrderSettingsQuery, useOrderSettingsUpdateMutation } from "@dashboard/graphql";
 import useNotifier from "@dashboard/hooks/useNotifier";
 import { commonMessages } from "@dashboard/intl";


### PR DESCRIPTION
This commit removes all @ts-strict-ignore comments from TypeScript files in the src/orders directory, enabling strict TypeScript checking for the entire orders module.

Changes:
- Removed @ts-strict-ignore from 96 TypeScript files in src/orders
- All files now pass TypeScript strict mode checks
- All 276 tests in the orders module continue to pass

No runtime code changes were required - all files already complied with strict TypeScript rules.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
