### PR TITLE
Remove @ts-strict-ignore and fix TypeScript errors [hooks]

### DIFF
--- a/src/hooks/makeMutation.ts
+++ b/src/hooks/makeMutation.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import {
   ApolloError,
   MutationFunction,
@@ -59,7 +58,10 @@ export function useMutation<TData, TVariables>(
               text: intl.formatMessage(commonMessages.readOnly),
             });
           } else if (err.graphQLErrors.some(isJwtError)) {
-            user.logout();
+            if (user.logout) {
+              user.logout();
+            }
+
             notify({
               status: "error",
               text: intl.formatMessage(commonMessages.sessionExpired),
@@ -87,7 +89,7 @@ export function useMutation<TData, TVariables>(
     mutateFn,
     {
       ...result,
-      status: getMutationStatus(result),
+      status: getMutationStatus(result as MutationResult<Record<string, any>>),
     },
   ];
 }

--- a/src/hooks/makeSearch.ts
+++ b/src/hooks/makeSearch.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { QueryResult } from "@apollo/client";
 import { DocumentNode } from "graphql";
 import { useState } from "react";
@@ -41,7 +40,7 @@ function makeSearch<TData, TVariables extends SearchVariables>(
       variables: {
         ...opts.variables,
         query: searchQuery,
-      },
+      } as any,
     });
 
     return {

--- a/src/hooks/makeTopLevelSearch/makeTopLevelSearch.ts
+++ b/src/hooks/makeTopLevelSearch/makeTopLevelSearch.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { PageInfoFragment } from "@dashboard/graphql";
 import { DocumentNode } from "graphql";
 
@@ -40,7 +39,7 @@ function makeTopLevelSearch<TData extends SearchData, TVariables extends SearchV
         {
           ...result.variables,
           after: result.data.search.pageInfo.endCursor,
-        },
+        } as Partial<TVariables>,
       );
     }
   });

--- a/src/hooks/useAddressValidation.ts
+++ b/src/hooks/useAddressValidation.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { AddressTypeInput } from "@dashboard/customers/types";
 import {
   AccountErrorCode,
@@ -24,7 +23,7 @@ function useAddressValidation<TInput, TOutput>(
     __typename: "AccountError",
     code: AccountErrorCode.REQUIRED,
     field: "country",
-    addressType,
+    addressType: addressType ?? null,
     message: "Country required",
   };
 

--- a/src/hooks/useFilterHandlers.test.ts
+++ b/src/hooks/useFilterHandlers.test.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { renderHook } from "@testing-library/react-hooks";
 
 import { useFilterHandlers } from "./useFilterHandlers";
@@ -69,7 +68,7 @@ describe("useFilterHandlers", () => {
         useFilterHandlers({
           getFilterQueryParam: jest.fn(filter => ({
             [filter.name]: filter.value,
-          })),
+          })) as any,
           createUrl,
           params: {
             activeTab: "tab",
@@ -98,8 +97,8 @@ describe("useFilterHandlers", () => {
       const { result } = renderHook(() =>
         useFilterHandlers({
           getFilterQueryParam: jest.fn(filter => ({
-            [filter.name]: filter.value[0],
-          })),
+            [filter.name]: filter.value?.[0],
+          })) as any,
           createUrl,
           params: {
             activeTab: "tab",
@@ -145,8 +144,8 @@ describe("useFilterHandlers", () => {
       const { result } = renderHook(() =>
         useFilterHandlers({
           getFilterQueryParam: jest.fn(filter => ({
-            [filter.name]: filter.value[0],
-          })),
+            [filter.name]: filter.value?.[0],
+          })) as any,
           createUrl,
           params: {
             activeTab: "tab",
@@ -210,8 +209,8 @@ describe("useFilterHandlers", () => {
       const { result } = renderHook(() =>
         useFilterHandlers({
           getFilterQueryParam: jest.fn(filter => ({
-            [filter.name]: filter.value[0],
-          })),
+            [filter.name]: filter.value?.[0],
+          })) as any,
           createUrl,
           params: {
             activeTab: "tab",
@@ -243,8 +242,8 @@ describe("useFilterHandlers", () => {
       const { result } = renderHook(() =>
         useFilterHandlers({
           getFilterQueryParam: jest.fn(filter => ({
-            [filter.name]: filter.value[0],
-          })),
+            [filter.name]: filter.value?.[0],
+          })) as any,
           createUrl,
           params: {
             activeTab: "tab",

--- a/src/hooks/useFilterHandlers.ts
+++ b/src/hooks/useFilterHandlers.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { IFilter } from "@dashboard/components/Filter/types";
 import { ActiveTab, Pagination, Search, Sort } from "@dashboard/types";
 import { GetFilterQueryParam, getFilterQueryParams } from "@dashboard/utils/filters";
@@ -43,7 +42,7 @@ export const useFilterHandlers = <
     const hasQuery = !!params.query?.trim();
 
     if (hasQuery || params.sort === "rank") {
-      prevAsc.current = params.asc;
+      prevAsc.current = params.asc ?? null;
     }
   }, [params.asc, params.query, params.sort]);
 

--- a/src/hooks/useFormset.test.ts
+++ b/src/hooks/useFormset.test.ts
@@ -1,0 +1,135 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+
+import useFormset, { FormsetAtomicData } from "./useFormset";
+
+interface TestData {
+  name: string;
+}
+
+interface TestAdditionalData {
+  count: number;
+}
+
+type TestFormsetData = FormsetAtomicData<TestData, string, TestAdditionalData>;
+
+describe("useFormset", () => {
+  describe("get", () => {
+    test("should throw error when item not found", () => {
+      // Arrange
+      const initialData: TestFormsetData[] = [
+        {
+          id: "1",
+          label: "Item 1",
+          value: "value1",
+          data: { name: "Test 1" },
+        },
+      ];
+      const { result } = renderHook(() => useFormset(initialData));
+
+      // Act & Assert
+      expect(() => result.current.get("non-existent-id")).toThrow(
+        'Item with id "non-existent-id" not found in formset',
+      );
+    });
+
+    test("should return item when found", () => {
+      // Arrange
+      const initialData: TestFormsetData[] = [
+        {
+          id: "1",
+          label: "Item 1",
+          value: "value1",
+          data: { name: "Test 1" },
+        },
+      ];
+      const { result } = renderHook(() => useFormset(initialData));
+
+      // Act
+      const item = result.current.get("1");
+
+      // Assert
+      expect(item).toEqual({
+        id: "1",
+        label: "Item 1",
+        value: "value1",
+        data: { name: "Test 1" },
+      });
+    });
+  });
+
+  describe("setAdditionalData with merge", () => {
+    test("should use additionalData directly when item.additionalData is undefined", () => {
+      // Arrange
+      const initialData: TestFormsetData[] = [
+        {
+          id: "1",
+          label: "Item 1",
+          value: "value1",
+          data: { name: "Test 1" },
+          // additionalData is undefined
+        },
+      ];
+      const { result } = renderHook(() => useFormset(initialData));
+      const mergeFn = jest.fn((prev: TestAdditionalData, next: TestAdditionalData) => ({
+        count: prev.count + next.count,
+      }));
+
+      // Act
+      act(() => {
+        result.current.setAdditionalData("1", { count: 5 }, mergeFn);
+      });
+
+      // Assert
+      expect(mergeFn).not.toHaveBeenCalled();
+      expect(result.current.data[0].additionalData).toEqual({ count: 5 });
+    });
+
+    test("should call merge function when item.additionalData is defined", () => {
+      // Arrange
+      const initialData: TestFormsetData[] = [
+        {
+          id: "1",
+          label: "Item 1",
+          value: "value1",
+          data: { name: "Test 1" },
+          additionalData: { count: 10 },
+        },
+      ];
+      const { result } = renderHook(() => useFormset(initialData));
+      const mergeFn = jest.fn((prev: TestAdditionalData, next: TestAdditionalData) => ({
+        count: prev.count + next.count,
+      }));
+
+      // Act
+      act(() => {
+        result.current.setAdditionalData("1", { count: 5 }, mergeFn);
+      });
+
+      // Assert
+      expect(mergeFn).toHaveBeenCalledWith({ count: 10 }, { count: 5 });
+      expect(result.current.data[0].additionalData).toEqual({ count: 15 });
+    });
+
+    test("should use additionalData directly when no merge function provided", () => {
+      // Arrange
+      const initialData: TestFormsetData[] = [
+        {
+          id: "1",
+          label: "Item 1",
+          value: "value1",
+          data: { name: "Test 1" },
+          additionalData: { count: 10 },
+        },
+      ];
+      const { result } = renderHook(() => useFormset(initialData));
+
+      // Act
+      act(() => {
+        result.current.setAdditionalData("1", { count: 5 });
+      });
+
+      // Assert
+      expect(result.current.data[0].additionalData).toEqual({ count: 5 });
+    });
+  });
+});

--- a/src/hooks/useFormset.ts
+++ b/src/hooks/useFormset.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { removeAtIndex } from "@dashboard/utils/lists";
 
 import useStateFromProps from "./useStateFromProps";
@@ -56,7 +55,13 @@ function useFormset<TData = {}, TValue = any, TAdditionalData = any>(
   }
 
   function getItem(id: string): FormsetAtomicData<TData, TValue, TAdditionalData> {
-    return data.find(item => item.id === id);
+    const item = data.find(item => item.id === id);
+
+    if (!item) {
+      throw new Error(`Item with id "${id}" not found in formset`);
+    }
+
+    return item;
   }
 
   function removeItem(id: string) {
@@ -86,14 +91,17 @@ function useFormset<TData = {}, TValue = any, TAdditionalData = any>(
   const setItemMetadata: FormsetAdditionalDataChange = (
     id: string,
     additionalData: TAdditionalData,
-    merge?: (prev, next) => TAdditionalData,
+    merge?: (prev: TAdditionalData, next: TAdditionalData) => TAdditionalData,
   ) => {
     setData(data =>
       data.map(item =>
         item.id === id
           ? {
               ...item,
-              additionalData: merge ? merge(item.additionalData, additionalData) : additionalData,
+              additionalData:
+                merge && item.additionalData !== undefined
+                  ? merge(item.additionalData, additionalData)
+                  : additionalData,
             }
           : item,
       ),

--- a/src/hooks/useListSettings.ts
+++ b/src/hooks/useListSettings.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import useLocalStorage from "@dashboard/hooks/useLocalStorage";
 import mergeWith from "lodash/mergeWith";
 
@@ -45,13 +44,13 @@ export default function useListSettings<TColumns extends string = string>(
     setListSettings(settings => ({
       ...settings,
       [listName]: {
-        ...settings[listName],
+        ...(settings[listName as keyof AppListViewSettings] as ListSettings),
         [key]: value,
       },
     }));
 
   return {
-    settings: settings[listName] as ListSettings<TColumns>,
+    settings: settings[listName as keyof AppListViewSettings] as ListSettings<TColumns>,
     updateListSettings,
   };
 }

--- a/src/hooks/useLocalPaginator.ts
+++ b/src/hooks/useLocalPaginator.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useEffect, useState } from "react";
 
 interface PageInfo {
@@ -99,14 +98,14 @@ function useLocalPaginator(setPaginationState: (paginationState: PaginationState
     const loadNextPage = () =>
       setPaginationState({
         ...paginationState,
-        after: pageInfo?.endCursor,
+        after: pageInfo?.endCursor ?? undefined,
         before: undefined,
       });
     const loadPreviousPage = () =>
       setPaginationState({
         ...paginationState,
         after: undefined,
-        before: pageInfo?.startCursor,
+        before: pageInfo?.startCursor ?? undefined,
       });
     const newPageInfo = pageInfo
       ? {

--- a/src/hooks/useWizard.ts
+++ b/src/hooks/useWizard.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import { useState } from "react";
 
 interface UseWizardActions<T> {
@@ -13,7 +12,7 @@ type UseWizard<T> = [T, UseWizardActions<T>];
 function useWizard<T>(initial: T, steps: T[], opts?: UseWizardOpts<T>): UseWizard<T> {
   const [stepIndex, setStepIndex] = useState(steps.indexOf(initial));
 
-  function goToStep(nextStepIndex) {
+  function goToStep(nextStepIndex: number) {
     if (typeof opts?.onTransition === "function") {
       opts.onTransition(steps[stepIndex], steps[nextStepIndex]);
     }


### PR DESCRIPTION
Remove @ts-strict-ignore directives and fix all type errors in hooks:

- useWizard.ts: Add explicit number type to goToStep parameter
- useLocalPaginator.ts: Convert null to undefined for cursor values
- useAddressValidation.ts: Convert undefined to null for addressType
- useFilterHandlers.ts: Convert undefined to null for prevAsc ref
- useFormset.ts: Add runtime check for getItem and handle undefined additionalData in merge
- useListSettings.ts: Add type assertions for AppListViewSettings indexing
- makeMutation.ts: Add runtime check for user.logout and type assertion for getMutationStatus
- makeQuery.ts: Add type assertions for permissions handling and make opts optional in makeQuery
- makeSearch.ts: Add type assertion for variables
- makeTopLevelSearch.ts: Add type assertion for loadMore variables
- useFilterHandlers.test.ts: Add type assertions and optional chaining for test mocks

Add comprehensive tests for useFormset runtime changes:
- Test error handling when item not found
- Test merge function with undefined additionalData
- Test merge function with defined additionalData

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
