### PR TITLE
Fix error with bulk operations on collection

### DIFF
--- a/.changeset/soft-grapes-shop.md
+++ b/.changeset/soft-grapes-shop.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed error when bulk operations on large number of items (over 20) caused runtime error - for example selecting 100 items to be unassigned from collecton, caused page to crash. Now limit is set to 100

--- a/src/attributes/index.tsx
+++ b/src/attributes/index.tsx
@@ -1,8 +1,8 @@
 import { ConditionalAttributesFilterProvider } from "@dashboard/components/ConditionalFilter";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/auth/index.tsx
+++ b/src/auth/index.tsx
@@ -1,5 +1,5 @@
 import { Route } from "@dashboard/components/Router";
-import { parse as parseQs } from "qs";
+import { parseQs } from "@dashboard/url-utils";
 import { createContext, useContext } from "react";
 import { Switch } from "react-router-dom";
 

--- a/src/auth/views/NewPassword.tsx
+++ b/src/auth/views/NewPassword.tsx
@@ -1,7 +1,7 @@
 import { AccountErrorFragment } from "@dashboard/graphql";
 import useNavigator from "@dashboard/hooks/useNavigator";
+import { parseQs } from "@dashboard/url-utils";
 import { useAuth } from "@saleor/sdk";
-import { parse as parseQs } from "qs";
 import { useState } from "react";
 import { RouteComponentProps } from "react-router";
 

--- a/src/categories/index.tsx
+++ b/src/categories/index.tsx
@@ -1,7 +1,7 @@
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/channels/index.tsx
+++ b/src/channels/index.tsx
@@ -1,7 +1,7 @@
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/collections/index.tsx
+++ b/src/collections/index.tsx
@@ -1,8 +1,8 @@
 import { ConditionalCollectionFilterProvider } from "@dashboard/components/ConditionalFilter";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/customers/index.tsx
+++ b/src/customers/index.tsx
@@ -1,8 +1,8 @@
 import { ConditionalCustomerFilterProvider } from "@dashboard/components/ConditionalFilter";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/discounts/index.tsx
+++ b/src/discounts/index.tsx
@@ -4,8 +4,8 @@ import {
 } from "@dashboard/components/ConditionalFilter";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/extensions/index.tsx
+++ b/src/extensions/index.tsx
@@ -14,7 +14,7 @@ import { InstalledExtensions } from "@dashboard/extensions/views/InstalledExtens
 import { PermissionEnum } from "@dashboard/graphql";
 import { sectionNames } from "@dashboard/intl";
 import NotFound from "@dashboard/NotFound";
-import { parse as parseQs } from "qs";
+import { parseQs } from "@dashboard/url-utils";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/giftCards/index.tsx
+++ b/src/giftCards/index.tsx
@@ -2,8 +2,8 @@ import { ConditionalGiftCardsFilterProver } from "@dashboard/components/Conditio
 import { Route } from "@dashboard/components/Router";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/modelTypes/index.tsx
+++ b/src/modelTypes/index.tsx
@@ -1,7 +1,7 @@
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";

--- a/src/modeling/index.tsx
+++ b/src/modeling/index.tsx
@@ -1,8 +1,8 @@
 import { ConditionalPageFilterProvider } from "@dashboard/components/ConditionalFilter";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/orders/index.tsx
+++ b/src/orders/index.tsx
@@ -4,8 +4,8 @@ import {
 } from "@dashboard/components/ConditionalFilter";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/permissionGroups/index.tsx
+++ b/src/permissionGroups/index.tsx
@@ -1,7 +1,7 @@
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/productTypes/index.tsx
+++ b/src/productTypes/index.tsx
@@ -1,8 +1,8 @@
 import { ConditionalProductTypesFilterProvider } from "@dashboard/components/ConditionalFilter";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/products/index.tsx
+++ b/src/products/index.tsx
@@ -1,9 +1,9 @@
 import { ConditionalProductFilterProvider } from "@dashboard/components/ConditionalFilter/context";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
 import { getArrayQueryParam } from "@dashboard/utils/urls";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { Redirect, RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/search/useSearchCriteria.ts
+++ b/src/search/useSearchCriteria.ts
@@ -1,6 +1,6 @@
 import useLocalStorage from "@dashboard/hooks/useLocalStorage";
 import useNavigator from "@dashboard/hooks/useNavigator";
-import { parse as parseQs } from "qs";
+import { parseQs } from "@dashboard/url-utils";
 import { useEffect, useState } from "react";
 
 export const useSearchCriteria = () => {

--- a/src/shipping/index.tsx
+++ b/src/shipping/index.tsx
@@ -1,6 +1,6 @@
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
-import { parse as parseQs } from "qs";
+import { parseQs } from "@dashboard/url-utils";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/staff/index.tsx
+++ b/src/staff/index.tsx
@@ -1,8 +1,8 @@
 import { ConditionalStaffMembersFilterProvider } from "@dashboard/components/ConditionalFilter";
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/structures/index.tsx
+++ b/src/structures/index.tsx
@@ -1,6 +1,6 @@
 import { Route } from "@dashboard/components/Router";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { RouteComponentProps, Switch } from "react-router-dom";
 
 import { MenuListUrlQueryParams, MenuListUrlSortField, menuPath, structuresListPath } from "./urls";

--- a/src/taxes/index.tsx
+++ b/src/taxes/index.tsx
@@ -1,6 +1,6 @@
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
-import { parse as parseQs } from "qs";
+import { parseQs } from "@dashboard/url-utils";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/translations/index.tsx
+++ b/src/translations/index.tsx
@@ -2,7 +2,7 @@
 import { Route } from "@dashboard/components/Router";
 import { LanguageCodeEnum } from "@dashboard/graphql";
 import { sectionNames } from "@dashboard/intl";
-import { parse as parseQs } from "qs";
+import { parseQs } from "@dashboard/url-utils";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 

--- a/src/url-utils.test.ts
+++ b/src/url-utils.test.ts
@@ -1,0 +1,115 @@
+import { parseQs } from "./url-utils";
+
+describe("parseQs", () => {
+  describe("arrayLimit", () => {
+    it("should parse arrays with up to 100 items", () => {
+      // Arrange
+      const items = Array.from({ length: 100 }, (_, i) => `item${i}`);
+      const queryString = items.map(item => `arr[]=${item}`).join("&");
+
+      // Act
+      const result = parseQs(queryString);
+
+      // Assert
+      expect(result.arr).toEqual(items);
+      expect(Array.isArray(result.arr)).toBe(true);
+      expect(result.arr).toHaveLength(100);
+    });
+
+    it("should parse arrays with exactly 100 items correctly", () => {
+      // Arrange
+      const queryString = Array.from({ length: 100 }, (_, i) => `ids[]=${i}`).join("&");
+
+      // Act
+      const result = parseQs(queryString);
+
+      // Assert
+      expect(Array.isArray(result.ids)).toBe(true);
+      expect(result.ids).toHaveLength(100);
+      expect((result.ids as string[])[0]).toBe("0");
+      expect((result.ids as string[])[99]).toBe("99");
+    });
+
+    it("should parse arrays with fewer than 100 items", () => {
+      // Arrange
+      const queryString = "tags[]=red&tags[]=blue&tags[]=green";
+
+      // Act
+      const result = parseQs(queryString);
+
+      // Assert
+      expect(result.tags).toEqual(["red", "blue", "green"]);
+      expect(Array.isArray(result.tags)).toBe(true);
+      expect(result.tags).toHaveLength(3);
+    });
+
+    it("should throw if limit is exceeded", () => {
+      // Arrange
+      const items = Array.from({ length: 999 }, (_, i) => `value${i}`);
+      const queryString = items.map(item => `data=${item}`).join("&");
+
+      // Act, Assert
+      // Prefer early error to be caught instead of strange conversion
+      expect(() => parseQs(queryString, { arrayLimit: 40 })).toThrow();
+    });
+
+    it("should handle empty arrays", () => {
+      // Arrange
+      const queryString = "emptyArray[]=";
+
+      // Act
+      const result = parseQs(queryString);
+
+      // Assert
+      expect(result.emptyArray).toEqual([""]);
+      expect(Array.isArray(result.emptyArray)).toBe(true);
+    });
+
+    it("should handle multiple arrays in the same query string", () => {
+      // Arrange
+      const colors = Array.from({ length: 50 }, (_, i) => `color${i}`);
+      const sizes = Array.from({ length: 50 }, (_, i) => `size${i}`);
+      const queryString = [
+        ...colors.map(c => `colors[]=${c}`),
+        ...sizes.map(s => `sizes[]=${s}`),
+      ].join("&");
+
+      // Act
+      const result = parseQs(queryString);
+
+      // Assert
+      expect(Array.isArray(result.colors)).toBe(true);
+      expect(result.colors).toHaveLength(50);
+      expect(Array.isArray(result.sizes)).toBe(true);
+      expect(result.sizes).toHaveLength(50);
+    });
+  });
+
+  describe("custom options", () => {
+    it("should allow overriding arrayLimit through options", () => {
+      // Arrange
+      const queryString = "items[]=1&items[]=2";
+
+      // Act
+      const result = parseQs(queryString, { arrayLimit: 2 });
+
+      // Assert
+      // The custom arrayLimit option is passed through to qs.parse
+      expect(Array.isArray(result.items)).toBe(true);
+      expect(result.items).toEqual(["1", "2"]);
+    });
+
+    it("should use default arrayLimit of 100 when no options provided", () => {
+      // Arrange
+      const items = Array.from({ length: 100 }, (_, i) => `${i}`);
+      const queryString = items.map(item => `nums[]=${item}`).join("&");
+
+      // Act
+      const result = parseQs(queryString);
+
+      // Assert
+      expect(Array.isArray(result.nums)).toBe(true);
+      expect(result.nums).toHaveLength(100);
+    });
+  });
+});

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -1,0 +1,9 @@
+import { BooleanOptional, IParseOptions, parse, ParsedQs } from "qs";
+
+/**
+ * Use default pre-configured parser with pre-set details
+ */
+export const parseQs = (
+  str: string,
+  options?: IParseOptions<BooleanOptional> & { decoder?: never | undefined },
+): ParsedQs => parse(str, { arrayLimit: 100, throwOnLimitExceeded: true, ...options });

--- a/src/warehouses/index.tsx
+++ b/src/warehouses/index.tsx
@@ -1,7 +1,7 @@
 import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
+import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
-import { parse as parseQs } from "qs";
 import { useIntl } from "react-intl";
 import { RouteComponentProps, Switch } from "react-router-dom";
 


### PR DESCRIPTION
`qs` package has a default limit of 20 items, this pr changes it to 100, which matches our graphql limits