### PR TITLE
Extract OrderSummary helpers to OrderDetailsViewModel

### DIFF
--- a/src/orders/utils/OrderDetailsViewModel.ts
+++ b/src/orders/utils/OrderDetailsViewModel.ts
@@ -46,6 +46,54 @@ export abstract class OrderDetailsViewModel {
     return orderActions.includes(OrderAction.MARK_AS_PAID);
   }
 
+  static canOrderCapture(actions: OrderAction[]): boolean {
+    return actions.includes(OrderAction.CAPTURE);
+  }
+
+  static canOrderVoid(actions: OrderAction[]): boolean {
+    return actions.includes(OrderAction.VOID);
+  }
+
+  static canOrderRefund(actions: OrderAction[]): boolean {
+    return actions.includes(OrderAction.REFUND);
+  }
+
+  static canGrantRefund(order: {
+    transactions: OrderDetailsFragment["transactions"];
+    payments: OrderDetailsFragment["payments"];
+  }): boolean {
+    return order.transactions.length > 0 || order.payments.length > 0;
+  }
+
+  static canSendRefund(grantedRefunds: OrderDetailsFragment["grantedRefunds"]): boolean {
+    return grantedRefunds.length > 0;
+  }
+
+  static canAnyRefund(order: {
+    transactions: OrderDetailsFragment["transactions"];
+    payments: OrderDetailsFragment["payments"];
+    grantedRefunds: OrderDetailsFragment["grantedRefunds"];
+  }): boolean {
+    return this.canGrantRefund(order) || this.canSendRefund(order.grantedRefunds);
+  }
+
+  static hasGiftCards(giftCardsAmount: number | null): boolean {
+    return (giftCardsAmount ?? 0) > 0;
+  }
+
+  static hasNoPayment(args: {
+    canAnyRefund: boolean;
+    shouldDisplay: ReturnType<typeof OrderDetailsViewModel.getShouldDisplayAmounts>;
+    hasGiftCards: boolean;
+  }): boolean {
+    return (
+      !args.canAnyRefund &&
+      !args.shouldDisplay.charged &&
+      !args.shouldDisplay.authorized &&
+      !args.hasGiftCards
+    );
+  }
+
   static getGiftCardsAmountUsed(args: {
     id: string;
     giftCards: OrderDetailsFragment["giftCards"];


### PR DESCRIPTION
## Summary

Extracted inline helper logic from OrderSummary component into reusable OrderDetailsViewModel static methods.

**New ViewModel methods:**
- `canOrderCapture()` / `canOrderVoid()` / `canOrderRefund()` - Check available order actions
- `canGrantRefund()` / `canSendRefund()` / `canAnyRefund()` - Refund capability checks
- `hasGiftCards()` / `hasNoPayment()` - Payment state helpers

**Changes:**
- Removed inline logic from OrderSummary component
- Replaced `extractOrderGiftCardUsedAmount()` with existing `getGiftCardsAmountUsed()`
- Added comprehensive test coverage (14 new test cases, 52 total passing)

This improves code reusability and makes order business logic accessible to other components.

## Test plan

- [x] Run type checking (`pnpm run check-types`) - Passing ✓
- [x] Run linting (`pnpm run lint`) - Passing ✓
- [x] Run unit tests for OrderDetailsViewModel - 52 tests passing ✓
- [ ] Manual testing: Verify OrderSummary displays correctly in order details
- [ ] Manual testing: Verify payment action buttons work as expected