### PR TITLE
Fix order fulfillment case

### DIFF
--- a/.changeset/nine-games-live.md
+++ b/.changeset/nine-games-live.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix order fulfillment page - don't require quantity to be set if warehouse is not selected

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -138,6 +138,7 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
     shopSettings?.fulfillmentAutoApprove && !shopSettings?.fulfillmentAllowUnpaid && !order?.isPaid;
   const areWarehousesSet = formsetData
     .filter(item => !!item?.value) // preorder case
+    .filter(item => item?.value?.[0]?.quantity)
     .every(line => line.value.every(v => v.warehouse));
   const shouldEnableSave = () => {
     if (!order || loading) {
@@ -323,5 +324,4 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
   );
 };
 
-OrderFulfillPage.displayName = "OrderFulfillPage";
 export default OrderFulfillPage;


### PR DESCRIPTION
## Scope of the change
Fix order fulfillment page - don't require quantity to be set if warehouse is not selected

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
