### PR TITLE
Upgrade react hooks plugin, set react compiler rules to warn

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,7 +36,7 @@ export default tseslint.config(
   tseslint.configs.recommended, // Note: we can migrate to rules using TypeScript types
   react.configs.flat.recommended,
   react.configs.flat["jsx-runtime"],
-  reactHooks.configs["recommended-latest"],
+  reactHooks.configs.flat["recommended-latest"],
   reactRefresh.configs.vite,
   reactYouMightNotNeedAnEffect.configs.recommended,
 
@@ -64,6 +64,23 @@ export default tseslint.config(
       "react-hooks/exhaustive-deps": "warn",
       // Allow constant exports is thanks to Vite (see recommended config)
       "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+
+      // Override React Compiler rules to warnings (for gradual adoption)
+      // The recommended config sets these as errors, we downgrade to warn
+      "react-hooks/purity": "warn", // Side effects during render
+      "react-hooks/refs": "warn", // Reading/writing refs during render
+      "react-hooks/set-state-in-render": "warn", // setState during render
+      "react-hooks/set-state-in-effect": "warn", // Synchronous setState in effects
+      "react-hooks/immutability": "warn", // Mutation of props/state
+      "react-hooks/static-components": "warn", // Dynamic component creation
+      "react-hooks/use-memo": "warn", // useMemo violations
+      "react-hooks/void-use-memo": "warn", // useMemo returning void
+      "react-hooks/component-hook-factories": "warn", // Component/hook factory violations
+      "react-hooks/preserve-manual-memoization": "warn", // Manual memoization issues
+      "react-hooks/globals": "warn", // Global variable usage
+      "react-hooks/error-boundaries": "warn", // Error boundary violations
+      "react-hooks/config": "warn", // Config violations
+      "react-hooks/gating": "warn", // Conditional rendering violations
 
       // Migration in progress:
       // Tracked in https://github.com/saleor/saleor-dashboard/issues/3813

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "eslint-plugin-formatjs": "^5.4.2",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "eslint-plugin-react-you-might-not-need-an-effect": "^0.5.6",
     "eslint-plugin-simple-import-sort": "^12.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,8 +406,8 @@ importers:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks:
-        specifier: ^5.2.0
-        version: 5.2.0(eslint@9.39.1(jiti@2.6.1))
+        specifier: 7.0.1
+        version: 7.0.1(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.4.24
         version: 0.4.24(eslint@9.39.1(jiti@2.6.1))
@@ -7879,12 +7879,12 @@ packages:
       "@typescript-eslint/parser":
         optional: true
 
-  eslint-plugin-react-hooks@5.2.0:
+  eslint-plugin-react-hooks@7.0.1:
     resolution:
       {
-        integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==,
+        integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==,
       }
-    engines: { node: ">=10" }
+    engines: { node: ">=18" }
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
@@ -8790,6 +8790,18 @@ packages:
     resolution:
       {
         integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==,
+      }
+
+  hermes-estree@0.25.1:
+    resolution:
+      {
+        integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==,
+      }
+
+  hermes-parser@0.25.1:
+    resolution:
+      {
+        integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==,
       }
 
   history@4.10.1:
@@ -19211,9 +19223,16 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-react-hooks@5.2.0(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
+      "@babel/core": 7.28.5
+      "@babel/parser": 7.28.5
       eslint: 9.39.1(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 3.5.3(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react-refresh@0.4.24(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
@@ -19856,6 +19875,12 @@ snapshots:
     dependencies:
       capital-case: 1.0.4
       tslib: 2.8.1
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   history@4.10.1:
     dependencies:


### PR DESCRIPTION
This PR upgdates react hooks eslint plugin, to latest version. Changed react compiler rules form error to warning.

We should migrate warnings in order to enable dependencies that use React 18+ features (e.g. newest apollo, etc.)
