### PR TITLE
fix: add support for feature branches in testenvs (CI/CD)

### DIFF
--- a/.github/actions/prepare-api-variables/action.yml
+++ b/.github/actions/prepare-api-variables/action.yml
@@ -55,16 +55,25 @@ runs:
           echo "POOL_NAME=${PREFIX}${PULL_REQUEST_NUMBER}" >> $GITHUB_OUTPUT
           echo "POOL_INSTANCE=https://${PREFIX}${PULL_REQUEST_NUMBER}.staging.saleor.cloud" >> $GITHUB_OUTPUT
 
-          if [[ "$DESTINATION_BRANCH" == 'main' ]]; then
-            echo "BACKUP_NAMESPACE=snapshot-automation-tests" >> $GITHUB_OUTPUT
-            echo "SALEOR_CLOUD_SERVICE=saleor-master-staging" >> $GITHUB_OUTPUT
-            echo "RUN_SLUG=${PREFIX}${PULL_REQUEST_NUMBER}" >> $GITHUB_OUTPUT
-          else
-            # it handles pull requests to the other branches than main, e.g. release branches
+          if [[ "$DESTINATION_BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            # handles pull requests to the other branches than main, e.g. release branches
             VERSION_SLUG=$(echo "${DESTINATION_BRANCH}" | sed "s/\.//")
             echo "BACKUP_NAMESPACE=snapshot-automation-tests-${DESTINATION_BRANCH}" >> $GITHUB_OUTPUT
             echo "SALEOR_CLOUD_SERVICE=saleor-staging-v${VERSION_SLUG}" >> $GITHUB_OUTPUT
             echo "RUN_SLUG=${DESTINATION_BRANCH}" >> $GITHUB_OUTPUT
+          else
+            # fallback to "saleor-master-staging" (i.e., 'main' branch) when the base
+            # branch isn't a version number (e.g., 3.21).
+            # We expect this to occur in two cases:
+            # 1. The base branch is `main`
+            # 2. The base branch is a feature branch, e.g., "unify-order-value-sections",
+            #    in which case it makes sense to fallback and to treat the PR as targeting
+            #    the `main` branch as `main` is an unstable (dev) branch, whereas
+            #    version number branches are stable branches thus we do not expect anyone
+            #    to be using feature branches against these.
+            echo "BACKUP_NAMESPACE=snapshot-automation-tests" >> $GITHUB_OUTPUT
+            echo "SALEOR_CLOUD_SERVICE=saleor-master-staging" >> $GITHUB_OUTPUT
+            echo "RUN_SLUG=${PREFIX}${PULL_REQUEST_NUMBER}" >> $GITHUB_OUTPUT
           fi
 
           exit 0


### PR DESCRIPTION
This fixes an issue where deploying to testenvs was crashing[^1] when a developer was using feature branches (e.g., `head=my-branch, base=my-feature` instead of `head=my-branch, base=main`)

We believe this is the simplest way of handling this case. We do not believe we need to build any complicated solutions for this issue as we do not expect anyone to be using feature branches against stables branches (e.g., 3.21)

Successfully tested here:
- `base_branch=3.21` - https://github.com/saleor/saleor-dashboard/actions/runs/20173937005/job/57916964511?pr=6203
- `base_branch=fix/cicd/testenvs/support-feature-branches` - https://github.com/saleor/saleor-dashboard/actions/runs/20173778041/job/57916378111

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [x] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [x] I used analytics "trackEvent" for important events

[^1]: It was crashing with errors like `Object with name=saleor-staging-vunify-order-value-sections does not exist.` where `unify-order-value-sections` was the name of the base branch but it was being used as the version number (i.e., the workflow was assuming the pattern was `^\d+\.\d+$`) - Example workflow run: https://github.com/saleor/saleor-dashboard/actions/runs/20172693679/job/57912520648?pr=6200