### PR TITLE
Fix customer->order filter redirection

### DIFF
--- a/.changeset/wide-signs-love.md
+++ b/.changeset/wide-signs-love.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed redirection between Customer Details -> See all orders to Orders List (which this customer selected). Now filter is properly set on the URL and only relevant orders are displayed

--- a/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/src/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -20,7 +20,7 @@ import { useBackLinkWithState } from "@dashboard/hooks/useBackLinkWithState";
 import { SubmitPromise } from "@dashboard/hooks/useForm";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { sectionNames } from "@dashboard/intl";
-import { orderListUrl } from "@dashboard/orders/urls";
+import { orderListUrlWithCustomerEmail } from "@dashboard/orders/urls";
 import { mapEdgesToItems, mapMetadataItemToInput } from "@dashboard/utils/maps";
 import { Divider } from "@saleor/macaw-ui-next";
 import { useIntl } from "react-intl";
@@ -111,9 +111,7 @@ const CustomerDetailsPage = ({
               <RequirePermissions requiredPermissions={[PermissionEnum.MANAGE_ORDERS]}>
                 <CustomerOrders
                   orders={mapEdgesToItems(customer?.orders)}
-                  viewAllHref={orderListUrl({
-                    customer: customer?.email,
-                  })}
+                  viewAllHref={orderListUrlWithCustomerEmail(customer?.email)}
                 />
                 <CardSpacer />
               </RequirePermissions>

--- a/src/orders/urls.ts
+++ b/src/orders/urls.ts
@@ -78,6 +78,11 @@ export type OrderListUrlQueryParams = BulkAction &
   OrderListUrlSort &
   Pagination &
   ActiveTab;
+
+/**
+ * @deprecated
+ * This helper is likely broken, at least filters don't work. Either construct url manually or fix it
+ */
 export const orderListUrl = (params?: OrderListUrlQueryParams): string => {
   const orderList = orderListPath;
 


### PR DESCRIPTION
Fixed redirection between Customer Details -> See all orders to Orders List (which this customer selected). Now filter is properly set on the URL and only relevant orders are displayed