### PR TITLE
Fix failing release

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ minimumReleaseAge: 720 # 12h
 trustPolicy: no-downgrade
 
 packages:
-  - saleor-dashboard
+  - "."
 
 # Keeps src/ and .github/workflows directories separated
 # as they are independent from one to another.


### PR DESCRIPTION
Added `saleor-dashboard` as package to pnpm-workspace, to fix failing release workflow
