### PR TITLE
ENG-1161 - bump notify-slack.yml to v1.10, add extra guard for tagging as latest

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   prepare-variables:
     name: Prepare variables
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     outputs:
@@ -36,7 +36,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CURRENT_TAG: ${{ github.ref_name }}
         run: |
-          set -u
+          set -ux
+
+          # Only stable semver releases (e.g. 3.22.0) can be tagged as latest.
+          # Non-semver refs (branch names, PR refs) are not valid candidates to become latest.
+          if ! [[ "$CURRENT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag inferred from this run ('$CURRENT_TAG') is not a semver release - can't be tagged as latest."
+            echo "IS_LATEST=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           CURRENT_LATEST=$(gh api "/repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)
           HIGHEST=$( (echo "$CURRENT_LATEST"; echo "$CURRENT_TAG") | sort -V | tail -1)
@@ -44,9 +52,9 @@ jobs:
           echo "Selected: $CURRENT_TAG, Latest: $CURRENT_LATEST"
 
           if [[ "$CURRENT_TAG" == "$HIGHEST" ]]; then
-            echo "is_latest=true" >> $GITHUB_OUTPUT
+            echo "IS_LATEST=true" >> $GITHUB_OUTPUT
           else
-            echo "is_latest=false" >> $GITHUB_OUTPUT
+            echo "IS_LATEST=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Docker metadata
@@ -61,7 +69,7 @@ jobs:
             type=ref,event=branch
             type=pep440,pattern={{version}}
             type=pep440,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ steps.check-latest.outputs.is_latest }}
+            type=raw,value=latest,enable=${{ steps.check-latest.outputs.IS_LATEST }}
           context: git
 
   build-push:
@@ -88,7 +96,7 @@ jobs:
 
   summary:
     needs: [prepare-variables, build-push]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -103,7 +111,8 @@ jobs:
   load-failure-secrets:
     if: failure()
     needs: [prepare-variables, build-push]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions: {}
     outputs:
       slack-webhook-url: ${{ steps.load-secrets.outputs.SLACK_WEBHOOK_URL }}
     steps:
@@ -118,10 +127,10 @@ jobs:
     if: failure()
     needs: [prepare-variables, build-push, load-failure-secrets]
     permissions: {}
-    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@cd1dfd59ee4486cceb63fa13b5e0c3b4f185712e # v1.9.0
+    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@eb0c692da7bf13f5e1a82c17488b24c514dd10a1 # v1.10.0
     with:
-      custom_title: "🚨 Docker Image Build Failed for *${{ needs.prepare-variables.outputs.version }}*"
+      custom_title: "🚨 Docker Image Build Failed for *${{ needs.prepare-variables.outputs.version || github.ref_name }}*"
       status: failure
-      mention_group_id: ${{ secrets.SLACK_DASHBOARD_GROUP_ID }}
     secrets:
       slack-webhook-url: ${{ needs.load-failure-secrets.outputs.slack-webhook-url }}
+      mention_group_id: ${{ secrets.SLACK_DASHBOARD_GROUP_ID }}


### PR DESCRIPTION
https://github.com/saleor/saleor-internal-actions v1.9.0 was incompatible with this workflow - as the mention_group_id is not a secret on reusable workflow side, it cannot be passed from secret on callers side as well (TIL). I released v1.10.0 which supports passing this value from secrets (see: https://github.com/saleor/saleor-internal-actions/releases/tag/v1.10.0_

* I am also adding extra guardrails in case prepare-variables fails, as in this case the ref will be empty and notification step will fail as it expects ref to be provided.

* I am also adding extra guard for `check-latest` - this is the same solution we used in core - only SEMVER versions can be considered as latest (so e.g. if there is tag like `main` or somehting, it won't be marked as latest (it would break the sort -V and will resolve `main > 3.xx`