### PR TITLE
fix(build): add missing git credentials

### DIFF
--- a/.github/workflows/new-current-patch-release.yml
+++ b/.github/workflows/new-current-patch-release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.get-token.outputs.token }}
-          persist-credentials: false
+          persist-credentials: true  # We need to be able to perform 'git push'
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Fixes build failures at https://github.com/saleor/saleor-dashboard/actions/runs/24442835386/job/71411772538

Git push would fail with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Which is caused by missing credentials.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
