### PR TITLE
fix(build): add missing permission for nested workflow

### DIFF
--- a/.github/workflows/deploy-staging-and-prepare-release.yaml
+++ b/.github/workflows/deploy-staging-and-prepare-release.yaml
@@ -299,6 +299,10 @@ jobs:
   run-tests-on-release:
     needs: [prepare-release, build]
     if: needs.prepare-release.outputs.hasChangesets == 'true'
+
+    permissions:
+      contents: read
+    
     uses: ./.github/workflows/run-tests-on-release.yml
     with:
       VERSION: ${{ needs.prepare-release.outputs.MINOR_VERSION }} # eg. "3.19"


### PR DESCRIPTION
`.github/workflows/run-tests-on-release.yml` needs `contents:read` but no permissions were granted thus leading to a failure.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [x] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [x] I used analytics "trackEvent" for important events
