### PR TITLE
fix(build): add missing checkout step

### DIFF
--- a/.github/workflows/deploy-staging-and-prepare-release.yaml
+++ b/.github/workflows/deploy-staging-and-prepare-release.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.get-token.outputs.token }}
-          persist-credentials: false
+          persist-credentials: true # 'pnpm run release' command needs to be able to run 'git push'
 
       - name: Set environment
         # Convert version into staging deployment name (e.g 3.3.0 -> saleor-staging-v33)

--- a/.github/workflows/deploy-staging-and-prepare-release.yaml
+++ b/.github/workflows/deploy-staging-and-prepare-release.yaml
@@ -25,6 +25,19 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Get Token
+        id: get-token
+        uses: saleor/saleor-internal-actions/request-vault-token@6a0fa7c073b3857a11d414f25a149065fe5a0fcf # v1.4.0
+        with:
+          vault-url: ${{ secrets.VAULT_URL }}
+          vault-jwt: ${{ secrets.VAULT_JWT }}
+
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.get-token.outputs.token }}
+          persist-credentials: false
+
       - name: Set environment
         # Convert version into staging deployment name (e.g 3.3.0 -> saleor-staging-v33)
         id: set-environment
@@ -52,19 +65,6 @@ jobs:
 
           minor_version=$(echo "$VERSION" | sed -n 's#\([0-9]\+\).\([0-9]\+\).*#\1.\2#p')
           echo "MINOR_VERSION=${minor_version}" >> "$GITHUB_OUTPUT"
-
-      - name: Get Token
-        id: get-token
-        uses: saleor/saleor-internal-actions/request-vault-token@6a0fa7c073b3857a11d414f25a149065fe5a0fcf # v1.4.0
-        with:
-          vault-url: ${{ secrets.VAULT_URL }}
-          vault-jwt: ${{ secrets.VAULT_JWT }}
-
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          token: ${{ steps.get-token.outputs.token }}
-          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 


### PR DESCRIPTION
The step `get-version` runs `git rev-parse --short HEAD` but checkout doesn't happen until later in the job. This fixes the issue by checking-out the code prior to running `git`

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [x] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [x] I used analytics "trackEvent" for important events
