### PR TITLE
fix(build): missing PNPM command

### DIFF
--- a/.github/workflows/run-tests-on-release.yml
+++ b/.github/workflows/run-tests-on-release.yml
@@ -161,6 +161,11 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: "package.json"
+          package-manager-cache: false
+
       - name: Install deps
         run: pnpm install
 

--- a/.github/workflows/run-tests-on-release.yml
+++ b/.github/workflows/run-tests-on-release.yml
@@ -74,6 +74,7 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -161,10 +162,13 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "package.json"
-          package-manager-cache: false
+          cache: "pnpm"
 
       - name: Install deps
         run: pnpm install


### PR DESCRIPTION
Fixes `pnpm install` command failing in `run-pw-tests` due to not having PNPM installed

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [x] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [x] I used analytics "trackEvent" for important events
