### PR TITLE
Update build-push-image-multi-platform action to 1.11

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -76,7 +76,7 @@ jobs:
 
   build-push:
     needs: prepare-variables
-    uses: saleor/saleor-internal-actions/.github/workflows/build-push-image-multi-platform.yaml@92c29aa0e4545de579b892b2ef9f2d6366c29c11 # v1.5.2
+    uses: saleor/saleor-internal-actions/.github/workflows/build-push-image-multi-platform.yaml@49a069ae9731cfccf3a1033fe1da4e3da84f4f2a # v1.11.0
     permissions:
       contents: read
       id-token: write # needed for AWS/ECR login (not used, but required permission)


### PR DESCRIPTION
Should fix Docker images tagging

Before: only first tag was pushed (e.g. 3.22.40)

After: both tags pushed (`3.22.40`, `3.22`). `3.22` tag should be rolling and point to last release

Currently we miss them for 3.23, on 3.22 is stale