### PR TITLE
pt-br update missing keys

### DIFF
--- a/locale/pt-BR.json
+++ b/locale/pt-BR.json
@@ -1,7697 +1,13865 @@
 {
-    "PRXpBm": {
-        "context": "dialog header",
-        "string": "Cancelar Pedido"
-    },
-    "ll2dE6": {
-        "context": "PageTypeDeleteWarningDialog multiple assigned items description",
-        "string": "Você tem certeza de que deseja excluir os tipos de página selecionados? Se você removê-los, não será capaz de atribuí-los às páginas criadas."
-    },
-    "qu8b3v": {
-        "context": "PageTypeDeleteWarningDialog multiple consent label",
-        "string": "Sim, quero excluir esses tipos de páginas e as páginas atribuídas"
-    },
-    "tQxBXs": {
-        "context": "PageTypeDeleteWarningDialog single assigned items description",
-        "string": "Você está prestes a excluir o tipo de página <b>{typeName}</b>. Ele está atribuído a {assignedItemsCount} {assignedItemsCount,plural,one{página} other{páginas}}. Excluir este tipo de página também excluirá essas páginas. Tem certeza de que deseja fazer isso?"
-    },
-    "RZ32u5": {
-        "context": "PageTypeDeleteWarningDialog single consent label",
-        "string": "Sim, quero excluir este tipo de página e as páginas atribuídas"
-    },
-    "VvFJ/T": {
-        "context": "PageTypeDeleteWarningDialog single no assigned items description",
-        "string": "Você tem certeza de que deseja excluir <b>{typeName}</b>? Se você removê-lo, não será capaz de atribuí-lo às páginas criadas."
-    },
-    "TnyLrZ": {
-        "context": "PageTypeDeleteWarningDialog with items multiple description",
-        "string": "Você está prestes a excluir vários tipos de páginas. Alguns deles estão atribuídos a páginas. Excluir esses tipos de página também excluirá essas páginas."
-    },
-    "2Sx05f": {
-        "context": "Previous discount label",
-        "string": "Valor anterior do desconto"
-    },
-    "aPqizA": {
-        "context": "ProductTypeDeleteWarningDialog multiple assigned items description",
-        "string": "Você tem certeza de que deseja excluir os tipos de produto selecionados? Se você removê-los, não será capaz de atribuí-los aos produtos criados."
-    },
-    "0em8tI": {
-        "context": "ProductTypeDeleteWarningDialog multiple consent label",
-        "string": "Sim, quero excluir esses tipos de produtos e os produtos atribuídos"
-    },
-    "ZFfG4L": {
-        "context": "ProductTypeDeleteWarningDialog single assigned items description",
-        "string": "Você está prestes a excluir o tipo de produto <b>{typeName}</b>. Ele está atribuído a {assignedItemsCount} {assignedItemsCount, plural, one {produto} other {produtos}}. Excluir este tipo de produto também excluirá esses produtos. Tem certeza de que deseja fazer isso?"
-    },
-    "bk9KUX": {
-        "context": "ProductTypeDeleteWarningDialog single consent label",
-        "string": "Sim, quero excluir este tipo de produto e os produtos atribuídos"
-    },
-    "HivFnX": {
-        "context": "ProductTypeDeleteWarningDialog single no assigned items description",
-        "string": "Você tem certeza de que deseja excluir <b>{typeName}</b>? Se você removê-lo, não será capaz de atribuí-lo aos produtos criados."
-    },
-    "3dVKNR": {
-        "context": "ProductTypeDeleteWarningDialog with items multiple description",
-        "string": "Você está prestes a excluir vários tipos de produtos. Alguns deles estão atribuídos a produtos. Excluir esses tipos de produto também excluirá esses produtos"
-    },
-    "nngeI3": {
-        "context": "amount title",
-        "string": "Valor reembolsado"
-    },
-    "xrPv2K": {
-        "context": "by preposition",
-        "string": "by"
-    },
-    "beuxAP": {
-        "context": "channel publication status",
-        "string": "Oculto"
-    },
-    "DIrxt7": {
-        "context": "channel publication date",
-        "string": "Visível desde {date}"
-    },
-    "nfbabo": {
-        "context": "channel publication date",
-        "string": "Estará disponível em {date}"
-    },
-    "mDgOmP": {
-        "context": "channel publication status",
-        "string": "Visível"
-    },
-    "19/lwV": {
-        "string": "Determine atributos usados para criar tipos de produtos"
-    },
-    "8vJCJ4": {
-        "string": "Defina e gerencie seus canais de venda"
-    },
-    "hpMcW8": {
-        "string": "Defina como os usuários poderão navegar pela sua loja"
-    },
-    "JPH/uP": {
-        "string": "Defina os tipos de páginas de conteúdo usadas na sua loja"
-    },
-    "ivJ1qt": {
-        "string": "Gerenciar grupos de premissões e suas permissões."
-    },
-    "n0RwMK": {
-        "string": "Defina os tipos de produtos que você vende"
-    },
-    "zxs6G3": {
-        "string": "Gerencie como você enviará os pedidos"
-    },
-    "5BajZK": {
-        "string": "Visualizar e atualizar as configurações do seu site."
-    },
-    "RQUkVW": {
-        "string": "Gerencie seus funcionários e suas permissões"
-    },
-    "EIULpW": {
-        "string": "Gerencie como sua loja cobrará impostos"
-    },
-    "5RmuD+": {
-        "string": "Gerencie e atualize suas informações de depósito."
-    },
-    "m19JfL": {
-        "string": "Visualizar e atualizar plugins e suas configurações."
-    },
-    "yJynYK": {
-        "context": "discount value",
-        "string": "desconto"
-    },
-    "ojHyj3": {
-        "context": "discount value label",
-        "string": "Valor do desconto"
-    },
-    "sHON47": {
-        "context": "refunded products list title",
-        "string": "Produtos reembolsados"
-    },
-    "nki0o/": {
-        "context": "replaced products list title",
-        "string": "Produtos substituídos"
-    },
-    "L5io1l": {
-        "context": "returned products list title",
-        "string": "Produtos devolvidos"
-    },
-    "a1uffz": {
-        "context": "draft created from replace products list title",
-        "string": "Produtos substituídos"
-    },
-    "undefined": {
-        "context": "error message",
-        "string": "Status inválido"
-    },
-    "/0JckE": {
-        "context": "order marked as paid event title",
-        "string": "Pedido foi marcado como pago por"
-    },
-    "AQSmqG": {
-        "context": "order discount was updated automatically event title",
-        "string": "Desconto do pedido foi atualizado automaticamente"
-    },
-    "/KWNJW": {
-        "context": "order discount was updated event title",
-        "string": "Desconto do pedido foi atualizado por"
-    },
-    "Zptsep": {
-        "context": "order was discounted event title",
-        "string": "Pedido recebeu desconto por"
-    },
-    "nayZY0": {
-        "context": "returned event title",
-        "string": "Produtos foram devolvidos por"
-    },
-    "Zhxu58": {
-        "context": "Fixed amount subtitle",
-        "string": "Quantia Fixa"
-    },
-    "T4wa2Y": {
-        "context": "global config plugin status popup title",
-        "string": "Global Plugin"
-    },
-    "BXkF8Z": {
-        "context": "header",
-        "string": "Atividade"
-    },
-    "wWTUrM": {
-        "string": "Atividades não encontrada."
-    },
-    "zWgbGg": {
-        "string": "Hoje"
-    },
-    "By5ZBp": {
-        "context": "header",
-        "string": "Olá, {userName}"
-    },
-    "aCX8rl": {
-        "context": "subheader",
-        "string": "Aqui estão algumas informações que coletamos sobre sua loja"
-    },
-    "0opVvi": {
-        "context": "number of ordered products",
-        "string": "{amount, plural,one {Um pedido} other {{amount} Pedidos}}"
-    },
-    "rr8fyf": {
-        "context": "header",
-        "string": "Principais produtos"
-    },
-    "Q1Uzbb": {
-        "string": "Nenhum produto encontrado."
-    },
-    "6L6Fy2": {
-        "context": "header",
-        "string": "Aviso legal"
-    },
-    "5LRkEs": {
-        "string": "A nova dashboard e o GraphQL API são softwares em revisão de qualidade."
-    },
-    "G7mu0y": {
-        "string": "O GraphQL API está em qualidade beta. Não está totalmente otimizado e algumas mutações e consultas podem estar faltando."
-    },
-    "QBxN6z": {
-        "context": "is filter range or value",
-        "string": "entre"
-    },
-    "I+UwqI": {
-        "context": "is filter range or value",
-        "string": "igual a"
-    },
-    "0OtaXa": {
-        "context": "dialog header",
-        "string": "Criar Menu"
-    },
-    "jhh/D6": {
-        "string": "Menu título"
-    },
-    "G/SYtU": {
-        "string": "Tem certeza de que deseja excluir o menu {menuName}?"
-    },
-    "QzseV7": {
-        "context": "dialog header",
-        "string": "Excluir Menu"
-    },
-    "E54eoT": {
-        "string": "Criar a estrutura de navegação é feita utilizando arrasta-e-solta. Crie um novo menu e então arraste-o no seu local de destino. Você pode mover itens dentro de outros itens para criar uma estrutura de árvore e arrastar itens para cima e para baixo para criar uma hierarquia."
-    },
-    "H3Uirw": {
-        "context": "create new menu item, header",
-        "string": "Adicionar item"
-    },
-    "fzDI3A": {
-        "context": "add link to navigation",
-        "string": "Link para: {url}"
-    },
-    "KKQUMK": {
-        "context": "edit menu item, header",
-        "string": "Editar Item"
-    },
-    "Urh2N3": {
-        "context": "label",
-        "string": "Link"
-    },
-    "28GZnc": {
-        "string": "Digite para pesquisar...."
-    },
-    "0Vyr8h": {
-        "context": "menu item name",
-        "string": "Nome"
-    },
-    "Uf3oHA": {
-        "context": "add new menu item",
-        "string": "Criar um item."
-    },
-    "dEUZg2": {
-        "context": "header",
-        "string": "Itens do Menu"
-    },
-    "WwZfNK": {
-        "string": "Adicione novo item de menu para começar a criar o menu"
-    },
-    "ugnggZ": {
-        "string": "Menu criado."
-    },
-    "bj1U23": {
-        "string": "Tem certeza de que deseja excluir {menuName}?"
-    },
-    "svK+kv": {
-        "string": "{counter,plural,one {Tem certeza de que deseja excluir este menu?} other {Tem certeza de que deseja excluir {displayQuantity} menus?}}"
-    },
-    "1LBYpE": {
-        "context": "dialog header",
-        "string": "Excluir menus"
-    },
-    "OwG/0z": {
-        "string": "Menu deletado"
-    },
-    "0nL1D6": {
-        "context": "number of menu items",
-        "string": "Itens"
-    },
-    "DWs4ba": {
-        "string": "Menu não encontrado"
-    },
-    "JXRYQg": {
-        "context": "button",
-        "string": "Criar Menu"
-    },
-    "MTl5o6": {
-        "context": "new discount label",
-        "string": "Novo valor de desconto"
-    },
-    "saKXY3": {
-        "context": "product label",
-        "string": "Não publicado"
-    },
-    "YI6Fhj": {
-        "context": "no address is set in draft order",
-        "string": "Não configurado"
-    },
-    "PX2zWy": {
-        "context": "customer is not set in draft order",
-        "string": "Não configurado"
-    },
-    "e7yOai": {
-        "context": "shipping address is not set in draft order",
-        "string": "Não configurado"
-    },
-    "5Jo3C5": {
-        "context": "vat not included in order price",
-        "string": "Não aplica"
-    },
-    "BftZHy": {
-        "context": "window title",
-        "string": "Criar Tipo de Página"
-    },
-    "W5SK5c": {
-        "string": "Selecione o tipo de conteúdo"
-    },
-    "gz9v22": {
-        "context": "PluginChannelConfigurationCell channel title",
-        "string": "Por canal"
-    },
-    "P/oGtb": {
-        "context": "product availability",
-        "string": "Disponível para compra"
-    },
-    "KupNHw": {
-        "context": "product field",
-        "string": "Categoria"
-    },
-    "jxoMLL": {
-        "context": "product field",
-        "string": "Coleções"
-    },
-    "YVIajc": {
-        "context": "product field",
-        "string": "Descrição"
-    },
-    "W8i2Ez": {
-        "context": "product field",
-        "string": "Nome"
-    },
-    "6y+k8V": {
-        "context": "product field",
-        "string": "Imagens do Produto"
-    },
-    "7JAAul": {
-        "context": "product field",
-        "string": "Exportar Peso do Produto"
-    },
-    "QVNg8A": {
-        "context": "product field",
-        "string": "Cobrar Impostos"
-    },
-    "Q/Nbku": {
-        "context": "product field",
-        "string": "Tipo"
-    },
-    "HYHLsB": {
-        "context": "product field",
-        "string": "Export Variant ID"
-    },
-    "Uo5MoU": {
-        "context": "product field",
-        "string": "imagens de variação"
-    },
-    "5kvaFR": {
-        "context": "product field",
-        "string": "Exportar SKU de variação"
-    },
-    "XBwpUv": {
-        "context": "product field",
-        "string": "Exportar peso da variação"
-    },
-    "4qe6hO": {
-        "context": "product stock, section header",
-        "string": "Inventário"
-    },
-    "SSWFo8": {
-        "context": "window title",
-        "string": "Criar tipo de produto"
-    },
-    "bq1eEx": {
-        "context": "header",
-        "string": "Criar Tipo de Produto"
-    },
-    "mUb8Gt": {
-        "context": "section header",
-        "string": "Impostos"
-    },
-    "9xUIAh": {
-        "string": "Tax group"
-    },
-    "OgFBAj": {
-        "context": "input label",
-        "string": "Preço"
-    },
-    "vuKrlW": {
-        "string": "estoque"
-    },
-    "ABgQcF": {
-        "context": "variant stock, header",
-        "string": "estoque"
-    },
-    "oIMMcO": {
-        "context": "no warehouses info",
-        "string": "Não existem depósito configurados para sua loja. Você pode configurar variações sem fornecer quantidades em estoque."
-    },
-    "Gjo89T": {
-        "context": "header",
-        "string": "Depósitos"
-    },
-    "D8nsBc": {
-        "context": "no warehouses info",
-        "string": "Não existem depósitos configurados para sua loja. Para adicionar a quantidade em estoque para a variação, por favor configure um depósito."
-    },
-    "RLBLPQ": {
-        "context": "no warehouses info",
-        "string": "Não existem depósitos configurados para sua loja. Para adicionar a quantidade em estoque para o produto, por favor configure um depósito."
-    },
-    "qJedl0": {
-        "context": "product label",
-        "string": "Publicado "
-    },
-    "ppLwx3": {
-        "context": "number of categories",
-        "string": "Categorias ({quantity})"
-    },
-    "QdGzUf": {
-        "context": "number of collections",
-        "string": "Coleções ({quantity})"
-    },
-    "bNw8PM": {
-        "context": "number of products",
-        "string": "Produtos ({quantity})"
-    },
-    "HVlMK2": {
-        "context": "number of variants",
-        "string": "Variantes ({quantity})"
-    },
-    "YFQBs1": {
-        "context": "product availability date label",
-        "string": "Definir data de disponibilidade"
-    },
-    "Krzyo+": {
-        "context": "shipment refund title",
-        "string": "Envio foi reembolsado"
-    },
-    "mLZMb6": {
-        "context": "ChannelsSection select field label",
-        "string": "Canal"
-    },
-    "yOaNWB": {
-        "context": "delete shipping method",
-        "string": "Tem certeza de que deseja excluir {name}?"
-    },
-    "LsgHmZ": {
-        "context": "delete shipping zone",
-        "string": "Tem certeza de que deseja excluir {name}?"
-    },
-    "PV0SQd": {
-        "context": "WarehousesSection select field label",
-        "string": "Depósito"
-    },
-    "skPoVe": {
-        "context": "button",
-        "string": "Aceitar"
-    },
-    "Y7UlMR": {
-        "context": "app extensions subsection",
-        "string": "Aplicativos"
-    },
-    "59XppT": {
-        "context": "button",
-        "string": "Aprovar"
-    },
-    "9q562c": {
-        "context": "apps section name",
-        "string": "Aplicativos"
-    },
-    "D/+84n": {
-        "context": "snackbar text",
-        "string": "Aplicativo ativado"
-    },
-    "USO8PB": {
-        "context": "snackbar text",
-        "string": "Aplicativo desativado"
-    },
-    "YHNozE": {
-        "context": "dialog header",
-        "string": "Ativar Aplicativo"
-    },
-    "Q47ovw": {
-        "context": "activate app",
-        "string": "Você tem certeza de que deseja ativar este aplicativo? Ativar começará a coletar eventos."
-    },
-    "JbUg2b": {
-        "context": "activate app",
-        "string": "Tem certeza que deseja ativar {name}? Ativá-lo irá iniciar a coleta de eventos."
-    },
-    "D3E2b5": {
-        "context": "button label",
-        "string": "Ativar"
-    },
-    "W+AFZY": {
-        "context": "button label",
-        "string": "Desativar"
-    },
-    "yMi8I8": {
-        "context": "dialog header",
-        "string": "Desativar aplicativo"
-    },
-    "73RU3R": {
-        "context": "deactivate app",
-        "string": "Tem certeza que deseja desabilitar este aplicativo? Seus dados serão mantidos até que você reative o aplicativo. Você ainda será cobrado pelo aplicativo."
-    },
-    "7O2EsY": {
-        "context": "deactivate local app",
-        "string": "Você tem certeza de que deseja desativar este aplicativo? Seus dados serão mantidos até que você reative o aplicativo."
-    },
-    "Np7J92": {
-        "context": "deactivate local named app",
-        "string": "Você tem certeza de que deseja desativar {name}? Seus dados serão mantidos até que você reative o aplicativo."
-    },
-    "w6Gau0": {
-        "context": "deactivate named app",
-        "string": "Tem certeza que deseja desabilitar {name}? Seus dados serão mantidos até que você reative o aplicativo. Você ainda será cobrado pelo aplicativo."
-    },
-    "LtqrM8": {
-        "context": "delete custom app",
-        "string": "Excluindo {name}, você excluirá todos os dados e webhooks relacionados a este aplicativo. Tem certeza que deseja fazer isto?"
-    },
-    "zQX6xO": {
-        "context": "dialog header",
-        "string": "Excluir Aplicativo"
-    },
-    "6hLZNA": {
-        "context": "delete app",
-        "string": "Tem certeza que deseja excluir este aplicativo?"
-    },
-    "EWD/wU": {
-        "context": "delete app",
-        "string": "Excluindo {name}, você excluirá a instalação do aplicativo. Se você está pagando pela assinatura do aplicativo, lembre-se de cancelar a assinatura do aplicativo no Marketplace Saleor. Tem certeza que deseja excluir o aplicativo?"
-    },
-    "whTEcF": {
-        "context": "link",
-        "string": "Desativar"
-    },
-    "Go50v2": {
-        "context": "app privacy policy link",
-        "string": "Exibir a política de privacidade do aplicativo"
-    },
-    "89PSdB": {
-        "context": "link",
-        "string": "Editar configurações"
-    },
-    "a55zOn": {
-        "context": "section header",
-        "string": "Privacidade de dados"
-    },
-    "Gjb6eq": {
-        "context": "link",
-        "string": "Obter Suporte"
-    },
-    "HtfL5/": {
-        "context": "button",
-        "string": "Abrir Aplicativo"
-    },
-    "P5twxk": {
-        "context": "link",
-        "string": "Ativar"
-    },
-    "VsGcdP": {
-        "context": "section header",
-        "string": "Permissões do aplicativo"
-    },
-    "7oQUMG": {
-        "context": "apps about permissions",
-        "string": "Este aplicativo tem permissão para:"
-    },
-    "jDIRQV": {
-        "context": "section header",
-        "string": "Sobre este aplicativo"
-    },
-    "MSItJD": {
-        "string": "Você está prestes a sair do Dashboard. Você quer continuar?"
-    },
-    "WnlZMO": {
-        "context": "title",
-        "string": "Existe um problema com o aplicativo."
-    },
-    "4yRwN+": {
-        "context": "content",
-        "string": "Saleor não conseguiu obter informações cruciais da instalação. Sem isto, o Sistema não pode instalar o aplicativo em seu Saleor. Por favor use o botão abaixo para voltar no dashboard do sistema."
-    },
-    "906uUr": {
-        "context": "button",
-        "string": "Voltar a página inicial"
-    },
-    "k5lHFp": {
-        "context": "app data privacy link",
-        "string": "Saiba mais sobre a privacidade de dados"
-    },
-    "PkCmGU": {
-        "context": "install button",
-        "string": "Instalar Aplicativo"
-    },
-    "BL/Lbk": {
-        "context": "install app permissions",
-        "string": "Instalando este aplicativo você concederá as seguintes permissões:"
-    },
-    "Id7C0X": {
-        "context": "section header",
-        "string": "Você está prestes a instalar {name}"
-    },
-    "UCHtG6": {
-        "context": "button",
-        "string": "Sobre"
-    },
-    "hdcGSJ": {
-        "context": "button",
-        "string": "Suporte/FAQ"
-    },
-    "llC1q8": {
-        "context": "button",
-        "string": "App home page"
-    },
-    "nIrjSR": {
-        "context": "section header",
-        "string": "Instalações em Andamento"
-    },
-    "+c/f61": {
-        "context": "retry installation",
-        "string": "Tentar Novamente"
-    },
-    "JufWFT": {
-        "context": "app installation error",
-        "string": "Ocorreu um problema durante a instalação"
-    },
-    "1qRwgQ": {
-        "context": "app installation",
-        "string": "Instalando aplicativo..."
-    },
-    "D4nzdD": {
-        "context": "checkbox label",
-        "string": "Conceder a este aplicativo, acesso total a loja"
-    },
-    "flP8Hj": {
-        "context": "card description",
-        "string": "Expanda ou restrinja as permissões do aplicativo para acessar determinada parte do sistema Saleor."
-    },
-    "GjH9uy": {
-        "context": "header",
-        "string": "Criar Novo Aplicativo"
-    },
-    "Kxiige": {
-        "string": "Token Gerado"
-    },
-    "DGCzal": {
-        "string": "Este token dará acesso a API da sua loja, que você encontrará aqui: {url}"
-    },
-    "r86alc": {
-        "context": "button",
-        "string": "Copiado"
-    },
-    "HVFq//": {
-        "context": "button",
-        "string": "Copiar token"
-    },
-    "ixjvkM": {
-        "string": "Nós criamos seu token padrão. Certifique-se de copiar seu novo token de acesso pessoal agora. Você não será capaz de vê-lo novamente."
-    },
-    "imYxM9": {
-        "context": "header",
-        "string": "Informações do Aplicativo"
-    },
-    "foNlhn": {
-        "context": "custom app name",
-        "string": "Nome do Aplicativo"
-    },
-    "MAsLIT": {
-        "context": "custom app token key",
-        "string": "Chave"
-    },
-    "bsP4f3": {
-        "string": "Nenhum token encontrado"
-    },
-    "0Mg8o5": {
-        "context": "header",
-        "string": "Tokens"
-    },
-    "RMB6fU": {
-        "context": "button",
-        "string": "Criar Token"
-    },
-    "0DRBjg": {
-        "string": "Anotações do Token"
-    },
-    "VHuzgq": {
-        "context": "table actions",
-        "string": "Ações"
-    },
-    "XB2Jj9": {
-        "context": "create app button",
-        "string": "Criar Aplicativo"
-    },
-    "voRaz3": {
-        "context": "custom apps content",
-        "string": "Seus aplicativos personalizados serão mostrados aqui."
-    },
-    "5+Xcrz": {
-        "context": "app deactivated",
-        "string": "Desativado"
-    },
-    "TBaMo2": {
-        "context": "about app",
-        "string": "Sobre"
-    },
-    "9tgY4G": {
-        "context": "apps content",
-        "string": "Você não tem nenhum aplicativo instalado na sua dashboard"
-    },
-    "ZeD2TK": {
-        "context": "section header",
-        "string": "Aplicativos de Terceiros"
-    },
-    "SwISVH": {
-        "context": "section header",
-        "string": "Marketplace Saleor"
-    },
-    "NskBjH": {
-        "context": "marketplace content",
-        "string": "Marketplace chegará em breve"
-    },
-    "wxFwUW": {
-        "context": "marketplace button",
-        "string": "Visitar Marketplace"
-    },
-    "LATpSE": {
-        "context": "marketplace content",
-        "string": "Descubra grandes aplicativos gratuitos e pagos em nosso Marketplace Saleor."
-    },
-    "k0rGBI": {
-        "string": "Token de acesso é usado para autenticar contas de serviços"
-    },
-    "t9a9GQ": {
-        "string": "Nós criamos seu token. Certifique-se de copiar seu novo token de acesso pessoal agora. Você não será capaz de vê-lo novamente."
-    },
-    "T5nU7u": {
-        "context": "header",
-        "string": "Criar Token"
-    },
-    "isM94c": {
-        "context": "create service token, button",
-        "string": "Criar"
-    },
-    "quV5zH": {
-        "context": "dialog title",
-        "string": "Excluir Token"
-    },
-    "2VSP8C": {
-        "context": "delete token",
-        "string": "Tem certeza de que deseja excluir o token {token}?"
-    },
-    "ac+Y98": {
-        "context": "app settings error",
-        "string": "Falha ao buscar as configurações do aplicativo"
-    },
-    "2cjt25": {
-        "context": "window title",
-        "string": "Instalar Aplicativo"
-    },
-    "5t/4um": {
-        "context": "message title",
-        "string": "Não foi possível instalar {name}"
-    },
-    "0fM/pV": {
-        "context": "message title",
-        "string": "Aplicativo instalado"
-    },
-    "ZprV2g": {
-        "context": "app has been installed",
-        "string": "{name} está pronto para uso"
-    },
-    "uIPD1i": {
-        "context": "app has been removed",
-        "string": "Aplicativo removido com sucesso"
-    },
-    "agZQkB": {
-        "context": "window title",
-        "string": "Criar Aplicativo"
-    },
-    "oiuwOl": {
-        "context": "button",
-        "string": "Atribuir"
-    },
-    "l2oVCF": {
-        "context": "attributes section name",
-        "string": "Atributos"
-    },
-    "eWV760": {
-        "string": "Atributo com esta identificação já existe"
-    },
-    "J/QqOI": {
-        "string": "Este valor já existe neste atributo"
-    },
-    "lG/MDw": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza que você quer deletar este atributo?} other {Tem certeza que você quer deletar {displayQuantity} atributos?}}"
-    },
-    "rKf4LU": {
-        "context": "dialog title",
-        "string": "Deletar atributos"
-    },
-    "JI2Xwp": {
-        "context": "dialog title",
-        "string": "Excluir atributo"
-    },
-    "h1rPPg": {
-        "context": "dialog content",
-        "string": "Tem certeza de que deseja excluir {attributeName}?"
-    },
-    "5XG1CO": {
-        "context": "acre-ft unit",
-        "string": "acre-ft"
-    },
-    "jBu2yj": {
-        "context": "acre-inch unit",
-        "string": "acre-inch"
-    },
-    "A9QSur": {
-        "context": "area units type",
-        "string": "Área"
-    },
-    "xOEZjV": {
-        "context": "attribute's label",
-        "string": "Etiqueta Padrão"
-    },
-    "P79U4b": {
-        "context": "attribute's slug short code label",
-        "string": "Código do Atributo"
-    },
-    "Q7uuDr": {
-        "context": "attribute slug input field helper text",
-        "string": "Isto é usado internamente. Garanta que você não está usando espaços."
-    },
-    "l5V0QT": {
-        "context": "boolean attribute type",
-        "string": "Boolean"
-    },
-    "fU+a9k": {
-        "context": "date attribute type",
-        "string": "Data"
-    },
-    "DzPVnj": {
-        "context": "date time attribute type",
-        "string": "Date Time"
-    },
-    "k/mTEl": {
-        "context": "distance units type",
-        "string": "Distância"
-    },
-    "bZksto": {
-        "context": "product attribute type",
-        "string": "Dropdown"
-    },
-    "LnRlch": {
-        "context": "attribute's editor component entity",
-        "string": "Entidade"
-    },
-    "z1y9oL": {
-        "context": "file attribute type",
-        "string": "Arquivo"
-    },
-    "YgE6ga": {
-        "context": "imperial unit system",
-        "string": "Imperial"
-    },
-    "oIvtua": {
-        "context": "attribute's editor component",
-        "string": "Tipo de entrada do catálogo para o proprietário da loja"
-    },
-    "ZayvsI": {
-        "context": "metric unit system",
-        "string": "Métrico"
-    },
-    "cKjFfl": {
-        "context": "product attribute type",
-        "string": "Seleção Multipla"
-    },
-    "SNiyXb": {
-        "context": "numeric attribute type",
-        "string": "Numérico"
-    },
-    "Iafyt5": {
-        "context": "page attribute entity type",
-        "string": "Páginas"
-    },
-    "B0PaVS": {
-        "context": "pint unit",
-        "string": "pint"
-    },
-    "5TUpjG": {
-        "context": "product attribute entity type",
-        "string": "Produtos"
-    },
-    "5dLpx0": {
-        "context": "references attribute type",
-        "string": "Referências"
-    },
-    "PiSXjb": {
-        "context": "check to require numeric attribute unit",
-        "string": "Selecione a unidade"
-    },
-    "gx4wCT": {
-        "context": "swatch attribute type",
-        "string": "Swatch"
-    },
-    "fdbqIs": {
-        "context": "text attribute type",
-        "string": "Text"
-    },
-    "Orgqv4": {
-        "context": "numeric attribute unit",
-        "string": "Unidade"
-    },
-    "zWM89r": {
-        "context": "numeric attribute units of",
-        "string": "Unidades de"
-    },
-    "ghje1I": {
-        "context": "numeric attribute unit system",
-        "string": "Sistema"
-    },
-    "njBulj": {
-        "context": "check to require attribute to have value",
-        "string": "Valor Necessário"
-    },
-    "cy8sV7": {
-        "context": "volume units types",
-        "string": "Volume"
-    },
-    "Vdy5g7": {
-        "context": "weight units type",
-        "string": "Peso"
-    },
-    "dKPMyh": {
-        "context": "tab name",
-        "string": "Todos os Atributos"
-    },
-    "IGvQ8k": {
-        "context": "button",
-        "string": "Criar atributo"
-    },
-    "1div9r": {
-        "string": "Pesquisar atributo"
-    },
-    "PsRG+v": {
-        "context": "use attribute in filtering",
-        "string": "Filtravel na Vitrine"
-    },
-    "rvk9ls": {
-        "context": "attribute can be used only in variants",
-        "string": "Variação Apenas"
-    },
-    "HQR2y0": {
-        "context": "attribute value is required",
-        "string": "Valor Necessário"
-    },
-    "cvbqJu": {
-        "context": "attribute",
-        "string": "Visible na Pagina de Produtos na Vitrine"
-    },
-    "ztQgD8": {
-        "string": "Nenhum atributo encontrado"
-    },
-    "yKuba7": {
-        "context": "attribute can be searched in dashboard",
-        "string": "Pesquisavel"
-    },
-    "oJkeS6": {
-        "string": "Código do Atributo"
-    },
-    "k6WDZl": {
-        "context": "attribute is visible",
-        "string": "Visível"
-    },
-    "HjUoHK": {
-        "context": "attribute's label'",
-        "string": "Etiqueta Padrão"
-    },
-    "ErNH3D": {
-        "string": "Defina onde este atributo deverá ser usado no sistema Saleor"
-    },
-    "nwvQPg": {
-        "context": "section header",
-        "string": "Empresa"
-    },
-    "v1pNHW": {
-        "string": "Classe do Atributo"
-    },
-    "zbJHl7": {
-        "context": "attribute type",
-        "string": "Conteúdo do Atributo"
-    },
-    "qkRuT0": {
-        "context": "attribute type",
-        "string": "Atributo de Produto"
-    },
-    "8cUEPV": {
-        "context": "page title",
-        "string": "Criar Novo Atributo"
-    },
-    "jswILH": {
-        "context": "add attribute as column in product list table",
-        "string": "Adicionar às opções de Colunas"
-    },
-    "AzMSmb": {
-        "context": "caption",
-        "string": "Se habilitado este atributo pode ser usado como uma coluna na tabela de produto"
-    },
-    "lCxfDe": {
-        "context": "attribute properties regarding dashboard",
-        "string": "Propriedades do Painel de Controle"
-    },
-    "RH+aOF": {
-        "context": "use attribute in filtering",
-        "string": "Uso em Filtragem"
-    },
-    "Q9wTrz": {
-        "context": "caption",
-        "string": "Se habilitado, este atributo pode ser utilizado como filtro na lista de produtos."
-    },
-    "AgY5Mv": {
-        "context": "attribute properties regarding storefront",
-        "string": "Propriedades da Vitrine"
-    },
-    "cJ5ASN": {
-        "context": "attribute position in storefront filters",
-        "string": "Posição na navegação"
-    },
-    "x8V/xS": {
-        "context": "attribute visibility in storefront",
-        "string": "Público"
-    },
-    "h2Hta6": {
-        "context": "caption",
-        "string": "Se habilitado, atributo estará acessível pelos clientes"
-    },
-    "I2wCwj": {
-        "context": "swatch attribute image label",
-        "string": "Imagem"
-    },
-    "0DgA8v": {
-        "context": "swatch attribute color picker label",
-        "string": "Seletor"
-    },
-    "JyQoES": {
-        "context": "delete attribute value",
-        "string": "Tem certeza de que deseja excluir o valor \"{name}\"  ?"
-    },
-    "WWV8aZ": {
-        "context": "dialog title",
-        "string": "Apagar valor do atributo"
-    },
-    "no3Ygn": {
-        "string": "Tem certeza de que deseja excluir o valor \"{name}\"? Se você excluí-lo, não poderá atribuí-lo a nenhum dos produtos com o atributo \"{attributeName}\"."
-    },
-    "XYhE8p": {
-        "context": "edit attribute value",
-        "string": "Editar Valor"
-    },
-    "PqMbma": {
-        "context": "add attribute value",
-        "string": "Adicionar Valor"
-    },
-    "UhcALJ": {
-        "context": "attribute name",
-        "string": "Nome"
-    },
-    "H60H6L": {
-        "context": "attribute values list: name column header",
-        "string": "Visual Padrão da Loja"
-    },
-    "3psvRS": {
-        "context": "attribute values list: slug column header",
-        "string": "Administrador"
-    },
-    "g5zIpS": {
-        "context": "No attribute values found",
-        "string": "Valor não encontrado"
-    },
-    "J3uE0t": {
-        "context": "section header",
-        "string": "Valores do Atributo"
-    },
-    "+iVKR1": {
-        "context": "assign attribute value button",
-        "string": "Atribuir valor"
-    },
-    "NUevU9": {
-        "context": "attribute values list: slug column header",
-        "string": "Swatch"
-    },
-    "jTifz+": {
-        "string": "Atributo criado com sucesso"
-    },
-    "7H2D5m": {
-        "context": "attribute value deleted",
-        "string": "Valor deletado"
-    },
-    "V/VAHG": {
-        "string": "Atributo deletado"
-    },
-    "xVn5B0": {
-        "context": "added new attribute value",
-        "string": "Adicionar novo valor"
-    },
-    "lw9WIk": {
-        "context": "deleted multiple attributes",
-        "string": "Atributos excluídos com sucesso"
-    },
-    "vzgZ3U": {
-        "context": "card header",
-        "string": "Entrar"
-    },
-    "AubJ/S": {
-        "context": "button",
-        "string": "Entrar"
-    },
-    "5sg7KC": {
-        "string": "Senha"
-    },
-    "3tbL7x": {
-        "context": "description",
-        "string": "Esqueceu a senha?"
-    },
-    "ENBELI": {
-        "context": "description",
-        "string": "ou faça login usando"
-    },
-    "M4q0Ye": {
-        "context": "error message",
-        "string": "Desculpe, o login deu errado. Por favor, tente novamente."
-    },
-    "tTtoKd": {
-        "context": "error message",
-        "string": "Desculpe, seu nome de usuário e/ou senha estão incorretos. Por favor, tente novamente."
-    },
-    "ChGI4V": {
-        "context": "error message",
-        "string": "Saleor não está disponível. Verifique sua conexão de rede e tente novamente."
-    },
-    "Ev6SEF": {
-        "string": "Nova senha"
-    },
-    "S22jIs": {
-        "context": "button",
-        "string": "Definir nova senha"
-    },
-    "vfG+nh": {
-        "string": "Confirmar Senha"
-    },
-    "m0Dz+2": {
-        "string": "Por favor, configure uma nova senha para sua conta. Repita sua nova senha para ter certeza de que será capaz de lembrá-la."
-    },
-    "7Chrsf": {
-        "string": "As senhas não coincidem"
-    },
-    "WhKGPA": {
-        "context": "page title",
-        "string": "Configurar nova senha"
-    },
-    "lm9NSK": {
-        "context": "password reset, button",
-        "string": "Envie um e-mail com link de redefinição"
-    },
-    "Yy/yDL": {
-        "string": "Redefinir senha"
-    },
-    "54M0Gu": {
-        "string": "Forneça-nos um e-mail - se o encontrarmos em nosso banco de dados, enviaremos um link para redefinir sua senha. Você deverá encontrá-lo em sua caixa de entrada nos próximos minutos."
-    },
-    "2oyWT9": {
-        "context": "button",
-        "string": "Voltar para o login"
-    },
-    "2ob30/": {
-        "string": "Sucesso! Em alguns minutos você irá receber uma mensagem com as instruções de como redefinir sua senha."
-    },
-    "C0JLNW": {
-        "string": "E-mail fornecido não encontrado no nosso banco de dados."
-    },
-    "hOxIeP": {
-        "string": "Disponibilidade"
-    },
-    "0OfZJA": {
-        "context": "button",
-        "string": "Voltar"
-    },
-    "7+GBlj": {
-        "string": "Error code {errorCode} {fieldError}"
-    },
-    "9uNz+T": {
-        "context": "button",
-        "string": "Cancelar"
-    },
-    "dOQB9o": {
-        "context": "payment status",
-        "string": "Cancelado"
-    },
-    "o8f4Sg": {
-        "context": "disabled option description",
-        "string": "Não é possível cumprir até que o pagamento seja capturado"
-    },
-    "GOdq5V": {
-        "string": "Catálogo"
-    },
-    "sK1FPw": {
-        "context": "categories section name",
-        "string": "Categorias"
-    },
-    "DP6b8U": {
-        "context": "section header",
-        "string": "Imagem de Fundo (opcional)"
-    },
-    "0iMYc+": {
-        "context": "field is optional",
-        "string": "(Opcional)"
-    },
-    "cgsY/X": {
-        "context": "page header",
-        "string": "Criar Nova Categoria"
-    },
-    "wQdR8M": {
-        "string": "Adicione título e descrição ao mecanismo de busca para facilitar a localização desta categoria"
-    },
-    "xo5UIb": {
-        "context": "dialog title",
-        "string": "Eliminar categoria"
-    },
-    "dJQxHt": {
-        "context": "delete category",
-        "string": "Tem certeza de que deseja excluir {categoryName}?"
-    },
-    "vEYtiq": {
-        "string": "Nome da Categoria"
-    },
-    "8HRy+U": {
-        "string": "Descrição da Categoria"
-    },
-    "vof5TR": {
-        "context": "button",
-        "string": "Criar categoria."
-    },
-    "JiXNEV": {
-        "string": "Pesquisar Categoria"
-    },
-    "vy7fjd": {
-        "context": "tab name",
-        "string": "Todas as Categorias"
-    },
-    "dM86a2": {
-        "string": "Nenhuma categoria encontrada"
-    },
-    "rrbzZt": {
-        "string": "Subcategoria não encontrada"
-    },
-    "BHQrgz": {
-        "context": "number of subcategories",
-        "string": "Subcategorias"
-    },
-    "k8ZJ5L": {
-        "context": "number of products",
-        "string": "No de Produtos"
-    },
-    "VQLIXd": {
-        "context": "product",
-        "string": "Nome"
-    },
-    "x/pIZ9": {
-        "context": "button",
-        "string": "Adicionar produto"
-    },
-    "z8jo8h": {
-        "context": "button",
-        "string": "Ver produtos"
-    },
-    "+43JV5": {
-        "context": "header",
-        "string": "Produtos em {categoryName}"
-    },
-    "JDz5h8": {
-        "context": "number of subcategories in category",
-        "string": "Subcategorias"
-    },
-    "V+fkAO": {
-        "context": "number of products in category",
-        "string": "Produtos"
-    },
-    "NivJal": {
-        "context": "section header",
-        "string": "Todas as Subcategorias"
-    },
-    "UycVMp": {
-        "context": "button",
-        "string": "Criar subcategoria"
-    },
-    "Irflxf": {
-        "context": "window title",
-        "string": "Criar categoria."
-    },
-    "7l5Bh9": {
-        "string": "{counter,plural,one {Você tem certeza que deseja deletar este produto?} other {Tem certeza que você quer deletar {displayQuantity} produtos?}}"
-    },
-    "xl7Fag": {
-        "string": "Categoria criada"
-    },
-    "Pp/7T7": {
-        "string": "{counter,plural,one {Tem certeza que deseja excluir esta categoria?} other {Tem certeza que deseja excluir {displayQuantity} categorias?}}"
-    },
-    "HvJPcU": {
-        "string": "Categoria deletada"
-    },
-    "KCjd1o": {
-        "context": "dialog title",
-        "string": "Deletar produtos"
-    },
-    "3DGvA/": {
-        "string": "Lembre-se de que isso também liberará todos os produtos atribuídos a esta categoria, tornando-os indisponíveis na loja."
-    },
-    "e+L+q3": {
-        "string": "Lembre-se de que isso irá deletar todos os produtos vinculados nesta categoria."
-    },
-    "sG0w22": {
-        "context": "dialog title",
-        "string": "Deletar categorias"
-    },
-    "xRkj2h": {
-        "string": "Tem certeza de que deseja excluir {categoryName}?"
-    },
-    "KeO51o": {
-        "string": "Canais"
-    },
-    "NlSJMM": {
-        "context": "channels section name",
-        "string": "Canais"
-    },
-    "37U5su": {
-        "context": "all variants label",
-        "string": "Todas as variantes"
-    },
-    "1w06LC": {
-        "context": "variants count label",
-        "string": "{variantsCount} variantes"
-    },
-    "8qL/tV": {
-        "context": "CannotDefineChannelsAvailabilityCard subtitle",
-        "string": "Você poderá definir a disponibilidade do produto após criar as variantes."
-    },
-    "CT5PAn": {
-        "context": "CannotDefineChannelsAvailabilityCard title",
-        "string": "Disponibilidade"
-    },
-    "QZoU0r": {
-        "context": "dialog header",
-        "string": "Excluir Canal"
-    },
-    "Mz0cx+": {
-        "context": "delete channel",
-        "string": "Excluir o canal excluirá todos os dados de produtos relativos a este canal. Tem certeza de que deseja excluir este canal?"
-    },
-    "sidKce": {
-        "context": "delete channel",
-        "string": "Todas as informações do pedido deste canal precisam ser movidas para um canal diferente. Por favor selecione os pedidos do canal que devem ser movidos para :."
-    },
-    "BXMSl4": {
-        "context": "currency channel",
-        "string": "Não há canal disponível para mover as informações do pedido. Crie um canal com a mesma moeda para que as informações possam ser movidas para ele."
-    },
-    "SZJhvK": {
-        "context": "dialog header",
-        "string": "Selecionar Canal"
-    },
-    "3y4r+z": {
-        "context": "channel settings",
-        "string": "Configurações do Canal"
-    },
-    "39yi8w": {
-        "context": "selected currency",
-        "string": "Moeda selecionada"
-    },
-    "74Zo/H": {
-        "context": "channel slug",
-        "string": "Slug"
-    },
-    "ZhaXLU": {
-        "context": "button",
-        "string": "Copiar"
-    },
-    "9Sz0By": {
-        "context": "channel currency",
-        "string": "Moeda"
-    },
-    "tV+Dcm": {
-        "string": "País padrão"
-    },
-    "UymotP": {
-        "context": "channel name",
-        "string": "Nome do canal"
-    },
-    "G/pgG3": {
-        "context": "dialog header",
-        "string": "Selecione um canal"
-    },
-    "nKwgxY": {
-        "context": "select label",
-        "string": "Nome do canal"
-    },
-    "X8qjg3": {
-        "context": "inactive",
-        "string": "Inativo"
-    },
-    "+tIkAe": {
-        "context": "status",
-        "string": "Status"
-    },
-    "MHVglr": {
-        "context": "deactivate",
-        "string": "Desativar"
-    },
-    "TSJRiZ": {
-        "context": "channel status title",
-        "string": "Status do Canal"
-    },
-    "QiN4hv": {
-        "context": "active",
-        "string": "Ativo"
-    },
-    "MQwT1W": {
-        "context": "activate",
-        "string": "Ativar"
-    },
-    "p/EWEZ": {
-        "context": "channels variants availability dialog title",
-        "string": "Gerenciar canais"
-    },
-    "yHaQWG": {
-        "context": "variants selected label",
-        "string": "{variantsAmount} variantes selecionados"
-    },
-    "8CbACQ": {
-        "context": "add shipping zone title",
-        "string": "Adicionar Zonas de Envio"
-    },
-    "+G9l7u": {
-        "context": "all selected zones card message",
-        "string": "Todas as zonas de envio disponíveis foram selecionadas"
-    },
-    "Ic7Wln": {
-        "context": "card subtitle",
-        "string": "Selecione zonas de envio que serão fornecidas através deste canal. Você pode atribuir zonas de envio a vários canais."
-    },
-    "gtKcPf": {
-        "context": "title",
-        "string": "{zonesCount} / {totalCount} zonas de envio"
-    },
-    "PTW56s": {
-        "context": "alert",
-        "string": "Limite de canais atingido"
-    },
-    "rZMT44": {
-        "context": "created channels counter",
-        "string": "{count}/{max} canais utilizados"
-    },
-    "j/vV0n": {
-        "context": "channel name",
-        "string": "Nome do Canal"
-    },
-    "/glQgs": {
-        "string": "Nenhum canal encontrado"
-    },
-    "OGm8wO": {
-        "context": "button",
-        "string": "Criar Canal"
-    },
-    "ZMy18J": {
-        "string": "Você atingiu o limite de canais e não poderá mais adicionar canais à sua loja. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
-    },
-    "J7mFhU": {
-        "context": "currency code select",
-        "string": "{code} - {countries}"
-    },
-    "DnghuS": {
-        "context": "channel create",
-        "string": "Novo Canal"
-    },
-    "OrMr/k": {
-        "context": "window title",
-        "string": "Criar Canal"
-    },
-    "D9Rg+F": {
-        "context": "window title",
-        "string": "Detalhes do canal"
-    },
-    "AkyGP2": {
-        "string": "Canal excluído"
-    },
-    "eWcvOc": {
-        "context": "button",
-        "string": "Escolher arquivo"
-    },
-    "2FQsYj": {
-        "context": "button",
-        "string": "Limpar"
-    },
-    "Qox+kb": {
-        "string": "em campo {fieldName}"
-    },
-    "NNT3Lp": {
-        "context": "collections section name",
-        "string": "Coleções"
-    },
-    "9vQR6c": {
-        "context": "collection label",
-        "string": "Visível"
-    },
-    "V8FhTt": {
-        "context": "collection label",
-        "string": "Oculto"
-    },
-    "Rj8LxK": {
-        "string": "Adicione título e descrição ao mecanismo de busca para facilitar a localização desta coleção"
-    },
-    "Fxa6xp": {
-        "context": "page header",
-        "string": "Adicionar Coleção"
-    },
-    "/WXs6H": {
-        "context": "collection name",
-        "string": "Nome"
-    },
-    "G4g5Ii": {
-        "context": "tab name",
-        "string": "Todas as Coleções"
-    },
-    "s97tLq": {
-        "string": "Pesquisar coleções"
-    },
-    "jyaAlB": {
-        "context": "button",
-        "string": "Criar coleção"
-    },
-    "9eC0MZ": {
-        "context": "collection",
-        "string": "Oculto"
-    },
-    "lL3YJO": {
-        "context": "collection",
-        "string": "Publicado "
-    },
-    "Yw+9F7": {
-        "string": "Coleção não encontrada"
-    },
-    "mWQt3s": {
-        "string": "No de Produtos"
-    },
-    "VZsE96": {
-        "string": "Nome da Coleção"
-    },
-    "UxdBmI": {
-        "context": "collection availability",
-        "string": "Disponibilidade"
-    },
-    "dpY94C": {
-        "context": "collection publication date",
-        "string": "Publicado em {date}"
-    },
-    "FcVEpe": {
-        "context": "collection publication date",
-        "string": "Não publicado"
-    },
-    "Mee46w": {
-        "context": "collection publication date",
-        "string": "Torna-se publicado o {date}"
-    },
-    "k+HcTv": {
-        "context": "product type",
-        "string": "Tipo"
-    },
-    "Oe62bR": {
-        "context": "product availability",
-        "string": "Disponibilidade"
-    },
-    "/dnWE8": {
-        "context": "products in collection",
-        "string": "Produtos em {name}"
-    },
-    "scHVdW": {
-        "context": "button",
-        "string": "Atribuir produto"
-    },
-    "6AMFki": {
-        "context": "product name",
-        "string": "Nome"
-    },
-    "Q8wHwJ": {
-        "string": "Coleção deletada"
-    },
-    "56vUeQ": {
-        "string": "Produto adicionado à coleção"
-    },
-    "MxhVZv": {
-        "string": "Tem certeza de que deseja excluir a imagem da coleção?"
-    },
-    "AulH/n": {
-        "string": "{counter,plural,one {Tem certeza que você deseja desvincular este produto?} other {Você tem certeza que deseja desvincular {displayQuantity} produtos?}}"
-    },
-    "WW+Ruy": {
-        "string": "Excluir produto da coleção"
-    },
-    "I1Mz7h": {
-        "string": "Gerenciar a Disponibilidade do Canal de Coleção"
-    },
-    "5OtU+V": {
-        "context": "dialog title",
-        "string": "Desvincular produtos da coleção"
-    },
-    "pVFoOk": {
-        "string": "Tem certeza de que deseja excluir {collectionName}?"
-    },
-    "ttMauu": {
-        "context": "window title",
-        "string": "Criar coleção"
-    },
-    "+wpvnk": {
-        "context": "dialog title",
-        "string": "Excluir coleção"
-    },
-    "67V0c0": {
-        "context": "unassign product from collection, button",
-        "string": "Não vinculado"
-    },
-    "fzk04H": {
-        "context": "dialog title",
-        "string": "excluir imagem"
-    },
-    "yT5zvU": {
-        "string": "{counter,plural,one {Você tem certeza que deseja deletar esta coleção?} other {Você tem certeza que deseja deletar {displayQuantity} coleções?}}"
-    },
-    "Ykw8k5": {
-        "context": "dialog title",
-        "string": "Excluir coleções"
-    },
-    "C7eDb9": {
-        "string": "Grupos de permissão"
-    },
-    "Fbr4Vp": {
-        "context": "dialog header",
-        "string": "Permissões"
-    },
-    "6cS4Rd": {
-        "context": "card section description",
-        "string": "Permissões disponiveis"
-    },
-    "MVU6ol": {
-        "context": "exceeded permissions description",
-        "string": "Estes grupos de permissões excedem suas permissões. Você pode gerenciar apenas permissões que você possui."
-    },
-    "VmMDLN": {
-        "context": "permission list item description",
-        "string": "Este grupo é a última fonte desta permissão"
-    },
-    "vONi+O": {
-        "string": "País"
-    },
-    "O95R3Z": {
-        "string": "Telefone"
-    },
-    "B52Em/": {
-        "string": "Endereço linha 1"
-    },
-    "TE4fIS": {
-        "string": "Cidade"
-    },
-    "oYGfnY": {
-        "string": "CEP"
-    },
-    "oQY0a2": {
-        "string": "Endereço linha 2"
-    },
-    "9YazHG": {
-        "string": "Empresa"
-    },
-    "AuwpCm": {
-        "string": "Área do país"
-    },
-    "Nv/toB": {
-        "context": "button",
-        "string": "Atribuir e salvar"
-    },
-    "PkjQS6": {
-        "context": "description",
-        "string": "Nenhum resultado encontrado"
-    },
-    "fP9FXB": {
-        "context": "input label",
-        "string": "Pesquisar Atributos"
-    },
-    "auxEP1": {
-        "context": "input placeholder",
-        "string": "Pesquisar por nome do atributo"
-    },
-    "QM9P8G": {
-        "context": "dialog header",
-        "string": "Atribuir Atributo"
-    },
-    "ylobu9": {
-        "context": "assign reference to product, button",
-        "string": "Atribuir"
-    },
-    "GUlwXU": {
-        "context": "dialog header",
-        "string": "Atribuir Valor de Atributo"
-    },
-    "RoKOQJ": {
-        "context": "label",
-        "string": "Buscar Valor de Atributo"
-    },
-    "NsgWhZ": {
-        "context": "placeholder",
-        "string": "Busque por nome de valor, etc..."
-    },
-    "sW9IyX": {
-        "context": "dialog header",
-        "string": "Atribuir Categoria"
-    },
-    "8hrH/z": {
-        "context": "dialog header",
-        "string": "Pesquisar Categoria"
-    },
-    "sf6FMK": {
-        "context": "dialog search placeholder",
-        "string": "Pesquisar por nome de categoria, etc...."
-    },
-    "XLYssG": {
-        "context": "assign categories to sale and save",
-        "string": "Assign and save"
-    },
-    "5tMkmJ": {
-        "context": "dialog header",
-        "string": "Atribuir coleção"
-    },
-    "f0hXz4": {
-        "context": "dialog header",
-        "string": "Pesquisar Coleção"
-    },
-    "JiRKgJ": {
-        "context": "dialog search placeholder",
-        "string": "Pesquisar por nome da coleção, etc...."
-    },
-    "cryH86": {
-        "context": "assign collections to sale and save",
-        "string": "Assign and save"
-    },
-    "/TF6BZ": {
-        "string": "Pesquisar Produtos"
-    },
-    "SHm7ee": {
-        "string": "Pesquisar por nome do produto, atributo, tipo do produto, etc..."
-    },
-    "dTCDMn": {
-        "context": "dialog header",
-        "string": "Atribuir Produto"
-    },
-    "WQnltU": {
-        "string": "Nenhum produto disponível no canal do pedido que corresponda à consulta fornecida"
-    },
-    "p4X/0H": {
-        "context": "button, assign variants to sale and save",
-        "string": "Atribuir e salvar"
-    },
-    "K+vjtE": {
-        "string": "Buscar Variantes"
-    },
-    "xAHOGV": {
-        "context": "dialog header",
-        "string": "Atribuir Variante"
-    },
-    "+HuipK": {
-        "context": "variant sku",
-        "string": "SKU {sku}"
-    },
-    "QZVD+5": {
-        "context": "button, unassign attribute from object",
-        "string": "Cancelar atribuição e salvar"
-    },
-    "8uLHBY": {
-        "context": "unassign attribute from object",
-        "string": "Tem certeza que deseja desatribuir  {attributeName} de {itemTypeName}?"
-    },
-    "z0gGP+": {
-        "context": "number of attributes",
-        "string": "{number} Atributos"
-    },
-    "3ukd9/": {
-        "context": "attributes, section header",
-        "string": "Atributos"
-    },
-    "j8PV7E": {
-        "context": "attribute values",
-        "string": "Valores"
-    },
-    "Ediw6/": {
-        "context": "button label",
-        "string": "Assign references"
-    },
-    "fgHLXc": {
-        "context": "attribute value",
-        "string": "Valor"
-    },
-    "jHJmjf": {
-        "string": "Sem resultados"
-    },
-    "XwrKOi": {
-        "context": "unassign multiple attributes from item",
-        "string": "{counter,plural,one {Are you sure you want to unassign this attribute from {itemTypeName}?} other {Are you sure you want to unassign {attributeQuantity} attributes from {itemTypeName}?}}"
-    },
-    "B2LE7A": {
-        "context": "menu item loading",
-        "string": "trabalhando..."
-    },
-    "5A6/2C": {
-        "context": "section header",
-        "string": "Disponibilidade"
-    },
-    "vY2lpx": {
-        "context": "channels availability text",
-        "string": "Disponível em {count} de {allCount, plural, one {# channel} outros {# channels}}"
-    },
-    "2i81/P": {
-        "context": "section header button",
-        "string": "Gerenciar"
-    },
-    "0cVk9I": {
-        "string": "Mostrar nas listas de produtos"
-    },
-    "UjsI4o": {
-        "context": "date",
-        "string": "desde {date}"
-    },
-    "Jt3DwJ": {
-        "context": "publish on date",
-        "string": "Publicar em"
-    },
-    "5ukAFZ": {
-        "string": "Desativar esta caixa de seleção removerá o produto das páginas de pesquisa e categoria. Estará disponível nas páginas da coleção."
-    },
-    "Y7Vy19": {
-        "context": "available on date",
-        "string": "Disponível em"
-    },
-    "U3BQKA": {
-        "string": "Definir data de publicação"
-    },
-    "tQuE1q": {
-        "string": "Selecione os canais que deseja para {contentType} esteja disponível em"
-    },
-    "B9yrkK": {
-        "string": "Nenhum canal encontrado"
-    },
-    "2/L4zZ": {
-        "string": "Selecionar todos os canais"
-    },
-    "EWCUdP": {
-        "string": "Canais de A a Z"
-    },
-    "ybaLoZ": {
-        "string": "Pesquisar canais"
-    },
-    "/lBLBI": {
-        "context": "channels alphabetically title",
-        "string": "Canais de A a Z"
-    },
-    "PctLol": {
-        "context": "no channels found title",
-        "string": "Nenhum canal encontrado"
-    },
-    "zR9Ozi": {
-        "context": "select all channels label",
-        "string": "Selecione todos os canais"
-    },
-    "7scATx": {
-        "context": "select title",
-        "string": "Selecione os canais que deseja para {contentType} esteja disponível em"
-    },
-    "cFVgOo": {
-        "context": "Channel label",
-        "string": "Channel"
-    },
-    "T0Mfxq": {
-        "context": "product status title",
-        "string": "{channelCount} {channelCount,plural, =1 {Channel} other {Channels}}"
-    },
-    "JgXBAw": {
-        "context": "dropdown label when there are no channels assigned",
-        "string": "Nenhum canal"
-    },
-    "sdA14A": {
-        "context": "Status label when object is published in a channel",
-        "string": "Publicado "
-    },
-    "GzbSQk": {
-        "context": "Status label when object is scheduled to publish in a channel",
-        "string": "Programado para publicação"
-    },
-    "s2y5eG": {
-        "context": "Status label",
-        "string": "Status"
-    },
-    "rHoRbE": {
-        "context": "Status label when object is unpublished in a channel",
-        "string": "Não publicado"
-    },
-    "TOMgXz": {
-        "context": "button",
-        "string": "Redefinir"
-    },
-    "62Ywh2": {
-        "context": "number of countries",
-        "string": "{number} Paises"
-    },
-    "zZCCqz": {
-        "context": "button",
-        "string": "Atribuir países"
-    },
-    "7NfoiJ": {
-        "context": "custom search delete, dialog header",
-        "string": "Excluir Pesquisa"
-    },
-    "UaYJJ8": {
-        "string": "Tem certeza que você deseja {name} das tabs de pesquisa?"
-    },
-    "LmKz3g": {
-        "string": "Loja"
-    },
-    "/X8Mjx": {
-        "string": "Brinque com <emphasis>GraphQL API</emphasis>"
-    },
-    "xwEc8K": {
-        "string": "API"
-    },
-    "4gZl/n": {
-        "string": "See <emphasis>DEMO STOREFRONT</emphasis>"
-    },
-    "7v2oBd": {
-        "context": "header",
-        "string": "Erro"
-    },
-    "9mGA/Q": {
-        "context": "button linking to dashboard",
-        "string": "Painel de controle"
-    },
-    "ypW4Mi": {
-        "context": "button refreshing page",
-        "string": "Atualizar a página"
-    },
-    "p0SUJj": {
-        "string": "Não se preocupe, vamos consertar isso em breve. Tente atualizar a página ou voltar ao painel."
-    },
-    "AQ+9Ez": {
-        "string": "Encontramos um erro inesperado"
-    },
-    "OA+fw+": {
-        "context": "conjunction, choice between going to dashboard or refreshing page",
-        "string": "ou"
-    },
-    "QCwBUI": {
-        "context": "button",
-        "string": "Excluir Pesquisa"
-    },
-    "qIgdO6": {
-        "string": "Personalizar Filtro"
-    },
-    "DEa1T1": {
-        "context": "button",
-        "string": "Salvar Pesquisa"
-    },
-    "zSOvI0": {
-        "string": "Filtros"
-    },
-    "HnVtSS": {
-        "context": "search",
-        "string": "Sem resultados"
-    },
-    "PLCwT/": {
-        "context": "search results",
-        "string": "Mostrar mais"
-    },
-    "FNpv6K": {
-        "context": "button",
-        "string": "Filtros"
-    },
-    "erC44f": {
-        "context": "filters error messages dependencies missing",
-        "string": "O filtro requer outros filtros: {dependencies}"
-    },
-    "34F7Jk": {
-        "context": "filter range separator",
-        "string": "e"
-    },
-    "USS3Q7": {
-        "context": "filters error messages unknown error",
-        "string": "Ocorreu um erro desconhecido"
-    },
-    "XkX56I": {
-        "context": "filters error messages value required",
-        "string": "Escolha um valor"
-    },
-    "sn2awN": {
-        "context": "ExitFormPrompt cancel button",
-        "string": "Descartar mudanças"
-    },
-    "MPOj0I": {
-        "context": "ExitFormPrompt confirm button",
-        "string": "Salvar alterações"
-    },
-    "1eEyJv": {
-        "context": "ExitFormPrompt continue editing button",
-        "string": "Continuar editando"
-    },
-    "TtZg/K": {
-        "context": "ExitFormPrompt title",
-        "string": "Gostaria de salvar as alterações?"
-    },
-    "FWWliu": {
-        "context": "ExitFormPrompt title",
-        "string": "Você tem alterações não salvas"
-    },
-    "NxeDbG": {
-        "context": "image upload",
-        "string": "Arraste até aqui para efetuar o upload"
-    },
-    "62T585": {
-        "context": "button",
-        "string": "{languageName} - {languageCode}"
-    },
-    "LkuDEb": {
-        "context": "metadata field value, header",
-        "string": "Valor"
-    },
-    "VcI+Zh": {
-        "context": "header",
-        "string": "Metadados"
-    },
-    "ETHnjq": {
-        "context": "header",
-        "string": "Metadados Privados"
-    },
-    "2+v1wX": {
-        "context": "number of metadata fields in model",
-        "string": "{number,plural,one {{number} string} other {{number} strings}}"
-    },
-    "nudPsY": {
-        "context": "metadata field name, header",
-        "string": "Campo"
-    },
-    "cY6H2C": {
-        "context": "empty metadata text",
-        "string": "Nenhum metadado criado para este elemento. Use o botão abaixo para adicionar um novo campo de metadados."
-    },
-    "GiDxS4": {
-        "context": "add metadata field,button",
-        "string": "Adicionar Campo"
-    },
-    "nEixpu": {
-        "context": "table action",
-        "string": "Ações"
-    },
-    "hptDxW": {
-        "context": "money",
-        "string": "para {money}"
-    },
-    "zTdwWM": {
-        "context": "money",
-        "string": "{fromMoney} - {toMoney}"
-    },
-    "lW5uJO": {
-        "context": "money",
-        "string": "de {money}"
-    },
-    "U2WgwW": {
-        "context": "add custom select input option",
-        "string": "Adicionar novo valor: {value}"
-    },
-    "hX5PAb": {
-        "string": "Nenhum resultado encontrado"
-    },
-    "EEW+ND": {
-        "string": "Navegador"
-    },
-    "8B8E+3": {
-        "context": "navigator placeholder",
-        "string": "Numero do Pedido"
-    },
-    "NqxvFh": {
-        "context": "navigator placeholder",
-        "string": "Digite o Comando"
-    },
-    "TpPx7V": {
-        "context": "navigator placeholder",
-        "string": "Pesquisar Cliente"
-    },
-    "4gT3eD": {
-        "context": "navigator section header",
-        "string": "Pesquisar em Clientes"
-    },
-    "BooQvo": {
-        "context": "navigator placeholder",
-        "string": "Tipo {key} para ver ações disponíveis"
-    },
-    "AOI4LW": {
-        "context": "navigator placeholder",
-        "string": "Pesquisar no Catálogo"
-    },
-    "YYkkhx": {
-        "context": "navigator section header",
-        "string": "Navegar para"
-    },
-    "EM+30g": {
-        "context": "navigator notification",
-        "string": "Nosso novo destaque para ajudar você com suas tarefas diárias. Navegue usando {keyboardShortcut} atalhos."
-    },
-    "me585h": {
-        "context": "navigator section header",
-        "string": "Ações rápidas"
-    },
-    "Gxm7Qx": {
-        "context": "navigator notification title",
-        "string": "Navegador está aqui para ajudar"
-    },
-    "ccXLVi": {
-        "string": "Categoria"
-    },
-    "phAZoj": {
-        "string": "Coleção"
-    },
-    "M1uijW": {
-        "context": "collection",
-        "string": "Não publicado"
-    },
-    "CjSRT1": {
-        "context": "button",
-        "string": "Criar Categoria"
-    },
-    "VdDcxc": {
-        "context": "button",
-        "string": "Criar Coleção"
-    },
-    "QooeI/": {
-        "context": "button",
-        "string": "Criar Cliente"
-    },
-    "cfQf0w": {
-        "context": "button",
-        "string": "Criar Pedido"
-    },
-    "V1mqpZ": {
-        "context": "button",
-        "string": "Criar Grupo de Permissão"
-    },
-    "JFmOfi": {
-        "context": "button",
-        "string": "Criar Produto"
-    },
-    "y9cvqE": {
-        "context": "button",
-        "string": "Criar cupom"
-    },
-    "1gzck6": {
-        "string": "{firstName} {lastName}"
-    },
-    "IyHQr0": {
-        "context": "navigator action",
-        "string": "Ir para o pedido #{orderNumber}"
-    },
-    "kbkjEc": {
-        "context": "navigator catalog mode description",
-        "string": "Pesquisar no Catálogo"
-    },
-    "3TlhJS": {
-        "context": "navigator command mode description",
-        "string": "Pesquisar Comando"
-    },
-    "DHBlFi": {
-        "context": "navigator customer mode description",
-        "string": "Pesquisar Clientes"
-    },
-    "Xel9C+": {
-        "context": "navigator default mode description",
-        "string": "Pesquisar Visuais e Ações"
-    },
-    "iAvKNf": {
-        "context": "navigator help mode description",
-        "string": "Mostrar Ajuda"
-    },
-    "usSkzP": {
-        "context": "navigator order mode description",
-        "string": "Pesquisar Pedidos"
-    },
-    "k8bltk": {
-        "string": "Sem resultados"
-    },
-    "x/ZVlU": {
-        "string": "Produto"
-    },
-    "yH56V+": {
-        "string": "Ooops!..."
-    },
-    "bj6pTd": {
-        "string": "Algo está faltando"
-    },
-    "nRiOg+": {
-        "string": "Desculpe, página não encontada"
-    },
-    "95oJ5d": {
-        "context": "button",
-        "string": "Voltar para a Dashboard"
-    },
-    "p3eRUm": {
-        "context": "indicator that feature is in preview mode",
-        "string": "Visualização"
-    },
-    "KGsaGO": {
-        "context": "tooltip",
-        "string": "Este recurso está em estado de visualização e pode estar sujeito a alterações posteriormente"
-    },
-    "WHkx+F": {
-        "string": "Preço não pode ser menor que 0"
-    },
-    "fNFEkh": {
-        "string": "No de Linhas:"
-    },
-    "liLrVs": {
-        "context": "save filter tab, header",
-        "string": "Salvar Pesquisa Personalizada"
-    },
-    "QcIFCs": {
-        "context": "save search tab",
-        "string": "Pesquisar Nome"
-    },
-    "w2Cewo": {
-        "string": "Titulo do mecanismo de busca"
-    },
-    "CXTIq8": {
-        "string": "Descrição do mecanismo de busca"
-    },
-    "s5Imt5": {
-        "context": "button",
-        "string": "Editar SEO do site"
-    },
-    "TGX4T1": {
-        "string": "Pré-visualização do Mecanismo de Busca"
-    },
-    "IoDlcd": {
-        "string": "Slug"
-    },
-    "ChAjJu": {
-        "context": "character limit",
-        "string": "{numberOfCharacters} de{maxCharacters} caracteres"
-    },
-    "s/sTT6": {
-        "string": "Se vazio, a pré-visualização será auto-gerada."
-    },
-    "450Fty": {
-        "string": "Nenhum"
-    },
-    "qu/hXD": {
-        "string": "Selecionado {number} itens"
-    },
-    "2HfSiT": {
-        "context": "pagination",
-        "string": "No. of rows"
-    },
-    "v/1VA6": {
-        "context": "add order note, button",
-        "string": "Enviar"
-    },
-    "3evXPj": {
-        "string": "Deixa sua anotação aqui..."
-    },
-    "zyXcBP": {
-        "string": "Sorting by this column requires active filter: {filterName}"
-    },
-    "qLbse5": {
-        "context": "button",
-        "string": "Sair"
-    },
-    "X8+Lpa": {
-        "context": "button",
-        "string": "Configurações da Conta"
-    },
-    "2r4cTE": {
-        "context": "button",
-        "string": "Habilitar Modo Escuro"
-    },
-    "akXDST": {
-        "context": "section header",
-        "string": "Visibilidade"
-    },
-    "qMB6d2": {
-        "context": "weight",
-        "string": "para {value} {unit}"
-    },
-    "5x6yT9": {
-        "context": "weight",
-        "string": "{fromValue} {fromUnit} - {toValue} {toUnit}"
-    },
-    "LICZeR": {
-        "context": "weight",
-        "string": "de {value} {unit}"
-    },
-    "NtFVFS": {
-        "context": "weight",
-        "string": "{value} {unit}"
-    },
-    "s8FlDW": {
-        "context": "hide error log label in notification",
-        "string": "Ocultar registro"
-    },
-    "w9xgN9": {
-        "context": "see error log label in notification",
-        "string": "Ver log de erros"
-    },
-    "xfGZsi": {
-        "context": "configuration section name",
-        "string": "Configuração"
-    },
-    "YZl6cv": {
-        "string": "Diversos"
-    },
-    "gTr0qE": {
-        "string": "Configurações de Entrega"
-    },
-    "HP6m+q": {
-        "string": "Atributos e tipos de produto"
-    },
-    "UN+yTt": {
-        "string": "Configurações da Equipe"
-    },
-    "HjXnIf": {
-        "string": "Gerenciamento de Conteúdo"
-    },
-    "jFrdB5": {
-        "string": "Configurações do Produto"
-    },
-    "MWSacl": {
-        "string": "Multicanal"
-    },
-    "DJFPzq": {
-        "context": "button",
-        "string": "Confirmar"
-    },
-    "yHeZRQ": {
-        "string": "Falha na Exportação do Produto"
-    },
-    "CJEIRC": {
-        "string": "A exportação do produto foi concluída e enviada para o seu endereço de e-mail."
-    },
-    "JTcz2G": {
-        "context": "csv file exporting has finished, header",
-        "string": "Exportação CSV concluída"
-    },
-    "ryAyPr": {
-        "string": "A fatura solicitada foi gerada. Ela foi adicionada ao topo da lista de faturas nesta visualização. Aproveite!"
-    },
-    "i+Vox0": {
-        "context": "invoice generating has finished, header",
-        "string": "Fatura Gerada"
-    },
-    "Dhherd": {
-        "context": "dialog header, title",
-        "string": "Geração de Fatura"
-    },
-    "8aV98y": {
-        "context": "new version notification content",
-        "string": "Você precisa atualizar o Saleor para a versão mais recente. Antes de fazer isso, salve todas as alterações para evitar perda de dados. Para atualizar use o botão abaixo."
-    },
-    "tEdFmZ": {
-        "context": "notification title",
-        "string": "System update required"
-    },
-    "XCIV8H": {
-        "context": "button",
-        "string": "Atualizar"
-    },
-    "Rjs1CD": {
-        "context": "button",
-        "string": "Continuar"
-    },
-    "H5NKfr": {
-        "context": "button",
-        "string": "Criar"
-    },
-    "w4R/SO": {
-        "string": "Aplicativos Locais"
-    },
-    "McN+wq": {
-        "context": "customers section name",
-        "string": "Clientes"
-    },
-    "gQGUsN": {
-        "context": "dialog title",
-        "string": "Editar Endereço "
-    },
-    "W0kQd+": {
-        "context": "dialog title",
-        "string": "Adicionar Endereço"
-    },
-    "rjy9/k": {
-        "context": "button",
-        "string": "Adicionar Endereço"
-    },
-    "kErneR": {
-        "string": "Este cliente não tem nenhum endereço adicionado ao catálogo de endereços. Você pode adicionar um endereço usando o botão abaixo."
-    },
-    "n5vskv": {
-        "context": "customer's address book, header",
-        "string": "Catálogo de Endereços de {fullName}"
-    },
-    "MpR4zK": {
-        "context": "customer details, header",
-        "string": "Detalhes de {fullName}"
-    },
-    "y/UWBR": {
-        "string": "Não há endereço para exibição para este cliente"
-    },
-    "CWqmRU": {
-        "context": "customer's address book when no customer name is available, header",
-        "string": "Address Book"
-    },
-    "hMRP6J": {
-        "string": "Endereço Padrão"
-    },
-    "VyzsWZ": {
-        "string": "Endereço de Cobrança Padrão"
-    },
-    "nLML8Y": {
-        "string": "Endereço de Entrega Padrão"
-    },
-    "puikeb": {
-        "context": "button",
-        "string": "Excluir Endereço"
-    },
-    "w+8BfK": {
-        "context": "button",
-        "string": "Editar Endereço "
-    },
-    "hLOEeb": {
-        "context": "button",
-        "string": "Definir como endereço de cobrança padrão"
-    },
-    "+7OsyM": {
-        "context": "button",
-        "string": "Definir como endereço de entrega padrão"
-    },
-    "BfJGij": {
-        "context": "header",
-        "string": "Informação do Endereço"
-    },
-    "Zd3Eew": {
-        "context": "subsection header",
-        "string": "Endereço de Entrega"
-    },
-    "bHdFph": {
-        "context": "subsection header",
-        "string": "Endereço"
-    },
-    "3d1RXL": {
-        "string": "Este cliente ainda não tem endereço"
-    },
-    "biVFKU": {
-        "context": "subsection header",
-        "string": "Endereço de Cobrança"
-    },
-    "jGGnSZ": {
-        "context": "page header",
-        "string": "Endereço Primário"
-    },
-    "wNQzS/": {
-        "string": "O endereço primário deste cliente."
-    },
-    "fjPWOA": {
-        "context": "header",
-        "string": "Visão Geral do Cliente"
-    },
-    "qNcoRY": {
-        "context": "notes about customer header",
-        "string": "Notas"
-    },
-    "uUQ+Al": {
-        "context": "note about customer",
-        "string": "Nota"
-    },
-    "w3sGrD": {
-        "string": "Insira qualquer informação extra sobre este cliente."
-    },
-    "N76zUg": {
-        "context": "page header",
-        "string": "Criar Cliente"
-    },
-    "+NUzaQ": {
-        "context": "check to mark this account as active",
-        "string": "Conta de usuário ativa"
-    },
-    "MjUyhA": {
-        "context": "section subheader",
-        "string": "Membro ativo desde {date}"
-    },
-    "SMakqb": {
-        "context": "customer contact section, header",
-        "string": "Informação de Contato"
-    },
-    "4v5gfh": {
-        "context": "account information, header",
-        "string": "Informação da conta"
-    },
-    "2mRLis": {
-        "string": "Pesquisar Cliente"
-    },
-    "QLVddq": {
-        "context": "button",
-        "string": "Criar cliente"
-    },
-    "xQK2EC": {
-        "context": "tab name",
-        "string": "Todos os Clientes"
-    },
-    "icz/jb": {
-        "context": "customer",
-        "string": "Data de Inscrição"
-    },
-    "fhksPD": {
-        "string": "Número de Pedidos"
-    },
-    "E8VDeH": {
-        "string": "Número de Pedidos"
-    },
-    "FpIcp9": {
-        "string": "Nenhum cliente encontrado"
-    },
-    "97l2MO": {
-        "string": "E-mail do cliente"
-    },
-    "Gr1SAu": {
-        "string": "Nome do Cliente"
-    },
-    "pURrk1": {
-        "context": "order status",
-        "string": "Status"
-    },
-    "1LiVhv": {
-        "context": "section header",
-        "string": "Pedidos recentes"
-    },
-    "nTF6tG": {
-        "context": "number of order",
-        "string": "Núm. do Pedido"
-    },
-    "3+990c": {
-        "context": "button",
-        "string": "Ver todos os pedidos"
-    },
-    "ri3kK9": {
-        "context": "order placement date",
-        "string": "Data"
-    },
-    "taX/V3": {
-        "context": "order total amount",
-        "string": "Total"
-    },
-    "RlfqSV": {
-        "string": "Nenhum pedido encontrado"
-    },
-    "FNAZoh": {
-        "string": "Ultimo login"
-    },
-    "HMD+ib": {
-        "string": "Último pedido"
-    },
-    "e7Nyu7": {
-        "context": "section header",
-        "string": "Histórico do Cliente"
-    },
-    "2p0tZx": {
-        "context": "delete customer, dialog content",
-        "string": "Tem certeza de que deseja excluir {email}?"
-    },
-    "ey0lZj": {
-        "context": "dialog header",
-        "string": "Deletar Cliente"
-    },
-    "qLOBff": {
-        "context": "dialog header",
-        "string": "Excluir Endereço"
-    },
-    "nX2pCU": {
-        "context": "window title",
-        "string": "Criar cliente"
-    },
-    "/kWzY1": {
-        "string": "Tem certeza de que deseja excluir este endereço do catálogo de endereços do usuário?"
-    },
-    "PXatmC": {
-        "string": "Cliente Removido"
-    },
-    "ftcHpD": {
-        "string": "Cliente criado"
-    },
-    "N2SbNc": {
-        "string": "{counter,plural,one {Tem certeza que deseja excluir este cliente? } other {Tem certeza que deseja excluir {displayQuantity} clientes? }}"
-    },
-    "q8ep2I": {
-        "context": "dialog header",
-        "string": "Deletar clientes"
-    },
-    "hzSNj4": {
-        "string": "Painel de controle"
-    },
-    "P7PLVj": {
-        "string": "Data"
-    },
-    "JqiqNj": {
-        "string": "Algo deu errado"
-    },
-    "ufmuTp": {
-        "context": "button",
-        "string": "Excluir"
-    },
-    "i0AcKY": {
-        "context": "notification message after log in",
-        "string": "Só para você saber ... Você está no modo de demonstração. Você pode brincar com o painel de controle, mas não pode salvar as alterações."
-    },
-    "Q8Qw5B": {
-        "string": "Descrição"
-    },
-    "bZenNC": {
-        "string": "Descrição (opcional)"
-    },
-    "n+Gwbu": {
-        "string": "Descontos"
-    },
-    "g3qjSf": {
-        "context": "button",
-        "string": "Atribuir categorias"
-    },
-    "AbyDC7": {
-        "context": "section header",
-        "string": "Categorias Elegíveis"
-    },
-    "Uu76vj": {
-        "context": "no categories",
-        "string": "Nenhuma categoria encontrada"
-    },
-    "fV6yX5": {
-        "context": "table head",
-        "string": "Nome da Categoria"
-    },
-    "QGjJcT": {
-        "context": "number of products",
-        "string": "Produtos"
-    },
-    "/6uK4C": {
-        "context": "button",
-        "string": "Atribuir coleções"
-    },
-    "XNeJay": {
-        "context": "section header",
-        "string": "Coleções Elegíveis"
-    },
-    "IoCMjg": {
-        "context": "no collections",
-        "string": "Coleção não encontrada"
-    },
-    "ht9yOD": {
-        "context": "table head",
-        "string": "Nome da Coleção"
-    },
-    "cvVIV/": {
-        "context": "dialog header",
-        "string": "Atribuir Países"
-    },
-    "dGqEJ9": {
-        "context": "search box placeholder",
-        "string": "Pesquisar pelo nome do país"
-    },
-    "dWK/Ck": {
-        "string": "Escolha os países aos quais deseja que o cupom seja limitado, na lista abaixo"
-    },
-    "8EGagh": {
-        "context": "search box label",
-        "string": "Filtrar Países"
-    },
-    "wgA48T": {
-        "context": "country selection",
-        "string": "Países de A a Z"
-    },
-    "AVF5T5": {
-        "context": "voucher end date, switch button",
-        "string": "Definir data de término"
-    },
-    "zKOGkU": {
-        "context": "time during discount is active, header",
-        "string": "Datas Ativas"
-    },
-    "U8eeLW": {
-        "context": "button",
-        "string": "Atribuir produtos"
-    },
-    "xqXYF+": {
-        "context": "section header",
-        "string": "Produtos Elegíveis"
-    },
-    "OrR3Qy": {
-        "context": "no products",
-        "string": "Nenhum produto encontrado."
-    },
-    "6cMkfT": {
-        "context": "table head",
-        "string": "Nome do Produto"
-    },
-    "bPFp8B": {
-        "context": "product type",
-        "string": "Tipo de produto"
-    },
-    "ySqrUU": {
-        "context": "button",
-        "string": "Atribuir variantes"
-    },
-    "lehGc9": {
-        "context": "section header",
-        "string": "Variantes elegíveis"
-    },
-    "/oyr6M": {
-        "context": "no variants",
-        "string": "Nenhuma variação encontrada."
-    },
-    "Q1HhPk": {
-        "context": "table head",
-        "string": "Tipo de produto"
-    },
-    "lHccsy": {
-        "context": "table head",
-        "string": "Nome da variante"
-    },
-    "2E1xZ0": {
-        "context": "page header",
-        "string": "Criar Venda"
-    },
-    "F56hOz": {
-        "context": "sale name",
-        "string": "Nome"
-    },
-    "MSD3A/": {
-        "string": "Pesquisar Venda"
-    },
-    "JHfbXR": {
-        "context": "button",
-        "string": "Criar Venda"
-    },
-    "Yjhgle": {
-        "context": "tab name",
-        "string": "Todas as Vendas"
-    },
-    "AnqH4p": {
-        "context": "sale status",
-        "string": "Ativo"
-    },
-    "1BNKCZ": {
-        "context": "sale channel",
-        "string": "Canal"
-    },
-    "RBxYJf": {
-        "context": "sale status",
-        "string": "Expirado"
-    },
-    "XDBeA+": {
-        "context": "discount type",
-        "string": "Quantia Fixa"
-    },
-    "s17U7u": {
-        "context": "discount type",
-        "string": "Porcentagem"
-    },
-    "BanAhF": {
-        "context": "sale status",
-        "string": "Agendado"
-    },
-    "zjHH6b": {
-        "context": "sale start date",
-        "string": "Iniciado"
-    },
-    "SpngiS": {
-        "context": "sale status",
-        "string": "Status"
-    },
-    "KHZlmi": {
-        "string": "Tipo do Desconto"
-    },
-    "XZR590": {
-        "context": "sale value",
-        "string": "Valor"
-    },
-    "giF5UV": {
-        "context": "sale end date",
-        "string": "Termina"
-    },
-    "51HE+Q": {
-        "string": "Nenhuma venda encontrada"
-    },
-    "iBSq6l": {
-        "context": "sale start date",
-        "string": "Inicia"
-    },
-    "WkxE8/": {
-        "context": "percentage or fixed, header",
-        "string": "Tipo do Desconto"
-    },
-    "JnzDrI": {
-        "context": "discount type",
-        "string": "Quantia Fixa"
-    },
-    "wHdMAX": {
-        "context": "sale value, header",
-        "string": "Valor"
-    },
-    "x3g4Ry": {
-        "context": "sale discount",
-        "string": "Valor de Desconto"
-    },
-    "cehiWu": {
-        "context": "channels sale info",
-        "string": "Os canais que não têm descontos atribuídos usarão seu canal pai para definir o preço. O preço será convertido para a moeda do canal"
-    },
-    "Hj3T7P": {
-        "context": "column title",
-        "string": "Nome do canal"
-    },
-    "PsclSa": {
-        "context": "page header",
-        "string": "Criar cupom"
-    },
-    "YjcN9w": {
-        "context": "time during voucher is active, header",
-        "string": "Datas Ativas"
-    },
-    "jd/LWa": {
-        "string": "Cupom se aplica a todos os países"
-    },
-    "glT6fm": {
-        "string": "Cupom é limitado a estes países"
-    },
-    "ibnmEd": {
-        "context": "voucher country range",
-        "string": "Países"
-    },
-    "jvKNMP": {
-        "string": "Código de Desconto"
-    },
-    "mSLr9d": {
-        "context": "voucher code, button",
-        "string": "Gerar Código"
-    },
-    "vTgRTZ": {
-        "context": "limit voucher",
-        "string": "Limitar a um uso por cliente"
-    },
-    "Qj/3sH": {
-        "context": "limit voucher",
-        "string": "Limite o número de vezes que este desconto pode ser usado no total"
-    },
-    "+jHXT3": {
-        "context": "limit voucher",
-        "string": "Limitar apenas ao pessoal"
-    },
-    "s51tHd": {
-        "context": "limit voucher",
-        "string": "Limite de Usuários"
-    },
-    "pzSF+b": {
-        "context": "voucher usage limit, header",
-        "string": "Limite de Uso"
-    },
-    "o8S0Ac": {
-        "context": "usage limit uses left caption",
-        "string": "Usos restantes"
-    },
-    "pNrF72": {
-        "context": "tab name",
-        "string": "Todos os Cupons"
-    },
-    "IruP2T": {
-        "string": "Pesquisar Cupom"
-    },
-    "GbhZJ4": {
-        "context": "button",
-        "string": "Criar cupom"
-    },
-    "amQg6f": {
-        "context": "voucher status",
-        "string": "Ativo"
-    },
-    "NLybdq": {
-        "context": "voucher channel",
-        "string": "Canal"
-    },
-    "t7UwLY": {
-        "context": "voucher status",
-        "string": "Expirado"
-    },
-    "Jj0de8": {
-        "context": "voucher status",
-        "string": "Agendado"
-    },
-    "ujFo4A": {
-        "context": "voucher start date",
-        "string": "Iniciado"
-    },
-    "uy+tB8": {
-        "context": "voucher status",
-        "string": "Status"
-    },
-    "h75GAF": {
-        "context": "voucher",
-        "string": "Contagem de Utilização"
-    },
-    "JV+EiM": {
-        "context": "voucher value",
-        "string": "Valor"
-    },
-    "tuYPlG": {
-        "context": "minimum amount of spent money to activate voucher",
-        "string": "Gasto Mínimo"
-    },
-    "b6L9n7": {
-        "context": "voucher is active until date",
-        "string": "Termina"
-    },
-    "yHwvLL": {
-        "context": "voucher uses",
-        "string": "Utilizações"
-    },
-    "5u7b3V": {
-        "context": "voucher is active from date",
-        "string": "Inicia"
-    },
-    "JsPIOX": {
-        "context": "voucher code",
-        "string": "Código"
-    },
-    "U2mOqA": {
-        "string": "Não vouchers encontrado"
-    },
-    "GVinbz": {
-        "context": "column title",
-        "string": "Valor"
-    },
-    "K+ROF8": {
-        "string": "Os canais que não têm descontos atribuídos usarão seu canal pai para definir o preço. O preço será convertido para a moeda do canal"
-    },
-    "yhv3HX": {
-        "context": "voucher requirements, header",
-        "string": "Requisitos Mínimos"
-    },
-    "u/hkKO": {
-        "context": "voucher has no requirements",
-        "string": "Nenhum"
-    },
-    "XT/ZvF": {
-        "context": "voucher requirement",
-        "string": "Quantidade mínima de ítens"
-    },
-    "bh9+8A": {
-        "context": "voucher requirement",
-        "string": "Valor mínimo do pedido"
-    },
-    "FOa+Xd": {
-        "context": "voucher value requirement",
-        "string": "Valor Mínimo do Pedido"
-    },
-    "bcf60I": {
-        "context": "voucher",
-        "string": "Aplica-se a"
-    },
-    "HLqWXA": {
-        "context": "voucher value requirement",
-        "string": "Limite de Uso"
-    },
-    "6cq+c+": {
-        "context": "header",
-        "string": "Tipo do Desconto"
-    },
-    "sS5aVm": {
-        "context": "voucher discount type",
-        "string": "Envio Grátis"
-    },
-    "fEfCtO": {
-        "context": "voucher discount type",
-        "string": "Porcentagem"
-    },
-    "vXFPD6": {
-        "context": "voucher discount type",
-        "string": "Quantia Fixa"
-    },
-    "1shOIS": {
-        "context": "column title",
-        "string": "Preço"
-    },
-    "/oaqFS": {
-        "context": "section header",
-        "string": "Valor"
-    },
-    "mmcHeH": {
-        "string": "Valor de Desconto"
-    },
-    "5c2JVF": {
-        "context": "voucher application, switch button",
-        "string": "Apenas uma vez por pedido"
-    },
-    "9UHfux": {
-        "string": "Informações Específicas do Cupom"
-    },
-    "ObRk1O": {
-        "string": "Se esta opção estiver desabilitada, o desconto será dado para todo produto elegível"
-    },
-    "bP7ZLP": {
-        "context": "voucher discount",
-        "string": "Todo o pedido"
-    },
-    "45zP+r": {
-        "context": "voucher discount",
-        "string": "Produtos específicos"
-    },
-    "WasHjQ": {
-        "context": "voucher discount",
-        "string": "Envio"
-    },
-    "n7Fg8i": {
-        "string": "Venda criada com sucesso"
-    },
-    "ESDTC/": {
-        "string": "Gerenciar a disponibilidade do canal de vendas"
-    },
-    "SqcGBK": {
-        "context": "channel availability dialog header",
-        "string": "Gerenciar a disponibilidade do canal"
-    },
-    "4C7I61": {
-        "context": "sale Details delete button",
-        "string": "Venda removida"
-    },
-    "V3fvcD": {
-        "context": "dialog content",
-        "string": "Venda removida"
-    },
-    "1/oG76": {
-        "context": "dialog header",
-        "string": "Excluir Venda"
-    },
-    "/V7UOC": {
-        "context": "unassign category from sale and save, button",
-        "string": "Unassign and save"
-    },
-    "GiJm1v": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza de que deseja cancelar a atribuição desta categoria?} other {Tem certeza de que deseja cancelar a atribuição de {displayQuantity} categorias?}}"
-    },
-    "B5yE8S": {
-        "context": "dialog header",
-        "string": "Cancelar atribuição de categorias da venda"
-    },
-    "6RtE2D": {
-        "context": "unassign collection from sale and save, button",
-        "string": "Unassign and save"
-    },
-    "UjoSZB": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza de que deseja cancelar a atribuição desta coleção?} other {Tem certeza de que deseja cancelar a atribuição de {displayQuantity} coleções?}}"
-    },
-    "0TQuo4": {
-        "context": "dialog header",
-        "string": "Unassign Collection From Sale"
-    },
-    "rNzkIt": {
-        "context": "dialog content",
-        "string": "Tem certeza de que deseja excluir {saleName}?"
-    },
-    "opIDox": {
-        "context": "unassign product from sale and save, button",
-        "string": "Cancelar atribuição e salvar"
-    },
-    "AHK0K9": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza de que deseja cancelar a atribuição deste produto?} other {Tem certeza de que deseja cancelar a atribuição de {displayQuantity} produtos?}}"
-    },
-    "n7GIKB": {
-        "context": "dialog header",
-        "string": "Cancelar atribuição de produto da venda"
-    },
-    "Uj2hj8": {
-        "context": "unassign variant from sale and save, button",
-        "string": "Cancelar atribuição e salvar"
-    },
-    "iWyoZn": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza de que deseja cancelar a atribuição desta variante?} other {Tem certeza de que deseja cancelar a atribuição de variantes {displayQuantity}?}}"
-    },
-    "Kyyr7D": {
-        "context": "dialog header",
-        "string": "Cancelar atribuição de variante da venda"
-    },
-    "ZWIjvr": {
-        "context": "dialog header",
-        "string": "Excluir Vendas"
-    },
-    "FPzzh7": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza de que deseja excluir esta venda?} other {Tem certeza de que deseja excluir {displayQuantity} vendas?}}"
-    },
-    "Eau5AV": {
-        "string": "Gerenciar a disponibilidade do canal de produtos"
-    },
-    "Q8mpW3": {
-        "string": "Cupom criado com sucesso."
-    },
-    "MmGlkp": {
-        "context": "dialog header",
-        "string": "Cancelar a atribuição de coleções do cupom"
-    },
-    "cNSLLO": {
-        "context": "button",
-        "string": "Unassign and save"
-    },
-    "cKCfSW": {
-        "context": "dialog header",
-        "string": "Cancelar a atribuição de produtos do cupom"
-    },
-    "LOSNq0": {
-        "context": "dialog header",
-        "string": "Cancelar atribuição de categorias do cupom"
-    },
-    "NEJo1I": {
-        "context": "dialog content",
-        "string": "Tem certeza de que deseja excluir {voucherCode}?"
-    },
-    "EM730i": {
-        "string": "Gerenciar a disponibilidade do canal"
-    },
-    "Hgz44z": {
-        "context": "dialog header",
-        "string": "Excluir Cupom"
-    },
-    "O9QPe1": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza que deseja excluir este cupom?} other {Tem certeza que deseja excluir {displayQuantity} cupons?}}"
-    },
-    "Q0JJ4F": {
-        "context": "dialog header",
-        "string": "Excluir Cupons"
-    },
-    "eOrLzG": {
-        "context": "button",
-        "string": "Feito"
-    },
-    "toDL5R": {
-        "context": "order status",
-        "string": "Rascunho"
-    },
-    "YMBn8d": {
-        "context": "draft orders section name",
-        "string": "Rascunhos de Pedidos"
-    },
-    "2atspc": {
-        "string": "Rascunhos"
-    },
-    "Ja7gHc": {
-        "context": "button",
-        "string": "Editar"
-    },
-    "hJZwTS": {
-        "string": "Email address"
-    },
-    "T4GOiX": {
-        "string": "Data Final"
-    },
-    "juBV+h": {
-        "string": "Hora de Término"
-    },
-    "KN7zKn": {
-        "string": "Erro"
-    },
-    "j0ugM4": {
-        "context": "Manage and Update your warehouse information",
-        "string": "Taxas de câmbio"
-    },
-    "Q6wcZ5": {
-        "string": "Nome"
-    },
-    "pkjXPD": {
-        "context": "order status",
-        "string": "Completo"
-    },
-    "pkUbrL": {
-        "string": "Informações Gerais"
-    },
-    "HSmg1/": {
-        "context": "gift cards section name",
-        "string": "Gift Cards"
-    },
-    "mbj1J5": {
-        "context": "bulk issue gift cards success alert description",
-        "string": "Os {cardsAmount} solicitados foram emitidos com sucesso"
-    },
-    "3bQz2o": {
-        "context": "bulk issue gift cards success alert title",
-        "string": "Cartões-presente emitidos"
-    },
-    "7dhhzL": {
-        "context": "bulk issue gift cards dialog title",
-        "string": "Cartões-presente de emissão em massa"
-    },
-    "YBqLHs": {
-        "context": "expiry date label",
-        "string": "Data exata"
-    },
-    "fzl482": {
-        "context": "expires on label",
-        "string": "Expirará em:"
-    },
-    "rl1t+o": {
-        "context": "expires in label",
-        "string": "Expira em"
-    },
-    "rzhcpD": {
-        "context": "set expiry date selected label",
-        "string": "Defina a data de validade do vale-presente"
-    },
-    "n9JOI3": {
-        "context": "money amount input label",
-        "string": "Insira o valor"
-    },
-    "vDnheO": {
-        "context": "gift card bulk create success dialog accept button",
-        "string": "Ok"
-    },
-    "NZtcLb": {
-        "context": "gift card bulk create success dialog content",
-        "string": "Emitimos todos os cartões-presente solicitados. Você pode baixar a lista de novos cartões-presente usando o botão abaixo."
-    },
-    "IVOjqW": {
-        "context": "gift card bulk create success dialog export button",
-        "string": "Exportar para e-mail"
-    },
-    "WyPitj": {
-        "context": "gift card bulk create success dialog title",
-        "string": "Cartões-presente de emissão em massa"
-    },
-    "hnBvH7": {
-        "context": "copied to clipboard alert title",
-        "string": "Copiado para a área de transferência"
-    },
-    "RXbkle": {
-        "context": "copy code button label",
-        "string": "Copiar código"
-    },
-    "zjZuhM": {
-        "context": "created gift card code label",
-        "string": "Este é o código de um vale-presente criado:"
-    },
-    "WzHfj8": {
-        "context": "successfully created gift card alert title",
-        "string": "Successfully created gift card"
-    },
-    "MgdgpT": {
-        "context": "customer input label",
-        "string": "Cliente"
-    },
-    "uilt7q": {
-        "context": "issued cards amount label",
-        "string": "Cartões emitidos"
-    },
-    "PilTI6": {
-        "context": "issue gift card button label",
-        "string": "Emitir"
-    },
-    "UKgP89": {
-        "context": "note input label",
-        "string": "Nota"
-    },
-    "ZuqkSp": {
-        "context": "note input subtitle",
-        "string": "Por que este cartão-presente foi emitido? Esta nota não será mostrada ao cliente. A nota será armazenada no histórico do cartão-presente"
-    },
-    "ArctEg": {
-        "context": "requires activation checkbox caption",
-        "string": "Todos os cartões emitidos exigem ativação pela equipe antes do uso."
-    },
-    "vCw7BP": {
-        "context": "requires activation checkbox label",
-        "string": "Requer ativação"
-    },
-    "JftRtx": {
-        "context": "issue gift card dialog title",
-        "string": "Emitir vale-presente"
-    },
-    "uQk8gB": {
-        "context": "export all items to csv file",
-        "string": "Todos os cartões-presente ({number})"
-    },
-    "n97Ii0": {
-        "context": "export selected items to csv file",
-        "string": "Vales-presente selecionados ({number})"
-    },
-    "CRAfpd": {
-        "context": "gift card export dialog confirm button label",
-        "string": "Exportar códigos"
-    },
-    "dsJ+Wv": {
-        "context": "note on export gift cards",
-        "string": "Observação: somente cartões-presente ativos e não utilizados serão exportados"
-    },
-    "3kwdxJ": {
-        "context": "gift card export type label",
-        "string": "gift cards"
-    },
-    "bDHiYK": {
-        "context": "gift card export success alert description",
-        "string": "No momento, estamos exportando os códigos do seu cartão-presente. Assim que seu arquivo estiver disponível, ele será enviado para seu endereço de e-mail"
-    },
-    "YEpYMB": {
-        "context": "gift card export csv success alert title",
-        "string": "Exportando CSV"
-    },
-    "DQJnB4": {
-        "context": "gift card export dialog title",
-        "string": "Exportar códigos de vale-presente"
-    },
-    "KqbfFa": {
-        "context": "expiry date selection info message",
-        "string": "Você pode definir que os cartões-presente expirem após um determinado período após a compra. Lembre-se de que em alguns países a expiração dos cartões-presente é proibida por lei."
-    },
-    "1J/bhZ": {
-        "context": "expiry date section header",
-        "string": "Data de validade"
-    },
-    "xHj9Qe": {
-        "context": "gift card settings header",
-        "string": "Gift Cards Configurações"
-    },
-    "fExm0/": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi ativado por {activatedBy}"
-    },
-    "pCy5EP": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi ativado"
-    },
-    "aEc9Ar": {
-        "context": "gift card history message",
-        "string": "O saldo do vale-presente foi zerado por {resetBy}"
-    },
-    "PcQRxi": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi comprado em ordem {orderNumber}"
-    },
-    "gAqkrG": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi desativado por {deactivatedBy}"
-    },
-    "NvwS/N": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi desativado"
-    },
-    "vQunFc": {
-        "context": "gift card history message",
-        "string": "A data de validade do vale-presente foi atualizada por {expiryUpdatedBy}"
-    },
-    "fLhj3a": {
-        "context": "gift card history message",
-        "string": "A data de validade do vale-presente foi atualizada"
-    },
-    "4Z0O2B": {
-        "context": "section header title",
-        "string": "Cronograma do vale-presente"
-    },
-    "30X9S8": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi emitido por {issuedBy}"
-    },
-    "jDovoJ": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi emitido"
-    },
-    "JgNb8X": {
-        "context": "notifier message",
-        "string": "Ocorreu um erro ao adicionar uma nota"
-    },
-    "WS4ov0": {
-        "context": "notifier message",
-        "string": "A nota foi adicionada com sucesso"
-    },
-    "gj3MUg": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi reenviado"
-    },
-    "tsL3IW": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi enviado ao cliente"
-    },
-    "vkAWwY": {
-        "context": "gift card history message",
-        "string": "As tags dos vales-presente foram atualizadas"
-    },
-    "Uu2B2G": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi usado como forma de pagamento no pedido {orderLink} <buyer>by</buyer>"
-    },
-    "408KSO": {
-        "context": "gift card history message",
-        "string": "O vale-presente foi usado como forma de pagamento no pedido {orderLink}"
-    },
-    "v01/tY": {
-        "context": "consent to send gift card to different address checkbox label",
-        "string": "Sim, quero enviar o vale-presente para um endereço diferente"
-    },
-    "ttk0w7": {
-        "context": "resend code to customer description",
-        "string": "O código do vale-presente será reenviado para o e-mail fornecido durante a finalização da compra. Você pode fornecer um endereço de e-mail diferente se desejar:"
-    },
-    "AqHafs": {
-        "context": "provided email input placeholder",
-        "string": "Endereço de e-mail fornecido"
-    },
-    "NLNonj": {
-        "context": "send to channel select label",
-        "string": "Enviar para o canal"
-    },
-    "s1IQuN": {
-        "context": "resend button label",
-        "string": "Reenviar"
-    },
-    "JQH+Iy": {
-        "context": "resent code success message",
-        "string": "Reenviar o código ao cliente com sucesso!"
-    },
-    "mslSpp": {
-        "context": "resend code to customer title",
-        "string": "Reenviar código ao cliente"
-    },
-    "STJx8N": {
-        "context": "change button label",
-        "string": "Alterar"
-    },
-    "kFkMoG": {
-        "context": "set balance dialog subtitle",
-        "string": "Como você gostaria de definir o saldo dos cartões. Quando você altera o saldo, ambos os valores serão alterados"
-    },
-    "tKxCld": {
-        "context": "set balance dialog title label",
-        "string": "Definir saldo"
-    },
-    "XAPFHP": {
-        "context": "card update success alert title",
-        "string": "Saldo do cartão atualizado com sucesso"
-    },
-    "Z/7hyu": {
-        "context": "card balance label",
-        "string": "Saldo do cartão"
-    },
-    "PJDcQs": {
-        "context": "set balance button label",
-        "string": "Definir saldo"
-    },
-    "a+kgkq": {
-        "context": "tag label",
-        "string": "Etiqueta de cartão"
-    },
-    "Zj/7QZ": {
-        "context": "details title",
-        "string": "detalhes"
-    },
-    "//k1GX": {
-        "context": "expired on label",
-        "string": "Expirou em {date}"
-    },
-    "JKbpH9": {
-        "context": "expiry date checkbox label",
-        "string": "O vale-presente expira"
-    },
-    "nFTvQW": {
-        "context": "expiration date label",
-        "string": "Data de validade"
-    },
-    "Jo01VZ": {
-        "context": "bought by label",
-        "string": "Comprado por"
-    },
-    "/AbHy4": {
-        "context": "creation label",
-        "string": "Criação"
-    },
-    "+pLi+M": {
-        "context": "issued by app label",
-        "string": "Emitido por aplicativo"
-    },
-    "V+h02n": {
-        "context": "issued by label",
-        "string": "Emitida pela"
-    },
-    "9TbDQD": {
-        "context": "order number label",
-        "string": "Número do pedido"
-    },
-    "kc4c4d": {
-        "context": "product label",
-        "string": "Produto comprado para ganhar vale-presente"
-    },
-    "Eh6KYS": {
-        "context": "info card title",
-        "string": "Informações do cartão"
-    },
-    "kS5Qgk": {
-        "context": "used by label",
-        "string": "Usado por"
-    },
-    "EA7rjI": {
-        "context": "disabled status label",
-        "string": "Disabled"
-    },
-    "aPYFO1": {
-        "context": "expired status label",
-        "string": "Expirado"
-    },
-    "lCPxtT": {
-        "context": "resend code label",
-        "string": "Reenviar código"
-    },
-    "GibKGn": {
-        "context": "success gift card disable message",
-        "string": "Vale-presente desativado com sucesso"
-    },
-    "bDO9DN": {
-        "context": "success gift card enable message",
-        "string": "Vale-presente ativado com sucesso"
-    },
-    "29L5Yq": {
-        "context": "gift card not found message",
-        "string": "Não foi possível encontrar o vale-presente"
-    },
-    "xPnZ0R": {
-        "context": "title",
-        "string": "detalhes"
-    },
-    "kcMVsB": {
-        "context": "balance amound missing error message",
-        "string": "O valor do saldo está faltando"
-    },
-    "bVbEZ/": {
-        "context": "amount filter label",
-        "string": "Montante"
-    },
-    "tXIgmR": {
-        "context": "balance curreny missing error message",
-        "string": "A moeda do saldo está faltando"
-    },
-    "osPBn1": {
-        "context": "currency filter label",
-        "string": "Moeda"
-    },
-    "e/61NZ": {
-        "context": "current balance filter label",
-        "string": "Saldo atual"
-    },
-    "tTuCYj": {
-        "context": "all gift cards label",
-        "string": "Todos os vales-presente"
-    },
-    "+WTmpr": {
-        "context": "disabled status option label",
-        "string": "Desabilitado"
-    },
-    "vC8vyb": {
-        "context": "enabled status option label",
-        "string": "Habilitado"
-    },
-    "VceXrc": {
-        "context": "initial balance filter label",
-        "string": "Balanço inicial"
-    },
-    "Sjd7wm": {
-        "context": "product filter label",
-        "string": "Produto"
-    },
-    "labkPK": {
-        "context": "search gift card placeholder",
-        "string": "Pesquisar cartões-presente, e.g {exampleGiftCardCode}"
-    },
-    "D4CsYK": {
-        "context": "status filter label",
-        "string": "Status"
-    },
-    "mE+fru": {
-        "context": "tag filter label",
-        "string": "Tags"
-    },
-    "WMGoqz": {
-        "context": "used by filter label",
-        "string": "Usado por"
-    },
-    "31hYP2": {
-        "context": "alert card message",
-        "string": "Os cartões-presente aparecerão após o pedido ser atendido. <link>Ver pedidos com cartões-presente</link>"
-    },
-    "qkt/Km": {
-        "context": "bulk delete label",
-        "string": "Excluir"
-    },
-    "IzEVek": {
-        "context": "bulk disable label",
-        "string": "Desativar"
-    },
-    "hz+9ES": {
-        "context": "bulk activate label",
-        "string": "Ativar"
-    },
-    "KcsJKm": {
-        "context": "error with activatation alert message",
-        "string": "Erro ao ativar o presente {count,plural,one{card} other{cards}}"
-    },
-    "C90nKP": {
-        "context": "error with deactivatation alert message",
-        "string": "Erros ao desativar presente {count,plural,one{card} other{cards}}"
-    },
-    "IwEQvz": {
-        "context": "success activate alert message",
-        "string": "Presente ativado com sucesso {count,plural,one{card} other{cards}}"
-    },
-    "SO56cv": {
-        "context": "success deactivate alert message",
-        "string": "Presente desativado com sucesso {count,plural,one{card} other{cards}}"
-    },
-    "9hab/1": {
-        "context": "bulk issue menu item",
-        "string": "Emissão em massa"
-    },
-    "38dS1A": {
-        "context": "code ending with label",
-        "string": "Código terminando com {last4CodeChars}"
-    },
-    "HqeqEV": {
-        "context": "create gift card product alert message",
-        "string": "Crie um produto de cartão-presente"
-    },
-    "8Hq18g": {
-        "context": "create gift card product type alert message",
-        "string": "Crie um tipo de produto de vale-presente"
-    },
-    "exvX+Z": {
-        "context": "export card codes menu item",
-        "string": "Exportar códigos de cartão"
-    },
-    "rCy3Fe": {
-        "context": "invalid date in expirydate field content",
-        "string": "Não é possível criar vale-presente com data de validade vencida"
-    },
-    "l1/Hwb": {
-        "context": "invalid date in expirydate field header",
-        "string": "Data incorreta inserida"
-    },
-    "AJgl5u": {
-        "context": "gift card product message",
-        "string": "produto de vale-presente"
-    },
-    "MbZHXE": {
-        "context": "column title balance",
-        "string": "Equilíbrio"
-    },
-    "MJBAqv": {
-        "context": "column title used by/customer",
-        "string": "Usado por"
-    },
-    "eLJQSh": {
-        "context": "column title gift card",
-        "string": "Gift Card"
-    },
-    "bwJc6V": {
-        "context": "column title product",
-        "string": "Produto"
-    },
-    "FEWgh/": {
-        "context": "column title tag",
-        "string": "Tag"
-    },
-    "RfPJ1E": {
-        "context": "issue card button label",
-        "string": "Cartão de emissão"
-    },
-    "E22x4H": {
-        "context": "no card defuned alert message",
-        "string": "Você não definiu um produto de vale-presente!"
-    },
-    "Rd0s80": {
-        "context": "no cards found title message",
-        "string": "Nenhum vale-presente encontrado"
-    },
-    "VI+X8H": {
-        "context": "no gift card product types alert message",
-        "string": "{createGiftCardProductType} para começar a vender cartões-presente em sua loja."
-    },
-    "jmh0rV": {
-        "context": "no gift card products alert message",
-        "string": "{createGiftCardProduct} para começar a vender cartões-presente em sua loja."
-    },
-    "U9o2bV": {
-        "context": "no gift card products and types alert message",
-        "string": "{createGiftCardProductType} e {giftCardProduct} para começar a vender cartões-presente em sua loja."
-    },
-    "F69lwk": {
-        "context": "settings menu item",
-        "string": "Configurações"
-    },
-    "vWTM6Y": {
-        "context": "customer gift cards card no cards subtitle",
-        "string": "Não há cartões-presente atribuídos a este cliente"
-    },
-    "Utq1fE": {
-        "context": "customer gift cards card title",
-        "string": "Gift Cards"
-    },
-    "mbOuGl": {
-        "context": "customer gift cards card issue button",
-        "string": "Emitir novo cartão"
-    },
-    "vzce9B": {
-        "context": "customer gift cards card subtitle",
-        "string": "Apenas cinco cartões-presente mais recentes são mostrados aqui"
-    },
-    "FQc5z6": {
-        "context": "customer gift cards card view all button",
-        "string": "Ver tudo"
-    },
-    "Yxihwg": {
-        "context": "consent removal of gift cards with balance button label",
-        "string": "{selectedItemsCount,plural,one {Estou ciente de que estou retirando um vale-presente com saldo} other {Estou ciente de que estou removendo vales-presente com saldo}}"
-    },
-    "S52JMl": {
-        "context": "default gift card delete description",
-        "string": "{selectedItemsCount,plural,one {Tem certeza de que deseja excluir este vale-presente?} other {Tem certeza de que deseja excluir {selected Items Count} vales-presente?}}"
-    },
-    "zLtb4N": {
-        "context": "gift card removed success alert message",
-        "string": "{selectedItemsCount,plural,one {Vale-presente excluído com sucesso} other {Vales-presente excluídos com sucesso}}"
-    },
-    "a+iRI1": {
-        "context": "single gift card title",
-        "string": "{selectedItemsCount,plural,one {Excluir vale-presente} other {Excluir vales-presente}}"
-    },
-    "RLZ1jd": {
-        "context": "delete gift cards with balance description",
-        "string": "{selectedItemsCount,plural,one {O vale-presente que você está prestes a excluir tem saldo disponível. Ao excluir este cartão você poderá remover o saldo disponível para seu cliente.} other {O vale-presente que você está prestes a excluir tem saldo disponível. Ao excluir este cartão você poderá remover o saldo disponível para seu cliente.}}"
-    },
-    "LA13a5": {
-        "context": "channel select label",
-        "string": "Canal"
-    },
-    "0sd4ez": {
-        "context": "selected customer channel subtitle",
-        "string": "O cliente receberá o código do vale-presente por meio do endereço de e-mail deste canal"
-    },
-    "FRJRmi": {
-        "context": "selected customer gift card is sent to subtitle",
-        "string": "O cliente selecionado receberá o código do vale-presente gerado. Outra pessoa pode resgatar o código do vale-presente. O vale-presente será atribuído à conta que resgatou o código."
-    },
-    "Um3g00": {
-        "context": "send to customer selected label",
-        "string": "Enviar vale-presente ao cliente"
-    },
-    "ps+h1G": {
-        "context": "checkbox label description",
-        "string": "A data de validade será definida automaticamente assim que o cartão-presente for emitido"
-    },
-    "j2l6cL": {
-        "context": "checkbox label",
-        "string": "Definir período de validade do vale-presente"
-    },
-    "XFtKV5": {
-        "context": "input placeholder tag",
-        "string": "Tag"
-    },
-    "mzASqs": {
-        "context": "days after label",
-        "string": "Dias após a emissão"
-    },
-    "54KYgS": {
-        "context": "months after label",
-        "string": "Meses após a emissão"
-    },
-    "15fg+o": {
-        "context": "weeks after label",
-        "string": "Semanas após a emissão"
-    },
-    "Qe4XHv": {
-        "context": "years after label",
-        "string": "Anos após a emissão"
-    },
-    "4JW9iJ": {
-        "context": "home section name",
-        "string": "Início"
-    },
-    "sjRXXz": {
-        "string": "O pedido nº {orderId} foi feito a partir do rascunho por {userEmail}"
-    },
-    "BNTZLv": {
-        "string": "O pedido nº {orderId} foi feito a partir do rascunho"
-    },
-    "5SPHkk": {
-        "string": "O pedido nº {orderId} foi totalmente pago"
-    },
-    "0dPP8O": {
-        "string": "O pedido nº {orderId} foi feito"
-    },
-    "Nuq83+": {
-        "string": "Create new channel"
-    },
-    "E9Jssl": {
-        "string": "Nenhum pedido pronto para faturar."
-    },
-    "5dyOs0": {
-        "string": "Sem pagamentos para serem realizados."
-    },
-    "bFhzRX": {
-        "string": "Nenhum produto está fora de estoque"
-    },
-    "c0H45L": {
-        "string": "{amount, plural,one {Um pedido está pronto para ser atendido} other {{amount} os pedidos estão prontos para serem atendidos}}"
-    },
-    "md326v": {
-        "string": "{amount, plural,one {Um pagamento para capturar} other {{amount} pagamentos para capturar}}"
-    },
-    "cdxwA8": {
-        "string": "{amount, plural,one {Um produto fora de estoque} other {{amount} produtos fora de estoque}}"
-    },
-    "gSQ0Ge": {
-        "string": "Variação {name} foi configurada como padrão."
-    },
-    "26+K4N": {
-        "string": "Houve um problema com o arquivo que você enviou como imagem e ele não pôde ser usado. Por favor, tente um arquivo diferente."
-    },
-    "Yo2kC+": {
-        "string": "Não foi possível processar a imagem"
-    },
-    "DOkfyZ": {
-        "string": "Permissões insuficientes"
-    },
-    "aheQdn": {
-        "string": "Sobrenome"
-    },
-    "8oIbMI": {
-        "string": "Limite atingido para este plano"
-    },
-    "IbVKSH": {
-        "context": "button",
-        "string": "Gerenciar"
-    },
-    "9C7PZE": {
-        "context": "navigation section name",
-        "string": "Navegação"
-    },
-    "wlQTfb": {
-        "context": "go to next step, button",
-        "string": "Próximo"
-    },
-    "oUWADl": {
-        "string": "Não"
-    },
-    "s9sOcC": {
-        "context": "button",
-        "string": "OK"
-    },
-    "lzdvwp": {
-        "context": "field is optional",
-        "string": "Opcional"
-    },
-    "Ta9j04": {
-        "context": "orders section name",
-        "string": "Pedidos"
-    },
-    "+svQBN": {
-        "context": "alert",
-        "string": "Order limit reached"
-    },
-    "TPW2tP": {
-        "string": "Você atingiu o limite do seu pedido. Você será cobrado extra por pedidos acima do limite. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
-    },
-    "aY0HAT": {
-        "context": "section header",
-        "string": "Canal de Vendas"
-    },
-    "NJbzcP": {
-        "context": "dialog header",
-        "string": "Cancelar Pedidos"
-    },
-    "i+JSEZ": {
-        "string": "{counter,plural,one {Tem certeza de que deseja cancelar este pedido?} other {Tem certeza de que deseja cancelar {displayQuantity} pedidos?}}"
-    },
-    "VSztEE": {
-        "string": "O cancelamento deste pedido liberará o estoque, para que possam ser comprados por outros clientes.<b>O pedido não será reembolsado ao cancelar o pedido - Você precisa fazer isso manualmente. </b>Tem certeza que deseja cancelar este pedido?"
-    },
-    "NhQboB": {
-        "context": "dialog header",
-        "string": "O sistema não pôde cancelar o pedido"
-    },
-    "b+jcaN": {
-        "string": "Ainda há faturamentos criadas para este pedido. Cancele as entregas antes de cancelar o pedido."
-    },
-    "FIZvTx": {
-        "context": "dialog content",
-        "string": "Selecione o método que deseja usar para alterar o endereço"
-    },
-    "D4W/LE": {
-        "context": "dialog header",
-        "string": "Alterar endereço de cobrança do cliente"
-    },
-    "RzDYi8": {
-        "context": "checkbox label",
-        "string": "Defina o mesmo para o endereço de cobrança"
-    },
-    "r4g/vD": {
-        "context": "search modal billing title",
-        "string": "Endereço de cobrança"
-    },
-    "vf56In": {
-        "context": "address type",
-        "string": "Use um dos endereços do cliente"
-    },
-    "qov29K": {
-        "context": "dialog content",
-        "string": "Selecione um dos endereços do cliente ou adicione um novo endereço: "
-    },
-    "CG+awx": {
-        "context": "dialog content",
-        "string": "Qual endereço você gostaria de usar como endereço de entrega para o cliente selecionado: "
-    },
-    "PBd/e+": {
-        "context": "dialog header",
-        "string": "Alterar endereço para pedido"
-    },
-    "9gb9b4": {
-        "context": "address type",
-        "string": "Adicionar novo endereço"
-    },
-    "Qph0GE": {
-        "context": "dialog content",
-        "string": "Adicione um novo endereço:"
-    },
-    "xWEFrR": {
-        "context": "dialog content",
-        "string": "Este cliente não possui nenhum endereço no catálogo de endereços. Forneça o endereço para pedido:"
-    },
-    "kQq6/o": {
-        "context": "info when addresses search is unsuccessful",
-        "string": "Nenhum resultado encontrado"
-    },
-    "zqarUF": {
-        "context": "modal information under title",
-        "string": "Selecione um endereço que deseja usar na lista abaixo"
-    },
-    "129wyQ": {
-        "context": "dialog header",
-        "string": "Alterar endereço de entrega do cliente"
-    },
-    "txOXvy": {
-        "context": "checkbox label",
-        "string": "Defina o mesmo para endereço de entrega"
-    },
-    "2OH46U": {
-        "context": "search modal shipping title",
-        "string": "Endereço de entrega"
-    },
-    "s6lW8R": {
-        "context": "option label",
-        "string": "Alterar endereço"
-    },
-    "Zg0dRo": {
-        "context": "dialog description",
-        "string": "Você alterou o cliente atribuído a este pedido. O que você gostaria de fazer com o endereço de entrega?"
-    },
-    "iue6mV": {
-        "context": "option label",
-        "string": "Manter endereço"
-    },
-    "uD93er": {
-        "context": "dialog header",
-        "string": "Changed Customer"
-    },
-    "VrFy8e": {
-        "string": "Nenhuma anotação pelo cliente"
-    },
-    "puALFo": {
-        "context": "notes about customer, header",
-        "string": "Notas"
-    },
-    "4Jp83O": {
-        "context": "subheader",
-        "string": "Informação de Contato"
-    },
-    "hkSkNx": {
-        "string": "Pesquisar Clientes"
-    },
-    "VCzrEZ": {
-        "context": "link",
-        "string": "Ver Perfil"
-    },
-    "DP5VOH": {
-        "string": "Endereço de Entrega"
-    },
-    "Y7M1YQ": {
-        "context": "section header",
-        "string": "Cliente"
-    },
-    "GLX9II": {
-        "context": "billing address",
-        "string": "Mesmo que o endereço de entrega"
-    },
-    "Qovenh": {
-        "string": "Usuário anônimo"
-    },
-    "c7/79+": {
-        "string": "Endereço de Cobrança"
-    },
-    "R98JLZ": {
-        "context": "OrderCustomer Fulfillment from All Warehouses",
-        "string": "Cumprir de todos os armazéns"
-    },
-    "/w919H": {
-        "context": "OrderCustomer Fulfillment from Local Warehouse",
-        "string": "Atender a partir do estoque local"
-    },
-    "AqXzM2": {
-        "string": "Pedido  #{orderNumber}"
-    },
-    "9ZtJhn": {
-        "context": "cancel button",
-        "string": "Cancelar pedido"
-    },
-    "maxT+q": {
-        "context": "save button",
-        "string": "Confirmar pedido"
-    },
-    "+RjQjs": {
-        "context": "return button",
-        "string": "Pedido de devolução/substituição"
-    },
-    "QSnh4Y": {
-        "context": "add button label",
-        "string": "Adicionar"
-    },
-    "nvSJNR": {
-        "context": "discount reason input lavel",
-        "string": "Razão"
-    },
-    "GAmGog": {
-        "context": "value input label",
-        "string": "Valor de descontro"
-    },
-    "fo7nfa": {
-        "context": "fixed amount",
-        "string": "Quantia Fixa"
-    },
-    "IN5iJz": {
-        "context": "value input helper text",
-        "string": "Valor inválido"
-    },
-    "WTj17Z": {
-        "context": "dialog title item discount",
-        "string": "Item com desconto"
-    },
-    "YFDAaX": {
-        "context": "dialog title order discount",
-        "string": "Desconto neste pedido por:"
-    },
-    "WUf3Iu": {
-        "context": "percentage option",
-        "string": "Porcentagem"
-    },
-    "APcoSA": {
-        "context": "dialog header",
-        "string": "Excluir Rascunho do Pedido"
-    },
-    "mxtAFx": {
-        "string": "Tem certeza de que deseja excluir o rascunho #{orderNumber}?"
-    },
-    "32dfzI": {
-        "context": "price or ordered products",
-        "string": "Preço"
-    },
-    "nEWp+k": {
-        "context": "quantity of ordered products",
-        "string": "Quantidade"
-    },
-    "UD7/q8": {
-        "string": "Nenhum produto adicionado ao pedido"
-    },
-    "lVwmf5": {
-        "context": "total price of ordered products",
-        "string": "Total"
-    },
-    "Myx1Qp": {
-        "context": "add discount button",
-        "string": "Adicionar desconto"
-    },
-    "BjxQ3u": {
-        "context": "add shipping address first label",
-        "string": "adicione o endereço de entrega primeiro"
-    },
-    "Jb1/3V": {
-        "context": "add shipping carrier button",
-        "string": "Adicionar transportadora"
-    },
-    "+8v1ny": {
-        "context": "discount button",
-        "string": "Desconto"
-    },
-    "M9LXb5": {
-        "context": "no shipping carriers title",
-        "string": "Nenhuma transportadora aplicável"
-    },
-    "xUvWaP": {
-        "context": "subtotal price",
-        "string": "Subtotal"
-    },
-    "mQtoRO": {
-        "context": "taxes title",
-        "string": "Impostos (IVA incluído)"
-    },
-    "S/yAtJ": {
-        "context": "total price",
-        "string": "Total"
-    },
-    "18wvf7": {
-        "context": "section header",
-        "string": "Detalhes do Pedido"
-    },
-    "C50ahv": {
-        "context": "button",
-        "string": "Adicionar produtos"
-    },
-    "w2eTzO": {
-        "context": "placed orders counter",
-        "string": "{count}/{max} orders"
-    },
-    "LshEVn": {
-        "context": "button",
-        "string": "Criar pedido"
-    },
-    "7a1S4K": {
-        "context": "tab name",
-        "string": "Todos os Rascunhos"
-    },
-    "NJEe12": {
-        "string": "Pesquisar Rascunho"
-    },
-    "vwMO04": {
-        "context": "draft order",
-        "string": "Criado"
-    },
-    "iEeIhY": {
-        "context": "draft order",
-        "string": "Cliente"
-    },
-    "KIh25E": {
-        "string": "Nenhum rascunho de pedidos encontrado"
-    },
-    "ps0WUQ": {
-        "string": "Núm. do Pedido"
-    },
-    "hkENym": {
-        "string": "Cliente"
-    },
-    "mCP0UD": {
-        "context": "order draft creation date",
-        "string": "Data"
-    },
-    "1Uj0Wd": {
-        "context": "order draft total price",
-        "string": "Total"
-    },
-    "PAqicb": {
-        "context": "button",
-        "string": "Cancelar pedido"
-    },
-    "4Z14xW": {
-        "context": "button",
-        "string": "Finalizar"
-    },
-    "6u4K7e": {
-        "context": "page header",
-        "string": "Pedido"
-    },
-    "kPIZ65": {
-        "context": "page header",
-        "string": "Pedido  #{orderNumber}"
-    },
-    "CJpx4E": {
-        "context": "page header",
-        "string": "Nº do pedido {orderNumber} - Adicionar Faturamento"
-    },
-    "N5UuEK": {
-        "context": "header",
-        "string": "Ítens prontos para despacho"
-    },
-    "z9wQ/U": {
-        "context": "no variant stock in warehouse",
-        "string": "Sem estoque"
-    },
-    "vW3tb6": {
-        "context": "name",
-        "string": "Nome do Produto"
-    },
-    "Kg0Fiu": {
-        "context": "quantity of fulfilled products",
-        "string": "Quantidade para faturar"
-    },
-    "0VDwAP": {
-        "context": "checkbox label",
-        "string": "Enviar detalhes de envio para o cliente"
-    },
-    "fw+VAN": {
-        "context": "product's sku",
-        "string": "SKU"
-    },
-    "BLX9dz": {
-        "context": "fulfill order, button",
-        "string": "Faturar"
-    },
-    "Uh9R9m": {
-        "context": "prepare order fulfillment, button",
-        "string": "Prepare fulfillment"
-    },
-    "bS7A8u": {
-        "context": "add tracking button",
-        "string": "Adicionar rastreamento"
-    },
-    "dTkmON": {
-        "context": "edit tracking button",
-        "string": "Editar rastreamento"
-    },
-    "K//bUK": {
-        "context": "refund button",
-        "string": "Restituição"
-    },
-    "4PlW0w": {
-        "context": "tracking number",
-        "string": "Código de Rastreamento: {trackingNumber}"
-    },
-    "EHsnZX": {
-        "context": "dialog description",
-        "string": "Tem certeza de que deseja aprovar este cumprimento?"
-    },
-    "SqhC7g": {
-        "context": "checkbox label, fulfillment approval",
-        "string": "Enviar detalhes de envio para o cliente"
-    },
-    "UQu75k": {
-        "context": "dialog header",
-        "string": "Approve this fulfillment"
-    },
-    "xco5tZ": {
-        "string": "Tem certeza de que deseja cancelar o faturamento? O cancelamento de um faturamento reabastecerá os produtos em um depósito selecionado."
-    },
-    "aHc89n": {
-        "context": "select warehouse to restock items",
-        "string": "Selecionar Depósito"
-    },
-    "bb4nSp": {
-        "context": "dialog header",
-        "string": "Cancelar faturamento"
-    },
-    "2MKkgX": {
-        "context": "checkbox label",
-        "string": "Permitir atendimento sem pagamento"
-    },
-    "XwQQ1f": {
-        "context": "checkbox label description",
-        "string": "Todos os cumprimentos serão aprovados automaticamente"
-    },
-    "05hqq6": {
-        "context": "checkbox label",
-        "string": "Aprovar automaticamente todos os cumprimentos"
-    },
-    "l9ETHu": {
-        "context": "checkbox label description",
-        "string": "Você poderá entregar produtos sem capturar o pagamento do pedido."
-    },
-    "G3ay2p": {
-        "context": "section header",
-        "string": "Configurações de atendimento"
-    },
-    "yT/GAp": {
-        "string": "Código de rastreamento"
-    },
-    "/BJQIq": {
-        "context": "dialog header",
-        "string": "Adicionar Código de Rastreio"
-    },
-    "RLTaAR": {
-        "context": "order history message",
-        "string": "Endereço do pedido foi atualizado"
-    },
-    "fkplbE": {
-        "context": "order history message",
-        "string": "Pedido foi marcado como pago"
-    },
-    "nHmugP": {
-        "context": "order history message",
-        "string": "Faturados {quantidade} itens"
-    },
-    "GLy2UR": {
-        "context": "order history message",
-        "string": "Faturamento foi cancelado"
-    },
-    "GJAX0z": {
-        "context": "order history message",
-        "string": "Pedido foi realizado"
-    },
-    "OzHN0Z": {
-        "context": "order history message",
-        "string": "Links para os produtos digitais do pedido foram enviados"
-    },
-    "OKGd/k": {
-        "context": "order history message",
-        "string": " O pedido foi criado a partir do rascunho"
-    },
-    "4Z6BtA": {
-        "context": "order history message",
-        "string": "Confirmação de pagamento foi enviado ao cliente"
-    },
-    "wOeIR4": {
-        "context": "order history message",
-        "string": "Reabastecidos {quantidade} itens"
-    },
-    "6WRFp2": {
-        "context": "order history message",
-        "string": "Uma nota foi adicionada ao pedido"
-    },
-    "oQ27V4": {
-        "context": "order history message",
-        "string": "Order placed information was sent to customer"
-    },
-    "cqZ5UH": {
-        "context": "order history message",
-        "string": "A confirmação do pedido foi enviada ao cliente"
-    },
-    "chvryR": {
-        "context": "order history message",
-        "string": "A fatura foi solicitada por {requestBy}"
-    },
-    "8RnPGF": {
-        "context": "order history message",
-        "string": "Pagamento foi cancelado"
-    },
-    "fehqPs": {
-        "context": "order history message",
-        "string": "Os produtos foram excluídos de um pedido"
-    },
-    "P/EDn1": {
-        "context": "order history message",
-        "string": "Pedido foi pago"
-    },
-    "ubasgL": {
-        "context": "order history message",
-        "string": "Pedido foi confirmado"
-    },
-    "2yV+s8": {
-        "context": "order history message",
-        "string": "Pagamento foi capturado"
-    },
-    "aq5ZiN": {
-        "context": "order history message",
-        "string": "A confirmação de faturamento foi enviada ao cliente"
-    },
-    "hWO1SD": {
-        "context": "order history message",
-        "string": "O rascunho do pedido foi criado"
-    },
-    "GVM/fi": {
-        "context": "order history message",
-        "string": "Pagamento foi autorizado"
-    },
-    "j3yE7I": {
-        "context": "order history message",
-        "string": "Número de rastreio foi enviado ao cliente"
-    },
-    "3fgyFh": {
-        "context": "order history message",
-        "string": "O pagamento foi reembolsado"
-    },
-    "D3WUc/": {
-        "context": "order history message",
-        "string": "Pedido foi reembolsado por {refundedBy}"
-    },
-    "U1eJIw": {
-        "context": "order history message",
-        "string": "Os produtos foram adicionados a um pedido"
-    },
-    "PcPMjC": {
-        "context": "order history message",
-        "string": "O cumprimento aguarda aprovação"
-    },
-    "6RQKxH": {
-        "context": "order history message",
-        "string": "Fatura {invoiceNumber} foi atualizada"
-    },
-    "XBfvKN": {
-        "string": "Histórico de pedidos"
-    },
-    "Fl3ORD": {
-        "context": "order history message",
-        "string": "{quantity} itens vendidos extra"
-    },
-    "9piUVz": {
-        "context": "order history message",
-        "string": "As informações de reembolso do pedido foram enviadas ao cliente"
-    },
-    "e92Uxp": {
-        "context": "order history message",
-        "string": "Número de rastreio do grupo de faturamento atualizado"
-    },
-    "TCR639": {
-        "context": "order history message",
-        "string": "Falha no pagamento"
-    },
-    "06bR4Z": {
-        "context": "order history message",
-        "string": "Informações de cancelamento do pedido foram enviadas ao cliente"
-    },
-    "BCPrmK": {
-        "context": "order history message",
-        "string": "Detalhes do envio foram enviados ao cliente"
-    },
-    "pTpx0p": {
-        "context": "order history message",
-        "string": "Fatura nº {invoiceNumber} foi gerada por {generatedBy}"
-    },
-    "qddy2Z": {
-        "context": "order history message",
-        "string": "A fatura foi enviada ao cliente por {sentBy} "
-    },
-    "zRrcOG": {
-        "context": "order history message",
-        "string": "Pedido foi cancelado"
-    },
-    "kVOslW": {
-        "context": "reason for discount label",
-        "string": "Motivo do desconto"
-    },
-    "kvSYZh": {
-        "context": "replacement created order history message description",
-        "string": "foi criado para produtos substituídos"
-    },
-    "A0Wlg7": {
-        "context": "product discount removed title",
-        "string": "{productName} desconto foi removido por"
-    },
-    "MPfyne": {
-        "string": "Tem certeza de que deseja enviar esta fatura: {invoiceNumber} para o cliente?"
-    },
-    "5JT4v2": {
-        "context": "dialog header",
-        "string": "Enviar Fatura"
-    },
-    "Gzg8hy": {
-        "context": "section header",
-        "string": "Faturas"
-    },
-    "F0AXNs": {
-        "context": "invoice create date prefix",
-        "string": "criado"
-    },
-    "hPB89Y": {
-        "string": "Número de faturas para exibição"
-    },
-    "m6IBe5": {
-        "context": "invoice number prefix",
-        "string": "Fatura"
-    },
-    "e0RKe+": {
-        "context": "generate invoice button",
-        "string": "Gerar"
-    },
-    "zyceue": {
-        "context": "placed order counter",
-        "string": "{count}/{max} pedidos"
-    },
-    "WbV1Xm": {
-        "context": "button",
-        "string": "Configurações do Pedido"
-    },
-    "wTHjt3": {
-        "string": "Pesquisar Pedidos..."
-    },
-    "WRkCFt": {
-        "context": "tab name",
-        "string": "Todos os Pedidos"
-    },
-    "lJP1iw": {
-        "context": "order",
-        "string": "Canal"
-    },
-    "biAxKR": {
-        "context": "click and collect",
-        "string": "Click&Collect"
-    },
-    "PzXIXh": {
-        "context": "order",
-        "string": "Cliente"
-    },
-    "JUQwne": {
-        "context": "order",
-        "string": "Gift Card"
-    },
-    "s5v6m0": {
-        "context": "order",
-        "string": "Vale-presente solicitado"
-    },
-    "Kgxlsf": {
-        "context": "order",
-        "string": "Pago com vale-presente"
-    },
-    "a4qX2+": {
-        "context": "order",
-        "string": "Criado"
-    },
-    "JYvf8/": {
-        "context": "is preorder",
-        "string": "Preorder"
-    },
-    "NWxomz": {
-        "string": "Status do faturamento"
-    },
-    "p+UDec": {
-        "context": "payment status",
-        "string": "Pagamento"
-    },
-    "5blVMu": {
-        "context": "e-mail or full name",
-        "string": "Cliente"
-    },
-    "PHUcrU": {
-        "context": "date when order was placed",
-        "string": "Data"
-    },
-    "k9hf7F": {
-        "context": "total order price",
-        "string": "Total"
-    },
-    "EbVf0Z": {
-        "context": "transaction reference",
-        "string": "Referência de transação"
-    },
-    "rwOx2s": {
-        "string": "Forneça uma referência de transação usando a entrada abaixo:"
-    },
-    "sfEbeB": {
-        "string": "Você vai marcar este pedido como pago."
-    },
-    "+B25o/": {
-        "context": "dialog header",
-        "string": "Marcar Pedido como Pago"
-    },
-    "+PbHKD": {
-        "context": "dialog header",
-        "string": "Capturar Pagamento"
-    },
-    "OhdPS1": {
-        "context": "amount of refunded money",
-        "string": "Montante"
-    },
-    "euRfu+": {
-        "string": "Tem certeza de que deseja cancelar este pagamento?"
-    },
-    "KszPFx": {
-        "context": "dialog header",
-        "string": "Cancelar Pagamento"
-    },
-    "BZ7BkQ": {
-        "context": "capture payment, button",
-        "string": "Receber"
-    },
-    "V+gwx7": {
-        "context": "order payment",
-        "string": "Quantidade capturada"
-    },
-    "ghGLbJ": {
-        "context": "OrderPayment click&collect shipping method",
-        "string": "click&collect"
-    },
-    "u0S2be": {
-        "context": "order discount",
-        "string": "Desconto"
-    },
-    "pr513b": {
-        "context": "ordered products",
-        "string": "{quantity} itens"
-    },
-    "+5HkZN": {
-        "context": "order, button",
-        "string": "Sinalizar como pago"
-    },
-    "5te3Tp": {
-        "context": "order payment",
-        "string": "Saldo excepcional"
-    },
-    "vM9quW": {
-        "context": "order payment",
-        "string": "Paid with Gift Card"
-    },
-    "SC/eNC": {
-        "context": "Payment card title",
-        "string": "Status do pagamento"
-    },
-    "uUsZ7m": {
-        "context": "order payment",
-        "string": "Quantidade pré-autorizada"
-    },
-    "HaQ8cg": {
-        "context": "button",
-        "string": "Restituição"
-    },
-    "q+gCyP": {
-        "context": "order payment",
-        "string": "Valor reembolsado"
-    },
-    "+CeEe3": {
-        "context": "order shipping method name",
-        "string": "Envio"
-    },
-    "uzAPCt": {
-        "context": "OrderPayment does not require shipping",
-        "string": "não aplica"
-    },
-    "Rsknyh": {
-        "context": "order does not require shipping",
-        "string": "não aplica"
-    },
-    "QJG+d/": {
-        "context": "staff added type order discount",
-        "string": "Staff added"
-    },
-    "T8rvXs": {
-        "context": "order subtotal price",
-        "string": "Subtotal"
-    },
-    "r+dgiv": {
-        "string": "Impostos"
-    },
-    "zb4eBO": {
-        "context": "order total price",
-        "string": "Total"
-    },
-    "dJVXIb": {
-        "context": "vat included in order price",
-        "string": "IVA incluido"
-    },
-    "sEjRyz": {
-        "context": "voucher type order discount",
-        "string": "Cupom"
-    },
-    "myyWNp": {
-        "context": "dialog header",
-        "string": "Adicionar Produto"
-    },
-    "b810WJ": {
-        "context": "product price",
-        "string": "Preço"
-    },
-    "WE8IFE": {
-        "context": "product name",
-        "string": "Produto"
-    },
-    "tvpAXl": {
-        "context": "ordered product quantity",
-        "string": "Quantidade"
-    },
-    "8J81ri": {
-        "context": "ordered product sku",
-        "string": "SKU"
-    },
-    "qT6YYk": {
-        "context": "order line total price",
-        "string": "Total"
-    },
-    "5aiFbL": {
-        "context": "tabel column header",
-        "string": "Preço"
-    },
-    "FNT4b+": {
-        "context": "tabel column header",
-        "string": "Produto"
-    },
-    "Tl+7X4": {
-        "context": "tabel column header",
-        "string": "Qtd reembolsada"
-    },
-    "2W4EBM": {
-        "context": "button",
-        "string": "Defina as quantidades máximas"
-    },
-    "+PclgM": {
-        "context": "tabel column header",
-        "string": "Total"
-    },
-    "xoyCZ/": {
-        "context": "error message",
-        "string": "Valor impróprio"
-    },
-    "MewrtN": {
-        "context": "section header",
-        "string": "Faturamento"
-    },
-    "H/f9KR": {
-        "context": "section header returned",
-        "string": "Cumprimento retornado"
-    },
-    "i/ZhxL": {
-        "context": "section header returned",
-        "string": "Cumprimento aguardando aprovação"
-    },
-    "0krqBj": {
-        "context": "page header",
-        "string": "Nº do pedido {orderNumber} - Reembolso"
-    },
-    "rVIlBs": {
-        "context": "page header with order number",
-        "string": "Pedido  #{orderNumber}"
-    },
-    "0oo+BT": {
-        "context": "section header",
-        "string": "Montante Reembolsado"
-    },
-    "8F2D1H": {
-        "context": "order refund amount, input button",
-        "string": "Reembolsar {currency} {amount}"
-    },
-    "JEIN47": {
-        "context": "label",
-        "string": "Quantidade Automática"
-    },
-    "FOehC/": {
-        "context": "label",
-        "string": "Quantidade Manual"
-    },
-    "EP+jcU": {
-        "context": "checkbox",
-        "string": "Reembolsar custos de envio"
-    },
-    "zzfj8H": {
-        "context": "label",
-        "string": "No refund"
-    },
-    "fbH51z": {
-        "context": "Amount error message",
-        "string": "O valor não pode ser maior do que o reembolso máximo"
-    },
-    "IKvOK+": {
-        "context": "Amount error message",
-        "string": "O valor deve ser maior que 0"
-    },
-    "L/O4LQ": {
-        "context": "order refund amount",
-        "string": "Quantidade Autorizada"
-    },
-    "lrq8O6": {
-        "context": "order refund amount, input label",
-        "string": "Montante"
-    },
-    "I7HyJZ": {
-        "context": "order refund amount",
-        "string": "Reembolso máximo"
-    },
-    "Q55cTG": {
-        "context": "order refund amount",
-        "string": "Reembolsado anteriormente"
-    },
-    "wDUBLR": {
-        "context": "order refund amount",
-        "string": "Valor de reembolso proposto"
-    },
-    "QkFeOa": {
-        "context": "order refund amount button",
-        "string": "Restituição"
-    },
-    "AKv2BI": {
-        "context": "order refund subtitle",
-        "string": "Itens reembolsados não podem ser processados"
-    },
-    "C6bb6x": {
-        "context": "order refund amount",
-        "string": "Reembolsar valor total"
-    },
-    "i56GGQ": {
-        "context": "order refund amount",
-        "string": "Valor dos produtos substituídos"
-    },
-    "bgO+7G": {
-        "context": "order return amount button",
-        "string": "Devolver e substituir produtos"
-    },
-    "Uo5/Ov": {
-        "context": "order return subtitle",
-        "string": "Itens devolvidos não podem ser processados"
-    },
-    "kak5vT": {
-        "context": "order refund amount",
-        "string": "Valor dos produtos selecionados"
-    },
-    "WGp+Fw": {
-        "context": "order refund amount",
-        "string": "Custo de transporte"
-    },
-    "B/y6LC": {
-        "context": "section header",
-        "string": "Produtos não faturados"
-    },
-    "iUIn50": {
-        "context": "section notice",
-        "string": "Produtos não faturados serão devolvidos ao estoque"
-    },
-    "bqAJCT": {
-        "context": "section header",
-        "string": "Pedido de Reembolso"
-    },
-    "LKpQYh": {
-        "context": "refund type",
-        "string": "Reembolso Diverso"
-    },
-    "CLB1k9": {
-        "context": "refund type",
-        "string": "Produtos de Reembolso"
-    },
-    "Y299ST": {
-        "context": "table column header",
-        "string": "Preço"
-    },
-    "0qg33z": {
-        "context": "table column header",
-        "string": "Return"
-    },
-    "aAAxKp": {
-        "context": "table column header",
-        "string": "Produto"
-    },
-    "ikM00B": {
-        "context": "table column header",
-        "string": "Substituir"
-    },
-    "EtkIxE": {
-        "context": "cancelled fulfillment, section header",
-        "string": "Cancelado ({quantity})"
-    },
-    "RlbhwF": {
-        "context": "product no longer exists error description",
-        "string": "Este produto não está mais no banco de dados, portanto não pode ser substituído nem devolvido"
-    },
-    "iJrw63": {
-        "context": "section header",
-        "string": "Faturado ({quantity})"
-    },
-    "ZPOyI1": {
-        "context": "fulfilled fulfillment, section header",
-        "string": "Cumprido a partir de {warehouseName}"
-    },
-    "oQhFlK": {
-        "context": "refunded fulfillment, section header",
-        "string": "Reembolsado ({quantity})"
-    },
-    "jNSOSu": {
-        "context": "cancelled fulfillment, section header",
-        "string": "Reembolsado e Devolvido ({quantity})"
-    },
-    "3stu21": {
-        "context": "refunded fulfillment, section header",
-        "string": "Substituído ({quantity})"
-    },
-    "eCRaHe": {
-        "context": "refunded fulfillment, section header",
-        "string": "Devolvido ({quantity})"
-    },
-    "p4zuQp": {
-        "context": "product no longer exists error title",
-        "string": "O produto não existe mais"
-    },
-    "NxRsHQ": {
-        "context": "section header",
-        "string": "Cumprimento - #{fulfilmentId}"
-    },
-    "BkFke9": {
-        "context": "section header",
-        "string": "Itens não cumpridos"
-    },
-    "/xXvjF": {
-        "context": "section header",
-        "string": "Não faturado"
-    },
-    "9ssWj+": {
-        "context": "unapproved fulfillment, section header",
-        "string": "Esperando aprovação ({quantity})"
-    },
-    "BBIQxQ": {
-        "context": "page header",
-        "string": "Pedido nº. {orderNumber} - Substituir/Devolver"
-    },
-    "Vu9nol": {
-        "context": "header",
-        "string": "Configurações do Pedido"
-    },
-    "yuiyES": {
-        "string": "Configurações Gerais"
-    },
-    "CLYlsu": {
-        "context": "section header",
-        "string": "Configurações"
-    },
-    "7UG1Lx": {
-        "context": "checkbox gift cards label",
-        "string": "Processar automaticamente cartões-presente que não podem ser enviados"
-    },
-    "Nfh9QM": {
-        "context": "checkbox gift cards label description",
-        "string": "quando ativados, os cartões-presente não entregáveis serão automaticamente definidos como cumpridos e enviados ao cliente"
-    },
-    "wpAXKX": {
-        "context": "checkbox label description",
-        "string": "Todos os pedidos serão confirmados automaticamente e todos os pagamentos serão capturados."
-    },
-    "RLYfMF": {
-        "context": "checkbox label",
-        "string": "Confirmar automaticamente todos os pedidos"
-    },
-    "V/YxJa": {
-        "context": "dialog header",
-        "string": "Editar Método de Envio"
-    },
-    "/Xwjww": {
-        "context": "button",
-        "string": "Faturar"
-    },
-    "ND5x+V": {
-        "string": "Estamos gerando a fatura que você solicitou. Por favor, aguarde um momento"
-    },
-    "9RCuN3": {
-        "string": "Pagamento capturado com sucesso"
-    },
-    "c4gbXr": {
-        "string": "Rascunho do pedido finalizado com sucesso"
-    },
-    "9OtpHt": {
-        "string": "Linha de pedido excluída"
-    },
-    "CZmloB": {
-        "string": "Faturamento atualizado com sucesso"
-    },
-    "Fn3bE0": {
-        "string": "Linha de pedido atualizada"
-    },
-    "lL1HTg": {
-        "string": "Pedido sinalizado como pago"
-    },
-    "HlCkMT": {
-        "string": "Linha do pedido adicionada"
-    },
-    "W/Es0H": {
-        "string": "Pedido cancelado com sucesso"
-    },
-    "KmPicj": {
-        "string": "Anotação adicionada com sucesso"
-    },
-    "L87bp7": {
-        "string": "Pagamento do pedido cancelado com sucesso"
-    },
-    "j2fPVo": {
-        "string": "Pedido atualizado com sucesso"
-    },
-    "+sX7yS": {
-        "string": "Cumprimento aprovado com sucesso"
-    },
-    "3u+4NZ": {
-        "string": "E-mail da fatura enviado"
-    },
-    "PKJqcq": {
-        "string": "Fatura está sendo gerada"
-    },
-    "7U8GRy": {
-        "string": "Forma de envio atualizada com sucesso"
-    },
-    "uMpv1v": {
-        "string": "Faturamento cancelado com sucesso"
-    },
-    "TLNf6K": {
-        "context": "window title",
-        "string": "Rascunho do pedido # {orderNumber}"
-    },
-    "GbBCmr": {
-        "context": "window title",
-        "string": "Pedido  #{orderNumber}"
-    },
-    "qbmeUI": {
-        "context": "dialog header",
-        "string": "Excluir rascunhos de pedido"
-    },
-    "ra2O4j": {
-        "string": "Excluir pedidos de rascunho"
-    },
-    "6udlH+": {
-        "string": "Rascunho do pedido criado com sucesso"
-    },
-    "Q6VRrE": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza que deseja excluir este rascunho de pedido?} other {Tem certeza que deseja excluir {displayQuantity} rascunhos de pedido?}}"
-    },
-    "2MKBk2": {
-        "context": "window title",
-        "string": "Faturar pedido nº {orderNumber}"
-    },
-    "CYEnGq": {
-        "context": "order fulfilled success message",
-        "string": " Itens Faturados"
-    },
-    "NzifUg": {
-        "context": "window title",
-        "string": "Faturar Pedido"
-    },
-    "XRf1Bi": {
-        "context": "order refunded success message",
-        "string": "Itens Reembolsados"
-    },
-    "XQBVEJ": {
-        "context": "order return error description when cannot refund",
-        "string": "Encontramos um problema ao reembolsar os produtos. Os produtos não foram reembolsados. Por favor, tente novamente."
-    },
-    "l9Lwjh": {
-        "context": "order return error title when cannot refund",
-        "string": "Não foi possível reembolsar produtos"
-    },
-    "/z9uo1": {
-        "context": "order returned success message",
-        "string": "Produtos devolvidos com sucesso!"
-    },
-    "a9S9Je": {
-        "context": "page types section name",
-        "string": "Tipos de Página"
-    },
-    "kTr2o8": {
-        "string": "Nome do atributo"
-    },
-    "uxPpRx": {
-        "context": "button",
-        "string": "Atribuir atributo"
-    },
-    "nf3XSt": {
-        "context": "attribute internal name",
-        "string": "Slug"
-    },
-    "iQxjow": {
-        "context": "section header",
-        "string": "Atributos de conteúdo"
-    },
-    "2Zyit2": {
-        "context": "delete page types with its pages",
-        "string": "{counter,plural,one {Os tipos de página que você deseja excluir são usados ​​por algumas páginas. Excluir esses tipos de página também excluirá essas páginas. Tem certeza de que deseja excluir este tipo de página ? Depois de fazer isso, você não poderá reverter as alterações.} other {Os tipos de página que você deseja excluir são usados ​​por algumas páginas. Excluir esses tipos de página também excluirá essas páginas. Tem certeza de que deseja excluir {displayQuantity} tipos de página ? Depois de fazer isso, você não poderá reverter as alterações.}}"
-    },
-    "CcEwXH": {
-        "context": "dialog header",
-        "string": "Excluir Tipos de Página"
-    },
-    "RZmdM3": {
-        "context": "delete page types",
-        "string": "{counter,plural,one {Tem certeza de que deseja excluir este tipo de página? Depois de fazer isso, você não poderá reverter as alterações.} other {Tem certeza de que deseja excluir {displayQuantity} tipos de página? Depois de fazer isso, você não poderá reverter as alterações.}}"
-    },
-    "kZfIl/": {
-        "string": "Estas são informações gerais sobre este tipo de conteúdo."
-    },
-    "OVOU1z": {
-        "context": "section header",
-        "string": "Metadados"
-    },
-    "caqRmN": {
-        "context": "header",
-        "string": "Criar Tipo de Página"
-    },
-    "lct0qd": {
-        "string": "Esta lista exibe todos os atributos que serão atribuídos às páginas que possuem este tipo de página atribuído."
-    },
-    "jWna9Q": {
-        "string": "Nome do tipo de conteúdo"
-    },
-    "umsU70": {
-        "string": "Pesquisar Tipo de Página"
-    },
-    "6JlXeD": {
-        "context": "button",
-        "string": "Criar tipo de página"
-    },
-    "oVDZUb": {
-        "context": "tab name",
-        "string": "Todos Tipos de Página"
-    },
-    "BQ2NVl": {
-        "context": "page type name",
-        "string": "Nome do tipo de conteúdo"
-    },
-    "6fORLY": {
-        "string": "Nenhum tipo de página encontrado"
-    },
-    "oHbgcK": {
-        "context": "PageTypeDeleteWarningDialog title",
-        "string": "Excluir página {selectedTypesCount,plural,one{type} other{types}}"
-    },
-    "I8mqqj": {
-        "context": "PageTypeDeleteWarningDialog single assigned items button label",
-        "string": "View pages"
-    },
-    "Rpfa+t": {
-        "context": "dialog header",
-        "string": "Cancelar atribuição de atributo do tipo de página"
-    },
-    "NGc9kE": {
-        "string": "Tipo de página excluído"
-    },
-    "WFG7Zk": {
-        "context": "unassign attribute from page type, button",
-        "string": "Não vinculado"
-    },
-    "/L8wzi": {
-        "context": "dialog header",
-        "string": "Cancelar atribuição de atributo do tipo de página"
-    },
-    "5bJ26s": {
-        "string": "Tipo de página criado com sucesso"
-    },
-    "H6NsC1": {
-        "context": "pages section name",
-        "string": "Páginas"
-    },
-    "gr53VQ": {
-        "context": "page header",
-        "string": "Criar Página"
-    },
-    "jZbT0O": {
-        "string": "Adicione título e descrição ao mecanismo de busca para facilitar a localização desta página"
-    },
-    "GZgjK7": {
-        "context": "page",
-        "string": "irá ficar visivel a partir de  {date}"
-    },
-    "X26jCC": {
-        "context": "page label",
-        "string": "Visível"
-    },
-    "/TK7QD": {
-        "context": "page label",
-        "string": "Oculto"
-    },
-    "gMwpNC": {
-        "context": "page content",
-        "string": "Conteúdo"
-    },
-    "gr+oXW": {
-        "context": "page title",
-        "string": "Título"
-    },
-    "AHRDWt": {
-        "context": "button",
-        "string": "Criar página"
-    },
-    "Of19Pn": {
-        "context": "Types",
-        "string": "Tipos de Página"
-    },
-    "UW1fLs": {
-        "context": "search pages placeholder",
-        "string": "Páginas de pesquisa"
-    },
-    "V2+HTM": {
-        "context": "dialog header",
-        "string": "Título"
-    },
-    "5GSYCR": {
-        "context": "page status",
-        "string": "Visibilidade"
-    },
-    "iMJka8": {
-        "string": "Nenhuma página encontrada"
-    },
-    "I8dAAe": {
-        "context": "page internal name",
-        "string": "Slug"
-    },
-    "G1KzEx": {
-        "context": "page status",
-        "string": "Publicado "
-    },
-    "UN3qWD": {
-        "context": "page status",
-        "string": "Não publicado"
-    },
-    "ufD5Jr": {
-        "string": "Tipo de Conteúdo"
-    },
-    "jU9GPX": {
-        "context": "section header",
-        "string": "Organizar Conteúdo"
-    },
-    "mX7zJJ": {
-        "context": "header",
-        "string": "Criar Página"
-    },
-    "JMbFNo": {
-        "string": "Nova página criada com sucesso"
-    },
-    "C1luwg": {
-        "context": "dialog header",
-        "string": "Excluir Página"
-    },
-    "4B32Ba": {
-        "context": "delete page",
-        "string": "Tem certeza de que deseja excluir {title}?"
-    },
-    "41z2Qi": {
-        "context": "notification",
-        "string": "Páginas removidas"
-    },
-    "yEmwxD": {
-        "context": "publish page, button",
-        "string": "Publicado"
-    },
-    "yHQQMQ": {
-        "context": "dialog header",
-        "string": "Páginas Não Publicadas"
-    },
-    "Wd8vG7": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza de que deseja cancelar a publicação desta página?} other {Tem certeza de que deseja cancelar a publicação de {displayQuantity} páginas?}}"
-    },
-    "F8gsds": {
-        "context": "unpublish page, button",
-        "string": "Remover"
-    },
-    "wyvzh9": {
-        "context": "dialog header",
-        "string": "Publicar Páginas"
-    },
-    "WRPQMM": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza de que deseja publicar esta página?} other {Tem certeza de que deseja publicar {displayQuantity} páginas?}}"
-    },
-    "UNwG+4": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza que deseja excluir esta página?} other {Tem certeza que deseja excluir  {displayQuantity}  páginas?}}"
-    },
-    "AzshS2": {
-        "context": "notification",
-        "string": "Páginas Publicadas"
-    },
-    "3Sz1/t": {
-        "context": "dialog header",
-        "string": "Excluir Páginas"
-    },
-    "2pw5dQ": {
-        "context": "payment status",
-        "string": "Totalmente pago"
-    },
-    "PbqNhi": {
-        "context": "order status",
-        "string": "Parcialmente faturado"
-    },
-    "INNPVX": {
-        "context": "payment status",
-        "string": "Parcialmente pago"
-    },
-    "OGemtu": {
-        "context": "payment status",
-        "string": "Parcialmente reembolsado"
-    },
-    "26BKkX": {
-        "context": "order status",
-        "string": "Parcialmente devolvido"
-    },
-    "6D+yYX": {
-        "string": "Status do pagamento"
-    },
-    "hLUYBt": {
-        "context": "payment status",
-        "string": "Pendente"
-    },
-    "DNTxWr": {
-        "context": "permission groups section name",
-        "string": "Grupos de Permissão"
-    },
-    "jUuHVn": {
-        "context": "description",
-        "string": "Nenhum membro encontrado"
-    },
-    "UQ4Kuh": {
-        "context": "input label",
-        "string": "Pesquisar Membros da Equipe"
-    },
-    "6sjBvJ": {
-        "context": "input placeholder",
-        "string": "Pesquisar por nome, e-mail, etc..."
-    },
-    "9Zlogd": {
-        "context": "staff member status",
-        "string": "Ativo"
-    },
-    "7WzUxn": {
-        "context": "staff member status",
-        "string": "Inativo"
-    },
-    "DPz5y6": {
-        "context": "dialog header",
-        "string": "Atribuir Membros da Equipe"
-    },
-    "lT5MYM": {
-        "context": "dialog title",
-        "string": "Cancelar atribuição de usuários"
-    },
-    "H/o4Ex": {
-        "context": "dialog content",
-        "string": "Você não pode modificar os membros deste grupo. Resolva este problema para continuar com o pedido."
-    },
-    "mAabef": {
-        "context": "checkbox label",
-        "string": "O grupo tem acesso total à loja"
-    },
-    "CYZse9": {
-        "context": "card description",
-        "string": "Expanda ou restrinja as permissões do grupo para acessar determinada parte do sistema Saleor."
-    },
-    "sR0urA": {
-        "context": "dialog content",
-        "string": "Tem certeza de que deseja excluir {name}?"
-    },
-    "L6+p8a": {
-        "context": "dialog title",
-        "string": "Excluir grupo de permissão"
-    },
-    "O22NIZ": {
-        "context": "deletion error message",
-        "string": "Não é possível excluir o grupo que está fora do seu escopo de permissão"
-    },
-    "rs815i": {
-        "context": "text field label",
-        "string": "Nome do grupo"
-    },
-    "5ftg/B": {
-        "context": "button",
-        "string": "criar grupo de permissão"
-    },
-    "szXISP": {
-        "context": "permission group name",
-        "string": "Nome do Grupo de Permissão"
-    },
-    "+a+2ug": {
-        "string": "Membros"
-    },
-    "wL7VAE": {
-        "string": "Ações"
-    },
-    "CXn88q": {
-        "string": "Nenhum grupo de permissão encontrado"
-    },
-    "gVD1os": {
-        "context": "empty list message",
-        "string": "Você ainda não atribuiu nenhum membro a este grupo de permissão."
-    },
-    "qrWOxx": {
-        "string": "Nenhum membro encontrado"
-    },
-    "xxQxLE": {
-        "string": "Endereço de e-mail"
-    },
-    "OhFGpX": {
-        "context": "button",
-        "string": "Atribuir membros"
-    },
-    "zD7/M6": {
-        "context": "empty list message",
-        "string": "Use o botão Designar membros para fazer isso."
-    },
-    "lGlDEH": {
-        "context": "header",
-        "string": "Membros do grupo"
-    },
-    "W32xfN": {
-        "context": "staff member full name",
-        "string": "Nome"
-    },
-    "XGBsoK": {
-        "context": "dialog content",
-        "string": "Tem certeza de que deseja cancelar a atribuição de {counter, plural, one {this member} outros {{displayQuantity} members}}?"
-    },
-    "eUjFjW": {
-        "string": "Grupo de permissões criado"
-    },
-    "15PiOX": {
-        "context": "button title",
-        "string": "Não-assinado"
-    },
-    "DovGIa": {
-        "string": "Grupo de permissões excluído"
-    },
-    "WhvuCb": {
-        "context": "plugins section name",
-        "string": "Extensões"
-    },
-    "6aBkJm": {
-        "context": "section header",
-        "string": "Autorização"
-    },
-    "Aeq79M": {
-        "context": "PluginDetailsChannelsCard no channels subtitle",
-        "string": "As configurações do plug-in são comuns a todos os canais"
-    },
-    "IUeGzv": {
-        "context": "plugin name",
-        "string": "Nome da Extensão"
-    },
-    "bL/Wrc": {
-        "context": "plugin status",
-        "string": "Status"
-    },
-    "w424P4": {
-        "context": "section header",
-        "string": "Informação da Extensão e Status"
-    },
-    "FA+MRz": {
-        "string": "Set plugin as active"
-    },
-    "qCH2eZ": {
-        "context": "header",
-        "string": "Adicionar Valor ao Campo de Autorização"
-    },
-    "Xy2T+y": {
-        "context": "header",
-        "string": "Editar Campo de Autorização"
-    },
-    "Egyh2T": {
-        "context": "section header",
-        "string": "Configurações da Extensão"
-    },
-    "EtGDeK": {
-        "context": "header",
-        "string": "{pluginName} Detalhes"
-    },
-    "BtErCZ": {
-        "string": "Pesquisar Plugins..."
-    },
-    "aOelhW": {
-        "context": "tab name",
-        "string": "Todos os Plugins"
-    },
-    "T/dYnE": {
-        "context": "plugin filters error messages status",
-        "string": "O status não está selecionado"
-    },
-    "zQnYKn": {
-        "context": "status section subtitle",
-        "string": "Status do canal"
-    },
-    "TC/EOG": {
-        "context": "status section title",
-        "string": "Status no canal"
-    },
-    "gZHmaV": {
-        "context": "plugin filters error messages channels",
-        "string": "Nenhum canal selecionado"
-    },
-    "cwoN25": {
-        "context": "config type section title",
-        "string": "Tipo de configuração"
-    },
-    "Co2U4u": {
-        "string": "Nenhuma extensão encontrada"
-    },
-    "rQOS7K": {
-        "context": "status label active",
-        "string": "Ativo"
-    },
-    "ycrTBX": {
-        "context": "table header channel col label",
-        "string": "Channel"
-    },
-    "HedXnw": {
-        "context": "plugin channel availability status title",
-        "string": "{activeChannelsCount,plural, =0 {Deactivated} other {Active in {activeChannelsCount}}}"
-    },
-    "AijtXU": {
-        "context": "table header configuration col label",
-        "string": "Configuração"
-    },
-    "ho75Lr": {
-        "context": "status label deactivated",
-        "string": "Desativado"
-    },
-    "reP5Uf": {
-        "context": "global config plugin status popup description",
-        "string": "Plug-ins globais são definidos em todos os canais do seu comércio eletrônico. Apenas o status é mostrado para esses tipos de plug-ins"
-    },
-    "xTIKA/": {
-        "context": "PluginChannelConfigurationCell global title",
-        "string": "Global"
-    },
-    "QH74y5": {
-        "context": "table header name col label",
-        "string": "Nome"
-    },
-    "8u7els": {
-        "context": "channel config plugin status popup title",
-        "string": "Atribuído a {activeChannelsCount} de {allChannelsCount} canais"
-    },
-    "N6lfS/": {
-        "context": "header",
-        "string": " Exclusão de campo de autorização"
-    },
-    "JRfJD9": {
-        "string": "O plugin pode parar de funcionar depois que este campo for limpo. Tem certeza de que deseja continuar?"
-    },
-    "6QjMei": {
-        "string": "O horário de término da encomenda precisa ser definido no futuro"
-    },
-    "YQ3EXR": {
-        "context": "product types section name",
-        "string": "Tipos de Produto"
-    },
-    "9scTQ0": {
-        "context": "section header",
-        "string": "Atributos do Produto"
-    },
-    "5pHBSU": {
-        "context": "switch button",
-        "string": "Tipo do produto usa Atributos de Variação"
-    },
-    "7nKXni": {
-        "context": "option description",
-        "string": "Este produto funcionará como forma de pagamento"
-    },
-    "kp2IYP": {
-        "context": "option",
-        "string": "Tipo de produto de vale-presente"
-    },
-    "xRbqcg": {
-        "context": "option",
-        "string": "Tipo de produto normal"
-    },
-    "H5yp8O": {
-        "context": "label",
-        "string": "Nome do Tipo de Produto"
-    },
-    "1KSqnn": {
-        "context": "tab name",
-        "string": "Todos os Tipos de Produtos"
-    },
-    "rpFdD1": {
-        "string": "Pesquisar Tipo de Produto"
-    },
-    "QY7FSs": {
-        "context": "button",
-        "string": "criar tipo de produto"
-    },
-    "X90t9n": {
-        "context": "product type",
-        "string": "Configurável"
-    },
-    "dS8Adx": {
-        "context": "product",
-        "string": "Digital"
-    },
-    "U5aVd8": {
-        "context": "product",
-        "string": "Entregável"
-    },
-    "Jsh6+U": {
-        "context": "product type is digital or physical",
-        "string": "Tipo"
-    },
-    "0nLsyM": {
-        "string": "Nenhum tipo de produto encontrado"
-    },
-    "yNb+dT": {
-        "context": "product type",
-        "string": "Produto simples"
-    },
-    "TalJlD": {
-        "context": "tax rate for a product type",
-        "string": "Imposto"
-    },
-    "jyTwDR": {
-        "context": "product type is either simple or configurable",
-        "string": "Tipo"
-    },
-    "hHOI7D": {
-        "context": "product type name",
-        "string": "Nome do Tipo"
-    },
-    "asdvmK": {
-        "context": "product type",
-        "string": "Digital"
-    },
-    "ADTNND": {
-        "context": "product type",
-        "string": "Físico"
-    },
-    "/2OOMe": {
-        "context": "product type shipping settings, section header",
-        "string": "Envio"
-    },
-    "IBw72y": {
-        "context": "switch button",
-        "string": "Este produto pode ser entregue?"
-    },
-    "VOiUXQ": {
-        "string": "Usado para calcular taxas de envio para produtos deste tipo, quando o peso específico não é informado"
-    },
-    "zCb8fX": {
-        "string": "Peso"
-    },
-    "vlLyvk": {
-        "string": "{inputType} atributos não podem ser usados ​​como atributos de seleção de variantes."
-    },
-    "4k9rMQ": {
-        "context": "variant attribute checkbox",
-        "string": "Seleção de variante"
-    },
-    "skEK/i": {
-        "context": "section header",
-        "string": "Atributos da Variação"
-    },
-    "x3leH4": {
-        "context": "ProductTypeDeleteWarningDialog title",
-        "string": "Deletar produto {selectedTypesCount,plural,one{type} other{types}}"
-    },
-    "GCPzKf": {
-        "context": "ProductTypeDeleteWarningDialog single assigned items button label",
-        "string": "Ver produtos"
-    },
-    "paa4m0": {
-        "string": "Tipo de produto criado com sucesso"
-    },
-    "F3Upht": {
-        "string": "Tipo de produto excluído"
-    },
-    "UJnqdm": {
-        "context": "dialog header",
-        "string": "Cancelar atribuição de atributo do tipo de produto"
-    },
-    "r1aQ2f": {
-        "context": "dialog header",
-        "string": "Cancelar atribuição de atributo do tipo de produto"
-    },
-    "S7j+Wf": {
-        "context": "unassign attribute from product type, button",
-        "string": "Não-assinado"
-    },
-    "K8xNLe": {
-        "context": "products section name",
-        "string": "Produtos"
-    },
-    "ulh3kf": {
-        "string": "Coleções"
-    },
-    "fyE8BN": {
-        "context": "product organization, header",
-        "string": "Empresa"
-    },
-    "LKoIB1": {
-        "string": "Adicione título e descrição ao mecanismo de busca para facilitar a localização deste produto"
-    },
-    "L7N+0y": {
-        "context": "product rating",
-        "string": "Avaliação do Produto"
-    },
-    "JGm7E5": {
-        "context": "option",
-        "string": "Exportar estoque para todos os depósitos"
-    },
-    "ZDJEat": {
-        "context": "button",
-        "string": "Carregar Mais"
-    },
-    "ve/Sph": {
-        "context": "there are more elements of list that are hidden",
-        "string": "e {number} mais"
-    },
-    "64aYF0": {
-        "context": "informations about product organization, header",
-        "string": "Organização do Produto"
-    },
-    "6xC/Ls": {
-        "context": "informations about product seo, header",
-        "string": " Informação SEO"
-    },
-    "qEZ463": {
-        "context": "export selected items to csv file",
-        "string": "Produtos selecionados ({number})"
-    },
-    "g6yuk2": {
-        "context": "export items to csv file, choice field label",
-        "string": "Exportar informações para:"
-    },
-    "xtUXnK": {
-        "context": "export all items to csv file",
-        "string": "Todos os produtos ({number})"
-    },
-    "WQMTKI": {
-        "context": "list of warehouses",
-        "string": "Depósitos A a Z"
-    },
-    "/68iG8": {
-        "context": "product export to csv file, header",
-        "string": "Informações exportadas"
-    },
-    "z1puMb": {
-        "context": "export items as csv or spreadsheet file",
-        "string": "Exportar como:"
-    },
-    "ki7Mr8": {
-        "context": "product export to csv file, header",
-        "string": "Configurações de Exportação"
-    },
-    "lQRnYK": {
-        "context": "selectt all options",
-        "string": "Selecionar Tudo"
-    },
-    "9Tl/bT": {
-        "context": "export items as spreadsheet",
-        "string": "Planilha do Excel, Números etc."
-    },
-    "YicEbK": {
-        "string": "Atributos de Pesquisa"
-    },
-    "ZRz3hM": {
-        "string": "Exportar Quantidade em Estoque de Produto para CSV"
-    },
-    "xjpTLF": {
-        "context": "informations about product stock, header",
-        "string": "Informações de Estoque"
-    },
-    "li1BBk": {
-        "context": "export items as csv file",
-        "string": "Arquivo CSV"
-    },
-    "Jwuu4X": {
-        "context": "select product informations to be exported",
-        "string": "Informações exportadas:"
-    },
-    "tIc2/h": {
-        "context": "input helper text, search attributes",
-        "string": "Pesquisar por nome do atributo"
-    },
-    "SZt9kC": {
-        "context": "export filtered items to csv file",
-        "string": "Pesquisa atual ({number})"
-    },
-    "jj3Cb8": {
-        "context": "informations about product prices etc, header",
-        "string": "Informações Financeiras"
-    },
-    "oOFrUd": {
-        "context": "export products to csv file, button",
-        "string": "exportar produtos"
-    },
-    "dc5KWn": {
-        "context": "products export type label",
-        "string": "produtos"
-    },
-    "xkjRu5": {
-        "context": "export products to csv file, dialog header",
-        "string": "Informações de Exportação"
-    },
-    "zDvDnG": {
-        "context": "modal header",
-        "string": "A mídia do URL fornecido será mostrada na galeria de mídia. Você poderá definir a ordem da galeria."
-    },
-    "4W/CKn": {
-        "context": "modal button",
-        "string": "Upload URL"
-    },
-    "7FL+WZ": {
-        "context": "export products to csv file, button",
-        "string": "Exportar Produtos"
-    },
-    "FwHWUm": {
-        "context": "alert",
-        "string": "SKU limit reached"
-    },
-    "Kw0jHS": {
-        "context": "created products counter",
-        "string": "{count}/{max} SKUs used"
-    },
-    "kIvvax": {
-        "string": "Pesquisar Produtos..."
-    },
-    "aFLtLk": {
-        "context": "tab name",
-        "string": "Todos os Produtos"
-    },
-    "5Vwnu+": {
-        "string": "Você atingiu seu limite de SKU, não poderá mais adicionar SKUs à sua loja. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
-    },
-    "diOQm7": {
-        "context": "product status",
-        "string": "Disponível"
-    },
-    "pbGIUg": {
-        "context": "sales channel",
-        "string": "Canal"
-    },
-    "Bx367s": {
-        "context": "product is hidden",
-        "string": "Oculto"
-    },
-    "pBTTtU": {
-        "context": "product kind",
-        "string": "Tipo de produto"
-    },
-    "Sna+WK": {
-        "context": "product status",
-        "string": "Sem Estoque"
-    },
-    "b1zuN9": {
-        "string": "Preço"
-    },
-    "3Z8972": {
-        "context": "product",
-        "string": "Quantidade em estoque"
-    },
-    "g+GAf4": {
-        "context": "product visibility",
-        "string": "Visibilidade"
-    },
-    "6Y1nQd": {
-        "context": "product is visible",
-        "string": "Visível"
-    },
-    "Jz/Cb+": {
-        "context": "product type",
-        "string": "Simples"
-    },
-    "+VEhV8": {
-        "context": "product channels",
-        "string": "Disponibilidade"
-    },
-    "Sd0Ppm": {
-        "context": "product publication date",
-        "string": "publicado em {date}"
-    },
-    "qpQ0uB": {
-        "context": "product publication date",
-        "string": "Não publicado"
-    },
-    "kVTWtR": {
-        "context": "product updated at",
-        "string": "Ultima atualização"
-    },
-    "r0hgpM": {
-        "context": "product publication date",
-        "string": "Será publicado em {date}"
-    },
-    "XUU9sU": {
-        "context": "section header",
-        "string": "Todas as mídias"
-    },
-    "Ihp4D3": {
-        "context": "header",
-        "string": "Editar mídia"
-    },
-    "9RvXNg": {
-        "context": "section header",
-        "string": "Informações sobre mídia"
-    },
-    "cW1RIo": {
-        "context": "section header",
-        "string": "Visualização de mídia"
-    },
-    "9CEu8k": {
-        "context": "modal button images upload",
-        "string": "Upload Images"
-    },
-    "Q2UXlW": {
-        "context": "modal button url upload",
-        "string": "Upload URL"
-    },
-    "/Mcvt4": {
-        "context": "section header",
-        "string": "Media"
-    },
-    "mGiA6q": {
-        "context": "modal button upload",
-        "string": "Upload"
-    },
-    "JjeZEG": {
-        "context": "section header",
-        "string": "Organizar Produto"
-    },
-    "Be+J13": {
-        "string": "Configurável"
-    },
-    "v+Pkm+": {
-        "context": "field is optional",
-        "string": "*Opcional. Adicionar produtos à coleção ajuda os usuários a encontrá-lo."
-    },
-    "anK7jD": {
-        "string": "Tipo de produto"
-    },
-    "3rIMq/": {
-        "context": "product shipping",
-        "string": "Envio"
-    },
-    "SUbxSK": {
-        "context": "product weight",
-        "string": "Peso"
-    },
-    "eAFU/E": {
-        "context": "product inventory, checkbox",
-        "string": "Variante atualmente em pré-encomenda"
-    },
-    "2qJc9y": {
-        "string": "CANCELAR DATA DE TÉRMINO"
-    },
-    "7wkGxW": {
-        "context": "app has been installed",
-        "string": "{unitsLeft} unidades restantes"
-    },
-    "xB7BTp": {
-        "string": "SKU (Unidade de Manutenção de Estoque)"
-    },
-    "KTAg0f": {
-        "context": "tabel column header",
-        "string": "Nome do Depósito"
-    },
-    "7Ii5ZQ": {
-        "string": "DATA DE TÉRMINO DA CONFIGURAÇÃO"
-    },
-    "bp/i0x": {
-        "context": "header",
-        "string": "Quantidade"
-    },
-    "Gz+4CI": {
-        "context": "info text",
-        "string": "Os produtos pré-encomendados estarão disponíveis em todos os armazéns. Você pode definir um limite para a quantidade vendida. Deixar a entrada em branco será interpretado como sem limite de venda. Os itens vendidos serão alocados no armazém atribuído à zona de envio escolhida."
-    },
-    "NcY4ph": {
-        "string": "Limite que não pode ser excedido mesmo que os limites por canal ainda estejam disponíveis"
-    },
-    "JyQEHU": {
-        "context": "tabel column header",
-        "string": "Canais"
-    },
-    "TjGYna": {
-        "context": "product inventory, checkbox",
-        "string": "Monitorar Estoque"
-    },
-    "cBHRxx": {
-        "context": "button",
-        "string": "Atribuir Depósito"
-    },
-    "REVk27": {
-        "context": "info text",
-        "string": "Configure uma data de término da pré-encomenda. Quando a data de término for atingida, o produto será automaticamente transferido da pré-encomenda para a venda padrão"
-    },
-    "ekXood": {
-        "string": "Unlimited"
-    },
-    "RJ5QxE": {
-        "string": "Global threshold"
-    },
-    "jABdx1": {
-        "string": "O rastreamento ativo de estoque calculará automaticamente as mudanças de estoque"
-    },
-    "TfY/Pi": {
-        "context": "checkbox",
-        "string": "Cobrar impostos sobre este produto"
-    },
-    "CdIHMu": {
-        "context": "select tax ratte",
-        "string": "Taxa de imposto"
-    },
-    "iYH3Y7": {
-        "context": "checkbox",
-        "string": "Substituir a taxa de imposto do tipo de produto"
-    },
-    "8uo4v1": {
-        "context": "title",
-        "string": "Limites de finalização de compra"
-    },
-    "n3+6w5": {
-        "context": "input helper text",
-        "string": "Seu cliente não poderá comprar uma quantidade maior por finalização de compra do que a indicada aqui."
-    },
-    "C7I2lg": {
-        "context": "input label",
-        "string": "Limitar quantidade por finalização de compra (opcional)"
-    },
-    "W3JbSQ": {
-        "context": "create product variants",
-        "string": "Como você gostaria de criar variantes:"
-    },
-    "vXA5xU": {
-        "context": "option description",
-        "string": "Use o criador de variantes para criar uma matriz de valores de atributos selecionados para criar variantes"
-    },
-    "uxZZXx": {
-        "context": "option",
-        "string": "Criar múltiplas variantes via criador de variantes"
-    },
-    "EzU7KV": {
-        "context": "option description",
-        "string": "Criar nova variante usando a visão de detalhes da variante"
-    },
-    "9EMudJ": {
-        "context": "option",
-        "string": "Criar variante única"
-    },
-    "XDeh5D": {
-        "context": "dialog header",
-        "string": "Criar Variações"
-    },
-    "f3B4tc": {
-        "context": "attributes, section header",
-        "string": "Atributos da Variação"
-    },
-    "o6260f": {
-        "context": "attributes, section header",
-        "string": "Seleção de Atributos da Variação"
-    },
-    "7hNjaI": {
-        "context": "button",
-        "string": "Excluir Variação"
-    },
-    "sw8Wl2": {
-        "context": "variant pricing section subtitle",
-        "string": "There is no channel to define prices for. You need to first add variant to channels to define prices."
-    },
-    "U9CIo7": {
-        "context": "button",
-        "string": "Salvar Variação"
-    },
-    "TPCRKr": {
-        "context": "variant price, header",
-        "string": "Preço"
-    },
-    "ClFzoD": {
-        "string": "Os valores selecionados serão usados ​​para criar variações para o produto configurável."
-    },
-    "Xr5zxu": {
-        "string": "Suas escolhas adicionarão {variantsNumber} SKUs ao seu catálogo que excederão seu limite em {aboveLimitVariantsNumber}. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
-    },
-    "lVZ5n7": {
-        "context": "variant attribute",
-        "string": "Atributo"
-    },
-    "TDXskW": {
-        "context": "variant attribute",
-        "string": "Selecionar Atributo"
-    },
-    "7WEC+G": {
-        "context": "page title",
-        "string": "Preço e SKUs"
-    },
-    "GQcp83": {
-        "context": "variant stock, header",
-        "string": "Estoque e Armazenamento"
-    },
-    "NXpFlL": {
-        "context": "product attribute values, page title",
-        "string": "Escolha os Valores"
-    },
-    "CrbI/c": {
-        "context": "variant channel price",
-        "string": "Preço {channel}"
-    },
-    "rVaB7c": {
-        "context": "attribute values, variant creation step",
-        "string": "Selecione os Valores"
-    },
-    "ucYPtV": {
-        "context": "variant attribute",
-        "string": "Escolha o atributo"
-    },
-    "slKV5G": {
-        "context": "variant creation step",
-        "string": "Resumo"
-    },
-    "lra7Ej": {
-        "string": "Aplicar preço único a todos os SKUs"
-    },
-    "J0UdxG": {
-        "string": "Pular preços por enquanto"
-    },
-    "L5rthO": {
-        "string": "Aplicar estoque único por atributo a cada SKU"
-    },
-    "EGG8f+": {
-        "string": "Aplicar preços únicos por atributo a cada SKU"
-    },
-    "STp3Hl": {
-        "string": "Aplicar estoque único a todos os SKUs"
-    },
-    "+bFHzi": {
-        "context": "button",
-        "string": "Próximo"
-    },
-    "rHXF43": {
-        "string": "Aqui está o resumo das variações que serão criadas. Você pode alterar os preços, estocar um SKU para cada um criado."
-    },
-    "BIqhVQ": {
-        "string": "Pular estoque por enquanto"
-    },
-    "Q3j++G": {
-        "context": "create multiple variants, button",
-        "string": "Criar"
-    },
-    "S5PVx1": {
-        "context": "variant creator summary card header",
-        "string": "Variações Criadas"
-    },
-    "/Qb92c": {
-        "string": "Com base em suas seleções, criaremos {numberOfProducts} produtos. Use esta etapa para personalizar o preço e os estoques de seus novos produtos"
-    },
-    "k4brJy": {
-        "string": "SKU"
-    },
-    "Sx7QVu": {
-        "context": "variant creation step",
-        "string": "Preços e SKU"
-    },
-    "iigydN": {
-        "string": "Com base em suas seleções, criaremos 8 produtos. Use esta etapa para personalizar o preço e os estoques de seus novos produtos."
-    },
-    "esg2wu": {
-        "context": "previous step, button",
-        "string": "Anterior"
-    },
-    "V76IV7": {
-        "context": "variant name",
-        "string": "Variação"
-    },
-    "rbkmfG": {
-        "context": "button",
-        "string": "Excluir variação"
-    },
-    "WwNtFn": {
-        "context": "delete product variant",
-        "string": "Tem certeza de que deseja excluir {name}?"
-    },
-    "GFJabu": {
-        "context": "dialog header",
-        "string": "Excluir Variação"
-    },
-    "XMvH/d": {
-        "context": "button label",
-        "string": "ACEITAR"
-    },
-    "dTCWqt": {
-        "string": "Você está prestes a encerrar a pré-encomenda de seus produtos. Você vendeu {variantGlobalSoldUnits} unidades desta variante. As unidades vendidas serão alocadas em armazéns apropriados. Lembre-se de adicionar estoque limite restante aos armazéns."
-    },
-    "Y4cy0i": {
-        "context": "dialog header",
-        "string": "Encerrando a pré-encomenda"
-    },
-    "iPk640": {
-        "context": "dialog header",
-        "string": "Seleção de mídia"
-    },
-    "2J6EFz": {
-        "context": "button",
-        "string": "Escolha a mídia"
-    },
-    "JfKvrV": {
-        "context": "select variant media",
-        "string": "Selecione uma mídia variante específica na mídia do produto"
-    },
-    "vZMs8f": {
-        "context": "default product variant indicator",
-        "string": "Padrão"
-    },
-    "1kdQdO": {
-        "context": "section header",
-        "string": "Variações"
-    },
-    "3C3Nj5": {
-        "context": "button",
-        "string": "Adicionar variação"
-    },
-    "gF7hbK": {
-        "context": "variant name",
-        "string": "Nova Variação"
-    },
-    "EsZH44": {
-        "context": "VariantDetailsChannelsAvailabilityCard item subtitle hidden",
-        "string": "Oculto"
-    },
-    "rJ3lkW": {
-        "context": "VariantDetailsChannelsAvailabilityCard item subtitle published",
-        "string": "Publicado desde {publicationDate}"
-    },
-    "jqJqdE": {
-        "context": "VariantDetailsChannelsAvailabilityCard no items available",
-        "string": "Esta variante não está disponível em nenhum dos canais"
-    },
-    "3+KwtP": {
-        "context": "VariantDetailsChannelsAvailabilityCard subtitle",
-        "string": "Disponível em {publishedInChannelsCount} fora de {availableChannelsCount}"
-    },
-    "sedoZ3": {
-        "context": "VariantDetailsChannelsAvailabilityCard title",
-        "string": "Disponibilidade"
-    },
-    "Xm9qOu": {
-        "context": "product pricing, section header",
-        "string": "Preços"
-    },
-    "JFtFgc": {
-        "context": "tabel column header",
-        "string": "Preço de Venda"
-    },
-    "KQSONM": {
-        "context": "tabel column header",
-        "string": "Cost"
-    },
-    "VvA7ai": {
-        "context": "info text",
-        "string": "Os canais que não têm preços atribuídos usarão seu canal pai para definir o preço. O preço será convertido para a moeda do canal"
-    },
-    "c8UT0c": {
-        "context": "tabel column header",
-        "string": "Nome do Canal"
-    },
-    "2zCmiR": {
-        "context": "tabel column header",
-        "string": "Preço de custo"
-    },
-    "SZH0fw": {
-        "context": "set variant as default, button",
-        "string": "Tornar padrão"
-    },
-    "6+sMz4": {
-        "context": "product variant inventory",
-        "string": "Indisponível em todos os locais"
-    },
-    "7mK2vs": {
-        "context": "product variant inventory",
-        "string": "Indisponível"
-    },
-    "n02c9W": {
-        "context": "product variant price",
-        "string": "Preço"
-    },
-    "uVssds": {
-        "context": "product variant inventory",
-        "string": "{stockQuantity,plural,one {{stockQuantity} disponível} other {{stockQuantity} disponíveis}}"
-    },
-    "FSinkL": {
-        "context": "variant stock status",
-        "string": "Estoque disponível em:"
-    },
-    "HcjV6k": {
-        "context": "button",
-        "string": "Criar variações"
-    },
-    "qbqMpk": {
-        "context": "product variant preorder threshold",
-        "string": "Em pré-encomenda"
-    },
-    "wWYYBR": {
-        "context": "product variant inventory",
-        "string": "{numLocations,plural,one {{numAvailable} disponível em {numLocations} local} other {{numAvailable} disponíveis em {numLocations} locais}}"
-    },
-    "rIJbNC": {
-        "string": "Use variações para produtos que tenham uma variedade de versões, por exemplo diferentes tamanhos ou cores"
-    },
-    "JtZ71e": {
-        "context": "filtering option",
-        "string": "Todos os Depósitos"
-    },
-    "kL3C+K": {
-        "context": "product variant inventory status",
-        "string": "Inventário"
-    },
-    "3VyHbJ": {
-        "context": "button",
-        "string": "Criar Variação"
-    },
-    "9PmyrU": {
-        "context": "product variant inventory",
-        "string": "Sem estoque"
-    },
-    "80FeaT": {
-        "context": "product variant preorder threshold",
-        "string": "{globalThreshold} Limite global"
-    },
-    "OTek3r": {
-        "context": "product variant name",
-        "string": "Variação"
-    },
-    "uCn/rd": {
-        "context": "dialog header",
-        "string": "Excluir Imagem"
-    },
-    "BUKMzM": {
-        "string": "Variação Removida"
-    },
-    "T6dXGG": {
-        "context": "header",
-        "string": "Criar Variação"
-    },
-    "VEext+": {
-        "string": "Tem certeza de que deseja apagar esta imagem?"
-    },
-    "MyM2oR": {
-        "context": "window title",
-        "string": "Criar Variação"
-    },
-    "PXx4Jk": {
-        "context": "window title",
-        "string": "Criar Produto"
-    },
-    "NBP8uu": {
-        "context": "page header",
-        "string": "Novo Produto"
-    },
-    "DO8+uV": {
-        "string": "Produto criado"
-    },
-    "yDkmX7": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza que deseja excluir este produto?} other {Tem certeza que deseja excluir  {displayQuantity} produtos?}}"
-    },
-    "5QKsu+": {
-        "context": "waiting for export to end, header",
-        "string": "Exportando CSV"
-    },
-    "F4WdSO": {
-        "context": "dialog header",
-        "string": "Excluir Produtos"
-    },
-    "dPYqy0": {
-        "string": "Estamos atualmente exportando seu CSV solicitado. Assim que estiver disponível, ele será enviado a você no seu e-mail"
-    },
-    "YKyNm9": {
-        "context": "label",
-        "string": "Gift Card"
-    },
-    "X/K4LI": {
-        "context": "label",
-        "string": "Normal"
-    },
-    "vlVTmY": {
-        "string": "Produto removido"
-    },
-    "ZHF4Z9": {
-        "context": "delete product dialog subtitle",
-        "string": "Tem certeza de que deseja excluir {name}?"
-    },
-    "TWVx7O": {
-        "context": "delete product dialog title",
-        "string": "Excluir Produto"
-    },
-    "ukdRUv": {
-        "context": "delete variant dialog subtitle",
-        "string": "{counter,plural,one {Are you sure you want to delete this variant?} other {Are you sure you want to delete {displayQuantity} variants?}}"
-    },
-    "6iw4VR": {
-        "context": "delete variant dialog title",
-        "string": "Excluir Variações do Produto"
-    },
-    "oChkS4": {
-        "context": "success message",
-        "string": "Variações criadas com sucesso"
-    },
-    "z+wMgQ": {
-        "context": "window title",
-        "string": "Criar Variações"
-    },
-    "IeoGgH": {
-        "context": "variant created success message",
-        "string": "Variant created"
-    },
-    "aI80kg": {
-        "string": "Propriedades"
-    },
-    "kFYlu2": {
-        "string": "O sistema está no modo somente leitura. Alterações não foram salvas."
-    },
-    "rqtV5d": {
-        "context": "order status",
-        "string": "Pronto para capturar"
-    },
-    "oLMXDv": {
-        "context": "order status",
-        "string": "Pronto para faturar"
-    },
-    "XJSRDK": {
-        "context": "payment status",
-        "string": "Totalmente reembolsado"
-    },
-    "nwnwJ0": {
-        "context": "payment status",
-        "string": "Refused"
-    },
-    "bu/fC1": {
-        "context": "button",
-        "string": "Remover"
-    },
-    "TKmub+": {
-        "string": "Este campo é necessário"
-    },
-    "4Dc2j0": {
-        "context": "order status",
-        "string": "Devolvida"
-    },
-    "kJQczl": {
-        "context": "sales section name",
-        "string": "Vendas"
-    },
-    "RaycYK": {
-        "context": "button",
-        "string": "Salvar"
-    },
-    "rqiCWU": {
-        "string": "Alterações salvas"
-    },
-    "a+x05s": {
-        "context": "select option, button",
-        "string": "Selecione"
-    },
-    "rfvBAF": {
-        "context": "select all options, button",
-        "string": "Selecionar Tudo"
-    },
-    "byP6IC": {
-        "string": "Selecionado"
-    },
-    "hqVMLQ": {
-        "context": "button",
-        "string": "Enviar"
-    },
-    "8xsKUv": {
-        "context": "service accounts section name",
-        "string": "Contas de Serviço"
-    },
-    "Fvvgoi": {
-        "string": "Sua sessão expirou. Por favor faça o login novamente para continuar."
-    },
-    "D9ie4n": {
-        "context": "shipping section name",
-        "string": "Métodos de Envio"
-    },
-    "nNeWAx": {
-        "context": "dialog header",
-        "string": "Excluir Forma de Envio"
-    },
-    "ER/yBq": {
-        "context": "max price in channel",
-        "string": "Valor Máx."
-    },
-    "aZDHYr": {
-        "context": "price rates info",
-        "string": "Esta taxa será aplicada a todos os pedidos"
-    },
-    "kN6SLs": {
-        "string": "Valor Min."
-    },
-    "u5c/tR": {
-        "context": "channels discount info",
-        "string": "Os canais que não têm descontos atribuídos usarão seu canal pai para definir o preço. O preço será convertido para a moeda do canal"
-    },
-    "yatGsm": {
-        "context": "card title",
-        "string": "Valor do Pedido"
-    },
-    "Dgp38J": {
-        "context": "checkbox label",
-        "string": "Restrict order value"
-    },
-    "vjsfyn": {
-        "string": "Valor Máx."
-    },
-    "0FexL7": {
-        "context": "min price in channel",
-        "string": "Valor Mín."
-    },
-    "7v8suW": {
-        "context": "info text",
-        "string": "Esta taxa será aplicada a todos os pedidos"
-    },
-    "r2dojI": {
-        "context": "checkbox label",
-        "string": "Restrict order weight"
-    },
-    "vWapBZ": {
-        "context": "card title",
-        "string": "Peso do Pedido"
-    },
-    "w+5Djm": {
-        "string": "Peso Mín. do Pedido"
-    },
-    "u0V06N": {
-        "string": "Peso Máx. do Pedido"
-    },
-    "TnTi/a": {
-        "context": "pricing card title",
-        "string": "Preços"
-    },
-    "5ZvuVw": {
-        "string": "Nenhum produto corresponde à consulta fornecida"
-    },
-    "FzEew9": {
-        "context": "assign products to shipping rate and save, button",
-        "string": "Atribuir e salvar"
-    },
-    "xZhxBJ": {
-        "context": "dialog header",
-        "string": "Atribuir Pordutos"
-    },
-    "Gg4+K7": {
-        "string": "Sem Produtos"
-    },
-    "t3aiWF": {
-        "context": "section header",
-        "string": "Produtos Excluídos"
-    },
-    "ZIc5lM": {
-        "string": "Nome do Produto"
-    },
-    "TLYeo5": {
-        "context": "label",
-        "string": "Descrição da taxa de envio"
-    },
-    "v17Lly": {
-        "context": "label",
-        "string": "Prazo máximo de entrega"
-    },
-    "GD/bom": {
-        "context": "label",
-        "string": "Prazo mínimo de entrega"
-    },
-    "FkDObY": {
-        "context": "label",
-        "string": "Nome da taxa de envio"
-    },
-    "4Kq3O6": {
-        "string": "Esta unidade será usada como peso de embalagem padrão"
-    },
-    "Rp/Okl": {
-        "string": "Unidade de peso de envio"
-    },
-    "llBnr+": {
-        "string": "Nome do Depósito"
-    },
-    "yzYXW/": {
-        "context": "header, dialog",
-        "string": "Criar Novo Depósito"
-    },
-    "LHPVg/": {
-        "context": "assign countries to shipping zone and save, button",
-        "string": "Atribuir e salvar"
-    },
-    "AjInNW": {
-        "context": "dialog description",
-        "string": "Escolha os países que deseja adicionar à zona de entrega da lista abaixo"
-    },
-    "f2F1NJ": {
-        "context": "section title",
-        "string": "Escolha rápida"
-    },
-    "K/ic0P": {
-        "context": "checkbox label",
-        "string": "Resto do Mundo"
-    },
-    "G+9nOZ": {
-        "context": "checkbox description",
-        "string": "Se selecionado, isso adicionará todos os países não selecionados a outras zonas de envio"
-    },
-    "pGDYG5": {
-        "context": "search label",
-        "string": "Pesquisar Países"
-    },
-    "1rpzrM": {
-        "context": "search placeholder",
-        "string": "Pesquisar pelo nome do país"
-    },
-    "55LMJv": {
-        "context": "country list header",
-        "string": "Países"
-    },
-    "6fxdUO": {
-        "context": "section header",
-        "string": "Criar Nova Zona de Envio"
-    },
-    "y7mfbl": {
-        "string": "Atualmente, não há países atribuídos a esta zona de envio"
-    },
-    "G0+gAp": {
-        "context": "shipping section header",
-        "string": "Envio"
-    },
-    "FkRNk+": {
-        "context": "field placeholder",
-        "string": "Descrição de uma zona de expedição."
-    },
-    "YpukUN": {
-        "context": "label",
-        "string": "Nome da zona de envio"
-    },
-    "axFFaD": {
-        "context": "range input label",
-        "string": "Postal codes (end)"
-    },
-    "DM/Ha1": {
-        "context": "add postal code range, button",
-        "string": "Adicionar"
-    },
-    "1T1fP8": {
-        "context": "range input label",
-        "string": "Códigos postais (start)"
-    },
-    "8InCjD": {
-        "string": "Forneça o intervalo de códigos postais que você deseja adicionar à lista de inclusão/exclusão.Please provide range of postal codes you want to add to the include/exclude list."
-    },
-    "2Xt+sw": {
-        "context": "dialog header",
-        "string": "Adicionar códigos postais"
-    },
-    "Pyjarj": {
-        "string": "Esta taxa de envio não tem códigos postais atribuídos"
-    },
-    "7qsOwa": {
-        "context": "action",
-        "string": "Incluir códigos postais"
-    },
-    "ju8zHP": {
-        "string": "Os códigos postais adicionados serão excluídos do uso destes métodos de entrega. Se nenhum for adicionado, todos os códigos postais poderão usar essa taxa de envio"
-    },
-    "1lk/oS": {
-        "context": "button",
-        "string": "Adicionar intervalo de códigos postais"
-    },
-    "ud0w8h": {
-        "context": "number of postal code ranges",
-        "string": "{number} intervalos de códigos postais"
-    },
-    "/Zee1r": {
-        "string": "Somente códigos postais adicionados poderão usar esta taxa de envio"
-    },
-    "FcTTvh": {
-        "context": "postal codes, header",
-        "string": "Códigos postais"
-    },
-    "YpLVVc": {
-        "context": "action",
-        "string": "Excluir código postal"
-    },
-    "RXPGi/": {
-        "context": "page title",
-        "string": " Criar taxa de preço"
-    },
-    "PRlD0A": {
-        "string": "Envio"
-    },
-    "NDm2Fe": {
-        "context": "page title",
-        "string": "Criar Taxa de Peso"
-    },
-    "EKoPNg": {
-        "context": "shipping method price",
-        "string": "Preço"
-    },
-    "WR8rir": {
-        "context": "button",
-        "string": "Criar taxa"
-    },
-    "njUQPz": {
-        "context": "shipping method price range",
-        "string": "Faixa de valor"
-    },
-    "RUzdUH": {
-        "string": "Nenhuma taxa de envio encontrada"
-    },
-    "FjrExY": {
-        "context": "price based shipping methods, section header",
-        "string": "Taxas baseadas em preços"
-    },
-    "aYhcie": {
-        "context": "shipping method weight range",
-        "string": "Faixa de Peso"
-    },
-    "foB6wx": {
-        "context": "weight based shipping methods, section header",
-        "string": "Taxas Baseadas em Peso"
-    },
-    "aPCrsp": {
-        "context": "shipping method name",
-        "string": "Nome"
-    },
-    "n25d+d": {
-        "context": "WarehousesSection select field add text",
-        "string": "Adicionar Novo Depósito"
-    },
-    "/cow4T": {
-        "context": "WarehousesSection select field placeholder",
-        "string": "Selecionar Depósito"
-    },
-    "wjKYSU": {
-        "context": "WarehousesSection subtitle",
-        "string": "Selecione o depósito de onde você enviará os produtos para esta zona de envio. O endereço do depósito também será usado para calcular impostos."
-    },
-    "t/R8nK": {
-        "context": "ShippingZoneSettingsCard title",
-        "string": "Configurações"
-    },
-    "uULcph": {
-        "context": "header",
-        "string": "Envio"
-    },
-    "h5r9+x": {
-        "context": "sort shipping methods by zone, section header",
-        "string": "Envio por zona"
-    },
-    "mIUNgR": {
-        "context": "button",
-        "string": "Criar Zona de Envio"
-    },
-    "aMwxYb": {
-        "string": "Países"
-    },
-    "gRa/TS": {
-        "context": "shipping zone",
-        "string": "Nome"
-    },
-    "IhK1F3": {
-        "string": "Nenhuma zona de envio encontrada"
-    },
-    "Gfbp36": {
-        "context": "dialog header",
-        "string": "Cancelar a atribuição de produtos do envio"
-    },
-    "p/Fd7s": {
-        "context": "unassign products from shipping rate and save, button",
-        "string": "Cancelar atribuição e salvar"
-    },
-    "57IYpr": {
-        "context": "error message",
-        "string": "Valor é inválido"
-    },
-    "pwqwcy": {
-        "context": "error message",
-        "string": "Preço máximo não pode ser menor que o mínimo"
-    },
-    "qf/m5l": {
-        "string": "Tem certeza que você deseja deletar a zona {shippingZoneName}?"
-    },
-    "k3EI/U": {
-        "context": "dialog header",
-        "string": "Excluir Zona de Envio"
-    },
-    "cpZLRH": {
-        "context": "dialog header",
-        "string": "Excluir Zonas de Envio"
-    },
-    "C9pcQx": {
-        "context": "dialog content",
-        "string": "{counter,plural,one {Tem certeza de que deseja excluir esta zona de envio ?} other {Tem certeza de que deseja excluir {displayQuantity} zonas de envio ?}}"
-    },
-    "YdeHZX": {
-        "context": "unassign products from shipping method, button",
-        "string": "Não vinculado"
-    },
-    "1zuQ2P": {
-        "context": "unassign country",
-        "string": "Tem certeza de que deseja remover {countryName} desta zona de envio?"
-    },
-    "M6s/9e": {
-        "context": "unassign country, dialog header",
-        "string": "Remover da zona de envio"
-    },
-    "MXZuVP": {
-        "context": "remove country from shipping zone and save, button",
-        "string": "Remover e salvar"
-    },
-    "H27/Gy": {
-        "context": "error message",
-        "string": "Peso máximo não pode ser menor que o mínimo"
-    },
-    "/8/Ffn": {
-        "context": "button",
-        "string": "Exibir"
-    },
-    "viFkCw": {
-        "context": "site settings section name",
-        "string": "Configurações do Site"
-    },
-    "+do3gl": {
-        "context": "input helper text",
-        "string": "Este número define a quantidade de itens na linha de checkout que podem ser comprados. Você pode substituir essa configuração por variante. Deixar esta configuração vazia significa que não há limites."
-    },
-    "QclvqG": {
-        "context": "input label",
-        "string": "Limite de fila de checkout"
-    },
-    "X7fqfM": {
-        "context": "title",
-        "string": "Estoque reservado"
-    },
-    "C4aDMy": {
-        "context": "description",
-        "string": "Configure o tempo que o estoque no checkout fica reservado para o cliente. Você pode definir valores separados para clientes autenticados e anônimos."
-    },
-    "+T0oJ7": {
-        "context": "input label",
-        "string": "Reserva de estoque para usuário anônimo (em minutos)"
-    },
-    "OaKyz4": {
-        "context": "input label",
-        "string": "Reserva de estoque para usuário autenticado (em minutos)"
-    },
-    "YEv+6G": {
-        "context": "input helper text",
-        "string": "Deixar esta configuração vazia significa que o estoque não será reservado"
-    },
-    "+jCDvp": {
-        "context": "section header",
-        "string": "Informações da Loja"
-    },
-    "Av74Fa": {
-        "context": "section description",
-        "string": "Você pode definir regras básicas de checkout que serão aplicadas globalmente a todos os seus canais"
-    },
-    "DASYUF": {
-        "context": "section title",
-        "string": "Configuração de check-out"
-    },
-    "pRYGUR": {
-        "context": "section description",
-        "string": "Este endereço será usado para gerar faturas e calcular taxas de envio. O endereço de e-mail fornecido aqui será usado como endereço de contato para seus clientes."
-    },
-    "rPX1f2": {
-        "context": "section title",
-        "string": "Informações da Empresa"
-    },
-    "LVa5ew": {
-        "string": "Saleor encontrou um problema inesperado"
-    },
-    "AQFMYU": {
-        "context": "staff section name",
-        "string": "Membros da Equipe"
-    },
-    "23g7PY": {
-        "context": "dialog header",
-        "string": "Convidar Membro da Equipe"
-    },
-    "hw9Fah": {
-        "context": "button",
-        "string": "Enviar convite"
-    },
-    "P+kVxW": {
-        "context": "card description",
-        "string": "Usuário está atribuído a:"
-    },
-    "XMrYaA": {
-        "context": "checkbox label",
-        "string": "Usuário está ativo"
-    },
-    "YJ4TXc": {
-        "context": "tab name",
-        "string": "Todos os Funcionários"
-    },
-    "OaA0f9": {
-        "string": "Você atingiu o limite de funcionários e não poderá mais adicionar funcionários à sua loja. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
-    },
-    "pA8Mlv": {
-        "context": "alert",
-        "string": "Staff Member limit reached"
-    },
-    "aDbrOK": {
-        "string": "Pesquisar Membro da Equipe"
-    },
-    "4JcNaA": {
-        "context": "button",
-        "string": "Convidar membro da equipe"
-    },
-    "9xlPgt": {
-        "context": "used staff users counter",
-        "string": "{count}/{max} members"
-    },
-    "HR9OTW": {
-        "context": "staff member's account",
-        "string": "Ativo"
-    },
-    "Fc3O3r": {
-        "context": "staff member's account",
-        "string": "Desativado"
-    },
-    "utaSh3": {
-        "context": "staff member's account",
-        "string": "Status"
-    },
-    "xJQX5t": {
-        "string": "Nenhum membro da equipe encontrado"
-    },
-    "cMFlOp": {
-        "context": "input label",
-        "string": "Nova senha"
-    },
-    "qEJT8e": {
-        "string": "Nova senha deve conter ao menos 8 caracteres"
-    },
-    "+kb2lM": {
-        "context": "dialog header",
-        "string": "Mudar senha"
-    },
-    "GXdwyR": {
-        "context": "input label",
-        "string": "Senha Antiga"
-    },
-    "mm0CXe": {
-        "string": "Você deve alterar sua senha todo mês para evitar problemas de segurança"
-    },
-    "N3Zot1": {
-        "context": "button",
-        "string": "Mude sua senha"
-    },
-    "ZhDQel": {
-        "context": "header",
-        "string": "Senha"
-    },
-    "JJgJwi": {
-        "string": "Selecionando isto, mudará o idioma do seu painel"
-    },
-    "e822us": {
-        "string": "Observe que, embora todos os ajustes de moeda e data estejam concluídos, as traduções de idiomas estão em diferentes graus de conclusão."
-    },
-    "mr9jbO": {
-        "string": "Língua Preferida"
-    },
-    "CLeDae": {
-        "context": "section header",
-        "string": "Preferências"
-    },
-    "+2VzH4": {
-        "context": "avatar change button",
-        "string": "Alterar"
-    },
-    "VTITVe": {
-        "context": "section header",
-        "string": "Informações do Membro da Equipe"
-    },
-    "11lR5V": {
-        "context": "avatar delete button",
-        "string": "Excluir"
-    },
-    "K/gnGg": {
-        "string": "Se você deseja desativar este usuário, desmarque a caixa abaixo."
-    },
-    "7yKZvp": {
-        "context": "section header",
-        "string": "User Status"
-    },
-    "GhXwO/": {
-        "context": "dialog header",
-        "string": "excluir Usuário da Equipe"
-    },
-    "fzpXvv": {
-        "string": "Tem certeza que você deseja deletar o avatar de {email}?"
-    },
-    "VKWPBf": {
-        "context": "dialog header",
-        "string": "Excluir Avatar do Membro da Equipe"
-    },
-    "gxPjIQ": {
-        "string": "Tem certeza de que gostaria de excluir {email} de membros da equipe?"
-    },
-    "QirE3M": {
-        "string": "Data Inicial"
-    },
-    "tWbE34": {
-        "string": "Hora Início"
-    },
-    "tzMNF3": {
-        "string": "Status"
-    },
-    "RrCui3": {
-        "string": "Resumo"
-    },
-    "5elC9k": {
-        "context": "taxes section name",
-        "string": "Impostos"
-    },
-    "lnQAos": {
-        "context": "header",
-        "string": "Impostos"
-    },
-    "3BTtL2": {
-        "string": "Nenhum país encontrado"
-    },
-    "/JENWS": {
-        "string": "Taxas de imposto reduzidas"
-    },
-    "07KB2d": {
-        "string": "Código do País"
-    },
-    "0GJfWd": {
-        "string": "Nome do País"
-    },
-    "la9cZ4": {
-        "string": " Taxa de imposto"
-    },
-    "QHB48n": {
-        "context": "header",
-        "string": "Taxas de impostos em {countryName}"
-    },
-    "Ubath+": {
-        "string": "Nenhuma categoria de imposto reduzido encontrada"
-    },
-    "4EuJKs": {
-        "string": "Todos os preços dos produtos são inclusos com os impostos"
-    },
-    "98isC5": {
-        "string": "Mostrar preço bruto a clientes na loja"
-    },
-    "FNKhkx": {
-        "string": "Cobrar impostos sobre taxas de envio"
-    },
-    "+OV+Gj": {
-        "context": "button",
-        "string": "Obter impostos"
-    },
-    "HtQGEH": {
-        "string": "Taxas de impostos obtidas com sucesso"
-    },
-    "u3sYPH": {
-        "context": "independent of any particular day, eg. 11:35",
-        "string": "Time"
-    },
-    "+xTpT1": {
-        "string": "Atributos"
-    },
-    "5fCMUI": {
-        "context": "translations section name",
-        "string": "Traduções"
-    },
-    "tUlsq+": {
-        "string": "Translating"
-    },
-    "QUyUJy": {
-        "string": "Main Product"
-    },
-    "bh+Keo": {
-        "string": "{numberOfFields} Traduções, {numberOfTranslatedFields} concluídas"
-    },
-    "Xtd0AT": {
-        "string": "Texto Original"
-    },
-    "/vCXIP": {
-        "string": "Tradução"
-    },
-    "vTN5DZ": {
-        "context": "button",
-        "string": "Descartar"
-    },
-    "T/5OyA": {
-        "string": "Nenhuma tradução ainda"
-    },
-    "DRMMDs": {
-        "string": "Nome do Atributo"
-    },
-    "SPBLzT": {
-        "context": "header",
-        "string": "Atributo de tradução \"{attribute}\" - {languageCode}"
-    },
-    "UvD+xp": {
-        "context": "attribute values",
-        "string": "Valor {number}"
-    },
-    "JE0TAx": {
-        "context": "section name",
-        "string": "Valores"
-    },
-    "US3IPU": {
-        "string": "Descrição do motor de busca"
-    },
-    "XitW/z": {
-        "string": "Categoria de tradução \"{categoryName}\" - {languageCode}"
-    },
-    "HlEpii": {
-        "string": "Titulo do mecanismo de busca"
-    },
-    "Bphmwe": {
-        "context": "header",
-        "string": "Coleção de tradução \"{collectionName}\" - {languageCode}"
-    },
-    "GsBRWL": {
-        "string": "Línguas"
-    },
-    "FemBUF": {
-        "context": "header",
-        "string": "Traduções para {language}"
-    },
-    "7NFfmz": {
-        "string": "Produtos"
-    },
-    "CxfKLC": {
-        "string": "Páginas"
-    },
-    "VKb1MS": {
-        "string": "Categorias"
-    },
-    "RzsKm8": {
-        "string": "Métodos de Envio"
-    },
-    "c8nvms": {
-        "string": "Vendas"
-    },
-    "etP0+D": {
-        "string": "Cupons"
-    },
-    "ikRuLs": {
-        "context": "translation progress",
-        "string": "{current} de {max}"
-    },
-    "vcwrgW": {
-        "string": "Nenhuma entidade traduzível encontrada"
-    },
-    "LWmYSU": {
-        "string": "Traduções concluídas"
-    },
-    "X6PF8z": {
-        "context": "entity (product, collection, shipping method) name",
-        "string": "Nome"
-    },
-    "ptPPVk": {
-        "string": "Nenhuma linguagem encontrada"
-    },
-    "y1Z3or": {
-        "string": "Língua"
-    },
-    "oUWXLO": {
-        "context": "header",
-        "string": "Página de tradução \"{pageName}\" - {languageCode}"
-    },
-    "PajjqE": {
-        "context": "attribute list",
-        "string": "Atributo {number}"
-    },
-    "gvOzOl": {
-        "string": "Título da Página"
-    },
-    "98WMlR": {
-        "context": "header",
-        "string": "Translation Product Variant \"{productName}\" - {languageCode}"
-    },
-    "T1f2Yl": {
-        "string": "Variant Name"
-    },
-    "22x9tu": {
-        "context": "header",
-        "string": "Produto de tradução \"{productName}\" - {languageCode}"
-    },
-    "zjkAMs": {
-        "context": "header",
-        "string": "Venda de tradução \"{saleName}\" - {languageCode}"
-    },
-    "s40PZt": {
-        "string": "Nome de Venda"
-    },
-    "GpqEl5": {
-        "context": "shipping method description",
-        "string": "Descrição"
-    },
-    "1UKx20": {
-        "context": "header",
-        "string": "Tradução Método de Envio \"{shippingMethodName}\" - {languageCode}"
-    },
-    "1tXSSK": {
-        "context": "header",
-        "string": "Tradução Cupom \"{voucherName}\" - {languageCode}"
-    },
-    "sfErC+": {
-        "string": "Nome do Cupom"
-    },
-    "MKtgZB": {
-        "string": "Somente usuários da equipe podem acessar o painel"
-    },
-    "+x84Ji": {
-        "context": "order status",
-        "string": "Não Confirmado"
-    },
-    "vN3qdA": {
-        "context": "button",
-        "string": "Desfazer"
-    },
-    "oB0y5Y": {
-        "context": "order status",
-        "string": "Não faturado"
-    },
-    "FBtqtl": {
-        "context": "payment status",
-        "string": "Não pago"
-    },
-    "Lx1ima": {
-        "context": "button",
-        "string": "Enviar Imagem"
-    },
-    "m8cjcK": {
-        "context": "add authorization key error",
-        "string": "Já existe uma chave de autorização com este tipo"
-    },
-    "+x4cZH": {
-        "string": "Apenas membros da equipe podem ser atribuídos"
-    },
-    "aggaJg": {
-        "string": "Este atributo já foi atribuído a este tipo de produto"
-    },
-    "u24Ppd": {
-        "string": "Este atributo não pode ser atribuído a este tipo de produto"
-    },
-    "cd13nN": {
-        "context": "product attribute error",
-        "string": "Todos os atributos devem ter valor"
-    },
-    "lLwtgs": {
-        "string": "As variações estão desativadas neste tipo de produto"
-    },
-    "IFWHn0": {
-        "context": "error message",
-        "string": "O endereço de cobrança não foi definido"
-    },
-    "ij7olm": {
-        "context": "error message",
-        "string": "Este faturamento não pode ser cancelado"
-    },
-    "BM1JiJ": {
-        "context": "error message",
-        "string": "Este pedido não pode ser cancelado"
-    },
-    "nOo0oL": {
-        "context": "error message",
-        "string": "Itens insuficientes para faturar"
-    },
-    "Xb6BJ9": {
-        "context": "error message",
-        "string": "Pagamento manual não pode ser devolvido"
-    },
-    "WzA5Ll": {
-        "string": "Não é possível remover o usuário do último grupo"
-    },
-    "sZ27WU": {
-        "context": "error message",
-        "string": "Apenas pagamentos previamente autorizados podem ser anulados"
-    },
-    "gKdGxP": {
-        "context": "error message",
-        "string": "Apenas pagamentos pré-autorizados podem ser recebidos"
-    },
-    "DK+8PB": {
-        "string": "Este canal já foi criado"
-    },
-    "V2BBQu": {
-        "string": "A moeda em ambos os canais deve ser a mesma"
-    },
-    "QFCUEt": {
-        "string": "Slug deve ser único"
-    },
-    "AY7Tuz": {
-        "string": "O mesmo objeto não pode estar em ambas as listas"
-    },
-    "E8T3e+": {
-        "string": "Não é possível adicionar e remover o grupo ao mesmo tempo"
-    },
-    "abTH5q": {
-        "context": "error message",
-        "string": "O endereço de e-mail não foi definido"
-    },
-    "c5pMZ8": {
-        "string": "Erro na API"
-    },
-    "d9UqaJ": {
-        "context": "error message",
-        "string": "Não é possível alterar a quantidade devido ao estoque insuficiente"
-    },
-    "577R2r": {
-        "string": "Valor inválido"
-    },
-    "pC6/1z": {
-        "string": "Formato de manifesto inválido"
-    },
-    "eu98dw": {
-        "string": "Senha inválida"
-    },
-    "D2qihU": {
-        "string": "Permissão inválida"
-    },
-    "g/BrOt": {
-        "string": "A URL tem um formato inválido"
-    },
-    "AdmPca": {
-        "context": "error message",
-        "string": "O valor máximo não pode ser inferior ao valor mínimo"
-    },
-    "0AQH0Q": {
-        "string": "O plug-in está configurado incorretamente e não pode ser ativado"
-    },
-    "FuAV5G": {
-        "string": "Este nome já está em uso. Forneça outro."
-    },
-    "3AqOxp": {
-        "context": "no category set error",
-        "string": "Categoria do produto não definida"
-    },
-    "Wlc67M": {
-        "context": "error message",
-        "string": "Não é possível escolher um método de envio para um pedido sem o endereço de envio"
-    },
-    "r+8q4B": {
-        "context": "error message",
-        "string": "Apenas rascunhos de pedidos podem ser editados"
-    },
-    "PCoO4D": {
-        "context": "error message",
-        "string": "Página não encontrada"
-    },
-    "Fz3kic": {
-        "context": "error message",
-        "string": " O endereço de cobrança não foi definido ou a fatura não está pronta para ser enviada"
-    },
-    "N43t3/": {
-        "context": "error message",
-        "string": "Número não definido para uma fatura"
-    },
-    "C4hCsD": {
-        "string": "O aplicativo está fora do seu escopo de permissões"
-    },
-    "1n1tOR": {
-        "string": "O grupo está fora do seu escopo de permissão"
-    },
-    "4prRLv": {
-        "string": "A permissão está fora do seu escopo"
-    },
-    "KRqgfo": {
-        "string": "O usuário está fora do seu escopo de permissões"
-    },
-    "cY42ht": {
-        "string": "A senha não pode ser totalmente numérica"
-    },
-    "Y1B0PN": {
-        "context": "error message",
-        "string": "Não há pagamento associado ao pedido"
-    },
-    "vVviA2": {
-        "string": "Estas permissões estão fora do seu escopo"
-    },
-    "mYs3tb": {
-        "string": "O preço do produto não pode ser inferior a 0."
-    },
-    "VEE4gD": {
-        "context": "error message",
-        "string": "Método de envio não é válido para o endereço de entrega escolhido."
-    },
-    "ychKsb": {
-        "context": "error message",
-        "string": "O método de envio é obrigatório para este pedido"
-    },
-    "rZf1qL": {
-        "context": "bulk variant create error",
-        "string": "SKUs devem ser únicos"
-    },
-    "nKjLjT": {
-        "context": "error message",
-        "string": "Slug deve ser único para cada depósito"
-    },
-    "wn3di2": {
-        "string": "Esta senha é muito comumente usada"
-    },
-    "LR3HlT": {
-        "string": "Esta senha é muito curta"
-    },
-    "1wyZpQ": {
-        "string": "As senhas são muito parecidas"
-    },
-    "TDhHMi": {
-        "string": "Isto precisa ser único"
-    },
-    "qDwvZ4": {
-        "string": "Erro desconhecido"
-    },
-    "DILs4b": {
-        "string": "Provedor de mídia incompatível ou URL incorreto"
-    },
-    "vP7g2+": {
-        "context": "error message",
-        "string": "URL não definida para uma fatura"
-    },
-    "Z6QAbw": {
-        "string": "Esta variação não possui nenhum conteúdo digital"
-    },
-    "i3Mvj8": {
-        "context": "product attribute error",
-        "string": "Esta variação já existe"
-    },
-    "iUy2dx": {
-        "context": "vouchers section name",
-        "string": "Cupons"
-    },
-    "ycMLN9": {
-        "context": "warehouses section name",
-        "string": "Depósitos"
-    },
-    "43Nlay": {
-        "context": "warehouse",
-        "string": "Informação do Endereço"
-    },
-    "GhcypC": {
-        "context": "header",
-        "string": "Criar Depósito"
-    },
-    "DTL7sE": {
-        "context": "dialog content",
-        "string": "Tem certeza de que deseja excluir {warehouseName}?"
-    },
-    "ny4zrH": {
-        "context": "dialog title",
-        "string": "Excluir Depósito"
-    },
-    "YkOzse": {
-        "context": "used warehouses counter",
-        "string": "{count}/{max} armazéns usados"
-    },
-    "caMMWN": {
-        "string": "Pesquisar Depósito"
-    },
-    "2yU+q9": {
-        "context": "tab name",
-        "string": "Todos os Depósitos"
-    },
-    "5HwLx9": {
-        "context": "alert",
-        "string": "Limite de armazém atingido"
-    },
-    "kFQvXv": {
-        "string": "Você atingiu o limite do seu armazém, não poderá mais adicionar armazéns à sua loja. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
-    },
-    "wmdHhD": {
-        "context": "button",
-        "string": "Criar Depósito"
-    },
-    "PFXGaR": {
-        "string": "Zonas de Entrega"
-    },
-    "2gsiR1": {
-        "string": "Nenhum depósito encontrado"
-    },
-    "aCJwVq": {
-        "context": "warehouse",
-        "string": "Nome"
-    },
-    "16PGt9": {
-        "context": "WarehouseSettings all warehouses label",
-        "string": "Todos os armazéns"
-    },
-    "LEZZkK": {
-        "context": "WarehouseSettings all warehouses description",
-        "string": "Se selecionado o cliente poderá escolher este armazém como ponto de recolha. Os produtos encomendados podem ser enviados aqui de um armazém diferente"
-    },
-    "OBQ+th": {
-        "context": "WarehouseSettings disabled warehouse label",
-        "string": "Desabilitada"
-    },
-    "M8z5WZ": {
-        "context": "WarehouseSettings disabled warehouse description",
-        "string": "Se o cliente selecionado não poderá escolher este armazém como ponto de coleta"
-    },
-    "tVybuM": {
-        "context": "WarehouseSettings local warehouse label",
-        "string": "Somente estoque local"
-    },
-    "6G41zU": {
-        "context": "WarehouseSettings local warehouse description",
-        "string": "Se selecionado o cliente poderá escolher este armazém como ponto de recolha. Os produtos encomendados serão atendidos apenas a partir deste estoque em armazém"
-    },
-    "cdiRSf": {
-        "context": "WarehouseSettings no shipping zones assigned",
-        "string": "Este depósito não tem zonas de entrega atribuídas"
-    },
-    "MIC9W7": {
-        "context": "WarehouseSettings pickup title",
-        "string": "Pickup"
-    },
-    "wpli4O": {
-        "context": "WarehouseSettings private stock label",
-        "string": "Estoque Privado"
-    },
-    "XlPKAR": {
-        "context": "WarehouseSettings private stock description",
-        "string": "Se ativado, o estoque neste armazém não será mostrado"
-    },
-    "86pLaG": {
-        "context": "WarehouseSettings public stock label",
-        "string": "Estoque Público"
-    },
-    "Ff+Gsm": {
-        "context": "WarehouseSettings public stock description",
-        "string": "Se ativado, o estoque neste armazém será mostrado"
-    },
-    "//iaFx": {
-        "context": "WarehouseSettings title",
-        "string": "Configurações"
-    },
-    "6nSTuC": {
-        "context": "webhooks section name",
-        "string": "Webhooks"
-    },
-    "hS+ZjH": {
-        "context": "delete webhook",
-        "string": "Tem certeza de que deseja excluir este webhook?"
-    },
-    "o5KXAN": {
-        "context": "delete webhook",
-        "string": "Tem certeza de que deseja excluir {name}?"
-    },
-    "X90ElB": {
-        "context": "dialog header",
-        "string": "Excluir Webhook"
-    },
-    "snUby7": {
-        "context": "header",
-        "string": "Detalhes sem nome do webhook"
-    },
-    "Ryh3iR": {
-        "context": "header",
-        "string": "Criar Webhook"
-    },
-    "OPtrMg": {
-        "context": "header",
-        "string": "{webhookName} Detalhes"
-    },
-    "QEvH8Q": {
-        "context": "section description",
-        "string": "Atribua permissões para registrar eventos assíncronos para este webhook."
-    },
-    "fHopox": {
-        "context": "section description",
-        "string": "Atribua permissões para registrar eventos síncronos para este webhook."
-    },
-    "TjbB4Y": {
-        "context": "section subheader",
-        "string": "Eventos assíncronos"
-    },
-    "GLewww": {
-        "context": "section header",
-        "string": "Eventos"
-    },
-    "9Yhddc": {
-        "context": "input label",
-        "string": "Eventos registrados"
-    },
-    "dQdxLT": {
-        "context": "section subheader",
-        "string": "Eventos síncronos"
-    },
-    "NPfmdK": {
-        "context": "webhook input label",
-        "string": "Chave secreta"
-    },
-    "tA5HJx": {
-        "context": "webhook input help text",
-        "string": "a chave é utilizada para criar uma assinatura hash em cada requisição. * campo opcional"
-    },
-    "u9/vj9": {
-        "context": "webhook input label",
-        "string": "URL alvo"
-    },
-    "0MetrR": {
-        "context": "webhook input help text",
-        "string": "Esta URL receberá requisições POST de webhook"
-    },
-    "WDy0tF": {
-        "context": "section header",
-        "string": "Informações do Webhook"
-    },
-    "D0KaT6": {
-        "context": "webhook input label",
-        "string": "Nome do Webhook"
-    },
-    "W+x5ZI": {
-        "context": "webhooks active label",
-        "string": "Webhook está ativo"
-    },
-    "IBCBi1": {
-        "context": "webhook active description",
-        "string": "Se você quer desativar este webhook, retire a seleção abaixo."
-    },
-    "1+M/52": {
-        "context": "section header",
-        "string": "Status do Webhook"
-    },
-    "wbjuR4": {
-        "string": "Nenhum webhook encontrado"
-    },
-    "wlr0Si": {
-        "context": "button",
-        "string": "Criar Webhook"
-    },
-    "jqnwW9": {
-        "context": "header",
-        "string": "Webhooks"
-    },
-    "a/QJBx": {
-        "context": "user action bar",
-        "string": "Ação"
-    },
-    "1eCau/": {
-        "string": "Webhook sem nome"
-    },
-    "OTpV1t": {
-        "context": "webhook name",
-        "string": "Nome"
-    },
-    "JVaz1C": {
-        "context": "window title",
-        "string": "Criar Webhook"
-    },
-    "a5msuh": {
-        "string": "Sim"
-    },
-    "g/FRtd": {
-        "context": "table column header, allocated product quantity",
-        "string": "alocado"
-    },
-    "MNZY28": {
-        "context": "table column header",
-        "string": "Limite do canal"
-    },
-    "ge/xFX": {
-        "context": "table column header",
-        "string": "Quantidade"
-    },
-    "HcQEUk": {
-        "context": "table column header, sold units preorder quantity",
-        "string": "Sold units"
-    },
-    "XWGZLL": {
-        "context": "transaction reference subtitle",
-        "string": "Referência de transação"
-    },
-    "Y9lv8z": {
-        "context": "product unavailability",
-        "string": "Indisponível para compra"
-    },
-    "CEavJt": {
-        "context": "section header",
-        "string": "Ilimitada"
-    },
-    "Gkip05": {
-        "context": "button",
-        "string": "Não vinculado"
-    },
-    "KSp+8B": {
-        "context": "product available for purchase date",
-        "string": "estará disponível em {date}"
-    },
-    "hAcUEl": {
-        "context": "product publication date label",
-        "string": "será publicado em {date}"
-    }
+  "++8ZWj": {
+    "context": "Transaction event status - requested",
+    "string": "Solicitado"
+  },
+  "+2VydL": {
+    "context": "card title",
+    "string": "Exceções de país"
+  },
+  "+2VzH4": {
+    "context": "avatar change button",
+    "string": "Alterar"
+  },
+  "+43JV5": {
+    "context": "header",
+    "string": "Produtos em {categoryName}"
+  },
+  "+470FM": {
+    "context": "voucher status expired",
+    "string": "Expirado"
+  },
+  "+5HkZN": {
+    "context": "order, button",
+    "string": "Sinalizar como pago"
+  },
+  "+7OsyM": {
+    "context": "button",
+    "string": "Definir como endereço de entrega padrão"
+  },
+  "+8v1ny": {
+    "context": "discount button",
+    "string": "Desconto"
+  },
+  "+B25o/": {
+    "context": "dialog header",
+    "string": "Marcar Pedido como Pago"
+  },
+  "+BkNuT": {
+    "context": "aria label for grid view button",
+    "string": "Visualização em grade"
+  },
+  "+CeEe3": {
+    "context": "order shipping method name",
+    "string": "Envio"
+  },
+  "+G2N98": {
+    "string": "Instalar a partir do manifesto"
+  },
+  "+G9l7u": {
+    "context": "all selected zones card message",
+    "string": "Todas as zonas de envio disponíveis foram selecionadas"
+  },
+  "+HuipK": {
+    "context": "variant sku",
+    "string": "SKU {sku}"
+  },
+  "+IayD+": {
+    "context": "order transaction refund summary title",
+    "string": "Valor do reembolso"
+  },
+  "+Jgot0": {
+    "context": "tax class for a product type",
+    "string": "Classe de imposto"
+  },
+  "+NUzaQ": {
+    "context": "check to mark this account as active",
+    "string": "Conta de usuário ativa"
+  },
+  "+OV+Gj": {
+    "context": "button",
+    "string": "Obter impostos"
+  },
+  "+PbHKD": {
+    "context": "dialog header",
+    "string": "Capturar Pagamento"
+  },
+  "+PclgM": {
+    "context": "tabel column header",
+    "string": "Total"
+  },
+  "+RffqY": {
+    "context": "Dry run dialog object title",
+    "string": "Selecione o tipo de objeto para realizar uma execução de teste na consulta fornecida"
+  },
+  "+RjQjs": {
+    "context": "return button",
+    "string": "Pedido de devolução/substituição"
+  },
+  "+SYLEL": {
+    "context": "refunded fulfillment, section header",
+    "string": "Reembolsado"
+  },
+  "+T0oJ7": {
+    "context": "input label",
+    "string": "Reserva de estoque para usuário anônimo (em minutos)"
+  },
+  "+U6ozc": {
+    "string": "Tipo"
+  },
+  "+VEhV8": {
+    "context": "product channels",
+    "string": "Disponibilidade"
+  },
+  "+WTmpr": {
+    "context": "disabled status option label",
+    "string": "Desabilitado"
+  },
+  "+Wm2vY": {
+    "context": "discount type percentage",
+    "string": "Porcentagem"
+  },
+  "+ZwF+1": {
+    "context": "Description for live status when product is visible but purchase is scheduled",
+    "string": "Visível, mas não comprável"
+  },
+  "+a+2ug": {
+    "string": "Membros"
+  },
+  "+ahkGr": {
+    "context": "section header",
+    "string": "Detalhes do cliente"
+  },
+  "+b/qJ9": {
+    "string": "Excluir pedidos em rascunho"
+  },
+  "+b3KCV": {
+    "context": "button",
+    "string": "Ativar"
+  },
+  "+bFHzi": {
+    "context": "button",
+    "string": "Próximo"
+  },
+  "+bhokL": {
+    "string": "Pesquisar descontos..."
+  },
+  "+c/f61": {
+    "context": "retry installation",
+    "string": "Tentar Novamente"
+  },
+  "+cGU63": {
+    "string": "Você tem certeza de que deseja cancelar o cumprimento?"
+  },
+  "+djx5u": {
+    "string": "Você não pode conceder a esta extensão permissões que você não possui."
+  },
+  "+do3gl": {
+    "context": "input helper text",
+    "string": "Este número define a quantidade de itens na linha de checkout que podem ser comprados. Você pode substituir essa configuração por variante. Deixar esta configuração vazia significa que não há limites."
+  },
+  "+fICx5": {
+    "string": "Importante"
+  },
+  "+hib+V": {
+    "context": "error message",
+    "string": "Este atributo já está atribuído."
+  },
+  "+iVKR1": {
+    "context": "assign attribute value button",
+    "string": "Atribuir valor"
+  },
+  "+jCDvp": {
+    "context": "section header",
+    "string": "Informações da Loja"
+  },
+  "+jHXT3": {
+    "context": "limit voucher",
+    "string": "Limitar apenas ao pessoal"
+  },
+  "+kb2lM": {
+    "context": "dialog header",
+    "string": "Mudar senha"
+  },
+  "+mbkbU": {
+    "context": "unknown customer display name",
+    "string": "Cliente desconhecido"
+  },
+  "+mmPxn": {
+    "context": "page header",
+    "string": "Conceder reembolso"
+  },
+  "+pGERa": {
+    "string": "Fornecer detalhes manualmente"
+  },
+  "+pLi+M": {
+    "context": "issued by app label",
+    "string": "Emitido por aplicativo"
+  },
+  "+q4WRK": {
+    "context": "Badge shown when channel has validation errors",
+    "string": "erro"
+  },
+  "+qDoi0": {
+    "context": "button",
+    "string": "Criar tipo de modelo"
+  },
+  "+sX7yS": {
+    "string": "Cumprimento aprovado com sucesso"
+  },
+  "+sXiWx": {
+    "context": "window title",
+    "string": "Editar concessão de reembolso"
+  },
+  "+svQBN": {
+    "context": "alert",
+    "string": "Order limit reached"
+  },
+  "+tIkAe": {
+    "context": "status",
+    "string": "Status"
+  },
+  "+vzDH4": {
+    "context": "error message used when manifest URL is incorrect (before any further validation)",
+    "string": "URL do manifesto inválido"
+  },
+  "+wpvnk": {
+    "context": "dialog title",
+    "string": "Excluir coleção"
+  },
+  "+x4cZH": {
+    "string": "Apenas membros da equipe podem ser atribuídos"
+  },
+  "+x84Ji": {
+    "context": "order status",
+    "string": "Não Confirmado"
+  },
+  "+xTpT1": {
+    "string": "Atributos"
+  },
+  "//iaFx": {
+    "context": "WarehouseSettings title",
+    "string": "Configurações"
+  },
+  "//k1GX": {
+    "context": "expired on label",
+    "string": "Expirou em {date}"
+  },
+  "/0JckE": {
+    "context": "order marked as paid event title",
+    "string": "Pedido foi marcado como pago por"
+  },
+  "/0gMCW": {
+    "string": "Tente atualizar a página ou navegar para uma página diferente e voltar."
+  },
+  "/2OOMe": {
+    "context": "product type shipping settings, section header",
+    "string": "Envio"
+  },
+  "/2o5cH": {
+    "context": "section description",
+    "string": "Controla se os usuários podem autenticar usando login baseado em senha. Você pode permitir para todos, restringir apenas a clientes ou desativar completamente."
+  },
+  "/4/nYx": {
+    "string": "Desconto atualizado"
+  },
+  "/4bJkA": {
+    "context": "header field value, header",
+    "string": "Valor"
+  },
+  "/5r4he": {
+    "context": "label for button",
+    "string": "Adicionar país"
+  },
+  "/68iG8": {
+    "context": "product export to csv file, header",
+    "string": "Informações exportadas"
+  },
+  "/6uK4C": {
+    "context": "button",
+    "string": "Atribuir coleções"
+  },
+  "/8/Ffn": {
+    "context": "button",
+    "string": "Exibir"
+  },
+  "/AbHy4": {
+    "context": "creation label",
+    "string": "Criação"
+  },
+  "/BJQIq": {
+    "context": "dialog header",
+    "string": "Adicionar Código de Rastreio"
+  },
+  "/C//FB": {
+    "context": "header, allocated product quantity",
+    "string": "Alocado"
+  },
+  "/DzBc6": {
+    "context": "section description",
+    "string": "A estratégia define a preferência dos armazéns para alocações e reservas de estoque."
+  },
+  "/H9LeU": {
+    "string": "Explore a Loja de Aplicativos Saleor"
+  },
+  "/ILyIf": {
+    "context": "tax classes menu header",
+    "string": "Rótulo da classe de imposto"
+  },
+  "/JENWS": {
+    "string": "Taxas de imposto reduzidas"
+  },
+  "/KWNJW": {
+    "context": "order discount was updated event title",
+    "string": "Desconto do pedido foi atualizado por"
+  },
+  "/L8wzi": {
+    "context": "dialog header",
+    "string": "Cancelar atribuição de atributo do tipo de página"
+  },
+  "/Mcvt4": {
+    "context": "section header",
+    "string": "Media"
+  },
+  "/Qb92c": {
+    "string": "Com base em suas seleções, criaremos {numberOfProducts} produtos. Use esta etapa para personalizar o preço e os estoques de seus novos produtos"
+  },
+  "/TF6BZ": {
+    "string": "Pesquisar Produtos"
+  },
+  "/TK7QD": {
+    "context": "page label",
+    "string": "Oculto"
+  },
+  "/U8FUp": {
+    "string": "Não foi possível carregar atividades"
+  },
+  "/UP01b": {
+    "context": "Fallback text shown when a product media image fails to load",
+    "string": "A imagem não pôde ser carregada"
+  },
+  "/V7UOC": {
+    "context": "unassign category from sale and save, button",
+    "string": "Unassign and save"
+  },
+  "/WXs6H": {
+    "context": "collection name",
+    "string": "Nome"
+  },
+  "/X8Mjx": {
+    "string": "Brinque com <emphasis>GraphQL API</emphasis>"
+  },
+  "/Xwjww": {
+    "context": "button",
+    "string": "Faturar"
+  },
+  "/Zee1r": {
+    "string": "Somente códigos postais adicionados poderão usar esta taxa de envio"
+  },
+  "/cow4T": {
+    "context": "WarehousesSection select field placeholder",
+    "string": "Selecionar Depósito"
+  },
+  "/dnWE8": {
+    "context": "products in collection",
+    "string": "Produtos em {name}"
+  },
+  "/eWPsp": {
+    "string": "Moeda inválida usada para criar transação"
+  },
+  "/glQgs": {
+    "string": "Nenhum canal encontrado"
+  },
+  "/iijFq": {
+    "context": "input label",
+    "string": "Limite global"
+  },
+  "/jJLYy": {
+    "string": "Transações"
+  },
+  "/kWzY1": {
+    "string": "Tem certeza de que deseja excluir este endereço do catálogo de endereços do usuário?"
+  },
+  "/lBLBI": {
+    "context": "channels alphabetically title",
+    "string": "Canais de A a Z"
+  },
+  "/ly15q": {
+    "context": "tab label for required attributes",
+    "string": "Atributos obrigatórios"
+  },
+  "/nZy6A": {
+    "context": "page subtitle",
+    "string": "Emitir reembolso"
+  },
+  "/oaqFS": {
+    "context": "section header",
+    "string": "Valor"
+  },
+  "/oyr6M": {
+    "context": "no variants",
+    "string": "Nenhuma variação encontrada."
+  },
+  "/qk66u": {
+    "context": "window title",
+    "string": "Conceder reembolso #{orderNumber}"
+  },
+  "/rsk2X": {
+    "context": "Badge shown when channel is newly added",
+    "string": "novo"
+  },
+  "/vCXIP": {
+    "string": "Tradução"
+  },
+  "/w919H": {
+    "context": "OrderCustomer Fulfillment from Local Warehouse",
+    "string": "Atender a partir do estoque local"
+  },
+  "/x7Y7U": {
+    "context": "search models placeholder",
+    "string": "Pesquisar modelos"
+  },
+  "/xJSe8": {
+    "context": "When users confirm their email account, all previous anonymous orders placed under the same email would be added to their order history.",
+    "string": "Quando os usuários confirmam sua conta de e-mail, todos os pedidos anônimos anteriores feitos sob o mesmo e-mail serão adicionados ao seu histórico de pedidos."
+  },
+  "/xXvjF": {
+    "context": "section header",
+    "string": "Não faturado"
+  },
+  "/yJJvI": {
+    "context": "dialog header",
+    "string": "Selecione um tipo de produto"
+  },
+  "/yy0uS": {
+    "context": "message when no SKU prefix is provided",
+    "string": "SKU não será definido"
+  },
+  "/z5aI6": {
+    "context": "section header",
+    "string": "Webhooks de Extensão"
+  },
+  "/z9uo1": {
+    "context": "order returned success message",
+    "string": "Produtos devolvidos com sucesso!"
+  },
+  "/zFGgP": {
+    "string": "+{count} mais"
+  },
+  "0+sGhF": {
+    "context": "Suffix for show-more button when hidden problems include active ones",
+    "string": ", incluindo {active} ativo"
+  },
+  "0+zatS": {
+    "string": "Olá {userName}, bem-vindo ao seu Painel da Loja"
+  },
+  "0/Y0nG": {
+    "context": "date group header",
+    "string": "Últimos 7 dias"
+  },
+  "00d8GP": {
+    "context": "info about variant metadata with link to edit",
+    "string": "Os metadados somente leitura da variante real usada neste pedido. {link}"
+  },
+  "033/zW": {
+    "context": "explore extensions section name",
+    "string": "Explorar"
+  },
+  "05hqq6": {
+    "context": "checkbox label",
+    "string": "Aprovar automaticamente todos os cumprimentos"
+  },
+  "06bR4Z": {
+    "context": "order history message",
+    "string": "Informações de cancelamento do pedido foram enviadas ao cliente"
+  },
+  "07KB2d": {
+    "string": "Código do País"
+  },
+  "0AQH0Q": {
+    "string": "O plug-in está configurado incorretamente e não pode ser ativado"
+  },
+  "0Azlrb": {
+    "string": "Gerenciar"
+  },
+  "0B0HS2": {
+    "context": "dialog header",
+    "string": "Excluir modelo"
+  },
+  "0DRBjg": {
+    "string": "Anotações do Token"
+  },
+  "0DTk+2": {
+    "context": "Add custom extension page subheader",
+    "string": "Saiba mais sobre {manifestFormatLink}"
+  },
+  "0DgA8v": {
+    "context": "swatch attribute color picker label",
+    "string": "Seletor"
+  },
+  "0FexL7": {
+    "context": "min price in channel",
+    "string": "Valor Mín."
+  },
+  "0GJfWd": {
+    "string": "Nome do País"
+  },
+  "0HBlkO": {
+    "string": "Pesquisar canais"
+  },
+  "0KVj6r": {
+    "string": "Copiar número de rastreamento"
+  },
+  "0Kz+nM": {
+    "string": "Data limite"
+  },
+  "0MetrR": {
+    "context": "webhook input help text",
+    "string": "Esta URL receberá requisições POST de webhook"
+  },
+  "0Mg8o5": {
+    "context": "header",
+    "string": "Tokens"
+  },
+  "0OAE9q": {
+    "string": "Checkout e pedidos"
+  },
+  "0OfZJA": {
+    "context": "button",
+    "string": "Voltar"
+  },
+  "0OtaXa": {
+    "context": "dialog header",
+    "string": "Criar Menu"
+  },
+  "0QE6RR": {
+    "context": "Message when all countries are covered",
+    "string": "Todos os países cobertos"
+  },
+  "0ReyKr": {
+    "context": "VariantDetailsChannelsAvailabilityCard item subtitle published",
+    "string": "Publicado desde {publishedAt}"
+  },
+  "0TQuo4": {
+    "context": "dialog header",
+    "string": "Unassign Collection From Sale"
+  },
+  "0V1q0d": {
+    "context": "add country dialog header",
+    "string": "Escolha o país que deseja adicionar"
+  },
+  "0VDwAP": {
+    "context": "checkbox label",
+    "string": "Enviar detalhes de envio para o cliente"
+  },
+  "0Vyr8h": {
+    "context": "menu item name",
+    "string": "Nome"
+  },
+  "0XHXTZ": {
+    "context": "column header",
+    "string": "Título"
+  },
+  "0YOedO": {
+    "context": "label for already charged amount",
+    "string": "Capturado até agora"
+  },
+  "0YjGFG": {
+    "context": "alert message",
+    "string": "Para assinatura"
+  },
+  "0a0fLZ": {
+    "context": "countries list menu label when no countries are assigned",
+    "string": "Não há países atribuídos"
+  },
+  "0cVk9I": {
+    "string": "Mostrar nas listas de produtos"
+  },
+  "0dCGBW": {
+    "context": "button",
+    "string": "Criar estrutura"
+  },
+  "0dPP8O": {
+    "string": "O pedido nº {orderId} foi feito"
+  },
+  "0em8tI": {
+    "context": "ProductTypeDeleteWarningDialog multiple consent label",
+    "string": "Sim, quero excluir esses tipos de produtos e os produtos atribuídos"
+  },
+  "0f6YvV": {
+    "context": "dialog title",
+    "string": "Capturar pagamento"
+  },
+  "0fM/pV": {
+    "context": "message title",
+    "string": "Aplicativo instalado"
+  },
+  "0g0LHg": {
+    "context": "card header and checkbox label",
+    "string": "Emitir webhooks de atualização para alterações de metadados"
+  },
+  "0iMYc+": {
+    "context": "field is optional",
+    "string": "(Opcional)"
+  },
+  "0iZ6Ds": {
+    "context": "snackbar text",
+    "string": "Extensão ativada"
+  },
+  "0ix6PR": {
+    "string": "Pedido cancelado"
+  },
+  "0kPdlb": {
+    "context": "deprecated secret key toolbar label",
+    "string": "Use assinatura RS256 em vez disso."
+  },
+  "0krqBj": {
+    "context": "page header",
+    "string": "Nº do pedido {orderNumber} - Reembolso"
+  },
+  "0mhR+F": {
+    "context": "Header row quantity label",
+    "string": "Quantidade"
+  },
+  "0nL1D6": {
+    "context": "number of menu items",
+    "string": "Itens"
+  },
+  "0nLsyM": {
+    "string": "Nenhum tipo de produto encontrado"
+  },
+  "0oo+BT": {
+    "context": "section header",
+    "string": "Montante Reembolsado"
+  },
+  "0opVvi": {
+    "context": "number of ordered products",
+    "string": "{amount, plural,one {Um pedido} other {{amount} Pedidos}}"
+  },
+  "0qg33z": {
+    "context": "table column header",
+    "string": "Return"
+  },
+  "0sd4ez": {
+    "context": "selected customer channel subtitle",
+    "string": "O cliente receberá o código do vale-presente por meio do endereço de e-mail deste canal"
+  },
+  "0u9Ng0": {
+    "context": "Dry run no objects found",
+    "string": "Nenhum objeto encontrado na consulta fornecida"
+  },
+  "0whAeC": {
+    "context": "sum of all pending refunds inside an order",
+    "string": "Reembolsos pendentes"
+  },
+  "0xMUfd": {
+    "string": "Nenhum resultado encontrado para \"{query}\""
+  },
+  "1+M/52": {
+    "context": "section header",
+    "string": "Status do Webhook"
+  },
+  "1+ROfp": {
+    "string": "Transação"
+  },
+  "1/bAgt": {
+    "context": "discount type fixed",
+    "string": "Fixo"
+  },
+  "1/oG76": {
+    "context": "dialog header",
+    "string": "Excluir Venda"
+  },
+  "1/oauz": {
+    "context": "grant refund table, column header",
+    "string": "Qtd a reembolsar"
+  },
+  "11ep0q": {
+    "context": "button",
+    "string": "Mostrar metadados"
+  },
+  "11lR5V": {
+    "context": "avatar delete button",
+    "string": "Excluir"
+  },
+  "129wyQ": {
+    "context": "dialog header",
+    "string": "Alterar endereço de entrega do cliente"
+  },
+  "12K83x": {
+    "context": "shipping method option when name unknown",
+    "string": "Método atual"
+  },
+  "15PiOX": {
+    "context": "button title",
+    "string": "Não-assinado"
+  },
+  "15fg+o": {
+    "context": "weeks after label",
+    "string": "Semanas após a emissão"
+  },
+  "16Dpgb": {
+    "context": "Synchronous events description",
+    "string": "Webhook síncrono envia carga útil e aguarda uma resposta da URL de destino para continuar o processamento."
+  },
+  "16PGt9": {
+    "context": "WarehouseSettings all warehouses label",
+    "string": "Todos os armazéns"
+  },
+  "16iwCI": {
+    "context": "section header",
+    "string": "Cumprido"
+  },
+  "18wvf7": {
+    "context": "section header",
+    "string": "Detalhes do Pedido"
+  },
+  "19/lwV": {
+    "string": "Determine atributos usados para criar tipos de produtos"
+  },
+  "19o9WS": {
+    "string": "Saiba mais sobre {userPermissions}"
+  },
+  "1ACBFw": {
+    "context": "Ripple tooltip confirmation button",
+    "string": "Mostre-me"
+  },
+  "1BNKCZ": {
+    "context": "sale channel",
+    "string": "Canal"
+  },
+  "1H+V6k": {
+    "context": "error message",
+    "string": "Página com esses atributos já existe."
+  },
+  "1H0tqc": {
+    "context": "Scheduled date for availability",
+    "string": "agendado {date}"
+  },
+  "1J/bhZ": {
+    "context": "expiry date section header",
+    "string": "Data de validade"
+  },
+  "1KSqnn": {
+    "context": "tab name",
+    "string": "Todos os Tipos de Produtos"
+  },
+  "1LBYpE": {
+    "context": "dialog header",
+    "string": "Excluir menus"
+  },
+  "1LiVhv": {
+    "context": "section header",
+    "string": "Pedidos recentes"
+  },
+  "1T1fP8": {
+    "context": "range input label",
+    "string": "Códigos postais (start)"
+  },
+  "1UKx20": {
+    "context": "header",
+    "string": "Tradução Método de Envio \"{shippingMethodName}\" - {languageCode}"
+  },
+  "1UQ9Qy": {
+    "string": "Prefixo do código (Opcional)"
+  },
+  "1Uj0Wd": {
+    "context": "order draft total price",
+    "string": "Total"
+  },
+  "1WbTJ5": {
+    "context": "product variants, title",
+    "string": "Variantes"
+  },
+  "1X6HtI": {
+    "string": "Todas as Categorias"
+  },
+  "1Znp5B": {
+    "string": "Tenha cuidado extra com impostos e extensões de pagamento, certifique-se de que sua configuração selecione outra extensão a ser usada"
+  },
+  "1div9r": {
+    "string": "Pesquisar atributo"
+  },
+  "1eCau/": {
+    "string": "Webhook sem nome"
+  },
+  "1eEyJv": {
+    "context": "ExitFormPrompt continue editing button",
+    "string": "Continuar editando"
+  },
+  "1gzck6": {
+    "string": "{firstName} {lastName}"
+  },
+  "1kdQdO": {
+    "context": "section header",
+    "string": "Variações"
+  },
+  "1lk/oS": {
+    "context": "button",
+    "string": "Adicionar intervalo de códigos postais"
+  },
+  "1n1tOR": {
+    "string": "O grupo está fora do seu escopo de permissão"
+  },
+  "1ncKJy": {
+    "context": "Warning when no warehouses configured",
+    "string": "Sem armazéns"
+  },
+  "1oYjZc": {
+    "context": "sum of all granted refunds for an order",
+    "string": "Reembolso concedido"
+  },
+  "1qRwgQ": {
+    "context": "app installation",
+    "string": "Instalando aplicativo..."
+  },
+  "1qukRr": {
+    "context": "message when all selected variant combinations already exist",
+    "string": "Todas as combinações selecionadas já existem como variantes"
+  },
+  "1rpzrM": {
+    "context": "search placeholder",
+    "string": "Pesquisar pelo nome do país"
+  },
+  "1shOIS": {
+    "context": "column title",
+    "string": "Preço"
+  },
+  "1tXSSK": {
+    "context": "header",
+    "string": "Tradução Cupom \"{voucherName}\" - {languageCode}"
+  },
+  "1w06LC": {
+    "context": "variants count label",
+    "string": "{variantsCount} variantes"
+  },
+  "1wbsEu": {
+    "context": "Transaction card title",
+    "string": "Transação"
+  },
+  "1wyZpQ": {
+    "string": "As senhas são muito parecidas"
+  },
+  "1zuQ2P": {
+    "context": "unassign country",
+    "string": "Tem certeza de que deseja remover {countryName} desta zona de envio?"
+  },
+  "2+v1wX": {
+    "context": "number of metadata fields in model",
+    "string": "{number,plural,one {{number} string} other {{number} strings}}"
+  },
+  "2/L4zZ": {
+    "string": "Selecionar todos os canais"
+  },
+  "21cJ+Z": {
+    "context": "structures section name",
+    "string": "Estruturas"
+  },
+  "22x9tu": {
+    "context": "header",
+    "string": "Produto de tradução \"{productName}\" - {languageCode}"
+  },
+  "23g7PY": {
+    "context": "dialog header",
+    "string": "Convidar Membro da Equipe"
+  },
+  "26+K4N": {
+    "string": "Houve um problema com o arquivo que você enviou como imagem e ele não pôde ser usado. Por favor, tente um arquivo diferente."
+  },
+  "26BKkX": {
+    "context": "order status",
+    "string": "Parcialmente devolvido"
+  },
+  "28GZnc": {
+    "string": "Digite para pesquisar...."
+  },
+  "28vvyx": {
+    "context": "deselect all values button",
+    "string": "Nenhum"
+  },
+  "29L5Yq": {
+    "context": "gift card not found message",
+    "string": "Não foi possível encontrar o vale-presente"
+  },
+  "2BHjVL": {
+    "context": "header",
+    "string": "Cabeçalhos de solicitação personalizados"
+  },
+  "2CBcub": {
+    "context": "CreateVariantTitle manage",
+    "string": "Gerenciar"
+  },
+  "2E1xZ0": {
+    "context": "page header",
+    "string": "Criar Venda"
+  },
+  "2FQ5xn": {
+    "context": "Status when product is currently available for purchase",
+    "string": "Disponível agora"
+  },
+  "2FQsYj": {
+    "context": "button",
+    "string": "Limpar"
+  },
+  "2HfSiT": {
+    "context": "pagination",
+    "string": "No. of rows"
+  },
+  "2J6EFz": {
+    "context": "button",
+    "string": "Escolha a mídia"
+  },
+  "2JBvj0": {
+    "context": "export products to csv file, button",
+    "string": "Exportar produtos"
+  },
+  "2MKBk2": {
+    "context": "window title",
+    "string": "Faturar pedido nº {orderNumber}"
+  },
+  "2MKkgX": {
+    "context": "checkbox label",
+    "string": "Permitir atendimento sem pagamento"
+  },
+  "2NdGVf": {
+    "context": "description for required non-selection attributes section",
+    "string": "Esses valores serão aplicados a todas as variantes geradas."
+  },
+  "2NgTCJ": {
+    "string": "Um produto com este SKU já existe"
+  },
+  "2OH46U": {
+    "context": "search modal shipping title",
+    "string": "Endereço de entrega"
+  },
+  "2RYRdr": {
+    "context": "webhooks active label",
+    "string": "Ativo"
+  },
+  "2Sx05f": {
+    "context": "Previous discount label",
+    "string": "Valor anterior do desconto"
+  },
+  "2V6eD8": {
+    "context": "refund type",
+    "string": "Reembolso diversificado"
+  },
+  "2VSP8C": {
+    "context": "delete token",
+    "string": "Tem certeza de que deseja excluir o token {token}?"
+  },
+  "2W4EBM": {
+    "context": "button",
+    "string": "Defina as quantidades máximas"
+  },
+  "2Xt+sw": {
+    "context": "dialog header",
+    "string": "Adicionar códigos postais"
+  },
+  "2Zyit2": {
+    "context": "delete page types with its pages",
+    "string": "{counter,plural,one {Os tipos de página que você deseja excluir são usados ​​por algumas páginas. Excluir esses tipos de página também excluirá essas páginas. Tem certeza de que deseja excluir este tipo de página ? Depois de fazer isso, você não poderá reverter as alterações.} other {Os tipos de página que você deseja excluir são usados ​​por algumas páginas. Excluir esses tipos de página também excluirá essas páginas. Tem certeza de que deseja excluir {displayQuantity} tipos de página ? Depois de fazer isso, você não poderá reverter as alterações.}}"
+  },
+  "2atspc": {
+    "string": "Rascunhos"
+  },
+  "2cjt25": {
+    "context": "window title",
+    "string": "Instalar Aplicativo"
+  },
+  "2dgbGR": {
+    "string": "Esses códigos já existem"
+  },
+  "2eHzVW": {
+    "string": "Reembolsos manuais não podem ser editados"
+  },
+  "2fgaAQ": {
+    "context": "search input placeholder",
+    "string": "Pesquisar zonas de envio..."
+  },
+  "2gsiR1": {
+    "string": "Nenhum depósito encontrado"
+  },
+  "2i81/P": {
+    "context": "section header button",
+    "string": "Gerenciar"
+  },
+  "2mRLis": {
+    "string": "Pesquisar Cliente"
+  },
+  "2nnp9+": {
+    "context": "Info box title when product is not available for purchase",
+    "string": "Visível, mas não comprável."
+  },
+  "2ob30/": {
+    "string": "Sucesso! Em alguns minutos você irá receber uma mensagem com as instruções de como redefinir sua senha."
+  },
+  "2oyWT9": {
+    "context": "button",
+    "string": "Voltar para o login"
+  },
+  "2p0tZx": {
+    "context": "delete customer, dialog content",
+    "string": "Tem certeza de que deseja excluir {email}?"
+  },
+  "2pw5dQ": {
+    "context": "payment status",
+    "string": "Totalmente pago"
+  },
+  "2qHTHI": {
+    "string": "Unidade de peso padrão atualizada"
+  },
+  "2qJc9y": {
+    "string": "CANCELAR DATA DE TÉRMINO"
+  },
+  "2qfU+C": {
+    "string": "O identificador da extensão já está em uso."
+  },
+  "2r4cTE": {
+    "context": "button",
+    "string": "Habilitar Modo Escuro"
+  },
+  "2x9ZgK": {
+    "context": "card title",
+    "string": "Saldo de reembolso"
+  },
+  "2xkzcr": {
+    "context": "btn label",
+    "string": "Ir para o Playground GraphQL"
+  },
+  "2yU+q9": {
+    "context": "tab name",
+    "string": "Todos os Depósitos"
+  },
+  "2yV+s8": {
+    "context": "order history message",
+    "string": "Pagamento foi capturado"
+  },
+  "2zCmiR": {
+    "context": "tabel column header",
+    "string": "Preço de custo"
+  },
+  "3+990c": {
+    "context": "button",
+    "string": "Ver todos os pedidos"
+  },
+  "3+KwtP": {
+    "context": "VariantDetailsChannelsAvailabilityCard subtitle",
+    "string": "Disponível em {publishedInChannelsCount} fora de {availableChannelsCount}"
+  },
+  "3/IQO9": {
+    "context": "extension install page, permissions section",
+    "string": "Instalar esta extensão dará a ela as seguintes permissões"
+  },
+  "30X9S8": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi emitido por {issuedBy}"
+  },
+  "31hYP2": {
+    "context": "alert card message",
+    "string": "Os cartões-presente aparecerão após o pedido ser atendido. <link>Ver pedidos com cartões-presente</link>"
+  },
+  "32Capp": {
+    "context": "page title",
+    "string": "Explorar"
+  },
+  "32dfzI": {
+    "context": "price or ordered products",
+    "string": "Preço"
+  },
+  "34F7Jk": {
+    "context": "filter range separator",
+    "string": "e"
+  },
+  "37U5su": {
+    "context": "all variants label",
+    "string": "Todas as variantes"
+  },
+  "38dS1A": {
+    "context": "code ending with label",
+    "string": "Código terminando com {last4CodeChars}"
+  },
+  "38dc43": {
+    "context": "Features preview",
+    "string": "Prévia de recursos"
+  },
+  "39yi8w": {
+    "context": "selected currency",
+    "string": "Moeda selecionada"
+  },
+  "3AqOxp": {
+    "context": "no category set error",
+    "string": "Categoria do produto não definida"
+  },
+  "3BTtL2": {
+    "string": "Nenhum país encontrado"
+  },
+  "3C3Nj5": {
+    "context": "button",
+    "string": "Adicionar variação"
+  },
+  "3CMUKE": {
+    "context": "password login mode option description",
+    "string": "Apenas usuários clientes podem fazer login com uma senha. Usuários da equipe que fazem login com uma senha serão tratados como clientes."
+  },
+  "3DGvA/": {
+    "string": "Lembre-se de que isso também liberará todos os produtos atribuídos a esta categoria, tornando-os indisponíveis na loja."
+  },
+  "3EFNZn": {
+    "context": "password login mode option",
+    "string": "Apenas clientes"
+  },
+  "3Eyq0y": {
+    "string": "Marcar como pago manualmente se o pagamento for confirmado"
+  },
+  "3Gkj+d": {
+    "context": "button to reset cut-off date to saved value",
+    "string": "Redefinir para o valor salvo"
+  },
+  "3PVGWj": {
+    "string": "Predefinição de filtro"
+  },
+  "3R7BmI": {
+    "context": "Extension by Author",
+    "string": "por"
+  },
+  "3SVI5p": {
+    "string": "Aviso"
+  },
+  "3Sz1/t": {
+    "context": "dialog header",
+    "string": "Excluir Páginas"
+  },
+  "3TlhJS": {
+    "context": "navigator command mode description",
+    "string": "Pesquisar Comando"
+  },
+  "3VsNbv": {
+    "context": "WarehouseSettings local warehouse description",
+    "string": "Se selecionado, o cliente poderá escolher este armazém como ponto de retirada.{break}Os produtos encomendados serão cumpridos apenas a partir do estoque deste armazém"
+  },
+  "3VyHbJ": {
+    "context": "button",
+    "string": "Criar Variação"
+  },
+  "3Z8972": {
+    "context": "product",
+    "string": "Quantidade em estoque"
+  },
+  "3a5wL8": {
+    "string": "Ativo"
+  },
+  "3bQz2o": {
+    "context": "bulk issue gift cards success alert title",
+    "string": "Cartões-presente emitidos"
+  },
+  "3d1RXL": {
+    "string": "Este cliente ainda não tem endereço"
+  },
+  "3dJ2Sc": {
+    "context": "model status",
+    "string": "Não publicado"
+  },
+  "3dVKNR": {
+    "context": "ProductTypeDeleteWarningDialog with items multiple description",
+    "string": "Você está prestes a excluir vários tipos de produtos. Alguns deles estão atribuídos a produtos. Excluir esses tipos de produto também excluirá esses produtos"
+  },
+  "3eR8iC": {
+    "string": "Mostre-me"
+  },
+  "3evXPj": {
+    "string": "Deixa sua anotação aqui..."
+  },
+  "3fBg0U": {
+    "context": "Message when no issues found",
+    "string": "Nenhum problema de disponibilidade detectado"
+  },
+  "3fgyFh": {
+    "context": "order history message",
+    "string": "O pagamento foi reembolsado"
+  },
+  "3kVRE2": {
+    "context": "Checkbox label for setting publication date",
+    "string": "Definir data de publicação"
+  },
+  "3kwdxJ": {
+    "context": "gift card export type label",
+    "string": "gift cards"
+  },
+  "3mvL2Q": {
+    "string": "e"
+  },
+  "3oQzWR": {
+    "context": "product availability",
+    "string": "Definir data de publicação"
+  },
+  "3psvRS": {
+    "context": "attribute values list: slug column header",
+    "string": "Administrador"
+  },
+  "3rIMq/": {
+    "context": "product shipping",
+    "string": "Envio"
+  },
+  "3stu21": {
+    "context": "refunded fulfillment, section header",
+    "string": "Substituído ({quantity})"
+  },
+  "3tbL7x": {
+    "context": "description",
+    "string": "Esqueceu a senha?"
+  },
+  "3u+4NZ": {
+    "string": "E-mail da fatura enviado"
+  },
+  "3ukd9/": {
+    "context": "attributes, section header",
+    "string": "Atributos"
+  },
+  "3xv4ez": {
+    "string": "Ir para usuários/membros da equipe"
+  },
+  "3y4r+z": {
+    "context": "channel settings",
+    "string": "Configurações do Canal"
+  },
+  "3yf2ND": {
+    "string": "Operador"
+  },
+  "3zdm8A": {
+    "context": "Dialog title",
+    "string": "Transação {actionType}"
+  },
+  "3zoKGn": {
+    "context": "subtitle for variant attributes section",
+    "string": "Atributos adicionais para informações específicas da variante.{br}Podem ser ajustados nas configurações de {productTypeLink}."
+  },
+  "408KSO": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi usado como forma de pagamento no pedido {orderLink}"
+  },
+  "41z2Qi": {
+    "context": "notification",
+    "string": "Páginas removidas"
+  },
+  "423QsF": {
+    "context": "option title",
+    "string": "Priorizar armazéns com maior estoque"
+  },
+  "43AOvZ": {
+    "context": "alert group message",
+    "string": "Você não poderá finalizar este rascunho porque:"
+  },
+  "43Nlay": {
+    "context": "warehouse",
+    "string": "Informação do Endereço"
+  },
+  "43QkTW": {
+    "context": "Transaction capture button - charge preauthorized transaction amount",
+    "string": "Captura"
+  },
+  "43b+ts": {
+    "context": "extensions list has been installed",
+    "string": "Extensão instalada"
+  },
+  "450Fty": {
+    "string": "Nenhum"
+  },
+  "45MmHa": {
+    "context": "Description for no variant priced error",
+    "string": "Defina um preço para pelo menos uma variante neste canal. O preço pode ser 0 para produtos gratuitos."
+  },
+  "45aV8u": {
+    "context": "gift card bulk create modal bottom explanation",
+    "string": "Após a criação, o Saleor criará uma lista de códigos de cartão-presente que você poderá baixar."
+  },
+  "45zP+r": {
+    "context": "voucher discount",
+    "string": "Produtos específicos"
+  },
+  "48dMqY": {
+    "context": "Dry run trigger button",
+    "string": "Executar"
+  },
+  "49vo8t": {
+    "string": "Pesquisa rápida"
+  },
+  "4B32Ba": {
+    "context": "delete page",
+    "string": "Tem certeza de que deseja excluir {title}?"
+  },
+  "4C7I61": {
+    "context": "sale Details delete button",
+    "string": "Venda removida"
+  },
+  "4CrCbD": {
+    "string": "Comunidade"
+  },
+  "4Dc2j0": {
+    "context": "order status",
+    "string": "Devolvida"
+  },
+  "4DkQt1": {
+    "context": "empty state for model types",
+    "string": "Nenhum tipo de modelo atribuído"
+  },
+  "4ELCCk": {
+    "context": "column picker section default header",
+    "string": "Categorias"
+  },
+  "4EdlF/": {
+    "context": "datagrid title label",
+    "string": "Selecione a transação para reembolsar"
+  },
+  "4EuJKs": {
+    "string": "Todos os preços dos produtos são inclusos com os impostos"
+  },
+  "4IawKc": {
+    "context": "onboarding step description",
+    "string": "Vá para todos os pedidos onde você pode criar um cumprimento e reembolso e revisar os status correspondentes. Veja o pedido no GraphQL"
+  },
+  "4JW9iJ": {
+    "context": "home section name",
+    "string": "Início"
+  },
+  "4JcNaA": {
+    "context": "button",
+    "string": "Convidar membro da equipe"
+  },
+  "4Jp83O": {
+    "context": "subheader",
+    "string": "Informação de Contato"
+  },
+  "4KRhwm": {
+    "context": "link in infoCardText, to Saleor docs",
+    "string": "Saiba mais sobre privacidade de dados."
+  },
+  "4Kq3O6": {
+    "string": "Esta unidade será usada como peso de embalagem padrão"
+  },
+  "4LRapg": {
+    "string": "Desconto removido"
+  },
+  "4PlW0w": {
+    "context": "tracking number",
+    "string": "Código de Rastreamento: {trackingNumber}"
+  },
+  "4Rj36Y": {
+    "string": "Criar novo Tipo de Modelo"
+  },
+  "4VLj3S": {
+    "context": "overcharged order status",
+    "string": "Cobrado em excesso"
+  },
+  "4VOIum": {
+    "context": "product availability",
+    "string": "Ativar esta caixa de seleção removerá o produto das páginas de pesquisa e categoria. Ele estará disponível nas páginas de coleção."
+  },
+  "4VivsY": {
+    "string": "Preço total"
+  },
+  "4W/CKn": {
+    "context": "modal button",
+    "string": "Upload URL"
+  },
+  "4X0ZI8": {
+    "string": "Cartão-presente"
+  },
+  "4XhJY+": {
+    "context": "dialog header",
+    "string": "Adicionar produto de {channelName}"
+  },
+  "4YJHut": {
+    "string": "Limpar pesquisa"
+  },
+  "4YyeCx": {
+    "context": "label for order total amount",
+    "string": "Total do pedido"
+  },
+  "4Z0O2B": {
+    "context": "section header title",
+    "string": "Cronograma do vale-presente"
+  },
+  "4Z14xW": {
+    "context": "button",
+    "string": "Finalizar"
+  },
+  "4Z6BtA": {
+    "context": "order history message",
+    "string": "Confirmação de pagamento foi enviado ao cliente"
+  },
+  "4fJ17F": {
+    "context": "Charge in progress transaction amount, data display header",
+    "string": "Cobrança pendente"
+  },
+  "4gT3eD": {
+    "context": "navigator section header",
+    "string": "Pesquisar em Clientes"
+  },
+  "4gZl/n": {
+    "string": "See <emphasis>DEMO STOREFRONT</emphasis>"
+  },
+  "4hl9rS": {
+    "context": "variant price in channel",
+    "string": "Preço"
+  },
+  "4i7ED7": {
+    "string": "Este reembolso foi processado com sucesso e não pode ser editado"
+  },
+  "4jcwS2": {
+    "context": "order history message",
+    "string": "Outro evento"
+  },
+  "4k38A6": {
+    "context": "card header and checkbox label",
+    "string": "Preservar campos de endereço não padrão"
+  },
+  "4k9rMQ": {
+    "context": "variant attribute checkbox",
+    "string": "Seleção de variante"
+  },
+  "4kcpaI": {
+    "context": "date group header",
+    "string": "Últimos 30 dias"
+  },
+  "4oWCm4": {
+    "string": "Classe de imposto atualizada"
+  },
+  "4p3bjX": {
+    "context": "tax strategy combobox choice",
+    "string": "Usar tarifas fixas"
+  },
+  "4prRLv": {
+    "string": "A permissão está fora do seu escopo"
+  },
+  "4qe6hO": {
+    "context": "product stock, section header",
+    "string": "Inventário"
+  },
+  "4sYqlg": {
+    "context": "error message when bulk variant creation fails completely",
+    "string": "Todas as variantes falharam ao criar"
+  },
+  "4v5gfh": {
+    "context": "account information, header",
+    "string": "Informação da conta"
+  },
+  "4y3Smi": {
+    "string": "Remover permissões pode causar a quebra da extensão."
+  },
+  "4yRwN+": {
+    "context": "content",
+    "string": "Saleor não conseguiu obter informações cruciais da instalação. Sem isto, o Sistema não pode instalar o aplicativo em seu Saleor. Por favor use o botão abaixo para voltar no dashboard do sistema."
+  },
+  "4z1O0N": {
+    "context": "Refund status success",
+    "string": "Sucesso"
+  },
+  "5+Xcrz": {
+    "context": "app deactivated",
+    "string": "Desativado"
+  },
+  "5/BH83": {
+    "context": "success activate alert message",
+    "string": "{count,plural,one{Cartão-presente} other{{count} cartões-presente}} ativados"
+  },
+  "51HE+Q": {
+    "string": "Nenhuma venda encontrada"
+  },
+  "52lmfF": {
+    "string": "Adicionar Extensão"
+  },
+  "53W0OD": {
+    "string": "Tipos de modelo excluídos"
+  },
+  "54KYgS": {
+    "context": "months after label",
+    "string": "Meses após a emissão"
+  },
+  "54M0Gu": {
+    "string": "Forneça-nos um e-mail - se o encontrarmos em nosso banco de dados, enviaremos um link para redefinir sua senha. Você deverá encontrá-lo em sua caixa de entrada nos próximos minutos."
+  },
+  "55LMJv": {
+    "context": "country list header",
+    "string": "Países"
+  },
+  "56vUeQ": {
+    "string": "Produto adicionado à coleção"
+  },
+  "577R2r": {
+    "string": "Valor inválido"
+  },
+  "57IYpr": {
+    "context": "error message",
+    "string": "Valor é inválido"
+  },
+  "59XppT": {
+    "context": "button",
+    "string": "Aprovar"
+  },
+  "5A5tMT": {
+    "string": "Valor fixo"
+  },
+  "5A6/2C": {
+    "context": "section header",
+    "string": "Disponibilidade"
+  },
+  "5BajZK": {
+    "string": "Visualizar e atualizar as configurações do seu site."
+  },
+  "5FSIZp": {
+    "string": "Criar novo atributo"
+  },
+  "5GSYCR": {
+    "context": "page status",
+    "string": "Visibilidade"
+  },
+  "5HwLx9": {
+    "context": "alert",
+    "string": "Limite de armazém atingido"
+  },
+  "5JT4v2": {
+    "context": "dialog header",
+    "string": "Enviar Fatura"
+  },
+  "5JUEIh": {
+    "context": "field label, refund amount",
+    "string": "Valor do reembolso"
+  },
+  "5Jo3C5": {
+    "context": "vat not included in order price",
+    "string": "Não aplica"
+  },
+  "5KS3f4": {
+    "string": "Título da estrutura"
+  },
+  "5LRkEs": {
+    "string": "A nova dashboard e o GraphQL API são softwares em revisão de qualidade."
+  },
+  "5M+hLZ": {
+    "string": "Permissões do usuário"
+  },
+  "5MtM5w": {
+    "context": "model label",
+    "string": "Oculto"
+  },
+  "5O8EIz": {
+    "context": "Authorize transactions instead of charging",
+    "string": "Autorizar transações em vez de cobrar"
+  },
+  "5ObBlW": {
+    "string": "Modo Escuro"
+  },
+  "5OtU+V": {
+    "context": "dialog title",
+    "string": "Desvincular produtos da coleção"
+  },
+  "5QKsu+": {
+    "context": "waiting for export to end, header",
+    "string": "Exportando CSV"
+  },
+  "5RmuD+": {
+    "string": "Gerencie e atualize suas informações de depósito."
+  },
+  "5SPHkk": {
+    "string": "O pedido nº {orderId} foi totalmente pago"
+  },
+  "5SdrZT": {
+    "context": "Badge label for problems reported by the app itself",
+    "string": "Aplicativo"
+  },
+  "5ShHx2": {
+    "context": "tooltip for disabled buttons",
+    "string": "Você não tem permissão para gerenciar extensões"
+  },
+  "5TUpjG": {
+    "context": "product attribute entity type",
+    "string": "Produtos"
+  },
+  "5Vwnu+": {
+    "string": "Você atingiu seu limite de SKU, não poderá mais adicionar SKUs à sua loja. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
+  },
+  "5W3qxG": {
+    "context": "edit refund title",
+    "string": "Editar reembolso com itens de linha"
+  },
+  "5WhtoK": {
+    "context": "tooltip when generate button is disabled because no selections made",
+    "string": "Selecione pelo menos um valor para cada atributo de seleção"
+  },
+  "5XG1CO": {
+    "context": "acre-ft unit",
+    "string": "acre-ft"
+  },
+  "5ZYUn5": {
+    "context": "Filter and element text",
+    "string": "E"
+  },
+  "5ZvuVw": {
+    "string": "Nenhum produto corresponde à consulta fornecida"
+  },
+  "5ZxAiY": {
+    "string": "Token"
+  },
+  "5aiFbL": {
+    "context": "tabel column header",
+    "string": "Preço"
+  },
+  "5b0Boq": {
+    "context": "Dry run items list default message",
+    "string": "Escolha o objeto"
+  },
+  "5bJ26s": {
+    "string": "Tipo de página criado com sucesso"
+  },
+  "5blVMu": {
+    "context": "e-mail or full name",
+    "string": "Cliente"
+  },
+  "5c2JVF": {
+    "context": "voucher application, switch button",
+    "string": "Apenas uma vez por pedido"
+  },
+  "5dLpx0": {
+    "context": "references attribute type",
+    "string": "Referências"
+  },
+  "5dyOs0": {
+    "string": "Sem pagamentos para serem realizados."
+  },
+  "5elC9k": {
+    "context": "taxes section name",
+    "string": "Impostos"
+  },
+  "5fCMUI": {
+    "context": "translations section name",
+    "string": "Traduções"
+  },
+  "5ftg/B": {
+    "context": "button",
+    "string": "criar grupo de permissão"
+  },
+  "5hFkdO": {
+    "context": "checkbox label",
+    "string": "Conceda a esta extensão acesso total à loja"
+  },
+  "5i/InH": {
+    "context": "open new window button",
+    "string": "Abra este pedido no GraphiQL"
+  },
+  "5ixtBQ": {
+    "string": "Atribuir Tipos de Modelo"
+  },
+  "5kODlC": {
+    "string": "{usedGiftCards, plural, one {Cartão-presente} other {Cartões-presente} } {giftCardCodesList}"
+  },
+  "5kvaFR": {
+    "context": "product field",
+    "string": "Exportar SKU de variação"
+  },
+  "5nrCxC": {
+    "string": "Ir para tipos de modelo"
+  },
+  "5o84YO": {
+    "context": "Filter where element text",
+    "string": "Onde"
+  },
+  "5oVmhu": {
+    "string": "Solicitação de cancelamento enviada ao provedor de pagamento"
+  },
+  "5pHBSU": {
+    "context": "switch button",
+    "string": "Tipo do produto usa Atributos de Variação"
+  },
+  "5sg7KC": {
+    "string": "Senha"
+  },
+  "5t/4um": {
+    "context": "message title",
+    "string": "Não foi possível instalar {name}"
+  },
+  "5tMkmJ": {
+    "context": "dialog header",
+    "string": "Atribuir coleção"
+  },
+  "5te3Tp": {
+    "context": "order payment",
+    "string": "Saldo excepcional"
+  },
+  "5u7b3V": {
+    "context": "voucher is active from date",
+    "string": "Inicia"
+  },
+  "5ukAFZ": {
+    "string": "Desativar esta caixa de seleção removerá o produto das páginas de pesquisa e categoria. Estará disponível nas páginas da coleção."
+  },
+  "5wktck": {
+    "context": "Description for no variant in channel error",
+    "string": "Variantes existem, mas nenhuma está disponível neste canal. Adicione listagens de canais de variante."
+  },
+  "5x6yT9": {
+    "context": "weight",
+    "string": "{fromValue} {fromUnit} - {toValue} {toUnit}"
+  },
+  "6+sMz4": {
+    "context": "product variant inventory",
+    "string": "Indisponível em todos os locais"
+  },
+  "6230rS": {
+    "string": "Regras de desconto para carrinhos e pedidos em rascunho."
+  },
+  "62T585": {
+    "context": "button",
+    "string": "{languageName} - {languageCode}"
+  },
+  "62Ywh2": {
+    "context": "number of countries",
+    "string": "{number} Paises"
+  },
+  "62nsdy": {
+    "string": "Tentar novamente"
+  },
+  "64aQXZ": {
+    "context": "product variants, full-screen title",
+    "string": "Variantes para: {name}"
+  },
+  "64aYF0": {
+    "context": "informations about product organization, header",
+    "string": "Organização do Produto"
+  },
+  "65j8ft": {
+    "context": "dialog title",
+    "string": "Criar novo reembolso"
+  },
+  "67V0c0": {
+    "context": "unassign product from collection, button",
+    "string": "Não vinculado"
+  },
+  "68Wuv1": {
+    "context": "search results",
+    "string": "Nenhuma coleção encontrada"
+  },
+  "6AMFki": {
+    "context": "product name",
+    "string": "Nome"
+  },
+  "6C1RWA": {
+    "string": "Nenhuma extensão instalada ainda"
+  },
+  "6D+yYX": {
+    "string": "Status do pagamento"
+  },
+  "6FLezz": {
+    "string": "Você tem certeza de que deseja excluir este desconto?"
+  },
+  "6G41zU": {
+    "context": "WarehouseSettings local warehouse description",
+    "string": "Se selecionado o cliente poderá escolher este armazém como ponto de recolha. Os produtos encomendados serão atendidos apenas a partir deste estoque em armazém"
+  },
+  "6GTAm2": {
+    "context": "order history message",
+    "string": "Os produtos foram excluídos do pedido"
+  },
+  "6HHPFy": {
+    "context": "tax strategy combobox hint",
+    "string": "Selecione o método de cálculo de imposto"
+  },
+  "6IteaF": {
+    "string": "Os aplicativos estão disponíveis para usuários do Saleor Cloud. A maioria deles está disponível para auto-hospedagem."
+  },
+  "6J1m2c": {
+    "string": "Criar um Modelo"
+  },
+  "6Jgwpc": {
+    "string": "Nenhum pagamento recebido"
+  },
+  "6JlXeD": {
+    "context": "button",
+    "string": "Criar tipo de página"
+  },
+  "6KqwHF": {
+    "context": "Error when no variant has price set",
+    "string": "Nenhuma variante tem um preço em \"{channelName}\""
+  },
+  "6L6Fy2": {
+    "context": "header",
+    "string": "Aviso legal"
+  },
+  "6LqbaB": {
+    "string": "Coleção criada"
+  },
+  "6QjMei": {
+    "string": "O horário de término da encomenda precisa ser definido no futuro"
+  },
+  "6RQKxH": {
+    "context": "order history message",
+    "string": "Fatura {invoiceNumber} foi atualizada"
+  },
+  "6RtE2D": {
+    "context": "unassign collection from sale and save, button",
+    "string": "Unassign and save"
+  },
+  "6SL46U": {
+    "string": "por {author}"
+  },
+  "6ScZk5": {
+    "context": "order transaction refund summary disabled shipping tooltip content",
+    "string": "O envio já foi reembolsado."
+  },
+  "6Tps09": {
+    "string": "Inativo"
+  },
+  "6V+aAL": {
+    "string": "Avatar atualizado"
+  },
+  "6WRFp2": {
+    "context": "order history message",
+    "string": "Uma nota foi adicionada ao pedido"
+  },
+  "6WqHWi": {
+    "string": "Aplica-se a"
+  },
+  "6Y1YDn": {
+    "string": "Permissões da extensão atualizadas"
+  },
+  "6Y1nQd": {
+    "context": "product is visible",
+    "string": "Visível"
+  },
+  "6ZubLQ": {
+    "string": "Gerenciar razões de reembolso disponíveis"
+  },
+  "6aBkJm": {
+    "context": "section header",
+    "string": "Autorização"
+  },
+  "6cMkfT": {
+    "context": "table head",
+    "string": "Nome do Produto"
+  },
+  "6cS4Rd": {
+    "context": "card section description",
+    "string": "Permissões disponiveis"
+  },
+  "6cq+c+": {
+    "context": "header",
+    "string": "Tipo do Desconto"
+  },
+  "6fAGSm": {
+    "context": "Product is not visible via public API",
+    "string": "Não visível"
+  },
+  "6fORLY": {
+    "string": "Nenhum tipo de página encontrado"
+  },
+  "6fxdUO": {
+    "context": "section header",
+    "string": "Criar Nova Zona de Envio"
+  },
+  "6hLZNA": {
+    "context": "delete app",
+    "string": "Tem certeza que deseja excluir este aplicativo?"
+  },
+  "6heBHt": {
+    "context": "tooltip, submit form",
+    "string": "A transação não é reembolsável. Você deve enviar o reembolso manualmente."
+  },
+  "6iw4VR": {
+    "context": "delete variant dialog title",
+    "string": "Excluir Variações do Produto"
+  },
+  "6j4TUi": {
+    "string": "Tipo de produto atualizado"
+  },
+  "6jyoEd": {
+    "context": "section header",
+    "string": "Sobre esta extensão"
+  },
+  "6nSTuC": {
+    "context": "webhooks section name",
+    "string": "Webhooks"
+  },
+  "6orx1c": {
+    "string": "Endereço de cobrança"
+  },
+  "6oxTyq": {
+    "string": "Todos os eventos relacionados a este pedido. Para mais informações sobre eventos de pedidos, visite nossa documentação {link}."
+  },
+  "6pPMp9": {
+    "string": "Preço subtotal"
+  },
+  "6sjBvJ": {
+    "context": "input placeholder",
+    "string": "Pesquisar por nome, e-mail, etc..."
+  },
+  "6sr5Sp": {
+    "string": "Qualquer termo corresponde"
+  },
+  "6u4K7e": {
+    "context": "page header",
+    "string": "Pedido"
+  },
+  "6udlH+": {
+    "string": "Rascunho do pedido criado com sucesso"
+  },
+  "6vf8AS": {
+    "context": "section title",
+    "string": "Validação de Endereço"
+  },
+  "6xC/Ls": {
+    "context": "informations about product seo, header",
+    "string": " Informação SEO"
+  },
+  "6xNl6V": {
+    "string": "Adicionar código"
+  },
+  "6y+k8V": {
+    "context": "product field",
+    "string": "Imagens do Produto"
+  },
+  "7+GBlj": {
+    "string": "Error code {errorCode} {fieldError}"
+  },
+  "71Agnt": {
+    "context": "deactivate app billing info",
+    "string": "Você ainda será cobrado pela extensão."
+  },
+  "71NpbR": {
+    "context": "Label shown on dismissed problems",
+    "string": "Dispensado"
+  },
+  "720c51": {
+    "context": "tax classes name input placeholder",
+    "string": "Nome da taxa de imposto"
+  },
+  "73RU3R": {
+    "context": "deactivate app",
+    "string": "Tem certeza que deseja desabilitar este aplicativo? Seus dados serão mantidos até que você reative o aplicativo. Você ainda será cobrado pelo aplicativo."
+  },
+  "73SSOz": {
+    "string": "Todas as linhas conforme solicitado pelo cliente."
+  },
+  "74Cxe8": {
+    "context": "table header product label",
+    "string": "Produto"
+  },
+  "74Zo/H": {
+    "context": "channel slug",
+    "string": "Slug"
+  },
+  "750Ymk": {
+    "context": "apps about permissions",
+    "string": "Esta extensão tem permissões para:"
+  },
+  "7A+FJl": {
+    "context": "link",
+    "string": "Ver perfil"
+  },
+  "7Chrsf": {
+    "string": "As senhas não coincidem"
+  },
+  "7EDqed": {
+    "context": "tab name",
+    "string": "Todos os cartões-presente"
+  },
+  "7FL+WZ": {
+    "context": "export products to csv file, button",
+    "string": "Exportar Produtos"
+  },
+  "7G7tg3": {
+    "context": "Number of variants that have stock available",
+    "string": "{count, plural, one {# variante em estoque} other {# variantes em estoque}}"
+  },
+  "7H2D5m": {
+    "context": "attribute value deleted",
+    "string": "Valor deletado"
+  },
+  "7Hdiw2": {
+    "string": "Nome da regra é obrigatório"
+  },
+  "7Ii5ZQ": {
+    "string": "DATA DE TÉRMINO DA CONFIGURAÇÃO"
+  },
+  "7JAAul": {
+    "context": "product field",
+    "string": "Exportar Peso do Produto"
+  },
+  "7JPV5U": {
+    "string": "Páginas publicadas"
+  },
+  "7Jg9ec": {
+    "context": "error message",
+    "string": "Você não tem permissão para fazer login."
+  },
+  "7JlauX": {
+    "string": "Explorar"
+  },
+  "7MUx0T": {
+    "string": "Desconto de {value} através do {channel}"
+  },
+  "7NFfmz": {
+    "string": "Produtos"
+  },
+  "7NfoiJ": {
+    "context": "custom search delete, dialog header",
+    "string": "Excluir Pesquisa"
+  },
+  "7O2EsY": {
+    "context": "deactivate local app",
+    "string": "Você tem certeza de que deseja desativar este aplicativo? Seus dados serão mantidos até que você reative o aplicativo."
+  },
+  "7QPLu0": {
+    "context": "empty state message",
+    "string": "Nenhuma transação feita para este pedido."
+  },
+  "7QhDjU": {
+    "context": "Health check subtitle when product cannot be purchased",
+    "string": "Verifique os problemas acima para corrigir a configuração"
+  },
+  "7U/NPm": {
+    "context": "tax class rates list label when no country is selected",
+    "string": "Adicione um país para acessar classes de imposto"
+  },
+  "7U8GRy": {
+    "string": "Forma de envio atualizada com sucesso"
+  },
+  "7UG1Lx": {
+    "context": "checkbox gift cards label",
+    "string": "Processar automaticamente cartões-presente que não podem ser enviados"
+  },
+  "7WEC+G": {
+    "context": "page title",
+    "string": "Preço e SKUs"
+  },
+  "7WEeNq": {
+    "context": "select label",
+    "string": "Verdadeiro"
+  },
+  "7WrRzs": {
+    "context": "dialog , editing order line metadata",
+    "string": "Representa os metadados do item encomendado dado"
+  },
+  "7WzUxn": {
+    "context": "staff member status",
+    "string": "Inativo"
+  },
+  "7X0w8O": {
+    "context": "model",
+    "string": "será visível a partir de {date}"
+  },
+  "7ZKQU3": {
+    "context": "no shipping method option",
+    "string": "Nenhum método de envio"
+  },
+  "7a1S4K": {
+    "context": "tab name",
+    "string": "Todos os Rascunhos"
+  },
+  "7dhhzL": {
+    "context": "bulk issue gift cards dialog title",
+    "string": "Cartões-presente de emissão em massa"
+  },
+  "7eGvyy": {
+    "context": "extension install page, extension permissions (from manifest)",
+    "string": "Permissões"
+  },
+  "7ejEbB": {
+    "context": "Authorized (amount locked on card, not transfered to store owner) transaction amount, data display header",
+    "string": "Autorizado"
+  },
+  "7hNjaI": {
+    "context": "button",
+    "string": "Excluir Variação"
+  },
+  "7jxSx8": {
+    "context": "Installed extensions column name",
+    "string": "Nome da Extensão"
+  },
+  "7l5Bh9": {
+    "string": "{counter,plural,one {Você tem certeza que deseja deletar este produto?} other {Tem certeza que você quer deletar {displayQuantity} produtos?}}"
+  },
+  "7mK2vs": {
+    "context": "product variant inventory",
+    "string": "Indisponível"
+  },
+  "7nKXni": {
+    "context": "option description",
+    "string": "Este produto funcionará como forma de pagamento"
+  },
+  "7oQUMG": {
+    "context": "apps about permissions",
+    "string": "Este aplicativo tem permissão para:"
+  },
+  "7qsOwa": {
+    "context": "action",
+    "string": "Incluir códigos postais"
+  },
+  "7scATx": {
+    "context": "select title",
+    "string": "Selecione os canais que deseja para {contentType} esteja disponível em"
+  },
+  "7v2oBd": {
+    "context": "header",
+    "string": "Erro"
+  },
+  "7v8suW": {
+    "context": "info text",
+    "string": "Esta taxa será aplicada a todos os pedidos"
+  },
+  "7vnKNE": {
+    "context": "structure item name",
+    "string": "Nome"
+  },
+  "7wkGxW": {
+    "context": "app has been installed",
+    "string": "{unitsLeft} unidades restantes"
+  },
+  "7yKZvp": {
+    "context": "section header",
+    "string": "User Status"
+  },
+  "7yfkyB": {
+    "context": "No variants have stock available",
+    "string": "Nenhuma variante em estoque"
+  },
+  "8/PQ07": {
+    "context": "delete custom app",
+    "string": "Ao excluir esta extensão, você excluirá todos os dados e webhooks relacionados a esta extensão."
+  },
+  "80FeaT": {
+    "context": "product variant preorder threshold",
+    "string": "{globalThreshold} Limite global"
+  },
+  "80g19N": {
+    "string": "Ver no GitHub"
+  },
+  "83egc7": {
+    "string": "Digite manualmente o código do voucher."
+  },
+  "84VEY1": {
+    "string": "Taxa de envio atualizada"
+  },
+  "86pLaG": {
+    "context": "WarehouseSettings public stock label",
+    "string": "Estoque Público"
+  },
+  "87NGDZ": {
+    "string": "O plugin não tem nenhum campo de configuração"
+  },
+  "89PSdB": {
+    "context": "link",
+    "string": "Editar configurações"
+  },
+  "8B8E+3": {
+    "context": "navigator placeholder",
+    "string": "Numero do Pedido"
+  },
+  "8BBMRj": {
+    "context": "default tax class name for new tax classes",
+    "string": "Nova classe de imposto"
+  },
+  "8CbACQ": {
+    "context": "add shipping zone title",
+    "string": "Adicionar Zonas de Envio"
+  },
+  "8Cjxdt": {
+    "string": "Cobrado em excesso"
+  },
+  "8Cve4h": {
+    "context": "checkbox label",
+    "string": "Enviar e-mail de cumprimento ao cliente"
+  },
+  "8EGagh": {
+    "context": "search box label",
+    "string": "Filtrar Países"
+  },
+  "8F2D1H": {
+    "context": "order refund amount, input button",
+    "string": "Reembolsar {currency} {amount}"
+  },
+  "8FDx9i": {
+    "context": "tooltip when generate variants is disabled due to product type configuration (hasVariants=false or no selection attributes)",
+    "string": "Para usar o Gerador, este tipo de produto precisa de:{newline}{newline}• 'O tipo de produto usa Atributos de Variante' ativado{newline}• Atributos de variante de seleção definidos"
+  },
+  "8GC/ah": {
+    "context": "variants section name",
+    "string": "Variantes"
+  },
+  "8HRy+U": {
+    "string": "Descrição da Categoria"
+  },
+  "8HmEqK": {
+    "context": "Transaction refund button - return captured amount to client",
+    "string": "Reembolso"
+  },
+  "8Hq18g": {
+    "context": "create gift card product type alert message",
+    "string": "Crie um tipo de produto de vale-presente"
+  },
+  "8InCjD": {
+    "string": "Forneça o intervalo de códigos postais que você deseja adicionar à lista de inclusão/exclusão.Please provide range of postal codes you want to add to the include/exclude list."
+  },
+  "8J81ri": {
+    "context": "ordered product sku",
+    "string": "SKU"
+  },
+  "8JEG80": {
+    "context": "warning when authorized is less than total",
+    "string": "A autorização restante não cobre o saldo. {shortfall} precisará de um pagamento separado."
+  },
+  "8Kk3r9": {
+    "context": "Status when product availability is scheduled for future date",
+    "string": "Agendado para {date}"
+  },
+  "8LWaFr": {
+    "context": "dialog content",
+    "string": "{counter,plural,one{Você tem certeza de que deseja despublicar este modelo?} other{Você tem certeza de que deseja despublicar {displayQuantity} modelos?}}"
+  },
+  "8MSYNw": {
+    "context": "order send refund, manual transaction refund was created",
+    "string": "Reembolso manual criado"
+  },
+  "8Mq3ku": {
+    "context": "btn label",
+    "string": "Ir para Extensões"
+  },
+  "8NBwu7": {
+    "context": "PageTypeDeleteWarningDialog with items multiple description",
+    "string": "Você está prestes a excluir vários tipos de modelo. Alguns deles estão atribuídos a modelos. Excluir esses tipos de modelo também excluirá esses modelos"
+  },
+  "8Q504V": {
+    "string": "Metadados"
+  },
+  "8RnPGF": {
+    "context": "order history message",
+    "string": "Pagamento foi cancelado"
+  },
+  "8V1ozm": {
+    "context": "order discount was updated automatically event title",
+    "string": "O desconto do pedido foi atualizado automaticamente"
+  },
+  "8VDOUy": {
+    "string": "Corresponde a \"café\", \"cafetaria\", etc."
+  },
+  "8W1v0N": {
+    "context": "Warning when channel has no shipping zones",
+    "string": "Nenhuma zona de envio para \"{channelName}\""
+  },
+  "8a4uf/": {
+    "context": "dialog content",
+    "string": "{counter,plural,one{Você tem certeza de que deseja excluir este modelo?} other{Você tem certeza de que deseja excluir {displayQuantity} modelos?}}"
+  },
+  "8a7vg2": {
+    "string": "Membro da equipe convidado"
+  },
+  "8aV98y": {
+    "context": "new version notification content",
+    "string": "Você precisa atualizar o Saleor para a versão mais recente. Antes de fazer isso, salve todas as alterações para evitar perda de dados. Para atualizar use o botão abaixo."
+  },
+  "8cUEPV": {
+    "context": "page title",
+    "string": "Criar Novo Atributo"
+  },
+  "8hrH/z": {
+    "context": "dialog header",
+    "string": "Pesquisar Categoria"
+  },
+  "8iUzOU": {
+    "context": "allow unpaid orders checbkox description",
+    "string": "Permite concluir o checkout com o pedido antes de um pagamento bem-sucedido."
+  },
+  "8jgfPX": {
+    "context": "automatic completion disabled info message",
+    "string": "Desativar a conclusão automática não interromperá checkouts que já estão agendados para conclusão."
+  },
+  "8oIbMI": {
+    "string": "Limite atingido para este plano"
+  },
+  "8pVWve": {
+    "string": "Este campo não pode estar em branco"
+  },
+  "8qL/tV": {
+    "context": "CannotDefineChannelsAvailabilityCard subtitle",
+    "string": "Você poderá definir a disponibilidade do produto após criar as variantes."
+  },
+  "8sOnqE": {
+    "context": "Warning when scheduling an available product for the future",
+    "string": "O produto não será comprável até esta data."
+  },
+  "8u7els": {
+    "context": "channel config plugin status popup title",
+    "string": "Atribuído a {activeChannelsCount} de {allChannelsCount} canais"
+  },
+  "8uLHBY": {
+    "context": "unassign attribute from object",
+    "string": "Tem certeza que deseja desatribuir  {attributeName} de {itemTypeName}?"
+  },
+  "8ugJiV": {
+    "string": "Tipo de valor de recompensa"
+  },
+  "8uo4v1": {
+    "context": "title",
+    "string": "Limites de finalização de compra"
+  },
+  "8vJCJ4": {
+    "string": "Defina e gerencie seus canais de venda"
+  },
+  "8vQGO0": {
+    "context": "tooltip content when line's variant has been deleted",
+    "string": "Esta variante não existe mais. Você ainda pode cumpri-la."
+  },
+  "8xsKUv": {
+    "context": "service accounts section name",
+    "string": "Contas de Serviço"
+  },
+  "8y4+0a": {
+    "context": "dialog content",
+    "string": "{counter,plural,one{Você tem certeza de que deseja publicar este modelo?} other{Você tem certeza de que deseja publicar {displayQuantity} modelos?}}"
+  },
+  "9+iLpf": {
+    "context": "link text to product type settings",
+    "string": "Configurar nas configurações do tipo de produto"
+  },
+  "906uUr": {
+    "context": "button",
+    "string": "Voltar a página inicial"
+  },
+  "91vQMc": {
+    "string": "gerenciamento de pedidos"
+  },
+  "945a4a": {
+    "context": "column header",
+    "string": "E-mail do cliente"
+  },
+  "95oJ5d": {
+    "context": "button",
+    "string": "Voltar para a Dashboard"
+  },
+  "97l2MO": {
+    "string": "E-mail do cliente"
+  },
+  "98Nw4g": {
+    "context": "card subtitle",
+    "string": "Preços renderizados"
+  },
+  "98WMlR": {
+    "context": "header",
+    "string": "Translation Product Variant \"{productName}\" - {languageCode}"
+  },
+  "98isC5": {
+    "string": "Mostrar preço bruto a clientes na loja"
+  },
+  "9B2mOB": {
+    "context": "tile view pagination label",
+    "string": "Nº de produtos"
+  },
+  "9B5R2I": {
+    "context": "success gift card enable message",
+    "string": "Cartão-presente ativado"
+  },
+  "9BvYb9": {
+    "string": "Voucher"
+  },
+  "9C7PZE": {
+    "context": "navigation section name",
+    "string": "Navegação"
+  },
+  "9CEu8k": {
+    "context": "modal button images upload",
+    "string": "Upload Images"
+  },
+  "9CW3TD": {
+    "context": "label",
+    "string": "Tipo de recompensa"
+  },
+  "9DUknc": {
+    "string": "Instalação falhou"
+  },
+  "9EMudJ": {
+    "context": "option",
+    "string": "Criar variante única"
+  },
+  "9FCrIN": {
+    "string": "Tipo de modelo"
+  },
+  "9FGTOt": {
+    "string": "Permitir acesso a pedidos de todos os canais"
+  },
+  "9Fiuq2": {
+    "string": "Saiba mais sobre {customExtensionDocsLink}"
+  },
+  "9HSbdS": {
+    "context": "structure loading",
+    "string": "trabalhando..."
+  },
+  "9IrVVZ": {
+    "context": "attribute can be searched in storefront",
+    "string": "Filtrável na vitrine"
+  },
+  "9MGrEp": {
+    "string": "Está disponível"
+  },
+  "9Mro3c": {
+    "context": "Transaction event status - pending",
+    "string": "Pendente"
+  },
+  "9OZ/fr": {
+    "context": "open full-screen mode with bulk edit",
+    "string": "Edição em massa"
+  },
+  "9OtpHt": {
+    "string": "Linha de pedido excluída"
+  },
+  "9PmyrU": {
+    "context": "product variant inventory",
+    "string": "Sem estoque"
+  },
+  "9QtKvB": {
+    "context": "Product type is shippable",
+    "string": "Enviável"
+  },
+  "9RCuN3": {
+    "string": "Pagamento capturado com sucesso"
+  },
+  "9RvXNg": {
+    "context": "section header",
+    "string": "Informações sobre mídia"
+  },
+  "9ScmSs": {
+    "string": "Pesquisar valores de atributos..."
+  },
+  "9Sz0By": {
+    "context": "channel currency",
+    "string": "Moeda"
+  },
+  "9TENcY": {
+    "string": "Todos os pagamentos de transações registradas."
+  },
+  "9TbDQD": {
+    "context": "order number label",
+    "string": "Número do pedido"
+  },
+  "9Tl/bT": {
+    "context": "export items as spreadsheet",
+    "string": "Planilha do Excel, Números etc."
+  },
+  "9UHfux": {
+    "string": "Informações Específicas do Cupom"
+  },
+  "9WhNiN": {
+    "context": "Pending authorization transaction amount, data display header",
+    "string": "Autorização pendente"
+  },
+  "9WmA6z": {
+    "context": "weight config modal title",
+    "string": "Configuração da unidade de peso padrão"
+  },
+  "9XYfOt": {
+    "context": "fulfillment section name",
+    "string": "Cumprimento"
+  },
+  "9Y5i/8": {
+    "context": "number of webhook headers in model",
+    "string": "{number,plural,one{{number} cabeçalho} other{{number} cabeçalhos de solicitação personalizados}}"
+  },
+  "9YazHG": {
+    "string": "Empresa"
+  },
+  "9Yhddc": {
+    "context": "input label",
+    "string": "Eventos registrados"
+  },
+  "9Z7LQq": {
+    "string": "Usar e-mail:"
+  },
+  "9Zlogd": {
+    "context": "staff member status",
+    "string": "Ativo"
+  },
+  "9ZtJhn": {
+    "context": "cancel button",
+    "string": "Cancelar pedido"
+  },
+  "9d24PR": {
+    "string": "Criar regra"
+  },
+  "9eC0MZ": {
+    "context": "collection",
+    "string": "Oculto"
+  },
+  "9gb9b4": {
+    "context": "address type",
+    "string": "Adicionar novo endereço"
+  },
+  "9hab/1": {
+    "context": "bulk issue menu item",
+    "string": "Emissão em massa"
+  },
+  "9kF+go": {
+    "string": "E (implícito)"
+  },
+  "9kzIFd": {
+    "context": "WarehouseSettings stock title",
+    "string": "Configurações de estoque"
+  },
+  "9mGA/Q": {
+    "context": "button linking to dashboard",
+    "string": "Painel de controle"
+  },
+  "9mrWKz": {
+    "context": "no products placeholder",
+    "string": "Nenhum produto está disponível correspondendo à consulta no canal atribuído a este pedido."
+  },
+  "9pGRfy": {
+    "context": "Add custom extension error link to Saleor Docs",
+    "string": "Saiba mais sobre este erro"
+  },
+  "9pLPLn": {
+    "context": "refund amounts were unsettled",
+    "string": "Não liquidado"
+  },
+  "9piUVz": {
+    "context": "order history message",
+    "string": "As informações de reembolso do pedido foram enviadas ao cliente"
+  },
+  "9q562c": {
+    "context": "apps section name",
+    "string": "Aplicativos"
+  },
+  "9qKFTA": {
+    "context": "Product category",
+    "string": "Categoria"
+  },
+  "9scTQ0": {
+    "context": "section header",
+    "string": "Atributos do Produto"
+  },
+  "9seX5T": {
+    "context": "attribute values search placeholder",
+    "string": "Pesquisar valores de atributos..."
+  },
+  "9ssWj+": {
+    "context": "unapproved fulfillment, section header",
+    "string": "Esperando aprovação ({quantity})"
+  },
+  "9tgY4G": {
+    "context": "apps content",
+    "string": "Você não tem nenhum aplicativo instalado na sua dashboard"
+  },
+  "9uNz+T": {
+    "context": "button",
+    "string": "Cancelar"
+  },
+  "9uqfGj": {
+    "string": "Variante atualizada"
+  },
+  "9vQR6c": {
+    "context": "collection label",
+    "string": "Visível"
+  },
+  "9xUIAh": {
+    "string": "Tax group"
+  },
+  "9xlPgt": {
+    "context": "used staff users counter",
+    "string": "{count}/{max} members"
+  },
+  "A+g/VP": {
+    "string": "Predefinição não salva"
+  },
+  "A02NDR": {
+    "context": "plain text attribute value was truncated",
+    "string": "Valor do atributo muito longo e truncado em {length} caracteres."
+  },
+  "A0Wlg7": {
+    "context": "product discount removed title",
+    "string": "{productName} desconto foi removido por"
+  },
+  "A7W4KO": {
+    "string": "Regra de catálogo"
+  },
+  "A9QSur": {
+    "context": "area units type",
+    "string": "Área"
+  },
+  "ABgQcF": {
+    "context": "variant stock, header",
+    "string": "estoque"
+  },
+  "AD1PlC": {
+    "context": "channels availability text",
+    "string": "Em {selectedChannelsCount} de {allChannelsCount, plural, one {# canal} other {# canais}}"
+  },
+  "ADTNND": {
+    "context": "product type",
+    "string": "Físico"
+  },
+  "ADvpV/": {
+    "context": "Product can be purchased by customers",
+    "string": "Comprável"
+  },
+  "AHK0K9": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza de que deseja cancelar a atribuição deste produto?} other {Tem certeza de que deseja cancelar a atribuição de {displayQuantity} produtos?}}"
+  },
+  "AHRDWt": {
+    "context": "button",
+    "string": "Criar página"
+  },
+  "AJgl5u": {
+    "context": "gift card product message",
+    "string": "produto de vale-presente"
+  },
+  "AKv2BI": {
+    "context": "order refund subtitle",
+    "string": "Itens reembolsados não podem ser processados"
+  },
+  "ALe+of": {
+    "string": "Você não tem permissão para gerenciar webhooks. Entre em contato com seu administrador para obter acesso."
+  },
+  "AN+zaK": {
+    "string": "Estruturas"
+  },
+  "AOI4LW": {
+    "context": "navigator placeholder",
+    "string": "Pesquisar no Catálogo"
+  },
+  "APcoSA": {
+    "context": "dialog header",
+    "string": "Excluir Rascunho do Pedido"
+  },
+  "AQ+9Ez": {
+    "string": "Encontramos um erro inesperado"
+  },
+  "AQDJ1d": {
+    "string": "Pedido em rascunho criado"
+  },
+  "AQFMYU": {
+    "context": "staff section name",
+    "string": "Membros da Equipe"
+  },
+  "AQSmqG": {
+    "context": "order discount was updated automatically event title",
+    "string": "Desconto do pedido foi atualizado automaticamente"
+  },
+  "AR/VVX": {
+    "context": "Indicates last login method user used",
+    "string": "Último usado"
+  },
+  "AUaL7R": {
+    "context": "notification",
+    "string": "Modelos selecionados foram publicados."
+  },
+  "AVF5T5": {
+    "context": "voucher end date, switch button",
+    "string": "Definir data de término"
+  },
+  "AWGJnU": {
+    "context": "replaced event title",
+    "string": "Produtos foram substituídos"
+  },
+  "AWyKB7": {
+    "context": "card header title",
+    "string": "Lista de canais"
+  },
+  "AY7Tuz": {
+    "string": "O mesmo objeto não pode estar em ambas as listas"
+  },
+  "AbyDC7": {
+    "context": "section header",
+    "string": "Categorias Elegíveis"
+  },
+  "Ad9EZ1": {
+    "string": "Produto atualizado"
+  },
+  "AdmPca": {
+    "context": "error message",
+    "string": "O valor máximo não pode ser inferior ao valor mínimo"
+  },
+  "Aeq79M": {
+    "context": "PluginDetailsChannelsCard no channels subtitle",
+    "string": "As configurações do plug-in são comuns a todos os canais"
+  },
+  "AgHhjW": {
+    "context": "dialog header",
+    "string": "Excluir modelos"
+  },
+  "AgY5Mv": {
+    "context": "attribute properties regarding storefront",
+    "string": "Propriedades da Vitrine"
+  },
+  "Ai4XSg": {
+    "context": "shown when shipping address is required but not set",
+    "string": "Nenhum endereço de envio"
+  },
+  "AijtXU": {
+    "context": "table header configuration col label",
+    "string": "Configuração"
+  },
+  "AiurXc": {
+    "string": "Autorizado pendente"
+  },
+  "AjInNW": {
+    "context": "dialog description",
+    "string": "Escolha os países que deseja adicionar à zona de entrega da lista abaixo"
+  },
+  "AkyGP2": {
+    "string": "Canal excluído"
+  },
+  "AnqH4p": {
+    "context": "sale status",
+    "string": "Ativo"
+  },
+  "AqHafs": {
+    "context": "provided email input placeholder",
+    "string": "Endereço de e-mail fornecido"
+  },
+  "AqXzM2": {
+    "string": "Pedido  #{orderNumber}"
+  },
+  "ArctEg": {
+    "context": "requires activation checkbox caption",
+    "string": "Todos os cartões emitidos exigem ativação pela equipe antes do uso."
+  },
+  "AubJ/S": {
+    "context": "button",
+    "string": "Entrar"
+  },
+  "AulH/n": {
+    "string": "{counter,plural,one {Tem certeza que você deseja desvincular este produto?} other {Você tem certeza que deseja desvincular {displayQuantity} produtos?}}"
+  },
+  "AuwpCm": {
+    "string": "Área do país"
+  },
+  "Av74Fa": {
+    "context": "section description",
+    "string": "Você pode definir regras básicas de checkout que serão aplicadas globalmente a todos os seus canais"
+  },
+  "AyQkmp": {
+    "string": "Classificação por esta coluna não está disponível"
+  },
+  "AzMSmb": {
+    "context": "caption",
+    "string": "Se habilitado este atributo pode ser usado como uma coluna na tabela de produto"
+  },
+  "AzshS2": {
+    "context": "notification",
+    "string": "Páginas Publicadas"
+  },
+  "B+Ba0R": {
+    "string": "Permissões solicitadas"
+  },
+  "B/y6LC": {
+    "context": "section header",
+    "string": "Produtos não faturados"
+  },
+  "B06DG8": {
+    "string": "Transação não foi encontrada"
+  },
+  "B0PaVS": {
+    "context": "pint unit",
+    "string": "pint"
+  },
+  "B0XvpR": {
+    "string": "Você não tem permissão para realizar esta ação. ({errorCode})"
+  },
+  "B0fwAj": {
+    "string": "e {itemsLength} mais"
+  },
+  "B1yzuX": {
+    "context": "button label",
+    "string": "Adicionar motivo"
+  },
+  "B2LE7A": {
+    "context": "menu item loading",
+    "string": "trabalhando..."
+  },
+  "B5/YE0": {
+    "string": "Perfil atualizado"
+  },
+  "B52Em/": {
+    "string": "Endereço linha 1"
+  },
+  "B54f/g": {
+    "context": "dialog, editing order line metadata",
+    "string": "Metadados da linha do pedido"
+  },
+  "B5KI59": {
+    "context": "Empty filters text",
+    "string": "Adicionar filtro para começar"
+  },
+  "B5yE8S": {
+    "context": "dialog header",
+    "string": "Cancelar atribuição de categorias da venda"
+  },
+  "B8MRsI": {
+    "string": "{count, plural, one {# item} other {# items}}"
+  },
+  "B8PvdI": {
+    "string": "estendendo o Saleor com Webhooks"
+  },
+  "B9yrkK": {
+    "string": "Nenhum canal encontrado"
+  },
+  "BA4leV": {
+    "string": "Guia da API"
+  },
+  "BBIQxQ": {
+    "context": "page header",
+    "string": "Pedido nº. {orderNumber} - Substituir/Devolver"
+  },
+  "BBt3jD": {
+    "context": "btn label",
+    "string": "Convidar membros"
+  },
+  "BCPrmK": {
+    "context": "order history message",
+    "string": "Detalhes do envio foram enviados ao cliente"
+  },
+  "BFR6CF": {
+    "context": "webhooks and events section name",
+    "string": "Webhooks & Eventos"
+  },
+  "BHQrgz": {
+    "context": "number of subcategories",
+    "string": "Subcategorias"
+  },
+  "BHr3fj": {
+    "context": "no warehouses info",
+    "string": "Não há armazéns configurados para este produto. Para adicionar quantidade de estoque ao produto <a>configure um armazém</a> ou use um existente clicando no botão abaixo."
+  },
+  "BIqhVQ": {
+    "string": "Pular estoque por enquanto"
+  },
+  "BJRu4V": {
+    "context": "pill status for partially captured outcome",
+    "string": "Capturado parcialmente"
+  },
+  "BJtUQI": {
+    "context": "button",
+    "string": "Adicionar"
+  },
+  "BL/Lbk": {
+    "context": "install app permissions",
+    "string": "Instalando este aplicativo você concederá as seguintes permissões:"
+  },
+  "BLX9dz": {
+    "context": "fulfill order, button",
+    "string": "Faturar"
+  },
+  "BM1JiJ": {
+    "context": "error message",
+    "string": "Este pedido não pode ser cancelado"
+  },
+  "BNTZLv": {
+    "string": "O pedido nº {orderId} foi feito a partir do rascunho"
+  },
+  "BQ2NVl": {
+    "context": "page type name",
+    "string": "Nome do tipo de conteúdo"
+  },
+  "BR8au7": {
+    "context": "delete channel",
+    "string": "Selecione o canal para o qual deseja mover pedidos existentes."
+  },
+  "BUKMzM": {
+    "string": "Variação Removida"
+  },
+  "BVDaKx": {
+    "string": "Desconto subtotal"
+  },
+  "BWpuKl": {
+    "string": "Atualizar"
+  },
+  "BXKn/d": {
+    "context": "charge status",
+    "string": "Cobrado em excesso"
+  },
+  "BXMSl4": {
+    "context": "currency channel",
+    "string": "Não há canal disponível para mover as informações do pedido. Crie um canal com a mesma moeda para que as informações possam ser movidas para ele."
+  },
+  "BXkF8Z": {
+    "context": "header",
+    "string": "Atividade"
+  },
+  "BYTvv/": {
+    "context": "Dry run events unavailable",
+    "string": "Os seguintes eventos da consulta fornecida não estão disponíveis para execução de teste:"
+  },
+  "BYfAwE": {
+    "context": "page title - installing app with manifestUrl provided",
+    "string": "Adicionar extensão"
+  },
+  "BZ7BkQ": {
+    "context": "capture payment, button",
+    "string": "Receber"
+  },
+  "BalldE": {
+    "string": "Linha do pedido"
+  },
+  "BanAhF": {
+    "context": "sale status",
+    "string": "Agendado"
+  },
+  "BaxGjT": {
+    "context": "variant stocks section subtitle",
+    "string": "Atribuir os estoques será possível após a variante ser salva."
+  },
+  "BbP+k3": {
+    "context": "variant availability in channel",
+    "string": "Disponível"
+  },
+  "Be+J13": {
+    "string": "Configurável"
+  },
+  "BfJGij": {
+    "context": "header",
+    "string": "Informação do Endereço"
+  },
+  "BftZHy": {
+    "context": "window title",
+    "string": "Criar Tipo de Página"
+  },
+  "BjxQ3u": {
+    "context": "add shipping address first label",
+    "string": "adicione o endereço de entrega primeiro"
+  },
+  "BkFke9": {
+    "context": "section header",
+    "string": "Itens não cumpridos"
+  },
+  "Bkxrhw": {
+    "context": "no webhooks message",
+    "string": "Nenhum webhook encontrado"
+  },
+  "Bl6896": {
+    "string": "Valor do reembolso"
+  },
+  "BooQvo": {
+    "context": "navigator placeholder",
+    "string": "Tipo {key} para ver ações disponíveis"
+  },
+  "Bphmwe": {
+    "context": "header",
+    "string": "Coleção de tradução \"{collectionName}\" - {languageCode}"
+  },
+  "BtErCZ": {
+    "string": "Pesquisar Plugins..."
+  },
+  "BtsJ+e": {
+    "context": "empty state message when no login method is available",
+    "string": "Login por senha está desativado. Entre em contato com seu administrador para configurar um método de autenticação externo ou habilitar o login por senha."
+  },
+  "BvGp1I": {
+    "string": "entre"
+  },
+  "Bx367s": {
+    "context": "product is hidden",
+    "string": "Oculto"
+  },
+  "BxuhWZ": {
+    "string": "Nenhuma extensão (aplicativo ou plugin) está configurada para lidar com a ação de transação solicitada"
+  },
+  "By5ZBp": {
+    "context": "header",
+    "string": "Olá, {userName}"
+  },
+  "ByYtFB": {
+    "string": "Token inválido ou expirado. Verifique seu token na URL"
+  },
+  "C+WD8j": {
+    "context": "alert message",
+    "string": "todos os"
+  },
+  "C035fF": {
+    "context": "grant refund, refund card explanation next to submit button",
+    "string": "Os fundos serão devolvidos em uma etapa separada"
+  },
+  "C0JLNW": {
+    "string": "E-mail fornecido não encontrado no nosso banco de dados."
+  },
+  "C0MnAi": {
+    "string": "desligado"
+  },
+  "C1luwg": {
+    "context": "dialog header",
+    "string": "Excluir Página"
+  },
+  "C2N30x": {
+    "context": "app has been removed",
+    "string": "Extensão removida"
+  },
+  "C4IOEN": {
+    "string": "Estrutura criada"
+  },
+  "C4aDMy": {
+    "context": "description",
+    "string": "Configure o tempo que o estoque no checkout fica reservado para o cliente. Você pode definir valores separados para clientes autenticados e anônimos."
+  },
+  "C4hCsD": {
+    "string": "O aplicativo está fora do seu escopo de permissões"
+  },
+  "C4zBRT": {
+    "context": "automatic completion cut-off date label",
+    "string": "Data limite"
+  },
+  "C50ahv": {
+    "context": "button",
+    "string": "Adicionar produtos"
+  },
+  "C5gcqL": {
+    "context": "btn label",
+    "string": "Marcar como concluído"
+  },
+  "C6bb6x": {
+    "context": "order refund amount",
+    "string": "Reembolsar valor total"
+  },
+  "C6pJYY": {
+    "context": "deactivate app",
+    "string": "Você tem certeza de que deseja desativar esta extensão? Seus dados serão mantidos até que você reative a extensão."
+  },
+  "C7I2lg": {
+    "context": "input label",
+    "string": "Limitar quantidade por finalização de compra (opcional)"
+  },
+  "C7eDb9": {
+    "string": "Grupos de permissão"
+  },
+  "C90nKP": {
+    "context": "error with deactivatation alert message",
+    "string": "Erros ao desativar presente {count,plural,one{card} other{cards}}"
+  },
+  "C9cgck": {
+    "string": "Saiba mais sobre {productConfigurations}"
+  },
+  "C9pcQx": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza de que deseja excluir esta zona de envio ?} other {Tem certeza de que deseja excluir {displayQuantity} zonas de envio ?}}"
+  },
+  "CB7xpk": {
+    "context": "subheader on extension install page",
+    "string": "Você está prestes a instalar {extensionName}"
+  },
+  "CD1NDm": {
+    "context": "placeholder for required attribute dropdown",
+    "string": "Selecione um valor"
+  },
+  "CEavJt": {
+    "context": "section header",
+    "string": "Ilimitada"
+  },
+  "CFG1Ix": {
+    "context": "shipping zone",
+    "string": "Faixa de preço"
+  },
+  "CFT171": {
+    "context": "card header title",
+    "string": "Lista de países"
+  },
+  "CG+awx": {
+    "context": "dialog content",
+    "string": "Qual endereço você gostaria de usar como endereço de entrega para o cliente selecionado: "
+  },
+  "CJEIRC": {
+    "string": "A exportação do produto foi concluída e enviada para o seu endereço de e-mail."
+  },
+  "CJpx4E": {
+    "context": "page header",
+    "string": "Nº do pedido {orderNumber} - Adicionar Faturamento"
+  },
+  "CKP9+i": {
+    "string": "Erros de webhook detectados."
+  },
+  "CLB1k9": {
+    "context": "refund type",
+    "string": "Produtos de Reembolso"
+  },
+  "CLYlsu": {
+    "context": "section header",
+    "string": "Configurações"
+  },
+  "CLeDae": {
+    "context": "section header",
+    "string": "Preferências"
+  },
+  "COWJSG": {
+    "context": "helper explaining the effect of assigning reference types",
+    "string": "A atribuição de tipos de referência restringe a lista de itens que este atributo pode referenciar."
+  },
+  "CPPACf": {
+    "string": "O campo 'customHeaders' para um webhook no manifesto da extensão é inválido. {docsLink} ({errorCode})"
+  },
+  "CQKgD/": {
+    "context": "bulk actions button label",
+    "string": "Excluir modelo"
+  },
+  "CQTTke": {
+    "string": "Solicitação de reembolso enviada ao provedor de pagamento"
+  },
+  "CRAfpd": {
+    "context": "gift card export dialog confirm button label",
+    "string": "Exportar códigos"
+  },
+  "CT5PAn": {
+    "context": "CannotDefineChannelsAvailabilityCard title",
+    "string": "Disponibilidade"
+  },
+  "CWDuMj": {
+    "context": "remaining quantity",
+    "string": "/ {max}"
+  },
+  "CWqmRU": {
+    "context": "customer's address book when no customer name is available, header",
+    "string": "Address Book"
+  },
+  "CXTIq8": {
+    "string": "Descrição do mecanismo de busca"
+  },
+  "CXn88q": {
+    "string": "Nenhum grupo de permissão encontrado"
+  },
+  "CYEnGq": {
+    "context": "order fulfilled success message",
+    "string": " Itens Faturados"
+  },
+  "CYZse9": {
+    "context": "card description",
+    "string": "Expanda ou restrinja as permissões do grupo para acessar determinada parte do sistema Saleor."
+  },
+  "CZmloB": {
+    "string": "Faturamento atualizado com sucesso"
+  },
+  "Cc3Z40": {
+    "string": "Saiba mais sobre o fluxo do processo de checkout do Saleor"
+  },
+  "CcEwXH": {
+    "context": "dialog header",
+    "string": "Excluir Tipos de Página"
+  },
+  "CdIHMu": {
+    "context": "select tax ratte",
+    "string": "Taxa de imposto"
+  },
+  "Cf7i/g": {
+    "context": "Info box title when product is not published",
+    "string": "Oculto da API pública."
+  },
+  "ChAjJu": {
+    "context": "character limit",
+    "string": "{numberOfCharacters} de{maxCharacters} caracteres"
+  },
+  "ChGI4V": {
+    "context": "error message",
+    "string": "Saleor não está disponível. Verifique sua conexão de rede e tente novamente."
+  },
+  "CiWUaq": {
+    "string": "Certifique-se de salvar o token, você não poderá vê-lo novamente."
+  },
+  "CjSRT1": {
+    "context": "button",
+    "string": "Criar Categoria"
+  },
+  "ClFzoD": {
+    "string": "Os valores selecionados serão usados ​​para criar variações para o produto configurável."
+  },
+  "ClKKID": {
+    "context": "channel publication status",
+    "string": "Não publicado"
+  },
+  "ClUKur": {
+    "context": "tooltip for subtotal amount",
+    "string": "Soma de todos os itens de linha"
+  },
+  "Cm2/+V": {
+    "string": "Leia a documentação"
+  },
+  "Cmu1M8": {
+    "context": "Product cannot be purchased by customers",
+    "string": "Não comprável"
+  },
+  "CmxKIg": {
+    "context": "window title",
+    "string": "Conceder reembolso"
+  },
+  "Cn6l5R": {
+    "context": "playground shortcut",
+    "string": "Playground"
+  },
+  "Co2U4u": {
+    "string": "Nenhuma extensão encontrada"
+  },
+  "CrY98m": {
+    "context": "button, marks order as paid (legacy payments)",
+    "string": "Marcar pedido como pago"
+  },
+  "CrbI/c": {
+    "context": "variant channel price",
+    "string": "Preço {channel}"
+  },
+  "Crht/3": {
+    "context": "custom app name",
+    "string": "Nome da Extensão"
+  },
+  "Crn8DZ": {
+    "context": "collection attribute entity type",
+    "string": "Coleções"
+  },
+  "CrnqOK": {
+    "string": "Taxas de imposto do país atualizadas"
+  },
+  "CxfKLC": {
+    "string": "Páginas"
+  },
+  "Cxkzpg": {
+    "context": "page title - installing app with manifestUrl form",
+    "string": "Adicionar extensão a partir do manifesto"
+  },
+  "D/+84n": {
+    "context": "snackbar text",
+    "string": "Aplicativo ativado"
+  },
+  "D0KaT6": {
+    "context": "webhook input label",
+    "string": "Nome do Webhook"
+  },
+  "D2qihU": {
+    "string": "Permissão inválida"
+  },
+  "D2u4pg": {
+    "string": "Você não tem permissão para gerenciar esta extensão. Entre em contato com seu administrador para assistência. ({errorCode})"
+  },
+  "D3E2b5": {
+    "context": "button label",
+    "string": "Ativar"
+  },
+  "D3WUc/": {
+    "context": "order history message",
+    "string": "Pedido foi reembolsado por {refundedBy}"
+  },
+  "D3idYv": {
+    "string": "Configurações"
+  },
+  "D4CsYK": {
+    "context": "status filter label",
+    "string": "Status"
+  },
+  "D4W/LE": {
+    "context": "dialog header",
+    "string": "Alterar endereço de cobrança do cliente"
+  },
+  "D4nzdD": {
+    "context": "checkbox label",
+    "string": "Conceder a este aplicativo, acesso total a loja"
+  },
+  "D5Wtf/": {
+    "context": "table header column",
+    "string": "Nome do país"
+  },
+  "D8nsBc": {
+    "context": "no warehouses info",
+    "string": "Não existem depósitos configurados para sua loja. Para adicionar a quantidade em estoque para a variação, por favor configure um depósito."
+  },
+  "D95l71": {
+    "context": "tab name",
+    "string": "Todos os clientes"
+  },
+  "D9Rg+F": {
+    "context": "window title",
+    "string": "Detalhes do canal"
+  },
+  "D9ie4n": {
+    "context": "shipping section name",
+    "string": "Métodos de Envio"
+  },
+  "DASYUF": {
+    "context": "section title",
+    "string": "Configuração de check-out"
+  },
+  "DDYrvn": {
+    "string": "O valor da recompensa da regra deve ser menor que 100"
+  },
+  "DEa1T1": {
+    "context": "button",
+    "string": "Salvar Pesquisa"
+  },
+  "DGCzal": {
+    "string": "Este token dará acesso a API da sua loja, que você encontrará aqui: {url}"
+  },
+  "DGWVA9": {
+    "context": "variant created error message",
+    "string": "Falha na criação da variante"
+  },
+  "DHBlFi": {
+    "context": "navigator customer mode description",
+    "string": "Pesquisar Clientes"
+  },
+  "DILs4b": {
+    "string": "Provedor de mídia incompatível ou URL incorreto"
+  },
+  "DIrxt7": {
+    "context": "channel publication date",
+    "string": "Visível desde {date}"
+  },
+  "DJFPzq": {
+    "context": "button",
+    "string": "Confirmar"
+  },
+  "DJatYh": {
+    "string": "Gerar vários códigos de uma vez"
+  },
+  "DK+8PB": {
+    "string": "Este canal já foi criado"
+  },
+  "DM/Ha1": {
+    "context": "add postal code range, button",
+    "string": "Adicionar"
+  },
+  "DNTxWr": {
+    "context": "permission groups section name",
+    "string": "Grupos de Permissão"
+  },
+  "DO8+uV": {
+    "string": "Produto criado"
+  },
+  "DOHARW": {
+    "context": "Refund status failure",
+    "string": "Falha"
+  },
+  "DOkfyZ": {
+    "string": "Permissões insuficientes"
+  },
+  "DP5VOH": {
+    "string": "Endereço de Entrega"
+  },
+  "DP6b8U": {
+    "context": "section header",
+    "string": "Imagem de Fundo (opcional)"
+  },
+  "DPz5y6": {
+    "context": "dialog header",
+    "string": "Atribuir Membros da Equipe"
+  },
+  "DQJnB4": {
+    "context": "gift card export dialog title",
+    "string": "Exportar códigos de vale-presente"
+  },
+  "DRMMDs": {
+    "string": "Nome do Atributo"
+  },
+  "DRaREj": {
+    "string": "O manifesto da extensão solicita permissões inválidas ou não reconhecidas. {docsLink} ({errorCode})"
+  },
+  "DTL7sE": {
+    "context": "dialog content",
+    "string": "Tem certeza de que deseja excluir {warehouseName}?"
+  },
+  "DVgMit": {
+    "context": "transaction event type, transaction was chargeback by payment provider",
+    "string": "Chargeback"
+  },
+  "DWWw3M": {
+    "string": "Nome do Tipo de Modelo"
+  },
+  "DWs4ba": {
+    "string": "Menu não encontrado"
+  },
+  "DaPGcn": {
+    "string": "Título do Modelo"
+  },
+  "DbNXK5": {
+    "string": "O Saleor não conseguiu se conectar à URL do manifesto fornecida. ({errorCode})"
+  },
+  "Dd0Dwl": {
+    "string": "Ir para promoções"
+  },
+  "Dg4Y2p": {
+    "context": "set shipping method link when no shipping method selected",
+    "string": "Definir método de envio"
+  },
+  "Dgp38J": {
+    "context": "checkbox label",
+    "string": "Restrict order value"
+  },
+  "DhFqJF": {
+    "string": "Editar desconto"
+  },
+  "Dhherd": {
+    "context": "dialog header, title",
+    "string": "Geração de Fatura"
+  },
+  "DnghuS": {
+    "context": "channel create",
+    "string": "Novo Canal"
+  },
+  "DovGIa": {
+    "string": "Grupo de permissões excluído"
+  },
+  "Duik8x": {
+    "context": "Link to publish the product immediately instead of scheduling",
+    "string": "Publicar imediatamente em vez disso"
+  },
+  "DyGpz4": {
+    "context": "unapproved fulfillment, section header",
+    "string": "Aguardando aprovação"
+  },
+  "DzPVnj": {
+    "context": "date time attribute type",
+    "string": "Date Time"
+  },
+  "E+n6Pt": {
+    "string": "Nada mudará em termos de permissões. O Painel redirecionará para a extensão e informará que você negou a solicitação."
+  },
+  "E+nSVG": {
+    "string": "Link de redefinição enviado"
+  },
+  "E/yzIO": {
+    "string": "Ver metadados"
+  },
+  "E1C9pp": {
+    "context": "transaction event type, authorization amount was changed",
+    "string": "Valor de autorização ajustado"
+  },
+  "E22x4H": {
+    "context": "no card defuned alert message",
+    "string": "Você não definiu um produto de vale-presente!"
+  },
+  "E2uiWk": {
+    "string": "Coleção atualizada"
+  },
+  "E3SyRJ": {
+    "context": "Button to manage channel availability",
+    "string": "Gerenciar"
+  },
+  "E4GW+N": {
+    "context": "fully paid checkout automatically completed message",
+    "string": "Pedido criado automaticamente a partir do checkout totalmente pago"
+  },
+  "E54eoT": {
+    "string": "Criar a estrutura de navegação é feita utilizando arrasta-e-solta. Crie um novo menu e então arraste-o no seu local de destino. Você pode mover itens dentro de outros itens para criar uma estrutura de árvore e arrastar itens para cima e para baixo para criar uma hierarquia."
+  },
+  "E8T3e+": {
+    "string": "Não é possível adicionar e remover o grupo ao mesmo tempo"
+  },
+  "E8VDeH": {
+    "string": "Número de Pedidos"
+  },
+  "E9E5Eh": {
+    "string": "Por favor, lembre-se de que as condições não serão atualizadas quando você mudar o canal."
+  },
+  "E9Jssl": {
+    "string": "Nenhum pedido pronto para faturar."
+  },
+  "EA7rjI": {
+    "context": "disabled status label",
+    "string": "Disabled"
+  },
+  "EAGfdH": {
+    "string": "Página atualizada"
+  },
+  "EAKKtg": {
+    "context": "Description for no shipping zones warning",
+    "string": "Os clientes não podem finalizar a compra sem métodos de envio. Adicione zonas de envio a este canal."
+  },
+  "EDihQs": {
+    "string": "Membro da equipe atualizado"
+  },
+  "EEW+ND": {
+    "string": "Navegador"
+  },
+  "EEWsPs": {
+    "string": "Plugin incorporado ao código base do Saleor"
+  },
+  "EGG8f+": {
+    "string": "Aplicar preços únicos por atributo a cada SKU"
+  },
+  "EGycu/": {
+    "context": "voucher status active",
+    "string": "Ativo"
+  },
+  "EHsnZX": {
+    "context": "dialog description",
+    "string": "Tem certeza de que deseja aprovar este cumprimento?"
+  },
+  "EIULpW": {
+    "string": "Gerencie como sua loja cobrará impostos"
+  },
+  "EKoPNg": {
+    "context": "shipping method price",
+    "string": "Preço"
+  },
+  "EM+30g": {
+    "context": "navigator notification",
+    "string": "Nosso novo destaque para ajudar você com suas tarefas diárias. Navegue usando {keyboardShortcut} atalhos."
+  },
+  "EM730i": {
+    "string": "Gerenciar a disponibilidade do canal"
+  },
+  "ENBELI": {
+    "context": "description",
+    "string": "ou faça login usando"
+  },
+  "EP+jcU": {
+    "context": "checkbox",
+    "string": "Reembolsar custos de envio"
+  },
+  "EQfaUv": {
+    "context": "onboarding step title",
+    "string": "Verifique nosso playground GraphQL e faça uma chamada de API"
+  },
+  "EQjp7M": {
+    "context": "Shown when country count cannot be determined",
+    "string": "Países: Desconhecido"
+  },
+  "EQpfkS": {
+    "string": "Concluído"
+  },
+  "ER/yBq": {
+    "context": "max price in channel",
+    "string": "Valor Máx."
+  },
+  "ESDTC/": {
+    "string": "Gerenciar a disponibilidade do canal de vendas"
+  },
+  "ESft7g": {
+    "context": "Warning when warehouse with stock not in shipping zone",
+    "string": "Estoque inacessível em \"{channelName}\""
+  },
+  "ETHnjq": {
+    "context": "header",
+    "string": "Metadados Privados"
+  },
+  "EWCUdP": {
+    "string": "Canais de A a Z"
+  },
+  "EWD/wU": {
+    "context": "delete app",
+    "string": "Excluindo {name}, você excluirá a instalação do aplicativo. Se você está pagando pela assinatura do aplicativo, lembre-se de cancelar a assinatura do aplicativo no Marketplace Saleor. Tem certeza que deseja excluir o aplicativo?"
+  },
+  "EXqb2l": {
+    "string": "Ir para Saleor Cloud"
+  },
+  "EYkW1J": {
+    "context": "checkbox label",
+    "string": "Cobrar impostos para este canal"
+  },
+  "Eau5AV": {
+    "string": "Gerenciar a disponibilidade do canal de produtos"
+  },
+  "EbVf0Z": {
+    "context": "transaction reference",
+    "string": "Referência de transação"
+  },
+  "EcglP9": {
+    "string": "Chave"
+  },
+  "Ed2705": {
+    "string": "Criar novo tipo de modelo"
+  },
+  "Ediw6/": {
+    "context": "button label",
+    "string": "Assign references"
+  },
+  "EewziG": {
+    "context": "checkbox gift cards label description",
+    "string": "Quando ativado, cartões-presente não enviáveis serão automaticamente definidos como cumpridos e enviados ao cliente"
+  },
+  "Egyh2T": {
+    "context": "section header",
+    "string": "Configurações da Extensão"
+  },
+  "Eh6KYS": {
+    "context": "info card title",
+    "string": "Informações do cartão"
+  },
+  "EoNN9v": {
+    "context": "Label for visible in listings toggle",
+    "string": "Mostrar em listagens"
+  },
+  "EoTI4r": {
+    "context": "authorize status none",
+    "string": "Nenhum"
+  },
+  "EojeG7": {
+    "context": "authorize status partial",
+    "string": "Parcial"
+  },
+  "Epm41J": {
+    "context": "change warehouse dialog warehouse list label",
+    "string": "Armazéns de A a Z"
+  },
+  "Eq3GFh": {
+    "string": "É cartão-presente"
+  },
+  "ErNH3D": {
+    "string": "Defina onde este atributo deverá ser usado no sistema Saleor"
+  },
+  "ErvPaM": {
+    "context": "header",
+    "string": "Nome do Armazém"
+  },
+  "EsZH44": {
+    "context": "VariantDetailsChannelsAvailabilityCard item subtitle hidden",
+    "string": "Oculto"
+  },
+  "EtGDeK": {
+    "context": "header",
+    "string": "{pluginName} Detalhes"
+  },
+  "EtkIxE": {
+    "context": "cancelled fulfillment, section header",
+    "string": "Cancelado ({quantity})"
+  },
+  "EuOXmr": {
+    "context": "add items title",
+    "string": "Adicionar {itemsName}"
+  },
+  "Ev6SEF": {
+    "string": "Nova senha"
+  },
+  "EwoyVr": {
+    "context": "bulk remove button label",
+    "string": "Excluir zonas de envio"
+  },
+  "EzU7KV": {
+    "context": "option description",
+    "string": "Criar nova variante usando a visão de detalhes da variante"
+  },
+  "F/JMp6": {
+    "context": "authorize status full",
+    "string": "Completo"
+  },
+  "F08wV2": {
+    "context": "issued by app label",
+    "string": "Emitido pela extensão"
+  },
+  "F0AXNs": {
+    "context": "invoice create date prefix",
+    "string": "criado"
+  },
+  "F0BhK/": {
+    "context": "Status when product is visible and purchasable",
+    "string": "Ao vivo"
+  },
+  "F2kF9e": {
+    "string": "Você deve selecionar a transação que deseja reembolsar"
+  },
+  "F3Upht": {
+    "string": "Tipo de produto excluído"
+  },
+  "F4WdSO": {
+    "context": "dialog header",
+    "string": "Excluir Produtos"
+  },
+  "F56hOz": {
+    "context": "sale name",
+    "string": "Nome"
+  },
+  "F62RkR": {
+    "context": "dialog header",
+    "string": "Desatribuir Variantes do Voucher"
+  },
+  "F69lwk": {
+    "context": "settings menu item",
+    "string": "Configurações"
+  },
+  "F6LHyk": {
+    "context": "Webhook details objects",
+    "string": "Objetos"
+  },
+  "F7DxHw": {
+    "string": "Subcategorias"
+  },
+  "F8gsds": {
+    "context": "unpublish page, button",
+    "string": "Remover"
+  },
+  "F8pCg4": {
+    "context": "input placeholder",
+    "string": "Opcional"
+  },
+  "FA+MRz": {
+    "string": "Set plugin as active"
+  },
+  "FBtqtl": {
+    "context": "payment status",
+    "string": "Não pago"
+  },
+  "FEWgh/": {
+    "context": "column title tag",
+    "string": "Tag"
+  },
+  "FIZvTx": {
+    "context": "dialog content",
+    "string": "Selecione o método que deseja usar para alterar o endereço"
+  },
+  "FN+iLO": {
+    "string": "Sugerir uma alteração"
+  },
+  "FNAZoh": {
+    "string": "Ultimo login"
+  },
+  "FNKhkx": {
+    "string": "Cobrar impostos sobre taxas de envio"
+  },
+  "FNT4b+": {
+    "context": "tabel column header",
+    "string": "Produto"
+  },
+  "FNpv6K": {
+    "context": "button",
+    "string": "Filtros"
+  },
+  "FOa+Xd": {
+    "context": "voucher value requirement",
+    "string": "Valor Mínimo do Pedido"
+  },
+  "FOehC/": {
+    "context": "label",
+    "string": "Quantidade Manual"
+  },
+  "FPzzh7": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza de que deseja excluir esta venda?} other {Tem certeza de que deseja excluir {displayQuantity} vendas?}}"
+  },
+  "FQc5z6": {
+    "context": "customer gift cards card view all button",
+    "string": "Ver tudo"
+  },
+  "FRJRmi": {
+    "context": "selected customer gift card is sent to subtitle",
+    "string": "O cliente selecionado receberá o código do vale-presente gerado. Outra pessoa pode resgatar o código do vale-presente. O vale-presente será atribuído à conta que resgatou o código."
+  },
+  "FS6Drh": {
+    "context": "sku prefix input label",
+    "string": "Prefixo do SKU"
+  },
+  "FSOOH7": {
+    "context": "option title",
+    "string": "Priorizar armazéns pela ordem de classificação"
+  },
+  "FSinkL": {
+    "context": "variant stock status",
+    "string": "Estoque disponível em:"
+  },
+  "FTYkgw": {
+    "string": "Excluir coleções"
+  },
+  "FWWliu": {
+    "context": "ExitFormPrompt title",
+    "string": "Você tem alterações não salvas"
+  },
+  "FWaL+x": {
+    "context": "gift card history message",
+    "string": "O saldo do cartão-presente foi redefinido"
+  },
+  "FWbv/u": {
+    "context": "page header",
+    "string": "Criar Desconto"
+  },
+  "FX7ts2": {
+    "context": "error message",
+    "string": "O valor deve ser maior que 0"
+  },
+  "FXtMVc": {
+    "string": "Um campo de URL dentro do manifesto da extensão tem um formato inválido. {docsLink} ({errorCode})"
+  },
+  "FYfoiF": {
+    "context": "section name",
+    "string": "Estratégia de alocação"
+  },
+  "FZTrzW": {
+    "string": "Reembolso manual"
+  },
+  "Fbr4Vp": {
+    "context": "dialog header",
+    "string": "Permissões"
+  },
+  "Fc3O3r": {
+    "context": "staff member's account",
+    "string": "Desativado"
+  },
+  "FcTTvh": {
+    "context": "postal codes, header",
+    "string": "Códigos postais"
+  },
+  "FcVEpe": {
+    "context": "collection publication date",
+    "string": "Não publicado"
+  },
+  "FemBUF": {
+    "context": "header",
+    "string": "Traduções para {language}"
+  },
+  "Ff+Gsm": {
+    "context": "WarehouseSettings public stock description",
+    "string": "Se ativado, o estoque neste armazém será mostrado"
+  },
+  "FiO/W/": {
+    "string": "Excluir categorias"
+  },
+  "FjrExY": {
+    "context": "price based shipping methods, section header",
+    "string": "Taxas baseadas em preços"
+  },
+  "FjywW1": {
+    "context": "automatic completion delay input description",
+    "string": "Tempo em minutos para esperar após o checkout estar totalmente pago antes de completá-lo automaticamente. Defina como 0 para conclusão imediata. O padrão é 30 minutos."
+  },
+  "FkDObY": {
+    "context": "label",
+    "string": "Nome da taxa de envio"
+  },
+  "FkRNk+": {
+    "context": "field placeholder",
+    "string": "Descrição de uma zona de expedição."
+  },
+  "Fl3ORD": {
+    "context": "order history message",
+    "string": "{quantity} itens vendidos extra"
+  },
+  "FmeBxD": {
+    "context": "custom app tokens list - missing token name",
+    "string": "(desconhecido)"
+  },
+  "FmwGVb": {
+    "context": "transaction refund tiles charged label",
+    "string": "Cobrado"
+  },
+  "Fn3bE0": {
+    "string": "Linha de pedido atualizada"
+  },
+  "FopBSj": {
+    "context": "error message",
+    "string": "Seu nome de usuário e/ou senha estão incorretos. Por favor, tente novamente."
+  },
+  "FpIcp9": {
+    "string": "Nenhum cliente encontrado"
+  },
+  "Ftz7VI": {
+    "context": "input label, transaction amount",
+    "string": "Valor da transação"
+  },
+  "FuAV5G": {
+    "string": "Este nome já está em uso. Forneça outro."
+  },
+  "FuIgAe": {
+    "string": "O manifesto da extensão tem um formato inválido. {docsLink} ({errorCode})"
+  },
+  "FvmV6q": {
+    "string": "Discord"
+  },
+  "Fvvgoi": {
+    "string": "Sua sessão expirou. Por favor faça o login novamente para continuar."
+  },
+  "FwHWUm": {
+    "context": "alert",
+    "string": "SKU limit reached"
+  },
+  "Fxa6xp": {
+    "context": "page header",
+    "string": "Adicionar Coleção"
+  },
+  "Fxahwt": {
+    "context": "modal title",
+    "string": "Adicionar motivo de reembolso para esta linha"
+  },
+  "Fyd+zC": {
+    "string": "Corresponde apenas à frase exata"
+  },
+  "Fz3kic": {
+    "context": "error message",
+    "string": " O endereço de cobrança não foi definido ou a fatura não está pronta para ser enviada"
+  },
+  "FzEew9": {
+    "context": "assign products to shipping rate and save, button",
+    "string": "Atribuir e salvar"
+  },
+  "Fzky6q": {
+    "context": "dialog header",
+    "string": "Redefinir senha"
+  },
+  "G+9nOZ": {
+    "context": "checkbox description",
+    "string": "Se selecionado, isso adicionará todos os países não selecionados a outras zonas de envio"
+  },
+  "G+MtyG": {
+    "context": "no shipping methods available",
+    "string": "Nenhum método de envio aplicável"
+  },
+  "G+UQmN": {
+    "context": "order returned success message",
+    "string": "Produtos retornados, reembolso enviado"
+  },
+  "G/SYtU": {
+    "string": "Tem certeza de que deseja excluir o menu {menuName}?"
+  },
+  "G/pgG3": {
+    "context": "dialog header",
+    "string": "Selecione um canal"
+  },
+  "G/yZLu": {
+    "string": "Remover"
+  },
+  "G0+gAp": {
+    "context": "shipping section header",
+    "string": "Envio"
+  },
+  "G1KzEx": {
+    "context": "page status",
+    "string": "Publicado "
+  },
+  "G3ay2p": {
+    "context": "section header",
+    "string": "Configurações de atendimento"
+  },
+  "G4g5Ii": {
+    "context": "tab name",
+    "string": "Todas as Coleções"
+  },
+  "G5ETO0": {
+    "string": "Categorias excluídas"
+  },
+  "G5NKx6": {
+    "context": "tooltip",
+    "string": "O tempo de reserva do checkout está habilitado nas configurações."
+  },
+  "G7mu0y": {
+    "string": "O GraphQL API está em qualidade beta. Não está totalmente otimizado e algumas mutações e consultas podem estar faltando."
+  },
+  "G9y5Ze": {
+    "context": "pill status for fully captured outcome",
+    "string": "Totalmente capturado"
+  },
+  "GA+Djy": {
+    "string": "Você tem certeza de que deseja excluir esses códigos de voucher?"
+  },
+  "GAmGog": {
+    "context": "value input label",
+    "string": "Valor de descontro"
+  },
+  "GCPzKf": {
+    "context": "ProductTypeDeleteWarningDialog single assigned items button label",
+    "string": "Ver produtos"
+  },
+  "GCho9N": {
+    "context": "delete channel",
+    "string": "Todas as informações de configurações de canal, como envio, listagens de produtos, atribuições de armazém, etc., serão perdidas."
+  },
+  "GD/bom": {
+    "context": "label",
+    "string": "Prazo mínimo de entrega"
+  },
+  "GFJabu": {
+    "context": "dialog header",
+    "string": "Excluir Variação"
+  },
+  "GFioCC": {
+    "context": "models section name",
+    "string": "Modelos"
+  },
+  "GFkb2t": {
+    "context": "automatically complete checkouts checkbox label",
+    "string": "Concluir automaticamente checkouts quando totalmente pagos"
+  },
+  "GIuS7b": {
+    "string": "criando extensões personalizadas"
+  },
+  "GJAX0z": {
+    "context": "order history message",
+    "string": "Pedido foi realizado"
+  },
+  "GJwcSd": {
+    "string": "Referência do PSP (opcional)"
+  },
+  "GK6pQa": {
+    "context": "section description",
+    "string": "Quando ativado, webhooks de atualização (por exemplo, customerUpdated) são enviados mesmo quando apenas os metadados mudam. Quando desativado, apenas webhooks específicos de metadados são enviados. Esse comportamento legado será removido em uma versão futura."
+  },
+  "GLX9II": {
+    "context": "billing address",
+    "string": "Mesmo que o endereço de entrega"
+  },
+  "GLewww": {
+    "context": "section header",
+    "string": "Eventos"
+  },
+  "GLsIie": {
+    "context": "model label",
+    "string": "Visível"
+  },
+  "GLy2UR": {
+    "context": "order history message",
+    "string": "Faturamento foi cancelado"
+  },
+  "GNKG74": {
+    "context": "webhooks inactive label",
+    "string": "Inativo"
+  },
+  "GOdq5V": {
+    "string": "Catálogo"
+  },
+  "GP0zGO": {
+    "context": "dialog header",
+    "string": "Selecione o canal de destino:"
+  },
+  "GQcp83": {
+    "context": "variant stock, header",
+    "string": "Estoque e Armazenamento"
+  },
+  "GTCg9O": {
+    "string": "Você deve adicionar pelo menos um código de voucher"
+  },
+  "GUeIcq": {
+    "context": "edit structure, header",
+    "string": "Editar Item"
+  },
+  "GUlwXU": {
+    "context": "dialog header",
+    "string": "Atribuir Valor de Atributo"
+  },
+  "GVGaij": {
+    "string": "Tipo de modelo atualizado"
+  },
+  "GVM/fi": {
+    "context": "order history message",
+    "string": "Pagamento foi autorizado"
+  },
+  "GVinbz": {
+    "context": "column title",
+    "string": "Valor"
+  },
+  "GXdwyR": {
+    "context": "input label",
+    "string": "Senha Antiga"
+  },
+  "GZgjK7": {
+    "context": "page",
+    "string": "irá ficar visivel a partir de  {date}"
+  },
+  "GbBCmr": {
+    "context": "window title",
+    "string": "Pedido  #{orderNumber}"
+  },
+  "GbhZJ4": {
+    "context": "button",
+    "string": "Criar cupom"
+  },
+  "Gbhrqd": {
+    "context": "model types section name",
+    "string": "Tipos de Modelo"
+  },
+  "Gfbp36": {
+    "context": "dialog header",
+    "string": "Cancelar a atribuição de produtos do envio"
+  },
+  "Gg4+K7": {
+    "string": "Sem Produtos"
+  },
+  "GgvbdW": {
+    "string": "Tipos de modelos"
+  },
+  "GhSB79": {
+    "context": "model status",
+    "string": "Publicado"
+  },
+  "GhXwO/": {
+    "context": "dialog header",
+    "string": "excluir Usuário da Equipe"
+  },
+  "GhY+pm": {
+    "context": "dynamic column description",
+    "string": "Atributos"
+  },
+  "GhcypC": {
+    "context": "header",
+    "string": "Criar Depósito"
+  },
+  "Gi8zwc": {
+    "string": "Imagem excluída"
+  },
+  "GiDxS4": {
+    "context": "add metadata field,button",
+    "string": "Adicionar Campo"
+  },
+  "GiJm1v": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza de que deseja cancelar a atribuição desta categoria?} other {Tem certeza de que deseja cancelar a atribuição de {displayQuantity} categorias?}}"
+  },
+  "GibKGn": {
+    "context": "success gift card disable message",
+    "string": "Vale-presente desativado com sucesso"
+  },
+  "GjEdSd": {
+    "context": "number of postal code ranges",
+    "string": "{number, plural, one {# faixa de código postal} other {# faixas de código postal}}"
+  },
+  "GjH9uy": {
+    "context": "header",
+    "string": "Criar Novo Aplicativo"
+  },
+  "Gjb6eq": {
+    "context": "link",
+    "string": "Obter Suporte"
+  },
+  "Gjo89T": {
+    "context": "header",
+    "string": "Depósitos"
+  },
+  "Gkip05": {
+    "context": "button",
+    "string": "Não vinculado"
+  },
+  "Go50v2": {
+    "context": "app privacy policy link",
+    "string": "Exibir a política de privacidade do aplicativo"
+  },
+  "GpqEl5": {
+    "context": "shipping method description",
+    "string": "Descrição"
+  },
+  "Gr1SAu": {
+    "string": "Nome do Cliente"
+  },
+  "GsBRWL": {
+    "string": "Línguas"
+  },
+  "Gt5T8I": {
+    "context": "automatic completion cut-off date warning",
+    "string": "Se a data limite não estiver definida, o sistema usará automaticamente a data e hora atuais. Se você quiser personalizar esse comportamento, pode fornecer um horário personalizado (passado ou futuro)"
+  },
+  "GuYTfQ": {
+    "context": "card description",
+    "string": "Expanda ou restrinja as permissões da extensão para acessar certas partes do sistema Saleor."
+  },
+  "GufXy5": {
+    "string": "Valor"
+  },
+  "GuihaP": {
+    "context": "order transaction refund summary label",
+    "string": "Envio"
+  },
+  "Gxm7Qx": {
+    "context": "navigator notification title",
+    "string": "Navegador está aqui para ajudar"
+  },
+  "Gxo/XC": {
+    "context": "header",
+    "string": "Criar tipo de modelo"
+  },
+  "GxsQuO": {
+    "string": "Você deve selecionar pelo menos um presente"
+  },
+  "GyXEWS": {
+    "string": "Aplicativo criado"
+  },
+  "Gz+4CI": {
+    "context": "info text",
+    "string": "Os produtos pré-encomendados estarão disponíveis em todos os armazéns. Você pode definir um limite para a quantidade vendida. Deixar a entrada em branco será interpretado como sem limite de venda. Os itens vendidos serão alocados no armazém atribuído à zona de envio escolhida."
+  },
+  "GzbSQk": {
+    "context": "Status label when object is scheduled to publish in a channel",
+    "string": "Programado para publicação"
+  },
+  "Gzg8hy": {
+    "context": "section header",
+    "string": "Faturas"
+  },
+  "H/f9KR": {
+    "context": "section header returned",
+    "string": "Cumprimento retornado"
+  },
+  "H/o4Ex": {
+    "context": "dialog content",
+    "string": "Você não pode modificar os membros deste grupo. Resolva este problema para continuar com o pedido."
+  },
+  "H1L1cc": {
+    "context": "url",
+    "string": "URL"
+  },
+  "H27/Gy": {
+    "context": "error message",
+    "string": "Peso máximo não pode ser menor que o mínimo"
+  },
+  "H3Uirw": {
+    "context": "create new menu item, header",
+    "string": "Adicionar item"
+  },
+  "H4Lcuk": {
+    "string": "Categoria atualizada"
+  },
+  "H5NKfr": {
+    "context": "button",
+    "string": "Criar"
+  },
+  "H5jL5+": {
+    "context": "button",
+    "string": "Adicionar Comentário"
+  },
+  "H5yp8O": {
+    "context": "label",
+    "string": "Nome do Tipo de Produto"
+  },
+  "H60H6L": {
+    "context": "attribute values list: name column header",
+    "string": "Visual Padrão da Loja"
+  },
+  "H6NsC1": {
+    "context": "pages section name",
+    "string": "Páginas"
+  },
+  "H6SfJd": {
+    "context": "draft created from replace event title",
+    "string": "Rascunho foi reemitido a partir do pedido"
+  },
+  "HA0fD3": {
+    "string": "Canal criado"
+  },
+  "HADMte": {
+    "context": "onboarding step title",
+    "string": "Explorar pedidos"
+  },
+  "HAlOn1": {
+    "string": "Nome"
+  },
+  "HFo3Qe": {
+    "context": "successfully created gift card alert title",
+    "string": "Cartão-presente criado"
+  },
+  "HLqWXA": {
+    "context": "voucher value requirement",
+    "string": "Limite de Uso"
+  },
+  "HLr8KQ": {
+    "context": "plain text attribute type",
+    "string": "Texto Simples"
+  },
+  "HMD+ib": {
+    "string": "Último pedido"
+  },
+  "HN1Gvw": {
+    "context": "option description",
+    "string": "Alocar linha de pedido para um armazém com mais estoque. Se não houver estoque suficiente disponível em um único armazém, a quantidade restante é alocada no próximo armazém com mais estoque e repetido se necessário."
+  },
+  "HP6m+q": {
+    "string": "Atributos e tipos de produto"
+  },
+  "HQR2y0": {
+    "context": "attribute value is required",
+    "string": "Valor Necessário"
+  },
+  "HR9OTW": {
+    "context": "staff member's account",
+    "string": "Ativo"
+  },
+  "HRXLYk": {
+    "context": "cta button label",
+    "string": "Entre em contato"
+  },
+  "HSYM17": {
+    "context": "outcome prediction showing resulting order status after capture",
+    "string": "Isso resultará em {status} pedido"
+  },
+  "HSmg1/": {
+    "context": "gift cards section name",
+    "string": "Gift Cards"
+  },
+  "HTiAMm": {
+    "string": "Impostos"
+  },
+  "HVFq//": {
+    "context": "button",
+    "string": "Copiar token"
+  },
+  "HVlMK2": {
+    "context": "number of variants",
+    "string": "Variantes ({quantity})"
+  },
+  "HW6Vef": {
+    "string": "Esta transação não é reembolsável"
+  },
+  "HYC6cH": {
+    "context": "input description",
+    "string": "Limite que não pode ser excedido, mesmo que os limites por canal ainda estejam disponíveis"
+  },
+  "HYHLsB": {
+    "context": "product field",
+    "string": "Export Variant ID"
+  },
+  "HYK65C": {
+    "string": "Regra de pedido"
+  },
+  "HaQ8cg": {
+    "context": "button",
+    "string": "Restituição"
+  },
+  "Hc58JL": {
+    "context": "card title",
+    "string": "Saldo após solicitações"
+  },
+  "HcQEUk": {
+    "context": "table column header, sold units preorder quantity",
+    "string": "Sold units"
+  },
+  "HcjV6k": {
+    "context": "button",
+    "string": "Criar variações"
+  },
+  "Hd3E1g": {
+    "context": "table header column",
+    "string": "Nome do canal"
+  },
+  "Hebup2": {
+    "context": "Health check subtitle when product is not published",
+    "string": "O produto não está publicado. Publique-o para torná-lo visível em sua loja."
+  },
+  "HedXnw": {
+    "context": "plugin channel availability status title",
+    "string": "{activeChannelsCount,plural, =0 {Deactivated} other {Active in {activeChannelsCount}}}"
+  },
+  "Hgz44z": {
+    "context": "dialog header",
+    "string": "Excluir Cupom"
+  },
+  "HivFnX": {
+    "context": "ProductTypeDeleteWarningDialog single no assigned items description",
+    "string": "Você tem certeza de que deseja excluir <b>{typeName}</b>? Se você removê-lo, não será capaz de atribuí-lo aos produtos criados."
+  },
+  "Hj3T7P": {
+    "context": "column title",
+    "string": "Nome do canal"
+  },
+  "HjUoHK": {
+    "context": "attribute's label'",
+    "string": "Etiqueta Padrão"
+  },
+  "HjXnIf": {
+    "string": "Gerenciamento de Conteúdo"
+  },
+  "HlCkMT": {
+    "string": "Linha do pedido adicionada"
+  },
+  "HlEpii": {
+    "string": "Titulo do mecanismo de busca"
+  },
+  "HnVtSS": {
+    "context": "search",
+    "string": "Sem resultados"
+  },
+  "HnZCl7": {
+    "context": "search input placeholder",
+    "string": "Pesquisar países de imposto"
+  },
+  "HoBGng": {
+    "string": "Vale criado"
+  },
+  "HqRNN8": {
+    "string": "Suporte"
+  },
+  "HqeqEV": {
+    "context": "create gift card product alert message",
+    "string": "Crie um produto de cartão-presente"
+  },
+  "HtQGEH": {
+    "string": "Taxas de impostos obtidas com sucesso"
+  },
+  "HtfL5/": {
+    "context": "button",
+    "string": "Abrir Aplicativo"
+  },
+  "HvJPcU": {
+    "string": "Categoria deletada"
+  },
+  "HwIhau": {
+    "context": "status pill for fully authorized payment",
+    "string": "Totalmente Autorizado"
+  },
+  "HwTMFL": {
+    "string": "Ir para canais"
+  },
+  "Hwp65F": {
+    "string": "Rascunho finalizado"
+  },
+  "HyMpO2": {
+    "string": "Porcentagem"
+  },
+  "I+1KzL": {
+    "context": "tab name",
+    "string": "Todos os atributos"
+  },
+  "I+UwqI": {
+    "context": "is filter range or value",
+    "string": "igual a"
+  },
+  "I/y4IU": {
+    "context": "alert message",
+    "string": "um dos"
+  },
+  "I1Mz7h": {
+    "string": "Gerenciar a Disponibilidade do Canal de Coleção"
+  },
+  "I2wCwj": {
+    "context": "swatch attribute image label",
+    "string": "Imagem"
+  },
+  "I40r9Y": {
+    "context": "WarehouseSettings all warehouses description",
+    "string": "Se o cliente selecionado puder escolher este armazém como ponto de retirada.{break}Os produtos encomendados podem ser enviados de um armazém diferente"
+  },
+  "I5vC7T": {
+    "context": "button label",
+    "string": "Editar motivo"
+  },
+  "I7HyJZ": {
+    "context": "order refund amount",
+    "string": "Reembolso máximo"
+  },
+  "I8dAAe": {
+    "context": "page internal name",
+    "string": "Slug"
+  },
+  "I8mqqj": {
+    "context": "PageTypeDeleteWarningDialog single assigned items button label",
+    "string": "View pages"
+  },
+  "IBCBi1": {
+    "context": "webhook active description",
+    "string": "Se você quer desativar este webhook, retire a seleção abaixo."
+  },
+  "IBw72y": {
+    "context": "switch button",
+    "string": "Este produto pode ser entregue?"
+  },
+  "ICeshC": {
+    "context": "product type",
+    "string": "Enviável"
+  },
+  "ICq8u7": {
+    "string": "Zona de envio criada"
+  },
+  "IDwsCU": {
+    "context": "onboarding step title",
+    "string": "Criar um novo produto"
+  },
+  "IFWHn0": {
+    "context": "error message",
+    "string": "O endereço de cobrança não foi definido"
+  },
+  "IGvQ8k": {
+    "context": "button",
+    "string": "Criar atributo"
+  },
+  "IH47ID": {
+    "string": "Use o botão acima para adicionar novas variantes de produto"
+  },
+  "IHTyjM": {
+    "context": "orderLine.variant.name, subheader, order line metadata dialog",
+    "string": "Variante"
+  },
+  "IKvOK+": {
+    "context": "Amount error message",
+    "string": "O valor deve ser maior que 0"
+  },
+  "ILgbKN": {
+    "context": "key-value field button add more key-value pairs",
+    "string": "Adicionar mais"
+  },
+  "ILrXJV": {
+    "string": "Pressione {key1} {key2} para enviar"
+  },
+  "IN5iJz": {
+    "context": "value input helper text",
+    "string": "Valor inválido"
+  },
+  "INKsSL": {
+    "context": "Transaction event status - success",
+    "string": "Sucesso"
+  },
+  "INNPVX": {
+    "context": "payment status",
+    "string": "Parcialmente pago"
+  },
+  "INlWvJ": {
+    "string": "OU"
+  },
+  "INw68F": {
+    "string": "Pesquisar tipos de modelo..."
+  },
+  "IOg+Hh": {
+    "string": "Reembolso com valor manual"
+  },
+  "ITYiRy": {
+    "string": "Ir para coleções"
+  },
+  "IU1lif": {
+    "context": "radio option for custom capture amount",
+    "string": "Valor personalizado"
+  },
+  "IUWJKt": {
+    "context": "order was discounted event title",
+    "string": "Pedido foi descontado"
+  },
+  "IUeGzv": {
+    "context": "plugin name",
+    "string": "Nome da Extensão"
+  },
+  "IVOjqW": {
+    "context": "gift card bulk create success dialog export button",
+    "string": "Exportar para e-mail"
+  },
+  "IW4YT7": {
+    "context": "delete app",
+    "string": "Ao excluir esta extensão, você removerá a instalação da extensão. Se você estiver pagando pela assinatura da extensão, lembre-se de cancelar a assinatura da extensão no Marketplace Saleor."
+  },
+  "IWP25U": {
+    "string": "Você não pode emitir um reembolso concedido para este pedido. Nenhuma de suas transações autorizou ou cobrou valor."
+  },
+  "IXCA8O": {
+    "string": "Grupo de permissões atualizado"
+  },
+  "IXswaJ": {
+    "context": "checkbox label, fulfillment approval",
+    "string": "Enviar e-mail de cumprimento ao cliente"
+  },
+  "IYuKD6": {
+    "string": "Nenhum desconto encontrado"
+  },
+  "Iafyt5": {
+    "context": "page attribute entity type",
+    "string": "Páginas"
+  },
+  "IalCDT": {
+    "string": "Nenhum tipo de modelo encontrado"
+  },
+  "IbVKSH": {
+    "context": "button",
+    "string": "Gerenciar"
+  },
+  "Ic7Wln": {
+    "context": "card subtitle",
+    "string": "Selecione zonas de envio que serão fornecidas através deste canal. Você pode atribuir zonas de envio a vários canais."
+  },
+  "IcTtTE": {
+    "context": "Description for live status",
+    "string": "Visível e comprável"
+  },
+  "Id7C0X": {
+    "context": "section header",
+    "string": "Você está prestes a instalar {name}"
+  },
+  "IeoGgH": {
+    "context": "variant created success message",
+    "string": "Variant created"
+  },
+  "IhK1F3": {
+    "string": "Nenhuma zona de envio encontrada"
+  },
+  "Ihhutz": {
+    "context": "Health check label for isAvailable field",
+    "string": "Em estoque"
+  },
+  "Ihp4D3": {
+    "context": "header",
+    "string": "Editar mídia"
+  },
+  "Ila7WO": {
+    "context": "change warehouse dialog description",
+    "string": "Escolha o armazém do qual deseja atender {productName}"
+  },
+  "IoCMjg": {
+    "context": "no collections",
+    "string": "Coleção não encontrada"
+  },
+  "IoDlcd": {
+    "string": "Slug"
+  },
+  "IpOugE": {
+    "string": "Mostrar metadados"
+  },
+  "IqRBql": {
+    "context": "variant name",
+    "string": "Nova variante"
+  },
+  "IradBW": {
+    "context": "date group header",
+    "string": "Ontem"
+  },
+  "Irflxf": {
+    "context": "window title",
+    "string": "Criar categoria."
+  },
+  "IruP2T": {
+    "string": "Pesquisar Cupom"
+  },
+  "IwEQvz": {
+    "context": "success activate alert message",
+    "string": "Presente ativado com sucesso {count,plural,one{card} other{cards}}"
+  },
+  "IyHQr0": {
+    "context": "navigator action",
+    "string": "Ir para o pedido #{orderNumber}"
+  },
+  "IzECoP": {
+    "string": "Pesquisar pedidos em rascunho..."
+  },
+  "IzEVek": {
+    "context": "bulk disable label",
+    "string": "Desativar"
+  },
+  "J/6a1+": {
+    "context": "tooltip for taxes when showing net prices",
+    "string": "Preços líquidos"
+  },
+  "J/QqOI": {
+    "string": "Este valor já existe neste atributo"
+  },
+  "J0UdxG": {
+    "string": "Pular preços por enquanto"
+  },
+  "J0lNnk": {
+    "context": "column label",
+    "string": "Armazém"
+  },
+  "J3W5LI": {
+    "context": "order line is gift",
+    "string": "É presente"
+  },
+  "J3uE0t": {
+    "context": "section header",
+    "string": "Valores do Atributo"
+  },
+  "J4E+jp": {
+    "string": "Nome da variante"
+  },
+  "J7mFhU": {
+    "context": "currency code select",
+    "string": "{code} - {countries}"
+  },
+  "J9z6wD": {
+    "context": "Number of shipping zones configured",
+    "string": "{count, plural, one {# zona de envio} other {# zonas de envio}}"
+  },
+  "JDvxO6": {
+    "context": "search gift card placeholder",
+    "string": "Pesquisar Cartões-presente (por código, e-mail, nome de usuário)"
+  },
+  "JDz5h8": {
+    "context": "number of subcategories in category",
+    "string": "Subcategorias"
+  },
+  "JE0TAx": {
+    "context": "section name",
+    "string": "Valores"
+  },
+  "JEIN47": {
+    "context": "label",
+    "string": "Quantidade Automática"
+  },
+  "JEw8ys": {
+    "string": "Lançamentos"
+  },
+  "JFmOfi": {
+    "context": "button",
+    "string": "Criar Produto"
+  },
+  "JFtFgc": {
+    "context": "tabel column header",
+    "string": "Preço de Venda"
+  },
+  "JGm7E5": {
+    "context": "option",
+    "string": "Exportar estoque para todos os depósitos"
+  },
+  "JHfbXR": {
+    "context": "button",
+    "string": "Criar Venda"
+  },
+  "JI2Xwp": {
+    "context": "dialog title",
+    "string": "Excluir atributo"
+  },
+  "JIQ7KX": {
+    "string": "Total capturado"
+  },
+  "JJ3PCA": {
+    "context": "export card codes structure item",
+    "string": "Exportar códigos de vale"
+  },
+  "JJLkzh": {
+    "string": "Selecionar transação para reembolso"
+  },
+  "JJgJwi": {
+    "string": "Selecionando isto, mudará o idioma do seu painel"
+  },
+  "JKbpH9": {
+    "context": "expiry date checkbox label",
+    "string": "O vale-presente expira"
+  },
+  "JMBsrr": {
+    "context": "table header available stock label",
+    "string": "Disponível"
+  },
+  "JMbFNo": {
+    "string": "Nova página criada com sucesso"
+  },
+  "JPH/uP": {
+    "string": "Defina os tipos de páginas de conteúdo usadas na sua loja"
+  },
+  "JQH+Iy": {
+    "context": "resent code success message",
+    "string": "Reenviar o código ao cliente com sucesso!"
+  },
+  "JRfJD9": {
+    "string": "O plugin pode parar de funcionar depois que este campo for limpo. Tem certeza de que deseja continuar?"
+  },
+  "JTcz2G": {
+    "context": "csv file exporting has finished, header",
+    "string": "Exportação CSV concluída"
+  },
+  "JTjg1r": {
+    "context": "onboarding step title",
+    "string": "Descubra as capacidades da extensão"
+  },
+  "JUQwne": {
+    "context": "order",
+    "string": "Gift Card"
+  },
+  "JV+EiM": {
+    "context": "voucher value",
+    "string": "Valor"
+  },
+  "JVaz1C": {
+    "context": "window title",
+    "string": "Criar Webhook"
+  },
+  "JXRYQg": {
+    "context": "button",
+    "string": "Criar Menu"
+  },
+  "JYfMRO": {
+    "context": "order discount was updated event title",
+    "string": "Desconto do pedido foi atualizado"
+  },
+  "JYvf8/": {
+    "context": "is preorder",
+    "string": "Preorder"
+  },
+  "Ja7gHc": {
+    "context": "button",
+    "string": "Editar"
+  },
+  "JaZh3+": {
+    "context": "title for required non-selection attributes section",
+    "string": "Atributos obrigatórios"
+  },
+  "Jb1/3V": {
+    "context": "add shipping carrier button",
+    "string": "Adicionar transportadora"
+  },
+  "JbUg2b": {
+    "context": "activate app",
+    "string": "Tem certeza que deseja ativar {name}? Ativá-lo irá iniciar a coleta de eventos."
+  },
+  "JfKvrV": {
+    "context": "select variant media",
+    "string": "Selecione uma mídia variante específica na mídia do produto"
+  },
+  "JftRtx": {
+    "context": "issue gift card dialog title",
+    "string": "Emitir vale-presente"
+  },
+  "JgNb8X": {
+    "context": "notifier message",
+    "string": "Ocorreu um erro ao adicionar uma nota"
+  },
+  "JgXBAw": {
+    "context": "dropdown label when there are no channels assigned",
+    "string": "Nenhum canal"
+  },
+  "JiRKgJ": {
+    "context": "dialog search placeholder",
+    "string": "Pesquisar por nome da coleção, etc...."
+  },
+  "JiUAB0": {
+    "string": "Um campo obrigatório está faltando na solicitação."
+  },
+  "JiVwOU": {
+    "string": "Houve um problema com o arquivo que você enviou como imagem e não pôde ser usado. Por favor, tente um arquivo diferente."
+  },
+  "JiXNEV": {
+    "string": "Pesquisar Categoria"
+  },
+  "Jj0de8": {
+    "context": "voucher status",
+    "string": "Agendado"
+  },
+  "JjeZEG": {
+    "context": "section header",
+    "string": "Organizar Produto"
+  },
+  "JkO0jp": {
+    "context": "input description",
+    "string": "{unitsLeft} unidades restantes"
+  },
+  "JmdBa3": {
+    "context": "product availability publish date",
+    "string": "Publicar em"
+  },
+  "JnzDrI": {
+    "context": "discount type",
+    "string": "Quantia Fixa"
+  },
+  "Jo01VZ": {
+    "context": "bought by label",
+    "string": "Comprado por"
+  },
+  "JotAJ3": {
+    "string": "E (explícito)"
+  },
+  "JqiqNj": {
+    "string": "Algo deu errado"
+  },
+  "JsLWyc": {
+    "context": "Error occurred during public API verification",
+    "string": "Verificação falhou"
+  },
+  "JsPIOX": {
+    "context": "voucher code",
+    "string": "Código"
+  },
+  "Jsh6+U": {
+    "context": "product type is digital or physical",
+    "string": "Tipo"
+  },
+  "Jt3DwJ": {
+    "context": "publish on date",
+    "string": "Publicar em"
+  },
+  "JtZ71e": {
+    "context": "filtering option",
+    "string": "Todos os Depósitos"
+  },
+  "JufWFT": {
+    "context": "app installation error",
+    "string": "Ocorreu um problema durante a instalação"
+  },
+  "JwICkk": {
+    "context": "warning dialog description when SKU and stock are not set",
+    "string": "Você não definiu um prefixo SKU ou estoque inicial. As variantes serão criadas sem esses valores. Você pode adicioná-los mais tarde editando variantes individuais."
+  },
+  "Jwuu4X": {
+    "context": "select product informations to be exported",
+    "string": "Informações exportadas:"
+  },
+  "JyQEHU": {
+    "context": "tabel column header",
+    "string": "Canais"
+  },
+  "JyQoES": {
+    "context": "delete attribute value",
+    "string": "Tem certeza de que deseja excluir o valor \"{name}\"  ?"
+  },
+  "Jz/Cb+": {
+    "context": "product type",
+    "string": "Simples"
+  },
+  "K+ROF8": {
+    "string": "Os canais que não têm descontos atribuídos usarão seu canal pai para definir o preço. O preço será convertido para a moeda do canal"
+  },
+  "K+vjtE": {
+    "string": "Buscar Variantes"
+  },
+  "K//bUK": {
+    "context": "refund button",
+    "string": "Restituição"
+  },
+  "K/gnGg": {
+    "string": "Se você deseja desativar este usuário, desmarque a caixa abaixo."
+  },
+  "K/ic0P": {
+    "context": "checkbox label",
+    "string": "Resto do Mundo"
+  },
+  "K1ycaD": {
+    "context": "input label",
+    "string": "Valor do reembolso"
+  },
+  "K58C4r": {
+    "string": "Estamos trabalhando para substituir plugins por aplicativos. Use aplicativos, a menos que não haja outra opção. {learnMore}"
+  },
+  "K8xNLe": {
+    "context": "products section name",
+    "string": "Produtos"
+  },
+  "KCjd1o": {
+    "context": "dialog title",
+    "string": "Deletar produtos"
+  },
+  "KDvRBi": {
+    "context": "button",
+    "string": "Instalar"
+  },
+  "KE/G/G": {
+    "context": "Placeholder text for channel controls",
+    "string": "Os controles do canal serão exibidos aqui"
+  },
+  "KFv8hX": {
+    "string": "Um atributo já existe."
+  },
+  "KGsaGO": {
+    "context": "tooltip",
+    "string": "Este recurso está em estado de visualização e pode estar sujeito a alterações posteriormente"
+  },
+  "KHI/qv": {
+    "string": "Você não tem permissão para gerenciar produtos"
+  },
+  "KHZlmi": {
+    "string": "Tipo do Desconto"
+  },
+  "KIh25E": {
+    "string": "Nenhum rascunho de pedidos encontrado"
+  },
+  "KJPsls": {
+    "context": "Tooltip line showing UTC timestamp of a problem event",
+    "string": "UTC: {time}"
+  },
+  "KKQUMK": {
+    "context": "edit menu item, header",
+    "string": "Editar Item"
+  },
+  "KMxiiF": {
+    "context": "button",
+    "string": "Tentar novamente"
+  },
+  "KN7zKn": {
+    "string": "Erro"
+  },
+  "KOqZv3": {
+    "context": "tooltip, submit form",
+    "string": "Você deve conceder o reembolso primeiro."
+  },
+  "KPmk40": {
+    "context": "charge status partial",
+    "string": "Parcial"
+  },
+  "KQSONM": {
+    "context": "tabel column header",
+    "string": "Cost"
+  },
+  "KRqgfo": {
+    "string": "O usuário está fora do seu escopo de permissões"
+  },
+  "KSp+8B": {
+    "context": "product available for purchase date",
+    "string": "estará disponível em {date}"
+  },
+  "KTAg0f": {
+    "context": "tabel column header",
+    "string": "Nome do Depósito"
+  },
+  "KTjTMW": {
+    "string": "Instalação pendente..."
+  },
+  "KWXwFo": {
+    "context": "grant refund table, column header",
+    "string": "Preço unitário"
+  },
+  "KYMCYg": {
+    "string": "Taxa de envio excluída"
+  },
+  "KcsJKm": {
+    "context": "error with activatation alert message",
+    "string": "Erro ao ativar o presente {count,plural,one{card} other{cards}}"
+  },
+  "KeO51o": {
+    "string": "Canais"
+  },
+  "Kfuqfq": {
+    "context": "transfer funds button",
+    "string": "Transferir fundos"
+  },
+  "Kg0Fiu": {
+    "context": "quantity of fulfilled products",
+    "string": "Quantidade para faturar"
+  },
+  "Kgxlsf": {
+    "context": "order",
+    "string": "Pago com vale-presente"
+  },
+  "KkufwD": {
+    "string": "Nenhum código de vale encontrado"
+  },
+  "KmPicj": {
+    "string": "Anotação adicionada com sucesso"
+  },
+  "KpP/aW": {
+    "string": "Pedido foi marcado como"
+  },
+  "KqbfFa": {
+    "context": "expiry date selection info message",
+    "string": "Você pode definir que os cartões-presente expirem após um determinado período após a compra. Lembre-se de que em alguns países a expiração dos cartões-presente é proibida por lei."
+  },
+  "Krzyo+": {
+    "context": "shipment refund title",
+    "string": "Envio foi reembolsado"
+  },
+  "KszPFx": {
+    "context": "dialog header",
+    "string": "Cancelar Pagamento"
+  },
+  "KupNHw": {
+    "context": "product field",
+    "string": "Categoria"
+  },
+  "Kv58Rx": {
+    "context": "default gift card delete description",
+    "string": "{selectedItemsCount,plural,one{Você tem certeza de que deseja excluir este cartão-presente?} other{Você tem certeza de que deseja excluir {selectedItemsCount} cartões-presente?}}"
+  },
+  "KvK69l": {
+    "context": "limit reached warning",
+    "string": "Máximo {limit} variantes podem ser geradas de uma só vez. Por favor, reduza sua seleção."
+  },
+  "Kw0jHS": {
+    "context": "created products counter",
+    "string": "{count}/{max} SKUs used"
+  },
+  "Kxiige": {
+    "string": "Token Gerado"
+  },
+  "Kyyr7D": {
+    "context": "dialog header",
+    "string": "Cancelar atribuição de variante da venda"
+  },
+  "KzgcFV": {
+    "context": "category attribute entity type",
+    "string": "Categorias"
+  },
+  "L/O4LQ": {
+    "context": "order refund amount",
+    "string": "Quantidade Autorizada"
+  },
+  "L/ZbnW": {
+    "context": "fulfillment status waiting for approval",
+    "string": "Aguardando Aprovação"
+  },
+  "L2tvTm": {
+    "context": "mark as paid strategy checkbox label",
+    "string": "Use o fluxo de Transação ao marcar o pedido como pago"
+  },
+  "L5IuDw": {
+    "string": "menor"
+  },
+  "L5io1l": {
+    "context": "returned products list title",
+    "string": "Produtos devolvidos"
+  },
+  "L5rthO": {
+    "string": "Aplicar estoque único por atributo a cada SKU"
+  },
+  "L6+p8a": {
+    "context": "dialog title",
+    "string": "Excluir grupo de permissão"
+  },
+  "L7N+0y": {
+    "context": "product rating",
+    "string": "Avaliação do Produto"
+  },
+  "L7j412": {
+    "context": "no models placeholder",
+    "string": "Nenhum modelo encontrado"
+  },
+  "L87bp7": {
+    "string": "Pagamento do pedido cancelado com sucesso"
+  },
+  "L8J/jr": {
+    "context": "status pill when order is fully paid",
+    "string": "Totalmente Capturado"
+  },
+  "L8seEc": {
+    "string": "Subtotal"
+  },
+  "LA13a5": {
+    "context": "channel select label",
+    "string": "Canal"
+  },
+  "LATHyi": {
+    "context": "dialog header",
+    "string": "Excluir Canal: {channelSlug}"
+  },
+  "LATpSE": {
+    "context": "marketplace content",
+    "string": "Descubra grandes aplicativos gratuitos e pagos em nosso Marketplace Saleor."
+  },
+  "LCmiky": {
+    "string": "Zonas de envio excluídas"
+  },
+  "LEZZkK": {
+    "context": "WarehouseSettings all warehouses description",
+    "string": "Se selecionado o cliente poderá escolher este armazém como ponto de recolha. Os produtos encomendados podem ser enviados aqui de um armazém diferente"
+  },
+  "LHPVg/": {
+    "context": "assign countries to shipping zone and save, button",
+    "string": "Atribuir e salvar"
+  },
+  "LICZeR": {
+    "context": "weight",
+    "string": "de {value} {unit}"
+  },
+  "LJPHdt": {
+    "context": "cancelled fulfillment, section header",
+    "string": "Reembolsado e Retornado"
+  },
+  "LJqVaO": {
+    "context": "automatic completion cut-off date earlier warning message",
+    "string": "Definir data limite {timeDifference} mais cedo (de {previousDate} para {newDate}) fará com que os checkouts criados entre essas datas sejam concluídos automaticamente."
+  },
+  "LKD6fB": {
+    "string": "Remover produto"
+  },
+  "LKoIB1": {
+    "string": "Adicione título e descrição ao mecanismo de busca para facilitar a localização deste produto"
+  },
+  "LKpQYh": {
+    "context": "refund type",
+    "string": "Reembolso Diverso"
+  },
+  "LLS4re": {
+    "string": "Ir para atributos"
+  },
+  "LLrOK3": {
+    "context": "paragraph, description in manual refund card",
+    "string": "Criar um reembolso manual para pagamentos não integrados"
+  },
+  "LOSNq0": {
+    "context": "dialog header",
+    "string": "Cancelar atribuição de categorias do cupom"
+  },
+  "LR3HlT": {
+    "string": "Esta senha é muito curta"
+  },
+  "LU8dtl": {
+    "context": "date group header",
+    "string": "Mais velho"
+  },
+  "LVa5ew": {
+    "string": "Saleor encontrou um problema inesperado"
+  },
+  "LVtwcF": {
+    "string": "Criar novo armazém"
+  },
+  "LWc61W": {
+    "context": "Title when diagnostics are limited due to permissions",
+    "string": "Diagnósticos limitados"
+  },
+  "LWmYSU": {
+    "string": "Traduções concluídas"
+  },
+  "LY5dS9": {
+    "context": "Charged transaction amount, data display header",
+    "string": "Cobrado"
+  },
+  "La3xKC": {
+    "context": "Description of public API verification feature",
+    "string": "Verifique se os clientes podem realmente comprar este produto"
+  },
+  "LdNCP/": {
+    "context": "Filter or element text",
+    "string": "Ou"
+  },
+  "LdzrxA": {
+    "string": "Construção personalizada"
+  },
+  "LeJClL": {
+    "context": "Popover title",
+    "string": "Condições"
+  },
+  "LgbKvU": {
+    "string": "Atributos que definem as opções de variante que os clientes podem escolher na vitrine.{br}Podem ser ajustados nas configurações de {productTypeLink}."
+  },
+  "LhGd2m": {
+    "context": "tooltip for variant selection attributes",
+    "string": "Pedido"
+  },
+  "Ljtqmt": {
+    "context": "page header, order id unknown",
+    "string": "Notificação de serviço externo"
+  },
+  "LkuDEb": {
+    "context": "metadata field value, header",
+    "string": "Valor"
+  },
+  "LlbAEg": {
+    "context": "order history message",
+    "string": "Webhook sem nome"
+  },
+  "Lm2Zw7": {
+    "context": "name placeholder",
+    "string": "Desconto de {value} na compra de {conditions} através do {channel}"
+  },
+  "LmKz3g": {
+    "string": "Loja"
+  },
+  "LnRlch": {
+    "context": "attribute's editor component entity",
+    "string": "Entidade"
+  },
+  "Lrp9WW": {
+    "string": "Selecionar quantidades para reembolso"
+  },
+  "LsgHmZ": {
+    "context": "delete shipping zone",
+    "string": "Tem certeza de que deseja excluir {name}?"
+  },
+  "LshEVn": {
+    "context": "button",
+    "string": "Criar pedido"
+  },
+  "LtqrM8": {
+    "context": "delete custom app",
+    "string": "Excluindo {name}, você excluirá todos os dados e webhooks relacionados a este aplicativo. Tem certeza que deseja fazer isto?"
+  },
+  "LwU0Vy": {
+    "context": "datagrid title label",
+    "string": "Você tem alterações não salvas nas variantes. Por favor, salve suas alterações antes de gerar novas variantes."
+  },
+  "LwWT6O": {
+    "context": "dialog description when opening generator with unsaved changes",
+    "string": "Nenhum tipo de produto atribuído"
+  },
+  "Lx1ima": {
+    "context": "button",
+    "string": "Enviar Imagem"
+  },
+  "M1uijW": {
+    "context": "collection",
+    "string": "Não publicado"
+  },
+  "M3aMq+": {
+    "context": "empty state for reference types",
+    "string": "Manual"
+  },
+  "M4q0Ye": {
+    "context": "error message",
+    "string": "Desculpe, o login deu errado. Por favor, tente novamente."
+  },
+  "M59JhX": {
+    "string": "Enviável"
+  },
+  "M61TN/": {
+    "context": "product type shippable",
+    "string": "Você não tem permissões para criar um reembolso manual."
+  },
+  "M6mWHL": {
+    "context": "tooltip helper text",
+    "string": "{count, plural, one {# armazém} other {# armazéns}}"
+  },
+  "M6s/9e": {
+    "context": "unassign country, dialog header",
+    "string": "Remover da zona de envio"
+  },
+  "M8z5WZ": {
+    "context": "WarehouseSettings disabled warehouse description",
+    "string": "Se o cliente selecionado não poderá escolher este armazém como ponto de coleta"
+  },
+  "M9LXb5": {
+    "context": "no shipping carriers title",
+    "string": "Nenhuma transportadora aplicável"
+  },
+  "MAsLIT": {
+    "context": "custom app token key",
+    "string": "Chave"
+  },
+  "MFC20a": {
+    "context": "Number of warehouses configured",
+    "string": "dd/mm/yyyy, --:--"
+  },
+  "MFUQrr": {
+    "context": "Placeholder for date picker",
+    "string": "Desconsiderar todos os problemas levantados pelo aplicativo"
+  },
+  "MFirbo": {
+    "context": "Button label to dismiss all problems for an app",
+    "string": "Ação de Teste"
+  },
+  "MH1qA1": {
+    "string": "Custo de envio"
+  },
+  "MHVglr": {
+    "context": "deactivate",
+    "string": "Desativar"
+  },
+  "MHY5da": {
+    "context": "tooltip for shipping amount",
+    "string": "de {value}"
+  },
+  "MIC9W7": {
+    "context": "WarehouseSettings pickup title",
+    "string": "Pickup"
+  },
+  "MIp3c7": {
+    "context": "input adornment helper text",
+    "string": "Total"
+  },
+  "MJ2jZQ": {
+    "string": "{count, plural, =0 {Nenhum armazém} one {# armazém} other {# armazéns}}"
+  },
+  "MJBAqv": {
+    "context": "column title used by/customer",
+    "string": "Usado por"
+  },
+  "MKtgZB": {
+    "string": "Somente usuários da equipe podem acessar o painel"
+  },
+  "MNZY28": {
+    "context": "table column header",
+    "string": "Limite do canal"
+  },
+  "MOQWz8": {
+    "context": "Number of warehouses",
+    "string": "O identificador da extensão já está em uso. ({errorCode})"
+  },
+  "MPOj0I": {
+    "context": "ExitFormPrompt confirm button",
+    "string": "Salvar alterações"
+  },
+  "MPfyne": {
+    "string": "Tem certeza de que deseja enviar esta fatura: {invoiceNumber} para o cliente?"
+  },
+  "MQwT1W": {
+    "context": "activate",
+    "string": "Ativar"
+  },
+  "MS86iy": {
+    "string": "Número de pedidos"
+  },
+  "MSD3A/": {
+    "string": "Pesquisar Venda"
+  },
+  "MSItJD": {
+    "string": "Você está prestes a sair do Dashboard. Você quer continuar?"
+  },
+  "MTGT8E": {
+    "context": "column header",
+    "string": "Todos"
+  },
+  "MTl5o6": {
+    "context": "new discount label",
+    "string": "Novo valor de desconto"
+  },
+  "MVU6ol": {
+    "context": "exceeded permissions description",
+    "string": "Estes grupos de permissões excedem suas permissões. Você pode gerenciar apenas permissões que você possui."
+  },
+  "MWSacl": {
+    "string": "Multicanal"
+  },
+  "MXZuVP": {
+    "context": "remove country from shipping zone and save, button",
+    "string": "Remover e salvar"
+  },
+  "MZDkkX": {
+    "context": "button label",
+    "string": "Excluir regra"
+  },
+  "MbZHXE": {
+    "context": "column title balance",
+    "string": "Equilíbrio"
+  },
+  "McN+wq": {
+    "context": "customers section name",
+    "string": "Clientes"
+  },
+  "MdFdbd": {
+    "string": "As chaves de metadados devem ser exclusivas, remova a chave duplicada"
+  },
+  "Mee46w": {
+    "context": "collection publication date",
+    "string": "Torna-se publicado o {date}"
+  },
+  "MewrtN": {
+    "context": "section header",
+    "string": "Faturamento"
+  },
+  "MfWHGz": {
+    "context": "metadata edit form, error message",
+    "string": "Disponível para captura (autorizado)"
+  },
+  "MgdgpT": {
+    "context": "customer input label",
+    "string": "Cliente"
+  },
+  "MhlYkx": {
+    "context": "label for available authorization amount",
+    "string": "Atributos obrigatórios ({attributes}) não são suportados.{newline}{newline}Para prosseguir:{newline}1. Torná-los opcionais no tipo de produto{newline}2. Gerar variantes{newline}3. Definir valores manualmente{newline}4. Restaurar configuração obrigatória"
+  },
+  "MjUyhA": {
+    "context": "section subheader",
+    "string": "Membro ativo desde {date}"
+  },
+  "Ml19/F": {
+    "context": "description for unsupported required attributes error",
+    "string": "Máx: {amount}"
+  },
+  "Mm/Stj": {
+    "context": "hint showing maximum allowed custom amount",
+    "string": "Estoque do armazém"
+  },
+  "MmGlkp": {
+    "context": "dialog header",
+    "string": "Cancelar a atribuição de coleções do cupom"
+  },
+  "Mmo9k2": {
+    "context": "table header warehouse stock label",
+    "string": "Ver detalhes"
+  },
+  "MnpUD7": {
+    "string": "Configurações de imposto atualizadas"
+  },
+  "MpOBnD": {
+    "string": "Os clientes não podem adicionar quantidades a um único carrinho acima do limite quando o valor é fornecido."
+  },
+  "MpR4zK": {
+    "context": "customer details, header",
+    "string": "Detalhes de {fullName}"
+  },
+  "MwfSVA": {
+    "context": "input helper text",
+    "string": "Falha"
+  },
+  "MxhVZv": {
+    "string": "Tem certeza de que deseja excluir a imagem da coleção?"
+  },
+  "MyM2oR": {
+    "context": "window title",
+    "string": "Criar Variação"
+  },
+  "Myx1Qp": {
+    "context": "add discount button",
+    "string": "Adicionar desconto"
+  },
+  "Mz0cx+": {
+    "context": "delete channel",
+    "string": "Excluir o canal excluirá todos os dados de produtos relativos a este canal. Tem certeza de que deseja excluir este canal?"
+  },
+  "MzXBdd": {
+    "context": "Refund failure status",
+    "string": "Armazém excluído"
+  },
+  "MzXzjL": {
+    "string": "Oculto da navegação."
+  },
+  "N1Z/Er": {
+    "context": "Title when product is not visible in listings",
+    "string": "Confirmar"
+  },
+  "N2IrpM": {
+    "string": "Editar metadados da linha do pedido"
+  },
+  "N2SbNc": {
+    "string": "{counter,plural,one {Tem certeza que deseja excluir este cliente? } other {Tem certeza que deseja excluir {displayQuantity} clientes? }}"
+  },
+  "N3Zot1": {
+    "context": "button",
+    "string": "Mude sua senha"
+  },
+  "N43t3/": {
+    "context": "error message",
+    "string": "Número não definido para uma fatura"
+  },
+  "N5UuEK": {
+    "context": "header",
+    "string": "Ítens prontos para despacho"
+  },
+  "N6lfS/": {
+    "context": "header",
+    "string": " Exclusão de campo de autorização"
+  },
+  "N6s/fl": {
+    "string": "Este nome já está em uso. Por favor, forneça outro."
+  },
+  "N76zUg": {
+    "context": "page header",
+    "string": "Criar Cliente"
+  },
+  "N7XGzW": {
+    "context": "error message",
+    "string": "Desatribuir atributo do tipo de modelo"
+  },
+  "N7tQ9P": {
+    "context": "dialog header",
+    "string": "Não há armazéns configurados para esta variante. Para adicionar quantidade de estoque à variante <a>configure um armazém</a> ou use um existente clicando no botão abaixo."
+  },
+  "NBP8uu": {
+    "context": "page header",
+    "string": "Novo Produto"
+  },
+  "NCp87D": {
+    "context": "no warehouses info",
+    "string": "Criar webhook/extensão manualmente"
+  },
+  "ND5x+V": {
+    "string": "Estamos gerando a fatura que você solicitou. Por favor, aguarde um momento"
+  },
+  "NDm2Fe": {
+    "context": "page title",
+    "string": "Criar Taxa de Peso"
+  },
+  "NEJo1I": {
+    "context": "dialog content",
+    "string": "Tem certeza de que deseja excluir {voucherCode}?"
+  },
+  "NGWTE4": {
+    "string": "Ação Visível"
+  },
+  "NGc9kE": {
+    "string": "Tipo de página excluído"
+  },
+  "NJ9ngY": {
+    "string": "Qtd"
+  },
+  "NJEe12": {
+    "string": "Pesquisar Rascunho"
+  },
+  "NJbzcP": {
+    "context": "dialog header",
+    "string": "Cancelar Pedidos"
+  },
+  "NL5C12": {
+    "context": "orderLine.quantity, subheader, oredr line metadata dialog",
+    "string": "{count,plural,one {Cartão-presente} other {{count} cartões-presente}} desativados"
+  },
+  "NLNonj": {
+    "context": "send to channel select label",
+    "string": "Enviar para o canal"
+  },
+  "NLybdq": {
+    "context": "voucher channel",
+    "string": "Canal"
+  },
+  "NNT3Lp": {
+    "context": "collections section name",
+    "string": "Coleções"
+  },
+  "NOwJdG": {
+    "context": "success deactivate alert message",
+    "string": "Produtos retornados, reembolso concedido"
+  },
+  "NPT+At": {
+    "context": "order returned success message",
+    "string": "Configurações da Conta"
+  },
+  "NPfmdK": {
+    "context": "webhook input label",
+    "string": "Chave secreta"
+  },
+  "NQgbYA": {
+    "string": "A extensão não fornece uma política de privacidade."
+  },
+  "NUBTlN": {
+    "string": "Modelagem"
+  },
+  "NUevU9": {
+    "context": "attribute values list: slug column header",
+    "string": "Swatch"
+  },
+  "NVp0fa": {
+    "context": "modeling section name",
+    "string": "<b>Importante:</b> Os reembolsos precisam ser emitidos <b>manualmente</b> após o cancelamento do pedido."
+  },
+  "NWA+MK": {
+    "context": "dialog content",
+    "string": "Conteúdo"
+  },
+  "NWxomz": {
+    "string": "Status do faturamento"
+  },
+  "NXpFlL": {
+    "context": "product attribute values, page title",
+    "string": "Escolha os Valores"
+  },
+  "NZtcLb": {
+    "context": "gift card bulk create success dialog content",
+    "string": "Emitimos todos os cartões-presente solicitados. Você pode baixar a lista de novos cartões-presente usando o botão abaixo."
+  },
+  "NcY4ph": {
+    "string": "Limite que não pode ser excedido mesmo que os limites por canal ainda estejam disponíveis"
+  },
+  "NelCIl": {
+    "context": "content section name",
+    "string": "Taxa de imposto"
+  },
+  "Nfh9QM": {
+    "context": "checkbox gift cards label description",
+    "string": "quando ativados, os cartões-presente não entregáveis serão automaticamente definidos como cumpridos e enviados ao cliente"
+  },
+  "NhQboB": {
+    "context": "dialog header",
+    "string": "O sistema não pôde cancelar o pedido"
+  },
+  "NivJal": {
+    "context": "section header",
+    "string": "Todas as Subcategorias"
+  },
+  "Nj9iSB": {
+    "context": "table header column",
+    "string": "Data agendada passada ({date})"
+  },
+  "NjORiU": {
+    "context": "Warning when scheduled publication date is in the past",
+    "string": "Criar classe"
+  },
+  "NlEVVT": {
+    "context": "label for button",
+    "string": "Pagamento"
+  },
+  "NlSJMM": {
+    "context": "channels section name",
+    "string": "Canais"
+  },
+  "NmK6zy": {
+    "string": "Digite o valor do reembolso diretamente. Nenhum cálculo adicional será feito."
+  },
+  "NmXWPM": {
+    "string": "As permissões indisponíveis são aquelas que excedem seus próprios direitos de acesso. Extensões não podem ter mais permissões do que seu criador. Entre em contato com um administrador para criar esta extensão para você ou conceder à sua conta as permissões necessárias"
+  },
+  "Nmbt6C": {
+    "context": "custom extension page create, callout message",
+    "string": "{transactionType} reembolso"
+  },
+  "NnhrxZ": {
+    "context": "amount of sent refund for transaction",
+    "string": "Nome"
+  },
+  "No4lyL": {
+    "context": "header field name, header",
+    "string": "Pesquisar tipos de produto..."
+  },
+  "Np7J92": {
+    "context": "deactivate local named app",
+    "string": "Você tem certeza de que deseja desativar {name}? Seus dados serão mantidos até que você reative o aplicativo."
+  },
+  "Nqh0na": {
+    "context": "Product types search input placeholder",
+    "string": "Pesquisar canais..."
+  },
+  "NqxvFh": {
+    "context": "navigator placeholder",
+    "string": "Digite o Comando"
+  },
+  "Nsbu46": {
+    "context": "Placeholder for channel search input",
+    "string": "Obter suporte"
+  },
+  "NsgWhZ": {
+    "context": "placeholder",
+    "string": "Busque por nome de valor, etc..."
+  },
+  "Nsk5WL": {
+    "context": "link",
+    "string": "Não ativo"
+  },
+  "NskBjH": {
+    "context": "marketplace content",
+    "string": "Marketplace chegará em breve"
+  },
+  "NtFVFS": {
+    "context": "weight",
+    "string": "{value} {unit}"
+  },
+  "Nuq83+": {
+    "string": "Create new channel"
+  },
+  "Nv/toB": {
+    "context": "button",
+    "string": "Atribuir e salvar"
+  },
+  "NvwS/N": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi desativado"
+  },
+  "NwQXZp": {
+    "context": "status",
+    "string": "Saleor inclui um Playground GraphQL, um editor GraphQL interativo, permitindo acesso à API da sua instância Saleor através do navegador da web. O Playground permite que você se familiarize rapidamente com a API, realize operações de exemplo e envie suas primeiras consultas e mutações."
+  },
+  "NxRsHQ": {
+    "context": "section header",
+    "string": "Cumprimento - #{fulfilmentId}"
+  },
+  "NxeDbG": {
+    "context": "image upload",
+    "string": "Arraste até aqui para efetuar o upload"
+  },
+  "Nyxzpe": {
+    "context": "onboarding step description",
+    "string": "Criar nova coleção"
+  },
+  "NzifUg": {
+    "context": "window title",
+    "string": "Faturar Pedido"
+  },
+  "O+3CZK": {
+    "string": "Não há produtos disponíveis neste canal."
+  },
+  "O22NIZ": {
+    "context": "deletion error message",
+    "string": "Não é possível excluir o grupo que está fora do seu escopo de permissão"
+  },
+  "O4QNFx": {
+    "context": "alert message",
+    "string": "Médico de Disponibilidade"
+  },
+  "O6C2jX": {
+    "context": "Product doctor card title",
+    "string": "Nenhum atributo de variante definido para este tipo de produto."
+  },
+  "O90S9P": {
+    "context": "empty state when no variant attributes",
+    "string": "Desinstalar a extensão removerá todos os metadados armazenados por {extensionName}. {learnMoreLink}"
+  },
+  "O95R3Z": {
+    "string": "Telefone"
+  },
+  "O9QPe1": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza que deseja excluir este cupom?} other {Tem certeza que deseja excluir {displayQuantity} cupons?}}"
+  },
+  "O9SefD": {
+    "context": "card text, app install page",
+    "string": "Criar um tipo de produto"
+  },
+  "OA+fw+": {
+    "context": "conjunction, choice between going to dashboard or refreshing page",
+    "string": "ou"
+  },
+  "OAuXGE": {
+    "string": "Não é possível usar o gerador"
+  },
+  "OBQ+th": {
+    "context": "WarehouseSettings disabled warehouse label",
+    "string": "Desabilitada"
+  },
+  "OCQLYd": {
+    "context": "title for unsupported required attributes error",
+    "string": "{productName} desconto foi removido"
+  },
+  "OErjoA": {
+    "string": "Tentativas:"
+  },
+  "OFTsI1": {
+    "string": "Variante"
+  },
+  "OGemtu": {
+    "context": "payment status",
+    "string": "Parcialmente reembolsado"
+  },
+  "OGm8wO": {
+    "context": "button",
+    "string": "Criar Canal"
+  },
+  "OK5+Fh": {
+    "string": "Você não tem permissão para realizar esta ação"
+  },
+  "OKGd/k": {
+    "context": "order history message",
+    "string": " O pedido foi criado a partir do rascunho"
+  },
+  "OPtrMg": {
+    "context": "header",
+    "string": "{webhookName} Detalhes"
+  },
+  "ORQvOg": {
+    "string": "Todas as transações são não reembolsáveis"
+  },
+  "OSnO9P": {
+    "string": "Todos os membros da equipe"
+  },
+  "OTDo9I": {
+    "context": "tab name",
+    "string": "Saldo restante"
+  },
+  "OTek3r": {
+    "context": "product variant name",
+    "string": "Variação"
+  },
+  "OTpV1t": {
+    "context": "webhook name",
+    "string": "Nome"
+  },
+  "OUMqG1": {
+    "context": "label for remaining balance to capture",
+    "string": "Tipo de modelo"
+  },
+  "OUX4LB": {
+    "context": "input label",
+    "string": "Referência Única"
+  },
+  "OVOU1z": {
+    "context": "section header",
+    "string": "Metadados"
+  },
+  "OZc365": {
+    "context": "single reference attribute type",
+    "string": "Webhook atualizado"
+  },
+  "OaA0f9": {
+    "string": "Você atingiu o limite de funcionários e não poderá mais adicionar funcionários à sua loja. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
+  },
+  "OaKyz4": {
+    "context": "input label",
+    "string": "Reserva de estoque para usuário autenticado (em minutos)"
+  },
+  "ObRk1O": {
+    "string": "Se esta opção estiver desabilitada, o desconto será dado para todo produto elegível"
+  },
+  "Oe62bR": {
+    "context": "product availability",
+    "string": "Disponibilidade"
+  },
+  "OeIWeD": {
+    "string": "Estoque inicial (todos os armazéns)"
+  },
+  "Of19Pn": {
+    "context": "Types",
+    "string": "Tipos de Página"
+  },
+  "OgFBAj": {
+    "context": "input label",
+    "string": "Preço"
+  },
+  "OhFGpX": {
+    "context": "button",
+    "string": "Atribuir membros"
+  },
+  "OhdPS1": {
+    "context": "amount of refunded money",
+    "string": "Montante"
+  },
+  "Om1LKj": {
+    "context": "stock input label",
+    "string": "Atribuir Modelo"
+  },
+  "OpgSjI": {
+    "context": "dialog header",
+    "string": "Quando ativado, o cartão-presente pode ser aplicado a um checkout usando a mutação addPromoCode."
+  },
+  "OqYCQ4": {
+    "context": "allow legacy gift card use description",
+    "string": "Nenhum canal corresponde à sua pesquisa"
+  },
+  "OrEUr6": {
+    "context": "Message when search returns no results",
+    "string": "Produto indisponível nos canais de coleção"
+  },
+  "OrMr/k": {
+    "context": "window title",
+    "string": "Criar Canal"
+  },
+  "OrR3Qy": {
+    "context": "no products",
+    "string": "Nenhum produto encontrado."
+  },
+  "Orgqv4": {
+    "context": "numeric attribute unit",
+    "string": "Unidade"
+  },
+  "OtMtzH": {
+    "string": "última ocorrência em"
+  },
+  "OutAI7": {
+    "context": "Label prefix for the last occurrence date of a recurring problem",
+    "string": "Tente novamente"
+  },
+  "OwG/0z": {
+    "string": "Menu deletado"
+  },
+  "Oy1LhB": {
+    "context": "button error state label",
+    "string": "Criar nova zona de envio"
+  },
+  "OzHN0Z": {
+    "context": "order history message",
+    "string": "Links para os produtos digitais do pedido foram enviados"
+  },
+  "P+kVxW": {
+    "context": "card description",
+    "string": "Usuário está atribuído a:"
+  },
+  "P/EDn1": {
+    "context": "order history message",
+    "string": "Pedido foi pago"
+  },
+  "P/oGtb": {
+    "context": "product availability",
+    "string": "Disponível para compra"
+  },
+  "P4Hja1": {
+    "string": "Catálogo"
+  },
+  "P5HhQl": {
+    "context": "catalog section name",
+    "string": "Nenhum produto encontrado"
+  },
+  "P5twxk": {
+    "context": "link",
+    "string": "Ativar"
+  },
+  "P6+RQ1": {
+    "context": "no products placeholder",
+    "string": "Desconto do pedido foi removido"
+  },
+  "P79U4b": {
+    "context": "attribute's slug short code label",
+    "string": "Código do Atributo"
+  },
+  "P7KpCX": {
+    "context": "order history message",
+    "string": "Todos os tipos de modelo"
+  },
+  "P7PLVj": {
+    "string": "Data"
+  },
+  "P8vgix": {
+    "context": "select all model types preset label",
+    "string": "Salvar predefinição de visualização"
+  },
+  "P9YktI": {
+    "context": "save preset, header",
+    "string": "Editar motivo do reembolso para esta linha"
+  },
+  "PALiyV": {
+    "context": "modal title",
+    "string": "Produtos e variantes específicas"
+  },
+  "PAqicb": {
+    "context": "button",
+    "string": "Cancelar pedido"
+  },
+  "PBd/e+": {
+    "context": "dialog header",
+    "string": "Alterar endereço para pedido"
+  },
+  "PCoO4D": {
+    "context": "error message",
+    "string": "Página não encontrada"
+  },
+  "PDF+8k": {
+    "context": "voucher discount",
+    "string": "Abra este produto no GraphiQL"
+  },
+  "PDw0YN": {
+    "context": "open new window button",
+    "string": "Problemas"
+  },
+  "PF7Zsp": {
+    "context": "Status when product has availability issues",
+    "string": "Você não pode gerenciar esta extensão porque ela tem mais permissões do que você."
+  },
+  "PFXGaR": {
+    "string": "Zonas de Entrega"
+  },
+  "PFmBz7": {
+    "string": "maior"
+  },
+  "PFnobO": {
+    "string": "Permissões"
+  },
+  "PHT8z1": {
+    "context": "extension form permissions section header",
+    "string": "Controla como os campos de endereço que não fazem parte do formato padrão de um país são tratados. Por padrão, tais campos são removidos durante a validação — habilitar esta configuração os preserva conforme inseridos."
+  },
+  "PHUcrU": {
+    "context": "date when order was placed",
+    "string": "Data"
+  },
+  "PJDcQs": {
+    "context": "set balance button label",
+    "string": "Definir saldo"
+  },
+  "PJGv35": {
+    "context": "section description",
+    "string": "Reembolso manual"
+  },
+  "PKJqcq": {
+    "string": "Fatura está sendo gerada"
+  },
+  "PLCwT/": {
+    "context": "search results",
+    "string": "Mostrar mais"
+  },
+  "PLX6FH": {
+    "context": "sum of all manual refunds for transaction",
+    "string": "Voltar"
+  },
+  "PNq9W/": {
+    "context": "back button",
+    "string": "Criar sem SKU e estoque?"
+  },
+  "PRXpBm": {
+    "context": "dialog header",
+    "string": "Cancelar Pedido"
+  },
+  "PRlD0A": {
+    "string": "Envio"
+  },
+  "PTW56s": {
+    "context": "alert",
+    "string": "Limite de canais atingido"
+  },
+  "PUVq0k": {
+    "context": "warning dialog title when SKU and stock are not set",
+    "string": "Bem-vindo ao Painel!"
+  },
+  "PV0SQd": {
+    "context": "WarehousesSection select field label",
+    "string": "Depósito"
+  },
+  "PX2zWy": {
+    "context": "customer is not set in draft order",
+    "string": "Não configurado"
+  },
+  "PXatmC": {
+    "string": "Cliente Removido"
+  },
+  "PXx4Jk": {
+    "context": "window title",
+    "string": "Criar Produto"
+  },
+  "PaQFmR": {
+    "context": "onboarding step title",
+    "string": "Cliente atualizado"
+  },
+  "PajjqE": {
+    "context": "attribute list",
+    "string": "Atributo {number}"
+  },
+  "PbqNhi": {
+    "context": "order status",
+    "string": "Parcialmente faturado"
+  },
+  "PcPMjC": {
+    "context": "order history message",
+    "string": "O cumprimento aguarda aprovação"
+  },
+  "PcQRxi": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi comprado em ordem {orderNumber}"
+  },
+  "PctLol": {
+    "context": "no channels found title",
+    "string": "Nenhum canal encontrado"
+  },
+  "PeEood": {
+    "string": "Pesquisar"
+  },
+  "PeMebc": {
+    "context": "search section name",
+    "string": "Você está prestes a"
+  },
+  "PiSXjb": {
+    "context": "check to require numeric attribute unit",
+    "string": "Selecione a unidade"
+  },
+  "PilTI6": {
+    "context": "issue gift card button label",
+    "string": "Emitir"
+  },
+  "PkCmGU": {
+    "context": "install button",
+    "string": "Instalar Aplicativo"
+  },
+  "PkjQS6": {
+    "context": "description",
+    "string": "Nenhum resultado encontrado"
+  },
+  "PlAdWI": {
+    "string": "Valor"
+  },
+  "Pnj+JH": {
+    "context": "key-value field input",
+    "string": "Nós o guiaremos pelas principais funcionalidades para que você possa começar a personalizar sua loja. Explore produtos, pedidos, coleções, clientes e descontos para se familiarizar com funções e conceitos-chave."
+  },
+  "Pp/7T7": {
+    "string": "{counter,plural,one {Tem certeza que deseja excluir esta categoria?} other {Tem certeza que deseja excluir {displayQuantity} categorias?}}"
+  },
+  "PqMbma": {
+    "context": "add attribute value",
+    "string": "Adicionar Valor"
+  },
+  "PrxZ/P": {
+    "context": "onboarding step description",
+    "string": "Recompensa"
+  },
+  "PsRG+v": {
+    "context": "use attribute in filtering",
+    "string": "Filtravel na Vitrine"
+  },
+  "PsclSa": {
+    "context": "page header",
+    "string": "Criar cupom"
+  },
+  "PuQb0P": {
+    "string": "Rascunho"
+  },
+  "PvrceS": {
+    "context": "Refund draft status",
+    "string": "Você está prestes a criar {count} variantes. Isso pode levar um momento para processar. Esta ação não pode ser desfeita automaticamente."
+  },
+  "Pyjarj": {
+    "string": "Esta taxa de envio não tem códigos postais atribuídos"
+  },
+  "PzXIXh": {
+    "context": "order",
+    "string": "Cliente"
+  },
+  "Q+oKl+": {
+    "context": "confirmation dialog description",
+    "string": "Execução a seco"
+  },
+  "Q/Nbku": {
+    "context": "product field",
+    "string": "Tipo"
+  },
+  "Q0JJ4F": {
+    "context": "dialog header",
+    "string": "Excluir Cupons"
+  },
+  "Q1HhPk": {
+    "context": "table head",
+    "string": "Tipo de produto"
+  },
+  "Q1Uzbb": {
+    "string": "Nenhum produto encontrado."
+  },
+  "Q2UXlW": {
+    "context": "modal button url upload",
+    "string": "Upload URL"
+  },
+  "Q2us5X": {
+    "context": "Dry run icon label",
+    "string": "Editar Produto"
+  },
+  "Q3j++G": {
+    "context": "create multiple variants, button",
+    "string": "Criar"
+  },
+  "Q47ovw": {
+    "context": "activate app",
+    "string": "Você tem certeza de que deseja ativar este aplicativo? Ativar começará a coletar eventos."
+  },
+  "Q4m1CG": {
+    "string": "Opcionalmente, forneça um número de rastreamento para este cumprimento"
+  },
+  "Q55cTG": {
+    "context": "order refund amount",
+    "string": "Reembolsado anteriormente"
+  },
+  "Q6VRrE": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza que deseja excluir este rascunho de pedido?} other {Tem certeza que deseja excluir {displayQuantity} rascunhos de pedido?}}"
+  },
+  "Q6wcZ5": {
+    "string": "Nome"
+  },
+  "Q7eRF7": {
+    "context": "tracking number input helper text",
+    "string": "Eventos de webhook"
+  },
+  "Q7uuDr": {
+    "context": "attribute slug input field helper text",
+    "string": "Isto é usado internamente. Garanta que você não está usando espaços."
+  },
+  "Q8Qw5B": {
+    "string": "Descrição"
+  },
+  "Q8mpW3": {
+    "string": "Cupom criado com sucesso."
+  },
+  "Q8wHwJ": {
+    "string": "Coleção deletada"
+  },
+  "Q9wTrz": {
+    "context": "caption",
+    "string": "Se habilitado, este atributo pode ser utilizado como filtro na lista de produtos."
+  },
+  "QAisk4": {
+    "context": "Webhook events header",
+    "string": "Tem categoria"
+  },
+  "QBxN6z": {
+    "context": "is filter range or value",
+    "string": "entre"
+  },
+  "QCwBUI": {
+    "context": "button",
+    "string": "Excluir Pesquisa"
+  },
+  "QEvH8Q": {
+    "context": "section description",
+    "string": "Atribua permissões para registrar eventos assíncronos para este webhook."
+  },
+  "QFCUEt": {
+    "string": "Slug deve ser único"
+  },
+  "QGjJcT": {
+    "context": "number of products",
+    "string": "Produtos"
+  },
+  "QH74y5": {
+    "context": "table header name col label",
+    "string": "Nome"
+  },
+  "QHB48n": {
+    "context": "header",
+    "string": "Taxas de impostos em {countryName}"
+  },
+  "QHDtwH": {
+    "string": "Selecionar um tipo de modelo"
+  },
+  "QJG+d/": {
+    "context": "staff added type order discount",
+    "string": "Staff added"
+  },
+  "QJJke/": {
+    "context": "dialog header",
+    "string": "Não publicado neste canal"
+  },
+  "QL4a0Z": {
+    "context": "alert message",
+    "string": "Criar novo pedido"
+  },
+  "QLVddq": {
+    "context": "button",
+    "string": "Criar cliente"
+  },
+  "QM9P8G": {
+    "context": "dialog header",
+    "string": "Atribuir Atributo"
+  },
+  "QOm7+P": {
+    "string": "Cancelar um cumprimento reabastecerá produtos em um armazém selecionado."
+  },
+  "QSnh4Y": {
+    "context": "add button label",
+    "string": "Adicionar"
+  },
+  "QUyUJy": {
+    "string": "Main Product"
+  },
+  "QV5QKO": {
+    "string": "Use a lista de produtos para sugerir o valor do reembolso. Ideal para reembolsar itens específicos ou o pedido inteiro."
+  },
+  "QVNg8A": {
+    "context": "product field",
+    "string": "Cobrar Impostos"
+  },
+  "QX0gQb": {
+    "context": "radio button label",
+    "string": "Pesquisar e selecionar valores..."
+  },
+  "QY31tL": {
+    "context": "placeholder for multiselect dropdown",
+    "string": "\"Marcar como pago\" recurso cria um {link} - usado por Aplicativos de Pagamento"
+  },
+  "QY7FSs": {
+    "context": "button",
+    "string": "criar tipo de produto"
+  },
+  "QZVD+5": {
+    "context": "button, unassign attribute from object",
+    "string": "Cancelar atribuição e salvar"
+  },
+  "QZoU0r": {
+    "context": "dialog header",
+    "string": "Excluir Canal"
+  },
+  "Qb2XN5": {
+    "string": "Excluir Extensão"
+  },
+  "QcIFCs": {
+    "context": "save search tab",
+    "string": "Pesquisar Nome"
+  },
+  "QclvqG": {
+    "context": "input label",
+    "string": "Limite de fila de checkout"
+  },
+  "QdGzUf": {
+    "context": "number of collections",
+    "string": "Coleções ({quantity})"
+  },
+  "QdanQw": {
+    "context": "dialog header",
+    "string": "Armazéns com estoque não estão atribuídos a nenhuma zona de envio neste canal."
+  },
+  "Qe4XHv": {
+    "context": "years after label",
+    "string": "Anos após a emissão"
+  },
+  "QfK+5Q": {
+    "context": "Description for warehouse not in zone warning",
+    "string": "Nenhum país coberto"
+  },
+  "Qhb89u": {
+    "context": "Warning when no countries covered",
+    "string": "Fechar"
+  },
+  "QiN4hv": {
+    "context": "active",
+    "string": "Ativo"
+  },
+  "QirE3M": {
+    "string": "Data Inicial"
+  },
+  "Qj/3sH": {
+    "context": "limit voucher",
+    "string": "Limite o número de vezes que este desconto pode ser usado no total"
+  },
+  "QjPJ78": {
+    "context": "close full-screen",
+    "string": "Ir para categorias"
+  },
+  "QjwEr6": {
+    "string": "Realizar um reembolso manual acionará imediatamente uma solicitação de reembolso e diminuirá o valor cobrado da transação, impactando o saldo do pedido."
+  },
+  "QkFeOa": {
+    "context": "order refund amount button",
+    "string": "Restituição"
+  },
+  "Ql7OM1": {
+    "string": "Os preços dos produtos são inseridos sem impostos"
+  },
+  "QooeI/": {
+    "context": "button",
+    "string": "Criar Cliente"
+  },
+  "Qovenh": {
+    "string": "Usuário anônimo"
+  },
+  "Qox+kb": {
+    "string": "em campo {fieldName}"
+  },
+  "QpBqa9": {
+    "context": "label for radio button",
+    "string": "Razões para reembolso"
+  },
+  "QpYazu": {
+    "string": "Visível na listagem"
+  },
+  "Qph0GE": {
+    "context": "dialog content",
+    "string": "Adicione um novo endereço:"
+  },
+  "QqnNUm": {
+    "string": "Novo reembolso"
+  },
+  "QslFl8": {
+    "context": "add new refund button",
+    "string": "Já capturado"
+  },
+  "QzseV7": {
+    "context": "dialog header",
+    "string": "Excluir Menu"
+  },
+  "R/YHMH": {
+    "context": "label for amount already captured from this transaction",
+    "string": "Número de rastreamento"
+  },
+  "R4IIw1": {
+    "context": "tracking number of the shipment",
+    "string": "Pesquisar por nome do modelo..."
+  },
+  "R4gIJc": {
+    "string": "{count, plural, one {{count} problema} other {{count} problemas}}"
+  },
+  "R5r0+F": {
+    "context": "Badge label showing total number of app problems",
+    "string": "Emissão de webhook"
+  },
+  "R8+DNv": {
+    "context": "section title",
+    "string": "Economize horas avaliando o Saleor por conta própria conversando com nosso engenheiro de soluções."
+  },
+  "R98JLZ": {
+    "context": "OrderCustomer Fulfillment from All Warehouses",
+    "string": "Cumprir de todos os armazéns"
+  },
+  "RABrGb": {
+    "string": "Cobertura total de casos avançados de checkout, como pagamentos divididos, cumprimentos divididos e pagamentos orquestrados."
+  },
+  "RBkNPr": {
+    "string": "Reembolso com valor manual"
+  },
+  "RBxYJf": {
+    "context": "sale status",
+    "string": "Expirado"
+  },
+  "REVk27": {
+    "context": "info text",
+    "string": "Configure uma data de término da pré-encomenda. Quando a data de término for atingida, o produto será automaticamente transferido da pré-encomenda para a venda padrão"
+  },
+  "RH+aOF": {
+    "context": "use attribute in filtering",
+    "string": "Uso em Filtragem"
+  },
+  "RJ5QxE": {
+    "string": "Global threshold"
+  },
+  "RK6l3Z": {
+    "context": "radio button label",
+    "string": "Novidades"
+  },
+  "RKHBh0": {
+    "string": "Reabastecido {quantity, plural, one {# item} other {# itens}}"
+  },
+  "RLBLPQ": {
+    "context": "no warehouses info",
+    "string": "Não existem depósitos configurados para sua loja. Para adicionar a quantidade em estoque para o produto, por favor configure um depósito."
+  },
+  "RLTaAR": {
+    "context": "order history message",
+    "string": "Endereço do pedido foi atualizado"
+  },
+  "RLYfMF": {
+    "context": "checkbox label",
+    "string": "Confirmar automaticamente todos os pedidos"
+  },
+  "RLZ1jd": {
+    "context": "delete gift cards with balance description",
+    "string": "{selectedItemsCount,plural,one {O vale-presente que você está prestes a excluir tem saldo disponível. Ao excluir este cartão você poderá remover o saldo disponível para seu cliente.} other {O vale-presente que você está prestes a excluir tem saldo disponível. Ao excluir este cartão você poderá remover o saldo disponível para seu cliente.}}"
+  },
+  "RMB6fU": {
+    "context": "button",
+    "string": "Criar Token"
+  },
+  "RQUkVW": {
+    "string": "Gerencie seus funcionários e suas permissões"
+  },
+  "RUS52q": {
+    "context": "order history message",
+    "string": "Correção de Bug"
+  },
+  "RUwHjA": {
+    "string": "Filtros {count, plural, =0 {} other {({count})} }"
+  },
+  "RUzdUH": {
+    "string": "Nenhuma taxa de envio encontrada"
+  },
+  "RXPGi/": {
+    "context": "page title",
+    "string": " Criar taxa de preço"
+  },
+  "RXbkle": {
+    "context": "copy code button label",
+    "string": "Copiar código"
+  },
+  "RZ32u5": {
+    "context": "PageTypeDeleteWarningDialog single consent label",
+    "string": "Sim, quero excluir este tipo de página e as páginas atribuídas"
+  },
+  "RZDxej": {
+    "context": "Popover trigger text (button)",
+    "string": "Regra criada"
+  },
+  "RZmdM3": {
+    "context": "delete page types",
+    "string": "{counter,plural,one {Tem certeza de que deseja excluir este tipo de página? Depois de fazer isso, você não poderá reverter as alterações.} other {Tem certeza de que deseja excluir {displayQuantity} tipos de página? Depois de fazer isso, você não poderá reverter as alterações.}}"
+  },
+  "RaQzn2": {
+    "string": "Não há classes de imposto"
+  },
+  "RaycYK": {
+    "context": "button",
+    "string": "Salvar"
+  },
+  "Rd0s80": {
+    "context": "no cards found title message",
+    "string": "Nenhum vale-presente encontrado"
+  },
+  "RfPJ1E": {
+    "context": "issue card button label",
+    "string": "Cartão de emissão"
+  },
+  "Rfk+8B": {
+    "context": "tax classes menu label when there are no tax classes",
+    "string": "Canal"
+  },
+  "RgdgqJ": {
+    "context": "order draft channel name",
+    "string": "Instalado"
+  },
+  "RiQ0v1": {
+    "context": "installed extensions section name",
+    "string": "Desativar Extensão"
+  },
+  "Rj8LxK": {
+    "string": "Adicione título e descrição ao mecanismo de busca para facilitar a localização desta coleção"
+  },
+  "Rjs1CD": {
+    "context": "button",
+    "string": "Continuar"
+  },
+  "RlbhwF": {
+    "context": "product no longer exists error description",
+    "string": "Este produto não está mais no banco de dados, portanto não pode ser substituído nem devolvido"
+  },
+  "RlfqSV": {
+    "string": "Nenhum pedido encontrado"
+  },
+  "RmEeMP": {
+    "context": "dialog header",
+    "string": "Taxas de classe de imposto"
+  },
+  "RoKOQJ": {
+    "context": "label",
+    "string": "Buscar Valor de Atributo"
+  },
+  "Rp/Okl": {
+    "string": "Unidade de peso de envio"
+  },
+  "Rpfa+t": {
+    "context": "dialog header",
+    "string": "Cancelar atribuição de atributo do tipo de página"
+  },
+  "RqtZQ6": {
+    "context": "tax classes card header",
+    "string": "Por favor, aguarde um momento antes de tentar novamente."
+  },
+  "RrCui3": {
+    "string": "Resumo"
+  },
+  "Rsknyh": {
+    "context": "order does not require shipping",
+    "string": "não aplica"
+  },
+  "RyZd9J": {
+    "context": "error message",
+    "string": "Falha ao buscar configurações da extensão"
+  },
+  "Ryh3iR": {
+    "context": "header",
+    "string": "Criar Webhook"
+  },
+  "RzDYi8": {
+    "context": "checkbox label",
+    "string": "Defina o mesmo para o endereço de cobrança"
+  },
+  "RzsKm8": {
+    "string": "Métodos de Envio"
+  },
+  "S/yAtJ": {
+    "context": "total price",
+    "string": "Total"
+  },
+  "S1u2pa": {
+    "context": "app settings error",
+    "string": "Pesquisar por nome do produto, atributo, tipo de produto etc..."
+  },
+  "S22jIs": {
+    "context": "button",
+    "string": "Definir nova senha"
+  },
+  "S2xLxV": {
+    "context": "search placeholder",
+    "string": "Quantidade"
+  },
+  "S5/nSq": {
+    "context": "grant refund table, column header",
+    "string": "Você não tem permissão para realizar esta ação."
+  },
+  "S52JMl": {
+    "context": "default gift card delete description",
+    "string": "{selectedItemsCount,plural,one {Tem certeza de que deseja excluir este vale-presente?} other {Tem certeza de que deseja excluir {selected Items Count} vales-presente?}}"
+  },
+  "S5PVx1": {
+    "context": "variant creator summary card header",
+    "string": "Variações Criadas"
+  },
+  "S6W6FM": {
+    "string": "Pagamento anulado"
+  },
+  "S6zKcD": {
+    "string": "Você tem certeza de que deseja cumprir esses produtos mesmo assim?"
+  },
+  "S7Rwl0": {
+    "context": "stock exceeded action question label",
+    "string": "Você tem certeza de que deseja excluir esta extensão?"
+  },
+  "S7j+Wf": {
+    "context": "unassign attribute from product type, button",
+    "string": "Não-assinado"
+  },
+  "S8ew6Q": {
+    "context": "delete app",
+    "string": "Condições"
+  },
+  "S8kqP9": {
+    "string": "Selecionar armazém..."
+  },
+  "SBb6Ej": {
+    "context": "select a warehouse to fulfill product from",
+    "string": "Pendente"
+  },
+  "SBlTvZ": {
+    "context": "Refund status pending",
+    "string": "Marcar como Pago"
+  },
+  "SC/eNC": {
+    "context": "Payment card title",
+    "string": "Status do pagamento"
+  },
+  "SDgGcU": {
+    "context": "Button to manually mark order as paid without actual payment",
+    "string": "Digite o código"
+  },
+  "SGdcJD": {
+    "string": "{count} já existem e serão ignorados"
+  },
+  "SHm5Dv": {
+    "context": "count of existing variants",
+    "string": "Atributo não encontrado."
+  },
+  "SHm7ee": {
+    "string": "Pesquisar por nome do produto, atributo, tipo do produto, etc..."
+  },
+  "SKFr04": {
+    "string": "SKU (Unidade de Manutenção de Estoque)"
+  },
+  "SM+yG0": {
+    "context": "input label",
+    "string": "Definir data limite {timeDifference} mais tarde (de {previousDate} para {newDate}) não impedirá checkouts que já estão agendados para conclusão."
+  },
+  "SMakqb": {
+    "context": "customer contact section, header",
+    "string": "Informação de Contato"
+  },
+  "SNiyXb": {
+    "context": "numeric attribute type",
+    "string": "Numérico"
+  },
+  "SO56cv": {
+    "context": "success deactivate alert message",
+    "string": "Presente desativado com sucesso {count,plural,one{card} other{cards}}"
+  },
+  "SPBLzT": {
+    "context": "header",
+    "string": "Atributo de tradução \"{attribute}\" - {languageCode}"
+  },
+  "SPGU7Z": {
+    "context": "automatic completion cut-off date later info message",
+    "string": "Pedidos não podem ser feitos em um canal inativo."
+  },
+  "SPp3cx": {
+    "context": "alert message",
+    "string": "Entregas pendentes e falhadas (últimos 10)"
+  },
+  "SRMNCS": {
+    "string": "Filtrável na vitrine"
+  },
+  "SSWFo8": {
+    "context": "window title",
+    "string": "Criar tipo de produto"
+  },
+  "STJx8N": {
+    "context": "change button label",
+    "string": "Alterar"
+  },
+  "STp3Hl": {
+    "string": "Aplicar estoque único a todos os SKUs"
+  },
+  "SUbxSK": {
+    "context": "product weight",
+    "string": "Peso"
+  },
+  "SV0FRm": {
+    "context": "attribute is filterable in storefront",
+    "string": "Desconsiderar"
+  },
+  "SW4GYL": {
+    "context": "Button label to dismiss a single app problem",
+    "string": "Tipo de produto criado"
+  },
+  "SZH0fw": {
+    "context": "set variant as default, button",
+    "string": "Tornar padrão"
+  },
+  "SZJhvK": {
+    "context": "dialog header",
+    "string": "Selecionar Canal"
+  },
+  "SZt9kC": {
+    "context": "export filtered items to csv file",
+    "string": "Pesquisa atual ({number})"
+  },
+  "SZyphU": {
+    "string": "Remover as seguintes permissões:"
+  },
+  "SceSNp": {
+    "string": "Digital"
+  },
+  "Sd0Ppm": {
+    "context": "product publication date",
+    "string": "publicado em {date}"
+  },
+  "SgFE10": {
+    "context": "product type digital",
+    "string": "Nenhum pagamento foi autorizado para este pedido. O valor total de {amount} não pode ser capturado."
+  },
+  "Sjd7wm": {
+    "context": "product filter label",
+    "string": "Produto"
+  },
+  "SnV3LR": {
+    "context": "error when no authorization exists",
+    "string": "Criar novo produto"
+  },
+  "Sna+WK": {
+    "context": "product status",
+    "string": "Sem Estoque"
+  },
+  "SpngiS": {
+    "context": "sale status",
+    "string": "Status"
+  },
+  "SqcGBK": {
+    "context": "channel availability dialog header",
+    "string": "Gerenciar a disponibilidade do canal"
+  },
+  "SqhC7g": {
+    "context": "checkbox label, fulfillment approval",
+    "string": "Enviar detalhes de envio para o cliente"
+  },
+  "SwISVH": {
+    "context": "section header",
+    "string": "Marketplace Saleor"
+  },
+  "Sx7QVu": {
+    "context": "variant creation step",
+    "string": "Preços e SKU"
+  },
+  "Sz6CRr": {
+    "string": "Defina onde este atributo deve ser usado no sistema Saleor"
+  },
+  "T/5OyA": {
+    "string": "Nenhuma tradução ainda"
+  },
+  "T/dYnE": {
+    "context": "plugin filters error messages status",
+    "string": "O status não está selecionado"
+  },
+  "T0Mfxq": {
+    "context": "product status title",
+    "string": "{channelCount} {channelCount,plural, =1 {Channel} other {Channels}}"
+  },
+  "T0lfLH": {
+    "context": "Define where this attribute should be used in Saleor system",
+    "string": "configuração de zonas de envio"
+  },
+  "T1f2Yl": {
+    "string": "Variant Name"
+  },
+  "T3cLGs": {
+    "context": "alert link message",
+    "string": "Gerar {count} {count, plural, one {variante} other {variantes}}"
+  },
+  "T4GOiX": {
+    "string": "Data Final"
+  },
+  "T4wa2Y": {
+    "context": "global config plugin status popup title",
+    "string": "Global Plugin"
+  },
+  "T5nU7u": {
+    "context": "header",
+    "string": "Criar Token"
+  },
+  "T61cLQ": {
+    "context": "generate button",
+    "string": "Produtos neste canal não podem ser cumpridos sem armazéns."
+  },
+  "T6dXGG": {
+    "context": "header",
+    "string": "Criar Variação"
+  },
+  "T7r26L": {
+    "context": "Description for no warehouses warning",
+    "string": "Pesquisar categorias..."
+  },
+  "T83iU7": {
+    "string": "Promoção"
+  },
+  "T8rvXs": {
+    "context": "order subtotal price",
+    "string": "Subtotal"
+  },
+  "TBaMo2": {
+    "context": "about app",
+    "string": "Sobre"
+  },
+  "TBdxTP": {
+    "context": "promotion type order discount",
+    "string": "Editar reembolso concedido"
+  },
+  "TBftMD": {
+    "context": "button. form submit, grant refund edit",
+    "string": "Estruturar Itens"
+  },
+  "TC/EOG": {
+    "context": "status section title",
+    "string": "Status no canal"
+  },
+  "TCR639": {
+    "context": "order history message",
+    "string": "Falha no pagamento"
+  },
+  "TD/GhR": {
+    "context": "header",
+    "string": "Definir disponível em"
+  },
+  "TDXskW": {
+    "context": "variant attribute",
+    "string": "Selecionar Atributo"
+  },
+  "TDhHMi": {
+    "string": "Isto precisa ser único"
+  },
+  "TE4fIS": {
+    "string": "Cidade"
+  },
+  "TGX4T1": {
+    "string": "Pré-visualização do Mecanismo de Busca"
+  },
+  "THpf1b": {
+    "context": "product availability available date",
+    "string": "Usar aplicativo de imposto"
+  },
+  "TJ7WHA": {
+    "context": "tax strategy combobox choice",
+    "string": "Cancelar"
+  },
+  "TKmub+": {
+    "string": "Este campo é necessário"
+  },
+  "TLDkvR": {
+    "context": "transaction event type, transaction was cancelled / voided",
+    "string": "Nome da Extensão"
+  },
+  "TLNf6K": {
+    "context": "window title",
+    "string": "Rascunho do pedido # {orderNumber}"
+  },
+  "TLYeo5": {
+    "context": "label",
+    "string": "Descrição da taxa de envio"
+  },
+  "TNlcZ5": {
+    "context": "extension form app name field placeholder",
+    "string": "Não foi possível instalar {name}"
+  },
+  "TOMgXz": {
+    "context": "button",
+    "string": "Redefinir"
+  },
+  "TPCRKr": {
+    "context": "variant price, header",
+    "string": "Preço"
+  },
+  "TPJeJF": {
+    "context": "extensions list has not been installed",
+    "string": "Organizar Modelo"
+  },
+  "TPP7j+": {
+    "context": "section header",
+    "string": "Criar uma transação manual para pagamentos não integrados"
+  },
+  "TPW2tP": {
+    "string": "Você atingiu o limite do seu pedido. Você será cobrado extra por pedidos acima do limite. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
+  },
+  "TSJRiZ": {
+    "context": "channel status title",
+    "string": "Status do Canal"
+  },
+  "TTVPyd": {
+    "context": "dialog subheading",
+    "string": "{count, plural, one {# código de vale excluído} other {# códigos de vale excluídos}}"
+  },
+  "TV940D": {
+    "string": "Abrir playground"
+  },
+  "TVR4E6": {
+    "string": "Redirecionar para a Página do Aplicativo"
+  },
+  "TWVx7O": {
+    "context": "delete product dialog title",
+    "string": "Excluir Produto"
+  },
+  "TWoYMj": {
+    "string": "Obrigatório"
+  },
+  "TZtvTG": {
+    "context": "table header required stock label",
+    "string": "Você só pode adicionar produtos disponíveis para o canal do pedido"
+  },
+  "Ta9j04": {
+    "context": "orders section name",
+    "string": "Pedidos"
+  },
+  "Taa5V7": {
+    "context": "dialog subtitle",
+    "string": "Saiba mais"
+  },
+  "TalJlD": {
+    "context": "tax rate for a product type",
+    "string": "Imposto"
+  },
+  "TdTXXf": {
+    "string": "Preços brutos"
+  },
+  "TdoAea": {
+    "context": "tooltip for taxes when showing gross prices",
+    "string": "Reembolso de envio: {currency} {amount}"
+  },
+  "Tenl9A": {
+    "context": "grant refund, refund card toggle",
+    "string": "Informações gerais"
+  },
+  "TfY/Pi": {
+    "context": "checkbox",
+    "string": "Cobrar impostos sobre este produto"
+  },
+  "TfzIXS": {
+    "context": "tax classes card header",
+    "string": "Execução a seco atualmente não está disponível para eventos síncronos"
+  },
+  "TjGYna": {
+    "context": "product inventory, checkbox",
+    "string": "Monitorar Estoque"
+  },
+  "TjbB4Y": {
+    "context": "section subheader",
+    "string": "Eventos assíncronos"
+  },
+  "Tl+7X4": {
+    "context": "tabel column header",
+    "string": "Qtd reembolsada"
+  },
+  "TnTi/a": {
+    "context": "pricing card title",
+    "string": "Preços"
+  },
+  "TnnDjx": {
+    "context": "Dry run sync events alert",
+    "string": "Junte-se à nossa comunidade de código aberto de especialistas do setor e saiba mais sobre código aberto no Saleor."
+  },
+  "TnyLrZ": {
+    "context": "PageTypeDeleteWarningDialog with items multiple description",
+    "string": "Você está prestes a excluir vários tipos de páginas. Alguns deles estão atribuídos a páginas. Excluir esses tipos de página também excluirá essas páginas."
+  },
+  "Tp5T7U": {
+    "string": "Editar reembolso concedido"
+  },
+  "TpPx7V": {
+    "context": "navigator placeholder",
+    "string": "Pesquisar Cliente"
+  },
+  "TtZg/K": {
+    "context": "ExitFormPrompt title",
+    "string": "Gostaria de salvar as alterações?"
+  },
+  "TxYWkD": {
+    "context": "page header, edit view",
+    "string": "O tempo em dias após os pedidos expirados será excluído. Faixa permitida entre 1 e 120."
+  },
+  "U+79k0": {
+    "context": "order expiration card description",
+    "string": "Autorizado"
+  },
+  "U0IK0G": {
+    "context": "label for authorized amount",
+    "string": "Você tem certeza de que deseja excluir a estrutura {menuName}?"
+  },
+  "U1eJIw": {
+    "context": "order history message",
+    "string": "Os produtos foram adicionados a um pedido"
+  },
+  "U2DyeR": {
+    "string": "Você tem certeza de que deseja excluir a predefinição {name}?"
+  },
+  "U2WgwW": {
+    "context": "add custom select input option",
+    "string": "Adicionar novo valor: {value}"
+  },
+  "U2mOqA": {
+    "string": "Não vouchers encontrado"
+  },
+  "U3BQKA": {
+    "string": "Definir data de publicação"
+  },
+  "U5CH0u": {
+    "string": "Armazéns"
+  },
+  "U5Da30": {
+    "string": "Publicado"
+  },
+  "U5aVd8": {
+    "context": "product",
+    "string": "Entregável"
+  },
+  "U5dMfQ": {
+    "context": "Label for published toggle",
+    "string": "Itens"
+  },
+  "U86VKF": {
+    "context": "number of structures",
+    "string": "Reverter para a data anterior"
+  },
+  "U8eeLW": {
+    "context": "button",
+    "string": "Atribuir produtos"
+  },
+  "U9CIo7": {
+    "context": "button",
+    "string": "Salvar Variação"
+  },
+  "U9TPGD": {
+    "context": "Link to revert date change",
+    "string": "País"
+  },
+  "U9o2bV": {
+    "context": "no gift card products and types alert message",
+    "string": "{createGiftCardProductType} e {giftCardProduct} para começar a vender cartões-presente em sua loja."
+  },
+  "UBuKZ9": {
+    "context": "searchbar placeholder",
+    "string": "Pesquisas Recentes"
+  },
+  "UCHtG6": {
+    "context": "button",
+    "string": "Sobre"
+  },
+  "UD7/q8": {
+    "string": "Nenhum produto adicionado ao pedido"
+  },
+  "UE9zNR": {
+    "string": "Cartão"
+  },
+  "UGm9nx": {
+    "context": "payment method type card",
+    "string": "Nenhuma categoria encontrada"
+  },
+  "UHhqmr": {
+    "context": "search results",
+    "string": "Completo"
+  },
+  "UIM5bq": {
+    "context": "charge status full",
+    "string": "Excluir códigos"
+  },
+  "UJ97Lb": {
+    "string": "O pedido não tem transações. Você deve enviar o reembolso manualmente."
+  },
+  "UJnqdm": {
+    "context": "dialog header",
+    "string": "Cancelar atribuição de atributo do tipo de produto"
+  },
+  "UKgP89": {
+    "context": "note input label",
+    "string": "Nota"
+  },
+  "UN+yTt": {
+    "string": "Configurações da Equipe"
+  },
+  "UN3qWD": {
+    "context": "page status",
+    "string": "Não publicado"
+  },
+  "UNwG+4": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza que deseja excluir esta página?} other {Tem certeza que deseja excluir  {displayQuantity}  páginas?}}"
+  },
+  "UQ4Kuh": {
+    "context": "input label",
+    "string": "Pesquisar Membros da Equipe"
+  },
+  "UQu75k": {
+    "context": "dialog header",
+    "string": "Approve this fulfillment"
+  },
+  "UR2wY+": {
+    "context": "tooltip, submit form",
+    "string": "Adicionar permissão permite que a extensão tenha mais acesso aos seus dados."
+  },
+  "URUNhT": {
+    "string": "Envio"
+  },
+  "US3IPU": {
+    "string": "Descrição do motor de busca"
+  },
+  "USO8PB": {
+    "context": "snackbar text",
+    "string": "Aplicativo desativado"
+  },
+  "USS3Q7": {
+    "context": "filters error messages unknown error",
+    "string": "Ocorreu um erro desconhecido"
+  },
+  "UVDfTs": {
+    "context": "discount type shipping",
+    "string": "Publicado"
+  },
+  "UW1fLs": {
+    "context": "search pages placeholder",
+    "string": "Páginas de pesquisa"
+  },
+  "UYKEsx": {
+    "context": "collection filter published",
+    "string": "Publicação agendada"
+  },
+  "UaYJJ8": {
+    "string": "Tem certeza que você deseja {name} das tabs de pesquisa?"
+  },
+  "Ubath+": {
+    "string": "Nenhuma categoria de imposto reduzido encontrada"
+  },
+  "UcrXYE": {
+    "context": "Description for scheduled status when publication date is in the future",
+    "string": "Todos os modelos"
+  },
+  "Uf3oHA": {
+    "context": "add new menu item",
+    "string": "Criar um item."
+  },
+  "UgCuqX": {
+    "context": "tab name",
+    "string": "Você tem certeza de que deseja excluir a instalação falhada de {name}?"
+  },
+  "Uh3NX/": {
+    "context": "remove failed installation dialog content",
+    "string": "Extensão desativada"
+  },
+  "Uh9R9m": {
+    "context": "prepare order fulfillment, button",
+    "string": "Prepare fulfillment"
+  },
+  "UhcALJ": {
+    "context": "attribute name",
+    "string": "Nome"
+  },
+  "Uj2hj8": {
+    "context": "unassign variant from sale and save, button",
+    "string": "Cancelar atribuição e salvar"
+  },
+  "UjoSZB": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza de que deseja cancelar a atribuição desta coleção?} other {Tem certeza de que deseja cancelar a atribuição de {displayQuantity} coleções?}}"
+  },
+  "UjsI4o": {
+    "context": "date",
+    "string": "desde {date}"
+  },
+  "Um3g00": {
+    "context": "send to customer selected label",
+    "string": "Enviar vale-presente ao cliente"
+  },
+  "Uo5/Ov": {
+    "context": "order return subtitle",
+    "string": "Itens devolvidos não podem ser processados"
+  },
+  "Uo5MoU": {
+    "context": "product field",
+    "string": "imagens de variação"
+  },
+  "UpgLo/": {
+    "context": "snackbar text",
+    "string": "Criar nova categoria"
+  },
+  "Uqf8Ny": {
+    "string": "Diagnósticos de disponibilidade total exigem permissões adicionais: {permissions}"
+  },
+  "Ur9yW3": {
+    "context": "Description explaining which permissions are needed",
+    "string": "Margem"
+  },
+  "Urh2N3": {
+    "context": "label",
+    "string": "Link"
+  },
+  "Us9cA1": {
+    "context": "profit margin",
+    "string": "Tipos de Referência"
+  },
+  "Utq1fE": {
+    "context": "customer gift cards card title",
+    "string": "Gift Cards"
+  },
+  "Uu2B2G": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi usado como forma de pagamento no pedido {orderLink} <buyer>by</buyer>"
+  },
+  "Uu76vj": {
+    "context": "no categories",
+    "string": "Nenhuma categoria encontrada"
+  },
+  "UvD+xp": {
+    "context": "attribute values",
+    "string": "Valor {number}"
+  },
+  "UvZuf7": {
+    "context": "section title for reference types selector",
+    "string": "Cobrança de transação solicitada"
+  },
+  "UxOcKE": {
+    "context": "order history message",
+    "string": "Atributos de produto e atributos de variante são mutuamente exclusivos. Um atributo não pode ser atribuído a ambas as seções dentro do mesmo tipo de produto."
+  },
+  "UxdBmI": {
+    "context": "collection availability",
+    "string": "Disponibilidade"
+  },
+  "Uxhquh": {
+    "context": "info message about attribute exclusivity in product type",
+    "string": "Zonas de Envio"
+  },
+  "UycVMp": {
+    "context": "button",
+    "string": "Criar subcategoria"
+  },
+  "UymotP": {
+    "context": "channel name",
+    "string": "Nome do canal"
+  },
+  "V+fkAO": {
+    "context": "number of products in category",
+    "string": "Produtos"
+  },
+  "V+gwx7": {
+    "context": "order payment",
+    "string": "Quantidade capturada"
+  },
+  "V+h02n": {
+    "context": "issued by label",
+    "string": "Emitida pela"
+  },
+  "V/VAHG": {
+    "string": "Atributo deletado"
+  },
+  "V/YxJa": {
+    "context": "dialog header",
+    "string": "Editar Método de Envio"
+  },
+  "V1MytH": {
+    "context": "shipping zones section name",
+    "string": "{currency} {totalAmount}"
+  },
+  "V1mqpZ": {
+    "context": "button",
+    "string": "Criar Grupo de Permissão"
+  },
+  "V2+HTM": {
+    "context": "dialog header",
+    "string": "Título"
+  },
+  "V21v8h": {
+    "string": "Instalado"
+  },
+  "V22724": {
+    "string": "Igual ao AND implícito, usando palavra-chave explícita"
+  },
+  "V2BBQu": {
+    "string": "A moeda em ambos os canais deve ser a mesma"
+  },
+  "V2JtVu": {
+    "string": "A zona de envio padrão já existe"
+  },
+  "V3fvcD": {
+    "context": "dialog content",
+    "string": "Venda removida"
+  },
+  "V76IV7": {
+    "context": "variant name",
+    "string": "Variação"
+  },
+  "V8FhTt": {
+    "context": "collection label",
+    "string": "Oculto"
+  },
+  "VCzrEZ": {
+    "context": "link",
+    "string": "Ver Perfil"
+  },
+  "VEE4gD": {
+    "context": "error message",
+    "string": "Método de envio não é válido para o endereço de entrega escolhido."
+  },
+  "VEext+": {
+    "string": "Tem certeza de que deseja apagar esta imagem?"
+  },
+  "VHuzgq": {
+    "context": "table actions",
+    "string": "Ações"
+  },
+  "VI+X8H": {
+    "context": "no gift card product types alert message",
+    "string": "{createGiftCardProductType} para começar a vender cartões-presente em sua loja."
+  },
+  "VIABHy": {
+    "context": "error message",
+    "string": "Não pode ser maior que o preço"
+  },
+  "VIdXPy": {
+    "context": "value input helper text",
+    "string": "Prosseguir"
+  },
+  "VKWPBf": {
+    "context": "dialog header",
+    "string": "Excluir Avatar do Membro da Equipe"
+  },
+  "VKb1MS": {
+    "string": "Categorias"
+  },
+  "VNX4fn": {
+    "string": "Reembolsar produtos"
+  },
+  "VOiUXQ": {
+    "string": "Usado para calcular taxas de envio para produtos deste tipo, quando o peso específico não é informado"
+  },
+  "VOjJWA": {
+    "context": "refund type",
+    "string": "Todos instalados"
+  },
+  "VQLIXd": {
+    "context": "product",
+    "string": "Nome"
+  },
+  "VQvNZx": {
+    "context": "page title",
+    "string": "Solicitar Extensão"
+  },
+  "VS0YOp": {
+    "context": "Request extension",
+    "string": "Razões atuais para reembolso de"
+  },
+  "VSLrmT": {
+    "string": "Cumprir mesmo assim"
+  },
+  "VSj89H": {
+    "context": "fulfill button label",
+    "string": "Detalhes do produto"
+  },
+  "VSztEE": {
+    "string": "O cancelamento deste pedido liberará o estoque, para que possam ser comprados por outros clientes.<b>O pedido não será reembolsado ao cancelar o pedido - Você precisa fazer isso manualmente. </b>Tem certeza que deseja cancelar este pedido?"
+  },
+  "VTITVe": {
+    "context": "section header",
+    "string": "Informações do Membro da Equipe"
+  },
+  "VYK2nN": {
+    "string": "Permissões atuais"
+  },
+  "VZsE96": {
+    "string": "Nome da Coleção"
+  },
+  "VcI+Zh": {
+    "context": "header",
+    "string": "Metadados"
+  },
+  "VceXrc": {
+    "context": "initial balance filter label",
+    "string": "Balanço inicial"
+  },
+  "VdDcxc": {
+    "context": "button",
+    "string": "Criar Coleção"
+  },
+  "Vdy5g7": {
+    "context": "weight units type",
+    "string": "Peso"
+  },
+  "VkYZQ8": {
+    "string": "Transação não é única"
+  },
+  "VmMDLN": {
+    "context": "permission list item description",
+    "string": "Este grupo é a última fonte desta permissão"
+  },
+  "VrFy8e": {
+    "string": "Nenhuma anotação pelo cliente"
+  },
+  "VsGcdP": {
+    "context": "section header",
+    "string": "Permissões do aplicativo"
+  },
+  "Vtjlpw": {
+    "string": "Produtos foram retornados"
+  },
+  "VtlDMr": {
+    "context": "returned event title",
+    "string": "Menu de comando"
+  },
+  "Vu9nol": {
+    "context": "header",
+    "string": "Configurações do Pedido"
+  },
+  "VvA7ai": {
+    "context": "info text",
+    "string": "Os canais que não têm preços atribuídos usarão seu canal pai para definir o preço. O preço será convertido para a moeda do canal"
+  },
+  "VvFJ/T": {
+    "context": "PageTypeDeleteWarningDialog single no assigned items description",
+    "string": "Você tem certeza de que deseja excluir <b>{typeName}</b>? Se você removê-lo, não será capaz de atribuí-lo às páginas criadas."
+  },
+  "VvhNCi": {
+    "context": "command menu shortcut",
+    "string": "Selecionar valores de atributo para criar todas as combinações possíveis de variantes"
+  },
+  "Vwqh4L": {
+    "context": "dialog subtitle explaining what user should do",
+    "string": "Pedido de substituição foi criado"
+  },
+  "VxStyU": {
+    "context": "order history message",
+    "string": "Digite o valor do reembolso sem usar a lista de produtos. Melhor para cobranças excessivas e ajustes personalizados."
+  },
+  "VyC+Bm": {
+    "context": "radio button label",
+    "string": "Você tem certeza de que deseja {actionType} esta transação?"
+  },
+  "VyKl39": {
+    "context": "Dialog warning text",
+    "string": "Canais"
+  },
+  "VyzsWZ": {
+    "string": "Endereço de Cobrança Padrão"
+  },
+  "Vze3qI": {
+    "context": "column category descriptor",
+    "string": "Mostrar {count} mais {count, plural, one {problema} other {problemas}}"
+  },
+  "W+AFZY": {
+    "context": "button label",
+    "string": "Desativar"
+  },
+  "W+x5ZI": {
+    "context": "webhooks active label",
+    "string": "Webhook está ativo"
+  },
+  "W/Es0H": {
+    "string": "Pedido cancelado com sucesso"
+  },
+  "W/Qs4m": {
+    "context": "Button label to expand and show additional hidden problems",
+    "string": "Tipo de modelo excluído"
+  },
+  "W/lDQA": {
+    "string": "Usar aplicativo: {name}"
+  },
+  "W0kQd+": {
+    "context": "dialog title",
+    "string": "Adicionar Endereço"
+  },
+  "W2OIhn": {
+    "string": "De {warehouseName}"
+  },
+  "W2glWk": {
+    "context": "fulfilled fulfillment, warehouse info",
+    "string": "Armazém"
+  },
+  "W32xfN": {
+    "context": "staff member full name",
+    "string": "Nome"
+  },
+  "W3JbSQ": {
+    "context": "create product variants",
+    "string": "Como você gostaria de criar variantes:"
+  },
+  "W5SK5c": {
+    "string": "Selecione o tipo de conteúdo"
+  },
+  "W5hb5H": {
+    "context": "warehouse input",
+    "string": "Rascunho"
+  },
+  "W6nwjo": {
+    "string": "Visível na vitrine"
+  },
+  "W75xMz": {
+    "context": "attribute is visible in storefront",
+    "string": "Aprovar"
+  },
+  "W8i2Ez": {
+    "context": "product field",
+    "string": "Nome"
+  },
+  "WCaf5C": {
+    "string": "Pesquisar armazéns"
+  },
+  "WCg2GZ": {
+    "context": "change warehouse dialog search placeholder",
+    "string": "Extensões"
+  },
+  "WD+kjr": {
+    "context": "page title - extensions",
+    "string": "Valor do link"
+  },
+  "WDrC7e": {
+    "context": "label",
+    "string": "Fora de estoque"
+  },
+  "WDy0tF": {
+    "context": "section header",
+    "string": "Informações do Webhook"
+  },
+  "WE8IFE": {
+    "context": "product name",
+    "string": "Produto"
+  },
+  "WFG7Zk": {
+    "context": "unassign attribute from page type, button",
+    "string": "Não vinculado"
+  },
+  "WGp+Fw": {
+    "context": "order refund amount",
+    "string": "Custo de transporte"
+  },
+  "WHgdsk": {
+    "string": "Cumprimento"
+  },
+  "WHkx+F": {
+    "string": "Preço não pode ser menor que 0"
+  },
+  "WK62MN": {
+    "string": "Tradução salva"
+  },
+  "WLyKAQ": {
+    "string": "Excluir códigos de vale"
+  },
+  "WMGoqz": {
+    "context": "used by filter label",
+    "string": "Usado por"
+  },
+  "WMN0q+": {
+    "string": "A extensão terá acesso a novas permissões. A partir de agora, ela poderá usá-las para realizar operações que essas permissões permitem. Você deve garantir que confia na extensão antes de aprovar."
+  },
+  "WMNtD2": {
+    "string": "Crítico"
+  },
+  "WPKADj": {
+    "context": "Badge label for critical severity problems",
+    "string": "Verificado {time}"
+  },
+  "WQMTKI": {
+    "context": "list of warehouses",
+    "string": "Depósitos A a Z"
+  },
+  "WQnltU": {
+    "string": "Nenhum produto disponível no canal do pedido que corresponda à consulta fornecida"
+  },
+  "WR8rir": {
+    "context": "button",
+    "string": "Criar taxa"
+  },
+  "WRPQMM": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza de que deseja publicar esta página?} other {Tem certeza de que deseja publicar {displayQuantity} páginas?}}"
+  },
+  "WRkCFt": {
+    "context": "tab name",
+    "string": "Todos os Pedidos"
+  },
+  "WS4ov0": {
+    "context": "notifier message",
+    "string": "A nota foi adicionada com sucesso"
+  },
+  "WTj17Z": {
+    "context": "dialog title item discount",
+    "string": "Item com desconto"
+  },
+  "WUKB5Z": {
+    "context": "Shown after verification with relative time",
+    "string": "Selecionar tipo de modelo"
+  },
+  "WUf3Iu": {
+    "context": "percentage option",
+    "string": "Porcentagem"
+  },
+  "WVrHXL": {
+    "string": "Este código já existe"
+  },
+  "WW+Ruy": {
+    "string": "Excluir produto da coleção"
+  },
+  "WWV8aZ": {
+    "context": "dialog title",
+    "string": "Apagar valor do atributo"
+  },
+  "WY3IXU": {
+    "string": "Todos os itens reembolsados"
+  },
+  "WasHjQ": {
+    "context": "voucher discount",
+    "string": "Envio"
+  },
+  "WbV1Xm": {
+    "context": "button",
+    "string": "Configurações do Pedido"
+  },
+  "Wd8vG7": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza de que deseja cancelar a publicação desta página?} other {Tem certeza de que deseja cancelar a publicação de {displayQuantity} páginas?}}"
+  },
+  "WhKGPA": {
+    "context": "page title",
+    "string": "Configurar nova senha"
+  },
+  "WhvuCb": {
+    "context": "plugins section name",
+    "string": "Extensões"
+  },
+  "WigK1f": {
+    "context": "helper text",
+    "string": "Problemas"
+  },
+  "Wj5TbN": {
+    "string": "Junte-se à comunidade de código aberto"
+  },
+  "Wk00wL": {
+    "string": "Cabeçalhos"
+  },
+  "WkxE8/": {
+    "context": "percentage or fixed, header",
+    "string": "Tipo do Desconto"
+  },
+  "Wlc67M": {
+    "context": "error message",
+    "string": "Não é possível escolher um método de envio para um pedido sem o endereço de envio"
+  },
+  "Wm+KUd": {
+    "string": "O login falhou. Por favor, tente novamente."
+  },
+  "WnlZMO": {
+    "context": "title",
+    "string": "Existe um problema com o aplicativo."
+  },
+  "Wr5UOV": {
+    "context": "error message",
+    "string": "Pesquisar classes de imposto"
+  },
+  "Ww69SE": {
+    "context": "search input placeholder",
+    "string": "O rastreamento de inventário ativo calculará automaticamente as mudanças de estoque"
+  },
+  "WwNtFn": {
+    "context": "delete product variant",
+    "string": "Tem certeza de que deseja excluir {name}?"
+  },
+  "WwZfNK": {
+    "string": "Adicione novo item de menu para começar a criar o menu"
+  },
+  "WyPitj": {
+    "context": "gift card bulk create success dialog title",
+    "string": "Cartões-presente de emissão em massa"
+  },
+  "Wyl25+": {
+    "context": "product inventory, checkbox description",
+    "string": "(não disponível)"
+  },
+  "WzA5Ll": {
+    "string": "Não é possível remover o usuário do último grupo"
+  },
+  "WzHfj8": {
+    "context": "successfully created gift card alert title",
+    "string": "Successfully created gift card"
+  },
+  "X/K4LI": {
+    "context": "label",
+    "string": "Normal"
+  },
+  "X1NCdA": {
+    "context": "shipping method not available label",
+    "string": "Atribuir e salvar"
+  },
+  "X1WqwZ": {
+    "context": "button, assign models and save",
+    "string": "Pedidos"
+  },
+  "X26jCC": {
+    "context": "page label",
+    "string": "Visível"
+  },
+  "X6PF8z": {
+    "context": "entity (product, collection, shipping method) name",
+    "string": "Nome"
+  },
+  "X7fqfM": {
+    "context": "title",
+    "string": "Estoque reservado"
+  },
+  "X7jl6w": {
+    "string": "Não totalmente cobrado"
+  },
+  "X8+Lpa": {
+    "context": "button",
+    "string": "Configurações da Conta"
+  },
+  "X8qjg3": {
+    "context": "inactive",
+    "string": "Inativo"
+  },
+  "X90ElB": {
+    "context": "dialog header",
+    "string": "Excluir Webhook"
+  },
+  "X90t9n": {
+    "context": "product type",
+    "string": "Configurável"
+  },
+  "X9tptP": {
+    "string": "Produto reordenado"
+  },
+  "XAPFHP": {
+    "context": "card update success alert title",
+    "string": "Saldo do cartão atualizado com sucesso"
+  },
+  "XAvER/": {
+    "string": "Pendente"
+  },
+  "XB2Jj9": {
+    "context": "create app button",
+    "string": "Criar Aplicativo"
+  },
+  "XBfvKN": {
+    "string": "Histórico de pedidos"
+  },
+  "XBwpUv": {
+    "context": "product field",
+    "string": "Exportar peso da variação"
+  },
+  "XCIV8H": {
+    "context": "button",
+    "string": "Atualizar"
+  },
+  "XDBeA+": {
+    "context": "discount type",
+    "string": "Quantia Fixa"
+  },
+  "XDeh5D": {
+    "context": "dialog header",
+    "string": "Criar Variações"
+  },
+  "XFErUZ": {
+    "context": "Refund pending status",
+    "string": "Alterar manualmente a permissão para a extensão."
+  },
+  "XFtKV5": {
+    "context": "input placeholder tag",
+    "string": "Tag"
+  },
+  "XGBsoK": {
+    "context": "dialog content",
+    "string": "Tem certeza de que deseja cancelar a atribuição de {counter, plural, one {this member} outros {{displayQuantity} members}}?"
+  },
+  "XJSRDK": {
+    "context": "payment status",
+    "string": "Totalmente reembolsado"
+  },
+  "XJm60a": {
+    "string": "Invisível via API pública"
+  },
+  "XLBNT0": {
+    "context": "Header description when product is hidden",
+    "string": "Cada regra é uma alternativa. Os clientes recebem o melhor desconto correspondente."
+  },
+  "XLYssG": {
+    "context": "assign categories to sale and save",
+    "string": "Assign and save"
+  },
+  "XMFpAP": {
+    "string": "Produto indisponível nos canais de vale"
+  },
+  "XMrYaA": {
+    "context": "checkbox label",
+    "string": "Usuário está ativo"
+  },
+  "XMvH/d": {
+    "context": "button label",
+    "string": "ACEITAR"
+  },
+  "XNeJay": {
+    "context": "section header",
+    "string": "Coleções Elegíveis"
+  },
+  "XOkUxQ": {
+    "string": "Anular"
+  },
+  "XPiJex": {
+    "context": "Transaction void button - return preauthorized amount to client",
+    "string": "Pedido"
+  },
+  "XPruqs": {
+    "string": "Disponibilidade"
+  },
+  "XQBVEJ": {
+    "context": "order return error description when cannot refund",
+    "string": "Encontramos um problema ao reembolsar os produtos. Os produtos não foram reembolsados. Por favor, tente novamente."
+  },
+  "XQfBeC": {
+    "context": "Availability card title",
+    "string": "Adicione novas funcionalidades ao Saleor e integre-o com serviços de terceiros. Eles podem ser instalados, gerenciados e renderizados aqui no Painel do Saleor."
+  },
+  "XRf1Bi": {
+    "context": "order refunded success message",
+    "string": "Itens Reembolsados"
+  },
+  "XT/ZvF": {
+    "context": "voucher requirement",
+    "string": "Quantidade mínima de ítens"
+  },
+  "XUU9sU": {
+    "context": "section header",
+    "string": "Todas as mídias"
+  },
+  "XVQpjm": {
+    "string": "Você tem certeza de que deseja excluir esta regra?"
+  },
+  "XVuPMw": {
+    "string": "Ir para todos os produtos"
+  },
+  "XWGZLL": {
+    "context": "transaction reference subtitle",
+    "string": "Referência de transação"
+  },
+  "XYhE8p": {
+    "context": "edit attribute value",
+    "string": "Editar Valor"
+  },
+  "XZR590": {
+    "context": "sale value",
+    "string": "Valor"
+  },
+  "XZpRr8": {
+    "context": "btn label",
+    "string": "editado"
+  },
+  "Xa8ZOn": {
+    "context": "Badge shown when channel has unsaved changes",
+    "string": "Vouchers excluídos"
+  },
+  "Xb/w18": {
+    "string": "Agendar para mais tarde"
+  },
+  "Xb6BJ9": {
+    "context": "error message",
+    "string": "Pagamento manual não pode ser devolvido"
+  },
+  "XbX2Ta": {
+    "context": "Checkbox label for scheduling publication for a future date",
+    "string": "Total:"
+  },
+  "Xel9C+": {
+    "context": "navigator default mode description",
+    "string": "Pesquisar Visuais e Ações"
+  },
+  "XgsXQv": {
+    "context": "order transaction refund summary label",
+    "string": "Selecionar valor a capturar:"
+  },
+  "XitW/z": {
+    "string": "Categoria de tradução \"{categoryName}\" - {languageCode}"
+  },
+  "XkX56I": {
+    "context": "filters error messages value required",
+    "string": "Escolha um valor"
+  },
+  "XlPKAR": {
+    "context": "WarehouseSettings private stock description",
+    "string": "Se ativado, o estoque neste armazém não será mostrado"
+  },
+  "Xm9qOu": {
+    "context": "product pricing, section header",
+    "string": "Preços"
+  },
+  "Xr5zxu": {
+    "string": "Suas escolhas adicionarão {variantsNumber} SKUs ao seu catálogo que excederão seu limite em {aboveLimitVariantsNumber}. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
+  },
+  "XrliJg": {
+    "context": "label for amount selection",
+    "string": "Pesquisar colunas"
+  },
+  "Xsh2Pa": {
+    "context": "column picker search input placeholder",
+    "string": "Definir para a data e hora atuais"
+  },
+  "XtULua": {
+    "context": "button to set cut-off date to current date and time",
+    "string": "Adicione sua primeira regra para configurar uma promoção"
+  },
+  "Xtd0AT": {
+    "string": "Texto Original"
+  },
+  "XtlUj6": {
+    "string": "Criar novo item"
+  },
+  "XvbjyW": {
+    "context": "add new structure",
+    "string": "Frase exata"
+  },
+  "XwQQ1f": {
+    "context": "checkbox label description",
+    "string": "Todos os cumprimentos serão aprovados automaticamente"
+  },
+  "XwrKOi": {
+    "context": "unassign multiple attributes from item",
+    "string": "{counter,plural,one {Are you sure you want to unassign this attribute from {itemTypeName}?} other {Are you sure you want to unassign {attributeQuantity} attributes from {itemTypeName}?}}"
+  },
+  "Xy2T+y": {
+    "context": "header",
+    "string": "Editar Campo de Autorização"
+  },
+  "XyURe6": {
+    "string": "Item:"
+  },
+  "Xz/sDf": {
+    "context": "Dry run items list item",
+    "string": "A operação não pode ser realizada no momento. Isso pode ser devido a uma instalação pendente com o mesmo identificador."
+  },
+  "Y/SXVb": {
+    "string": "Regra excluída"
+  },
+  "Y0EpoG": {
+    "string": "Selecionar método de reembolso:"
+  },
+  "Y0NwOq": {
+    "context": "dialog subtitle",
+    "string": "Desatribuir"
+  },
+  "Y1B0PN": {
+    "context": "error message",
+    "string": "Não há pagamento associado ao pedido"
+  },
+  "Y299ST": {
+    "context": "table column header",
+    "string": "Preço"
+  },
+  "Y3ELdI": {
+    "context": "unassign attribute from model type, button",
+    "string": "Aplicar apenas a um único produto elegível mais barato"
+  },
+  "Y3zr/B": {
+    "context": "voucher application, switch button",
+    "string": "Falha ao excluir códigos de vale"
+  },
+  "Y4cy0i": {
+    "context": "dialog header",
+    "string": "Encerrando a pré-encomenda"
+  },
+  "Y7M1YQ": {
+    "context": "section header",
+    "string": "Cliente"
+  },
+  "Y7UlMR": {
+    "context": "app extensions subsection",
+    "string": "Aplicativos"
+  },
+  "Y7Vy19": {
+    "context": "available on date",
+    "string": "Disponível em"
+  },
+  "Y8XVvH": {
+    "string": "Adicionar novo item de estrutura para começar a criar a estrutura"
+  },
+  "Y9lv8z": {
+    "context": "product unavailability",
+    "string": "Indisponível para compra"
+  },
+  "YBqLHs": {
+    "context": "expiry date label",
+    "string": "Data exata"
+  },
+  "YEIFiI": {
+    "string": "Criar vale"
+  },
+  "YEpYMB": {
+    "context": "gift card export csv success alert title",
+    "string": "Exportando CSV"
+  },
+  "YEv+6G": {
+    "context": "input helper text",
+    "string": "Deixar esta configuração vazia significa que o estoque não será reservado"
+  },
+  "YFDAaX": {
+    "context": "dialog title order discount",
+    "string": "Desconto neste pedido por:"
+  },
+  "YFQBs1": {
+    "context": "product availability date label",
+    "string": "Definir data de disponibilidade"
+  },
+  "YHNozE": {
+    "context": "dialog header",
+    "string": "Ativar Aplicativo"
+  },
+  "YI6Fhj": {
+    "context": "no address is set in draft order",
+    "string": "Não configurado"
+  },
+  "YIT1XP": {
+    "string": "Atraso antes da conclusão (minutos). O padrão é 30."
+  },
+  "YJ4TXc": {
+    "context": "tab name",
+    "string": "Todos os Funcionários"
+  },
+  "YKyNm9": {
+    "context": "label",
+    "string": "Gift Card"
+  },
+  "YL8K/3": {
+    "context": "automatic completion delay input label",
+    "string": "Valor fixo"
+  },
+  "YMBn8d": {
+    "context": "draft orders section name",
+    "string": "Rascunhos de Pedidos"
+  },
+  "YPCB7b": {
+    "context": "label for fixed amount discount type",
+    "string": "Definir atraso para 0 concluirá os checkouts imediatamente após o pagamento. Isso pode quebrar sua vitrine se ela esperar que o objeto Checkout permaneça disponível. ({link})"
+  },
+  "YQ3EXR": {
+    "context": "product types section name",
+    "string": "Tipos de Produto"
+  },
+  "YTvn5m": {
+    "context": "automatic completion zero delay warning message",
+    "string": "Cancelamento pendente"
+  },
+  "YUaalK": {
+    "context": "Cancel in progress transaction amount, data display header",
+    "string": "Desconsiderado por {email}"
+  },
+  "YVIajc": {
+    "context": "product field",
+    "string": "Descrição"
+  },
+  "YVsbL4": {
+    "context": "Tooltip showing which user dismissed a problem",
+    "string": "Atribuir Tipos de Produtos"
+  },
+  "YXhaCZ": {
+    "string": "Os clientes podem comprar este produto"
+  },
+  "YYkkhx": {
+    "context": "navigator section header",
+    "string": "Navegar para"
+  },
+  "YZl6cv": {
+    "string": "Diversos"
+  },
+  "YaCu4U": {
+    "context": "Health check status when product can be purchased",
+    "string": "Todos"
+  },
+  "YdeHZX": {
+    "context": "unassign products from shipping method, button",
+    "string": "Não vinculado"
+  },
+  "YgE6ga": {
+    "context": "imperial unit system",
+    "string": "Imperial"
+  },
+  "YhGcC5": {
+    "context": "select all values button",
+    "string": "Alocar estoque no primeiro armazém da lista atribuído a este canal. Se o estoque for insuficiente, a quantidade restante é alocada no próximo armazém da lista e repetido se necessário."
+  },
+  "YiC3cn": {
+    "context": "option description",
+    "string": "Zona de envio atualizada"
+  },
+  "YicEbK": {
+    "string": "Atributos de Pesquisa"
+  },
+  "YjcN9w": {
+    "context": "time during voucher is active, header",
+    "string": "Datas Ativas"
+  },
+  "Yjhgle": {
+    "context": "tab name",
+    "string": "Todas as Vendas"
+  },
+  "YjrPCx": {
+    "string": "Excluir Pedido em Rascunho"
+  },
+  "Yk0avO": {
+    "context": "dialog header",
+    "string": "Totalmente cobrado"
+  },
+  "YkOzse": {
+    "context": "used warehouses counter",
+    "string": "{count}/{max} armazéns usados"
+  },
+  "Ykw8k5": {
+    "context": "dialog title",
+    "string": "Excluir coleções"
+  },
+  "Ynjq+C": {
+    "string": "Saiba mais sobre permissões"
+  },
+  "Yo2kC+": {
+    "string": "Não foi possível processar a imagem"
+  },
+  "Yo4h/D": {
+    "string": "Teste"
+  },
+  "YpLVVc": {
+    "context": "action",
+    "string": "Excluir código postal"
+  },
+  "YpnjMB": {
+    "context": "Button to test public API availability",
+    "string": "O valor reembolsado não será automaticamente devolvido ao cliente. Você precisará decidir sobre um método e reembolsar via seção de balanço da ordem."
+  },
+  "YpukUN": {
+    "context": "label",
+    "string": "Nome da zona de envio"
+  },
+  "Ys86kI": {
+    "string": "Informações da Extensão"
+  },
+  "YtCaCm": {
+    "context": "header",
+    "string": "Conceda a esta extensão acesso total à loja"
+  },
+  "Yuv3Ou": {
+    "string": "Certifique-se de que este valor seja maior que 0."
+  },
+  "Yw+9F7": {
+    "string": "Coleção não encontrada"
+  },
+  "Yxihwg": {
+    "context": "consent removal of gift cards with balance button label",
+    "string": "{selectedItemsCount,plural,one {Estou ciente de que estou retirando um vale-presente com saldo} other {Estou ciente de que estou removendo vales-presente com saldo}}"
+  },
+  "Yy/yDL": {
+    "string": "Redefinir senha"
+  },
+  "YzLUXA": {
+    "string": "Avatar excluído"
+  },
+  "Z/7hyu": {
+    "context": "card balance label",
+    "string": "Saldo do cartão"
+  },
+  "Z/jtCO": {
+    "string": "Retornar & Substituir"
+  },
+  "Z3T6zR": {
+    "context": "card title",
+    "string": "O estoque para os itens mostrados abaixo não é suficiente para preparar o cumprimento:"
+  },
+  "Z6QAbw": {
+    "string": "Esta variação não possui nenhum conteúdo digital"
+  },
+  "Z7Tf8e": {
+    "context": "stock exceeded dialog description",
+    "string": "Não definido"
+  },
+  "Z7YrIb": {
+    "context": "no customer assigned to order",
+    "string": "Cancelado"
+  },
+  "Z7lX6t": {
+    "context": "canceled fulfillment, section header",
+    "string": "Convide membros da equipe e atribua permissões sobre Gestão de Informações de Produtos (PIM), Sistema de Gestão de Pedidos (OMS), mecanismo de Promoções, Extensões (aplicativos, plugins)"
+  },
+  "Z7vQSa": {
+    "string": "Retornado"
+  },
+  "Z8TzWt": {
+    "context": "refunded fulfillment, section header",
+    "string": "Países"
+  },
+  "ZAaXfz": {
+    "context": "Taxes section title",
+    "string": "Presente"
+  },
+  "ZBs2Pb": {
+    "string": "Não visível para os clientes"
+  },
+  "ZBzfHn": {
+    "context": "Description for hidden status",
+    "string": "Limitar o uso do código de vale uma vez"
+  },
+  "ZCSOaS": {
+    "string": "Copiar para a área de transferência"
+  },
+  "ZDJEat": {
+    "context": "button",
+    "string": "Carregar Mais"
+  },
+  "ZFfG4L": {
+    "context": "ProductTypeDeleteWarningDialog single assigned items description",
+    "string": "Você está prestes a excluir o tipo de produto <b>{typeName}</b>. Ele está atribuído a {assignedItemsCount} {assignedItemsCount, plural, one {produto} other {produtos}}. Excluir este tipo de produto também excluirá esses produtos. Tem certeza de que deseja fazer isso?"
+  },
+  "ZGmd4h": {
+    "context": "button",
+    "string": "Cartões-presente usados por este cliente"
+  },
+  "ZHF4Z9": {
+    "context": "delete product dialog subtitle",
+    "string": "Tem certeza de que deseja excluir {name}?"
+  },
+  "ZIc5lM": {
+    "string": "Nome do Produto"
+  },
+  "ZJJ2vA": {
+    "context": "customer gift cards card title",
+    "string": "Produto não existe mais"
+  },
+  "ZJOX8n": {
+    "context": "alert message",
+    "string": "Cabeçalhos com o seguinte formato são aceitos: <code>authorization*</code>, <code>x-*</code>"
+  },
+  "ZJPYFl": {
+    "context": "accepted header names",
+    "string": "Falha ao redefinir a senha"
+  },
+  "ZLcjD2": {
+    "string": "Cobrado em excesso"
+  },
+  "ZMy18J": {
+    "string": "Você atingiu o limite de canais e não poderá mais adicionar canais à sua loja. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
+  },
+  "ZOamBQ": {
+    "context": "charge status overcharged",
+    "string": "O pedido em rascunho será criado automaticamente para produtos substituídos"
+  },
+  "ZPOyI1": {
+    "context": "fulfilled fulfillment, section header",
+    "string": "Cumprido a partir de {warehouseName}"
+  },
+  "ZRz3hM": {
+    "string": "Exportar Quantidade em Estoque de Produto para CSV"
+  },
+  "ZTG+Dv": {
+    "string": "Nenhum reembolso feito para este pedido."
+  },
+  "ZU1Kz8": {
+    "context": "empty state message",
+    "string": "Ocorreu um problema inesperado ao analisar o manifesto. Por favor, entre em contato com o suporte. ({errorCode})"
+  },
+  "ZWIjvr": {
+    "context": "dialog header",
+    "string": "Excluir Vendas"
+  },
+  "ZXOpCJ": {
+    "string": "Quando ativado, os checkouts detectados como totalmente pagos serão concluídos automaticamente, sem a mutação checkoutComplete. {link}"
+  },
+  "ZZb4E+": {
+    "context": "automatically complete checkouts checkbox description",
+    "string": "Última atualização: {date}"
+  },
+  "ZayvsI": {
+    "context": "metric unit system",
+    "string": "Métrico"
+  },
+  "Zd3Eew": {
+    "context": "subsection header",
+    "string": "Endereço de Entrega"
+  },
+  "ZdCdo5": {
+    "string": "Item"
+  },
+  "ZeD2TK": {
+    "context": "section header",
+    "string": "Aplicativos de Terceiros"
+  },
+  "ZepEWY": {
+    "context": "Dry run item",
+    "string": "Copiar cabeçalhos"
+  },
+  "Zg0dRo": {
+    "context": "dialog description",
+    "string": "Você alterou o cliente atribuído a este pedido. O que você gostaria de fazer com o endereço de entrega?"
+  },
+  "ZhDQel": {
+    "context": "header",
+    "string": "Senha"
+  },
+  "ZhaXLU": {
+    "context": "button",
+    "string": "Copiar"
+  },
+  "ZhqH8J": {
+    "context": "button",
+    "string": "Endereço de envio"
+  },
+  "Zhxu58": {
+    "context": "Fixed amount subtitle",
+    "string": "Quantia Fixa"
+  },
+  "Zj/7QZ": {
+    "context": "details title",
+    "string": "detalhes"
+  },
+  "ZpVtCa": {
+    "string": "Excluir desconto"
+  },
+  "ZprV2g": {
+    "context": "app has been installed",
+    "string": "{name} está pronto para uso"
+  },
+  "Zptsep": {
+    "context": "order was discounted event title",
+    "string": "Pedido recebeu desconto por"
+  },
+  "ZrIt1W": {
+    "string": "Não há cartões-presente usados por este cliente"
+  },
+  "ZrdoSS": {
+    "context": "customer gift cards card no cards subtitle",
+    "string": "Referência da API"
+  },
+  "ZuqkSp": {
+    "context": "note input subtitle",
+    "string": "Por que este cartão-presente foi emitido? Esta nota não será mostrada ao cliente. A nota será armazenada no histórico do cartão-presente"
+  },
+  "Zvo5iu": {
+    "string": "Página criada"
+  },
+  "ZwtDkP": {
+    "string": "editado"
+  },
+  "Zx1w1e": {
+    "string": "Ver Documentação"
+  },
+  "a+WuZg": {
+    "context": "cta button label",
+    "string": "Venda"
+  },
+  "a+iRI1": {
+    "context": "single gift card title",
+    "string": "{selectedItemsCount,plural,one {Excluir vale-presente} other {Excluir vales-presente}}"
+  },
+  "a+kgkq": {
+    "context": "tag label",
+    "string": "Etiqueta de cartão"
+  },
+  "a+x05s": {
+    "context": "select option, button",
+    "string": "Selecione"
+  },
+  "a/JR9Y": {
+    "context": "sale type order discount",
+    "string": "{cardsAmount} cartões-presente emitidos"
+  },
+  "a/QJBx": {
+    "context": "user action bar",
+    "string": "Ação"
+  },
+  "a/x3DZ": {
+    "context": "bulk issue gift cards success alert description",
+    "string": "Todos os Resultados da Pesquisa"
+  },
+  "a0TDWs": {
+    "context": "search section name",
+    "string": "Para excluir {channelSlug} você deve criar um canal com moeda: {currency} para poder mover todos os pedidos existentes."
+  },
+  "a1uffz": {
+    "context": "draft created from replace products list title",
+    "string": "Produtos substituídos"
+  },
+  "a24HjK": {
+    "context": "currency channel",
+    "string": "A permissão não pode ser escolhida, porque você não a possui"
+  },
+  "a2o5uc": {
+    "context": "custom extension page create, tooltip",
+    "string": "[TODO] Permission cannot be chosen, because you don't have it yourself"
+  },
+  "a4qX2+": {
+    "context": "order",
+    "string": "Criado"
+  },
+  "a55zOn": {
+    "context": "section header",
+    "string": "Privacidade de dados"
+  },
+  "a5msuh": {
+    "string": "Sim"
+  },
+  "a6GDem": {
+    "context": "tab name",
+    "string": "Todos os descontos"
+  },
+  "a9S9Je": {
+    "context": "page types section name",
+    "string": "Tipos de Página"
+  },
+  "aAAxKp": {
+    "context": "table column header",
+    "string": "Produto"
+  },
+  "aAhfh6": {
+    "context": "Title for configuration summary section",
+    "string": "Resumo da configuração"
+  },
+  "aBpkVh": {
+    "context": "gift cards docs link",
+    "string": "cartões-presente"
+  },
+  "aC7AjR": {
+    "context": "deactivate named app",
+    "string": "Você tem certeza de que deseja desativar {name}? Seus dados serão mantidos até que você reative a extensão."
+  },
+  "aCJwVq": {
+    "context": "warehouse",
+    "string": "Nome"
+  },
+  "aCX8rl": {
+    "context": "subheader",
+    "string": "Aqui estão algumas informações que coletamos sobre sua loja"
+  },
+  "aCdAsI": {
+    "string": "Copiar para a área de transferência"
+  },
+  "aDbrOK": {
+    "string": "Pesquisar Membro da Equipe"
+  },
+  "aEc9Ar": {
+    "context": "gift card history message",
+    "string": "O saldo do vale-presente foi zerado por {resetBy}"
+  },
+  "aFLtLk": {
+    "context": "tab name",
+    "string": "Todos os Produtos"
+  },
+  "aFVFeH": {
+    "context": "submit button",
+    "string": "Adicionar captura manual"
+  },
+  "aHIrs/": {
+    "string": "Falha ao carregar os dados do filtro. Por favor, atualize a página para tentar novamente."
+  },
+  "aHc89n": {
+    "context": "select warehouse to restock items",
+    "string": "Selecionar Depósito"
+  },
+  "aHoX+i": {
+    "context": "Tooltip indicating a problem was dismissed by the app itself",
+    "string": "Dispensado pelo aplicativo"
+  },
+  "aI80kg": {
+    "string": "Propriedades"
+  },
+  "aJm/by": {
+    "context": "Taxes section title",
+    "string": "Classes de imposto"
+  },
+  "aKSUWR": {
+    "string": "Não é possível criar transação para pedido inexistente"
+  },
+  "aMWJ7/": {
+    "context": "local error",
+    "string": "Este campo não pode estar em branco para um novo webhook"
+  },
+  "aMwxYb": {
+    "string": "Países"
+  },
+  "aOelhW": {
+    "context": "tab name",
+    "string": "Todos os Plugins"
+  },
+  "aPCrsp": {
+    "context": "shipping method name",
+    "string": "Nome"
+  },
+  "aPYFO1": {
+    "context": "expired status label",
+    "string": "Expirado"
+  },
+  "aPqizA": {
+    "context": "ProductTypeDeleteWarningDialog multiple assigned items description",
+    "string": "Você tem certeza de que deseja excluir os tipos de produto selecionados? Se você removê-los, não será capaz de atribuí-los aos produtos criados."
+  },
+  "aUUgUV": {
+    "context": "Button with  app settings label",
+    "string": "Configurações da extensão"
+  },
+  "aWJPo+": {
+    "context": "tooltip explaining why cut-off date checkbox is disabled",
+    "string": "A data de corte não pode ser desativada uma vez que a conclusão automática esteja habilitada. Você pode alterar a data para um valor diferente."
+  },
+  "aWzvoq": {
+    "string": "{counter,plural,one{Você tem certeza de que deseja excluir esta estrutura?} other{Você tem certeza de que deseja excluir {displayQuantity} estruturas?}}"
+  },
+  "aXytBR": {
+    "string": "Um campo obrigatório está faltando no manifesto da extensão. {docsLink} ({errorCode})"
+  },
+  "aY0HAT": {
+    "context": "section header",
+    "string": "Canal de Vendas"
+  },
+  "aYhcie": {
+    "context": "shipping method weight range",
+    "string": "Faixa de Peso"
+  },
+  "aZDHYr": {
+    "context": "price rates info",
+    "string": "Esta taxa será aplicada a todos os pedidos"
+  },
+  "aaj/MI": {
+    "context": "tooltip for total amount",
+    "string": "Total do pedido"
+  },
+  "aasX8r": {
+    "context": "label",
+    "string": "Tipo de link"
+  },
+  "abTH5q": {
+    "context": "error message",
+    "string": "O endereço de e-mail não foi definido"
+  },
+  "ac+Y98": {
+    "context": "app settings error",
+    "string": "Falha ao buscar as configurações do aplicativo"
+  },
+  "acgbDa": {
+    "context": "product created at",
+    "string": "Criado em"
+  },
+  "aecovk": {
+    "context": "Summary of issues found",
+    "string": "{errorCount, plural, =0 {} one {# erro} other {# erros}}{hasWarnings, select, true {, } other {}}{warningCount, plural, =0 {} one {# aviso} other {# avisos}}"
+  },
+  "aenDwE": {
+    "string": "Gerenciar extensão"
+  },
+  "agZQkB": {
+    "context": "window title",
+    "string": "Criar Aplicativo"
+  },
+  "aggaJg": {
+    "string": "Este atributo já foi atribuído a este tipo de produto"
+  },
+  "aheQdn": {
+    "string": "Sobrenome"
+  },
+  "ak62Oe": {
+    "context": "plugin details page header",
+    "string": "Detalhes do {pluginName}"
+  },
+  "akXDST": {
+    "context": "section header",
+    "string": "Visibilidade"
+  },
+  "amQg6f": {
+    "context": "voucher status",
+    "string": "Ativo"
+  },
+  "anK7jD": {
+    "string": "Tipo de produto"
+  },
+  "aq5ZiN": {
+    "context": "order history message",
+    "string": "A confirmação de faturamento foi enviada ao cliente"
+  },
+  "arT1bu": {
+    "string": "Armazém atualizado"
+  },
+  "asdvmK": {
+    "context": "product type",
+    "string": "Digital"
+  },
+  "auxEP1": {
+    "context": "input placeholder",
+    "string": "Pesquisar por nome do atributo"
+  },
+  "avj76v": {
+    "context": "ChannelsSection subtitle",
+    "string": "Atribua canais a esta zona de envio para que saibamos quais pedidos serão suportados"
+  },
+  "awNXI/": {
+    "string": "Gerar códigos automaticamente"
+  },
+  "axFFaD": {
+    "context": "range input label",
+    "string": "Postal codes (end)"
+  },
+  "ayylzh": {
+    "context": "status pill for partial authorization",
+    "string": "Autorização parcial"
+  },
+  "azych5": {
+    "context": "Message when no diagnostic issues found",
+    "string": "Todos os canais configurados corretamente"
+  },
+  "b+jcaN": {
+    "string": "Ainda há faturamentos criadas para este pedido. Cancele as entregas antes de cancelar o pedido."
+  },
+  "b1j4K6": {
+    "context": "select label",
+    "string": "Falso"
+  },
+  "b1lW6g": {
+    "string": "Última vez visto {date}."
+  },
+  "b1t9bM": {
+    "context": "empty headers text",
+    "string": "Nenhum cabeçalho de solicitação personalizado criado para este webhook. Use o botão abaixo para adicionar um novo cabeçalho de solicitação personalizado."
+  },
+  "b1zuN9": {
+    "string": "Preço"
+  },
+  "b2DlTO": {
+    "context": "Taxes section title",
+    "string": "Canais"
+  },
+  "b6L9n7": {
+    "context": "voucher is active until date",
+    "string": "Termina"
+  },
+  "b810WJ": {
+    "context": "product price",
+    "string": "Preço"
+  },
+  "bBiDNg": {
+    "context": "order history message",
+    "string": "Evento de transação"
+  },
+  "bDBiac": {
+    "context": "dropdown or column label",
+    "string": "Classe de imposto"
+  },
+  "bDHiYK": {
+    "context": "gift card export success alert description",
+    "string": "No momento, estamos exportando os códigos do seu cartão-presente. Assim que seu arquivo estiver disponível, ele será enviado para seu endereço de e-mail"
+  },
+  "bDO9DN": {
+    "context": "success gift card enable message",
+    "string": "Vale-presente ativado com sucesso"
+  },
+  "bFhzRX": {
+    "string": "Nenhum produto está fora de estoque"
+  },
+  "bGqAdR": {
+    "context": "seo complete text",
+    "string": "Completo"
+  },
+  "bHG5/d": {
+    "context": "promotions section name",
+    "string": "Promoções"
+  },
+  "bHdFph": {
+    "context": "subsection header",
+    "string": "Endereço"
+  },
+  "bIAY+o": {
+    "string": "Endereço atualizado"
+  },
+  "bKCoN5": {
+    "context": "order line discount updated title",
+    "string": "O desconto de {productName} foi atualizado"
+  },
+  "bKTEnb": {
+    "context": "button to cancel order",
+    "string": "Cancelar pedido"
+  },
+  "bL/Wrc": {
+    "context": "plugin status",
+    "string": "Status"
+  },
+  "bNw8PM": {
+    "context": "number of products",
+    "string": "Produtos ({quantity})"
+  },
+  "bP7ZLP": {
+    "context": "voucher discount",
+    "string": "Todo o pedido"
+  },
+  "bPFp8B": {
+    "context": "product type",
+    "string": "Tipo de produto"
+  },
+  "bPshhv": {
+    "string": "Pesquisar vouchers..."
+  },
+  "bRJD/v": {
+    "context": "button",
+    "string": "Criar grupo de permissões"
+  },
+  "bRQeJp": {
+    "context": "success message when all variants are created",
+    "string": "{count, plural, one {# variante criada com sucesso} other {# variantes criadas com sucesso}}"
+  },
+  "bRXgSC": {
+    "context": "capture button with amount",
+    "string": "Capturar {amount}"
+  },
+  "bS7A8u": {
+    "context": "add tracking button",
+    "string": "Adicionar rastreamento"
+  },
+  "bT71VU": {
+    "context": "total of all sent refunds",
+    "string": "Resultado"
+  },
+  "bVY7j0": {
+    "context": "Translated Name",
+    "string": "Tradução"
+  },
+  "bVbEZ/": {
+    "context": "amount filter label",
+    "string": "Montante"
+  },
+  "bZenNC": {
+    "string": "Descrição (opcional)"
+  },
+  "bZksto": {
+    "context": "product attribute type",
+    "string": "Dropdown"
+  },
+  "bb4nSp": {
+    "context": "dialog header",
+    "string": "Cancelar faturamento"
+  },
+  "bcf60I": {
+    "context": "voucher",
+    "string": "Aplica-se a"
+  },
+  "beuxAP": {
+    "context": "channel publication status",
+    "string": "Oculto"
+  },
+  "bfj3NC": {
+    "context": "Button with Manage app label",
+    "string": "Gerenciar extensão"
+  },
+  "bfuxy3": {
+    "context": "button, create new transaction with refund amount",
+    "string": "Reembolso"
+  },
+  "bgO+7G": {
+    "context": "order return amount button",
+    "string": "Devolver e substituir produtos"
+  },
+  "bh+Keo": {
+    "string": "{numberOfFields} Traduções, {numberOfTranslatedFields} concluídas"
+  },
+  "bh9+8A": {
+    "context": "voucher requirement",
+    "string": "Valor mínimo do pedido"
+  },
+  "biAxKR": {
+    "context": "click and collect",
+    "string": "Click&Collect"
+  },
+  "biDgQS": {
+    "context": "button, opens modal to create transaction in order",
+    "string": "Transação manual"
+  },
+  "biVFKU": {
+    "context": "subsection header",
+    "string": "Endereço de Cobrança"
+  },
+  "bj1U23": {
+    "string": "Tem certeza de que deseja excluir {menuName}?"
+  },
+  "bj6pTd": {
+    "string": "Algo está faltando"
+  },
+  "bk2M4q": {
+    "context": "button",
+    "string": "Cancelar data final"
+  },
+  "bk9KUX": {
+    "context": "ProductTypeDeleteWarningDialog single consent label",
+    "string": "Sim, quero excluir este tipo de produto e os produtos atribuídos"
+  },
+  "blWvag": {
+    "string": "Modelos"
+  },
+  "blZJmA": {
+    "context": "ExitFormPrompt ignore changes button",
+    "string": "Ignorar alterações"
+  },
+  "bnMF4j": {
+    "context": "notification",
+    "string": "Os modelos selecionados foram despublicados."
+  },
+  "bp/i0x": {
+    "context": "header",
+    "string": "Quantidade"
+  },
+  "bq1eEx": {
+    "context": "header",
+    "string": "Criar Tipo de Produto"
+  },
+  "bqAJCT": {
+    "context": "section header",
+    "string": "Pedido de Reembolso"
+  },
+  "brkxbY": {
+    "string": "Não há transações para reembolsar"
+  },
+  "bsP4f3": {
+    "string": "Nenhum token encontrado"
+  },
+  "bu/fC1": {
+    "context": "button",
+    "string": "Remover"
+  },
+  "bwJc6V": {
+    "context": "column title product",
+    "string": "Produto"
+  },
+  "byP6IC": {
+    "string": "Selecionado"
+  },
+  "c0H45L": {
+    "string": "{amount, plural,one {Um pedido está pronto para ser atendido} other {{amount} os pedidos estão prontos para serem atendidos}}"
+  },
+  "c0hLoI": {
+    "string": "Atributo criado"
+  },
+  "c24hjq": {
+    "context": "status",
+    "string": "Ativo"
+  },
+  "c4gbXr": {
+    "string": "Rascunho do pedido finalizado com sucesso"
+  },
+  "c5B5Cg": {
+    "context": "password login mode option description",
+    "string": "Nenhum usuário pode fazer login com uma senha"
+  },
+  "c5fFin": {
+    "context": "ExitFormPrompt title",
+    "string": "Sair sem salvar alterações?"
+  },
+  "c5pMZ8": {
+    "string": "Erro na API"
+  },
+  "c5tWY8": {
+    "context": "dialog title",
+    "string": "Gerar Variantes"
+  },
+  "c7/79+": {
+    "string": "Endereço de Cobrança"
+  },
+  "c7cakc": {
+    "context": "model attribute entity type",
+    "string": "Modelos"
+  },
+  "c8UT0c": {
+    "context": "tabel column header",
+    "string": "Nome do Canal"
+  },
+  "c8nvms": {
+    "string": "Vendas"
+  },
+  "cBHRxx": {
+    "context": "button",
+    "string": "Atribuir Depósito"
+  },
+  "cBVHN5": {
+    "context": "grant refund, reason input field placeholder",
+    "string": "Razão para reembolso"
+  },
+  "cD0BQQ": {
+    "context": "sku preview example showing resulting SKU",
+    "string": "→ {example}"
+  },
+  "cEO6Yx": {
+    "context": "dialog header",
+    "string": "Ativar Extensão"
+  },
+  "cEoeGG": {
+    "string": "Ambos os termos devem corresponder"
+  },
+  "cErw9O": {
+    "context": "Shown when warehouse count cannot be determined",
+    "string": "Armazéns: Desconhecido"
+  },
+  "cFA9vl": {
+    "context": "link",
+    "string": "Ver pedidos"
+  },
+  "cFVgOo": {
+    "context": "Channel label",
+    "string": "Channel"
+  },
+  "cHsr1m": {
+    "context": "badge for new variant that will be created",
+    "string": "Novo"
+  },
+  "cIoOf0": {
+    "context": "relative time in minutes",
+    "string": "{minutes}m atrás"
+  },
+  "cJ5ASN": {
+    "context": "attribute position in storefront filters",
+    "string": "Posição na navegação"
+  },
+  "cKCfSW": {
+    "context": "dialog header",
+    "string": "Cancelar a atribuição de produtos do cupom"
+  },
+  "cKjFfl": {
+    "context": "product attribute type",
+    "string": "Seleção Multipla"
+  },
+  "cLcy6F": {
+    "string": "Número de produtos"
+  },
+  "cMFlOp": {
+    "context": "input label",
+    "string": "Nova senha"
+  },
+  "cN8pa0": {
+    "context": "radio button label",
+    "string": "Reembolso com itens de linha"
+  },
+  "cNSLLO": {
+    "context": "button",
+    "string": "Unassign and save"
+  },
+  "cNXv4f": {
+    "string": "Cumprimento cancelado"
+  },
+  "cOki0G": {
+    "string": "O que acontece se eu negar?"
+  },
+  "cPAc45": {
+    "context": "column picker search no results message",
+    "string": "Nenhum resultado encontrado"
+  },
+  "cRQ9hb": {
+    "string": "Estrutura excluída"
+  },
+  "cS1wAx": {
+    "string": "Eu sei o que estou fazendo - confirmar"
+  },
+  "cVjewM": {
+    "context": "label for radio button",
+    "string": "Os preços dos produtos são inseridos com imposto"
+  },
+  "cW1RIo": {
+    "context": "section header",
+    "string": "Visualização de mídia"
+  },
+  "cXAlMR": {
+    "string": "Agendado"
+  },
+  "cY42ht": {
+    "string": "A senha não pode ser totalmente numérica"
+  },
+  "cY6H2C": {
+    "context": "empty metadata text",
+    "string": "Nenhum metadado criado para este elemento. Use o botão abaixo para adicionar um novo campo de metadados."
+  },
+  "cZN5Jd": {
+    "context": "Webhook details events",
+    "string": "Eventos"
+  },
+  "caMMWN": {
+    "string": "Pesquisar Depósito"
+  },
+  "caqRmN": {
+    "context": "header",
+    "string": "Criar Tipo de Página"
+  },
+  "ccXLVi": {
+    "string": "Categoria"
+  },
+  "cd13nN": {
+    "context": "product attribute error",
+    "string": "Todos os atributos devem ter valor"
+  },
+  "cdiRSf": {
+    "context": "WarehouseSettings no shipping zones assigned",
+    "string": "Este depósito não tem zonas de entrega atribuídas"
+  },
+  "cdxwA8": {
+    "string": "{amount, plural,one {Um produto fora de estoque} other {{amount} produtos fora de estoque}}"
+  },
+  "ce2kVF": {
+    "string": "Ver no provedor de pagamento"
+  },
+  "ce5Hp1": {
+    "string": "Falha ao copiar para a área de transferência"
+  },
+  "cehiWu": {
+    "context": "channels sale info",
+    "string": "Os canais que não têm descontos atribuídos usarão seu canal pai para definir o preço. O preço será convertido para a moeda do canal"
+  },
+  "cfQf0w": {
+    "context": "button",
+    "string": "Criar Pedido"
+  },
+  "cgsY/X": {
+    "context": "page header",
+    "string": "Criar Nova Categoria"
+  },
+  "chvryR": {
+    "context": "order history message",
+    "string": "A fatura foi solicitada por {requestBy}"
+  },
+  "ckSjjv": {
+    "string": "Condições muito complexas para exibir, use o playground para ver os detalhes."
+  },
+  "cnvyqW": {
+    "context": "ChannelsSection select field placeholder",
+    "string": "Adicionar Canal"
+  },
+  "cohh4s": {
+    "context": "Refund success status",
+    "string": "Sucesso"
+  },
+  "cpI605": {
+    "string": "Melhoria"
+  },
+  "cpZLRH": {
+    "context": "dialog header",
+    "string": "Excluir Zonas de Envio"
+  },
+  "cqZ5UH": {
+    "context": "order history message",
+    "string": "A confirmação do pedido foi enviada ao cliente"
+  },
+  "cryH86": {
+    "context": "assign collections to sale and save",
+    "string": "Assign and save"
+  },
+  "ctdEON": {
+    "string": "Últimas atualizações e melhorias"
+  },
+  "cti4iA": {
+    "string": "Leia o post do blog"
+  },
+  "cvVIV/": {
+    "context": "dialog header",
+    "string": "Atribuir Países"
+  },
+  "cvbqJu": {
+    "context": "attribute",
+    "string": "Visible na Pagina de Produtos na Vitrine"
+  },
+  "cwjmte": {
+    "context": "fulfillment status refunded",
+    "string": "Reembolsado"
+  },
+  "cwoN25": {
+    "context": "config type section title",
+    "string": "Tipo de configuração"
+  },
+  "cy8sV7": {
+    "context": "volume units types",
+    "string": "Volume"
+  },
+  "cyR7Kh": {
+    "string": "Voltar"
+  },
+  "d+qgix": {
+    "string": "Próximo passo"
+  },
+  "d12NWZ": {
+    "context": "tooltip when generate button is disabled because no new variants can be created",
+    "string": "Todas as combinações possíveis de variantes já existem"
+  },
+  "d1AzfC": {
+    "context": "hint text showing number of available options in multiselect",
+    "string": "{count} opções disponíveis"
+  },
+  "d1PvC8": {
+    "context": "checkbox",
+    "string": "Conceder reembolso por itens devolvidos"
+  },
+  "d3jlO3": {
+    "context": "Label prefix for the creation date of a recurring problem",
+    "string": "Começou em"
+  },
+  "d68yq7": {
+    "string": "Excluir cartões-presente"
+  },
+  "d7dT8o": {
+    "context": "button, sets granted refund amount in input",
+    "string": "Definir máximo"
+  },
+  "d9UqaJ": {
+    "context": "error message",
+    "string": "Não é possível alterar a quantidade devido ao estoque insuficiente"
+  },
+  "dAst+b": {
+    "context": "attribute values list: no attribute values found",
+    "string": "Nenhum valor encontrado"
+  },
+  "dDCLFW": {
+    "context": "alert message",
+    "string": "Não disponível para venda neste canal"
+  },
+  "dEUZg2": {
+    "context": "header",
+    "string": "Itens do Menu"
+  },
+  "dGqEJ9": {
+    "context": "search box placeholder",
+    "string": "Pesquisar pelo nome do país"
+  },
+  "dHAwu8": {
+    "string": "Código já existe"
+  },
+  "dJQxHt": {
+    "context": "delete category",
+    "string": "Tem certeza de que deseja excluir {categoryName}?"
+  },
+  "dJVXIb": {
+    "context": "vat included in order price",
+    "string": "IVA incluido"
+  },
+  "dKPMyh": {
+    "context": "tab name",
+    "string": "Todos os Atributos"
+  },
+  "dLIeRH": {
+    "context": "charge status none",
+    "string": "Nenhum"
+  },
+  "dLQhIT": {
+    "context": "Health check showing variants with stock count",
+    "string": "Variantes com estoque: {count}/{total}"
+  },
+  "dM86a2": {
+    "string": "Nenhuma categoria encontrada"
+  },
+  "dOQB9o": {
+    "context": "payment status",
+    "string": "Cancelado"
+  },
+  "dPYqy0": {
+    "string": "Estamos atualmente exportando seu CSV solicitado. Assim que estiver disponível, ele será enviado a você no seu e-mail"
+  },
+  "dQdxLT": {
+    "context": "section subheader",
+    "string": "Eventos síncronos"
+  },
+  "dQn96a": {
+    "string": "Ir para modelos"
+  },
+  "dS8Adx": {
+    "context": "product",
+    "string": "Digital"
+  },
+  "dTCDMn": {
+    "context": "dialog header",
+    "string": "Atribuir Produto"
+  },
+  "dTCWqt": {
+    "string": "Você está prestes a encerrar a pré-encomenda de seus produtos. Você vendeu {variantGlobalSoldUnits} unidades desta variante. As unidades vendidas serão alocadas em armazéns apropriados. Lembre-se de adicionar estoque limite restante aos armazéns."
+  },
+  "dTkmON": {
+    "context": "edit tracking button",
+    "string": "Editar rastreamento"
+  },
+  "dTzCqd": {
+    "context": "Health check status when product is not published but otherwise ready",
+    "string": "Não visível para os clientes"
+  },
+  "dVk241": {
+    "string": "configurações de produto"
+  },
+  "dWK/Ck": {
+    "string": "Escolha os países aos quais deseja que o cupom seja limitado, na lista abaixo"
+  },
+  "da1ebU": {
+    "string": "Tipo de produto"
+  },
+  "dc5KWn": {
+    "context": "products export type label",
+    "string": "produtos"
+  },
+  "diOQm7": {
+    "context": "product status",
+    "string": "Disponível"
+  },
+  "dnbJKr": {
+    "string": "Esta transação não possui eventos"
+  },
+  "dpY94C": {
+    "context": "collection publication date",
+    "string": "Publicado em {date}"
+  },
+  "dsJ+Wv": {
+    "context": "note on export gift cards",
+    "string": "Observação: somente cartões-presente ativos e não utilizados serão exportados"
+  },
+  "dxCVWI": {
+    "context": "error message",
+    "string": "Não é possível solicitar uma fatura para pedido em rascunho"
+  },
+  "e+L+q3": {
+    "string": "Lembre-se de que isso irá deletar todos os produtos vinculados nesta categoria."
+  },
+  "e/61NZ": {
+    "context": "current balance filter label",
+    "string": "Saldo atual"
+  },
+  "e0RKe+": {
+    "context": "generate invoice button",
+    "string": "Gerar"
+  },
+  "e0lt+l": {
+    "string": "Veja a documentação"
+  },
+  "e4UtKH": {
+    "context": "Transaction event status - failure",
+    "string": "Falha"
+  },
+  "e5Mlfh": {
+    "context": "Transaction title",
+    "string": "Cartão-presente (**** {code})"
+  },
+  "e61nVn": {
+    "string": "Envio atualizado"
+  },
+  "e71euF": {
+    "string": "Tipo de modelo de reembolsos"
+  },
+  "e7Nyu7": {
+    "context": "section header",
+    "string": "Histórico do Cliente"
+  },
+  "e7yOai": {
+    "context": "shipping address is not set in draft order",
+    "string": "Não configurado"
+  },
+  "e822us": {
+    "string": "Observe que, embora todos os ajustes de moeda e data estejam concluídos, as traduções de idiomas estão em diferentes graus de conclusão."
+  },
+  "e8O72h": {
+    "context": "password login mode option",
+    "string": "Desativado"
+  },
+  "e92Uxp": {
+    "context": "order history message",
+    "string": "Número de rastreio do grupo de faturamento atualizado"
+  },
+  "e9z98s": {
+    "string": "Você não tem acesso a esta permissão"
+  },
+  "eAFU/E": {
+    "context": "product inventory, checkbox",
+    "string": "Variante atualmente em pré-encomenda"
+  },
+  "eB6oHa": {
+    "context": "Message when product is not in any channel",
+    "string": "O produto não está listado em nenhum canal"
+  },
+  "eCA3n1": {
+    "context": "Health check label for isAvailableForPurchase field",
+    "string": "Pode adicionar ao carrinho"
+  },
+  "eCRaHe": {
+    "context": "refunded fulfillment, section header",
+    "string": "Devolvido ({quantity})"
+  },
+  "eIGXwJ": {
+    "context": "Alert text",
+    "string": "Você está usando uma versão antiga dos presets de filtro. Os seguintes presets: {presetNames} devem ser atualizados para continuar usando filtros"
+  },
+  "eKEL/g": {
+    "string": "Pendente"
+  },
+  "eLJQSh": {
+    "context": "column title gift card",
+    "string": "Gift Card"
+  },
+  "eOrLzG": {
+    "context": "button",
+    "string": "Feito"
+  },
+  "eR2vV/": {
+    "string": "Se deixado desmarcado, cria um {link} - usado por Plugins de Pagamento"
+  },
+  "eRqx44": {
+    "string": "Pesquisar coleções..."
+  },
+  "eS8xZ6": {
+    "context": "card header",
+    "string": "Taxas de classe de imposto: {country}"
+  },
+  "eUjFjW": {
+    "string": "Grupo de permissões criado"
+  },
+  "eVrDft": {
+    "string": "Sem valor"
+  },
+  "eW36Jx": {
+    "string": "Consultas de pesquisa salvas aparecerão aqui"
+  },
+  "eWV760": {
+    "string": "Atributo com esta identificação já existe"
+  },
+  "eWcvOc": {
+    "context": "button",
+    "string": "Escolher arquivo"
+  },
+  "eY+BKQ": {
+    "string": "O manifesto da extensão não foi encontrado. ({errorCode})"
+  },
+  "eaoi2W": {
+    "context": "tab name",
+    "string": "Todos os armazéns"
+  },
+  "ecM5eL": {
+    "context": "page title - creating custom app",
+    "string": "Adicionar extensão manualmente"
+  },
+  "ekXood": {
+    "string": "Unlimited"
+  },
+  "empNV9": {
+    "context": "add products button tooltip",
+    "string": "Adicionar produtos de {channelName}"
+  },
+  "epB7b7": {
+    "context": "fulfillment status replaced",
+    "string": "Substituído"
+  },
+  "erC44f": {
+    "context": "filters error messages dependencies missing",
+    "string": "O filtro requer outros filtros: {dependencies}"
+  },
+  "esg2wu": {
+    "context": "previous step, button",
+    "string": "Anterior"
+  },
+  "etP0+D": {
+    "string": "Cupons"
+  },
+  "eu98dw": {
+    "string": "Senha inválida"
+  },
+  "euRfu+": {
+    "string": "Tem certeza de que deseja cancelar este pagamento?"
+  },
+  "exvX+Z": {
+    "context": "export card codes menu item",
+    "string": "Exportar códigos de cartão"
+  },
+  "ey0lZj": {
+    "context": "dialog header",
+    "string": "Deletar Cliente"
+  },
+  "f/Drvo": {
+    "context": "order history message",
+    "string": "Cancelamento de transação solicitado"
+  },
+  "f0hXz4": {
+    "context": "dialog header",
+    "string": "Pesquisar Coleção"
+  },
+  "f1Pj99": {
+    "string": "Desconto de {value} através do {channel} com {unknown} condições"
+  },
+  "f2F1NJ": {
+    "context": "section title",
+    "string": "Escolha rápida"
+  },
+  "f2WJW7": {
+    "context": "transaction event type, amount was captured from client",
+    "string": "Capturar"
+  },
+  "f3B4tc": {
+    "context": "attributes, section header",
+    "string": "Atributos da Variação"
+  },
+  "f4oJRg": {
+    "context": "order transaction refund summary description",
+    "string": "O valor do reembolso é calculado automaticamente com base nos itens selecionados. Você pode modificá-lo manualmente, se necessário."
+  },
+  "f71A+Y": {
+    "context": "Title for delivery configuration section in channel",
+    "string": "Configuração de entrega"
+  },
+  "fDc5ys": {
+    "context": "order transaction refund summary label",
+    "string": "Produtos selecionados"
+  },
+  "fEeZGG": {
+    "string": "Pesquisar Modelos"
+  },
+  "fEfCtO": {
+    "context": "voucher discount type",
+    "string": "Porcentagem"
+  },
+  "fExm0/": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi ativado por {activatedBy}"
+  },
+  "fHopox": {
+    "context": "section description",
+    "string": "Atribua permissões para registrar eventos síncronos para este webhook."
+  },
+  "fITtdb": {
+    "context": "helper text",
+    "string": "{value} já reembolsado"
+  },
+  "fKLe7r": {
+    "string": "Início da entrega:"
+  },
+  "fKrRhF": {
+    "string": "Informações gerais"
+  },
+  "fL08MU": {
+    "string": "Valor do pedido"
+  },
+  "fLhj3a": {
+    "context": "gift card history message",
+    "string": "A data de validade do vale-presente foi atualizada"
+  },
+  "fNFEkh": {
+    "string": "No de Linhas:"
+  },
+  "fOXF9A": {
+    "string": "Solicitar Extensão"
+  },
+  "fP9FXB": {
+    "context": "input label",
+    "string": "Pesquisar Atributos"
+  },
+  "fS2rip": {
+    "context": "tooltip for taxes amount",
+    "string": "Valor do imposto"
+  },
+  "fU+a9k": {
+    "context": "date attribute type",
+    "string": "Data"
+  },
+  "fV6yX5": {
+    "context": "table head",
+    "string": "Nome da Categoria"
+  },
+  "fWaj1M": {
+    "string": "A versão do Saleor que sua extensão está tentando usar é mais nova do que sua versão atual do Saleor. {docsLink} ({errorCode})"
+  },
+  "fXdkiI": {
+    "string": "é"
+  },
+  "fbH51z": {
+    "context": "Amount error message",
+    "string": "O valor não pode ser maior do que o reembolso máximo"
+  },
+  "fdbqIs": {
+    "context": "text attribute type",
+    "string": "Text"
+  },
+  "fehqPs": {
+    "context": "order history message",
+    "string": "Os produtos foram excluídos de um pedido"
+  },
+  "fg8dzN": {
+    "string": "Adicionar condição"
+  },
+  "fgHLXc": {
+    "context": "attribute value",
+    "string": "Valor"
+  },
+  "fhksPD": {
+    "string": "Número de Pedidos"
+  },
+  "fi9Qa/": {
+    "context": "Dry run dialog header",
+    "string": "Execução a seco"
+  },
+  "fjPWOA": {
+    "context": "header",
+    "string": "Visão Geral do Cliente"
+  },
+  "fkgack": {
+    "context": "button, sends refund for transaction",
+    "string": "Solicitar reembolso"
+  },
+  "fkoxZY": {
+    "context": "extensions section name",
+    "string": "Extensões"
+  },
+  "fkplbE": {
+    "context": "order history message",
+    "string": "Pedido foi marcado como pago"
+  },
+  "flP8Hj": {
+    "context": "card description",
+    "string": "Expanda ou restrinja as permissões do aplicativo para acessar determinada parte do sistema Saleor."
+  },
+  "fo7nfa": {
+    "context": "fixed amount",
+    "string": "Quantia Fixa"
+  },
+  "foB6wx": {
+    "context": "weight based shipping methods, section header",
+    "string": "Taxas Baseadas em Peso"
+  },
+  "foNlhn": {
+    "context": "custom app name",
+    "string": "Nome do Aplicativo"
+  },
+  "fpafCx": {
+    "context": "deleted multiple attributes",
+    "string": "Atributos excluídos"
+  },
+  "fqJXzO": {
+    "context": "order history message",
+    "string": "Reembolso de transação solicitado"
+  },
+  "fqXQq6": {
+    "string": "Solicitação de captura enviada ao provedor de pagamento"
+  },
+  "fsBsMy": {
+    "context": "button, form submit, grant refund create",
+    "string": "Conceder reembolso"
+  },
+  "ftOPoy": {
+    "context": "bulk actions button label",
+    "string": "Despublicar"
+  },
+  "ftcHpD": {
+    "string": "Cliente criado"
+  },
+  "fuFCpI": {
+    "context": "allow unpaid orders checkbox label",
+    "string": "Permitir pedidos não pagos"
+  },
+  "fuUksg": {
+    "context": "column header",
+    "string": "Tipo de Modelo"
+  },
+  "fw+VAN": {
+    "context": "product's sku",
+    "string": "SKU"
+  },
+  "fxbjge": {
+    "context": "Status when product is currently visible on storefront",
+    "string": "Visível agora"
+  },
+  "fyE8BN": {
+    "context": "product organization, header",
+    "string": "Empresa"
+  },
+  "fzDI3A": {
+    "context": "add link to navigation",
+    "string": "Link para: {url}"
+  },
+  "fzk04H": {
+    "context": "dialog title",
+    "string": "excluir imagem"
+  },
+  "fzl482": {
+    "context": "expires on label",
+    "string": "Expirará em:"
+  },
+  "fzpXvv": {
+    "string": "Tem certeza que você deseja deletar o avatar de {email}?"
+  },
+  "g+GAf4": {
+    "context": "product visibility",
+    "string": "Visibilidade"
+  },
+  "g/BrOt": {
+    "string": "A URL tem um formato inválido"
+  },
+  "g/FRtd": {
+    "context": "table column header, allocated product quantity",
+    "string": "alocado"
+  },
+  "g0GAdN": {
+    "string": "Excluir atributos"
+  },
+  "g1bk+A": {
+    "context": "payment method type other",
+    "string": "Outro"
+  },
+  "g3qjSf": {
+    "context": "button",
+    "string": "Atribuir categorias"
+  },
+  "g5zIpS": {
+    "context": "No attribute values found",
+    "string": "Valor não encontrado"
+  },
+  "g6yuk2": {
+    "context": "export items to csv file, choice field label",
+    "string": "Exportar informações para:"
+  },
+  "g8lXTL": {
+    "context": "swatch attribute",
+    "string": "Amostra"
+  },
+  "g9HrbF": {
+    "string": "Precisa de ajuda técnica?"
+  },
+  "g9M3PH": {
+    "string": "Problemas encontrados.{break}Revise os alertas da extensão."
+  },
+  "g9Mb+U": {
+    "context": "change warehouse dialog title",
+    "string": "Alterar armazém"
+  },
+  "gAqkrG": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi desativado por {deactivatedBy}"
+  },
+  "gCZYcl": {
+    "context": "tooltip shown when shipping method is selected but no other options exist",
+    "string": "Nenhum método de envio alternativo disponível"
+  },
+  "gDvd3v": {
+    "context": "tooltip when generate variants is disabled due to unsupported required attributes",
+    "string": "Atributos obrigatórios com tipos não suportados:{newline}{attributes}{newline}{newline}Para usar o Gerador:{newline}1. Torne-os opcionais no tipo de produto{newline}2. Gere variantes{newline}3. Defina valores manualmente{newline}4. Restaure a configuração obrigatória"
+  },
+  "gE6aiQ": {
+    "context": "PageTypeDeleteWarningDialog single no assigned items description",
+    "string": "Você tem certeza de que deseja excluir <b>{typeName}</b>? Se você removê-lo, não poderá atribuí-lo aos modelos criados."
+  },
+  "gF7hbK": {
+    "context": "variant name",
+    "string": "Nova Variação"
+  },
+  "gG4YAW": {
+    "context": "Number of shipping zones",
+    "string": "{count, plural, =0 {Nenhuma zona de envio} one {# zona de envio} other {# zonas de envio}}"
+  },
+  "gHB1Wx": {
+    "context": "Number of countries covered by shipping",
+    "string": "{count, plural, one {# país} other {# países}} cobertos"
+  },
+  "gK7mIl": {
+    "string": "Nome do desconto"
+  },
+  "gKary4": {
+    "context": "Description for inactive channel error",
+    "string": "Este canal não está ativo. Os produtos não podem ser comprados até que o canal seja ativado."
+  },
+  "gKdGxP": {
+    "context": "error message",
+    "string": "Apenas pagamentos pré-autorizados podem ser recebidos"
+  },
+  "gMwpNC": {
+    "context": "page content",
+    "string": "Conteúdo"
+  },
+  "gNm1li": {
+    "context": "Refunded transaction amount, data display header",
+    "string": "Reembolsado"
+  },
+  "gOiREw": {
+    "string": "Configurações do aplicativo atualizadas"
+  },
+  "gQGUsN": {
+    "context": "dialog title",
+    "string": "Editar Endereço "
+  },
+  "gRa/TS": {
+    "context": "shipping zone",
+    "string": "Nome"
+  },
+  "gSQ0Ge": {
+    "string": "Variação {name} foi configurada como padrão."
+  },
+  "gTr0qE": {
+    "string": "Configurações de Entrega"
+  },
+  "gVD1os": {
+    "context": "empty list message",
+    "string": "Você ainda não atribuiu nenhum membro a este grupo de permissão."
+  },
+  "gVqSnA": {
+    "string": "Atribuir e salvar"
+  },
+  "gZHmaV": {
+    "context": "plugin filters error messages channels",
+    "string": "Nenhum canal selecionado"
+  },
+  "gaOXvo": {
+    "context": "notification, form submitted",
+    "string": "Concessão de reembolso para o pedido #{orderNumber} foi atualizado"
+  },
+  "ge/xFX": {
+    "context": "table column header",
+    "string": "Quantidade"
+  },
+  "gelco+": {
+    "string": "Metadados atualizados"
+  },
+  "gfRbEV": {
+    "string": "Nota atualizada"
+  },
+  "ghGLbJ": {
+    "context": "OrderPayment click&collect shipping method",
+    "string": "click&collect"
+  },
+  "ghje1I": {
+    "context": "numeric attribute unit system",
+    "string": "Sistema"
+  },
+  "giF5UV": {
+    "context": "sale end date",
+    "string": "Termina"
+  },
+  "giVGCH": {
+    "string": "Digite o código do voucher"
+  },
+  "gj3MUg": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi reenviado"
+  },
+  "gjBiyj": {
+    "string": "Carregando..."
+  },
+  "gksZwp": {
+    "context": "button",
+    "string": "Criar tipo de produto"
+  },
+  "glR0om": {
+    "context": "shipping label",
+    "string": "Envio"
+  },
+  "glT6fm": {
+    "string": "Cupom é limitado a estes países"
+  },
+  "gmU4T7": {
+    "context": "Warning when channel has no warehouses",
+    "string": "Nenhum armazém atribuído a \"{channelName}\""
+  },
+  "gr+oXW": {
+    "context": "page title",
+    "string": "Título"
+  },
+  "gr53VQ": {
+    "context": "page header",
+    "string": "Criar Página"
+  },
+  "grkY2V": {
+    "string": "Você não tem acesso a nenhum canal"
+  },
+  "gt05TH": {
+    "context": "tooltip message",
+    "string": "Você não tem permissão para gerenciar a equipe"
+  },
+  "gtKcPf": {
+    "context": "title",
+    "string": "{zonesCount} / {totalCount} zonas de envio"
+  },
+  "gvOzOl": {
+    "string": "Título da Página"
+  },
+  "gx4wCT": {
+    "context": "swatch attribute type",
+    "string": "Swatch"
+  },
+  "gxPjIQ": {
+    "string": "Tem certeza de que gostaria de excluir {email} de membros da equipe?"
+  },
+  "gygOA1": {
+    "context": "button",
+    "string": "Desativar"
+  },
+  "gz9v22": {
+    "context": "PluginChannelConfigurationCell channel title",
+    "string": "Por canal"
+  },
+  "gzM1em": {
+    "string": "Adicionar regra"
+  },
+  "h0IgEq": {
+    "context": "checkbox",
+    "string": "Enviar automaticamente o reembolso concedido"
+  },
+  "h0mEWF": {
+    "context": "Availability card subtitle showing channel count",
+    "string": "Em {listed} de {total} canais"
+  },
+  "h1rPPg": {
+    "context": "dialog content",
+    "string": "Tem certeza de que deseja excluir {attributeName}?"
+  },
+  "h2Hta6": {
+    "context": "caption",
+    "string": "Se habilitado, atributo estará acessível pelos clientes"
+  },
+  "h2vipu": {
+    "string": "Código"
+  },
+  "h5P++h": {
+    "string": "Variantes"
+  },
+  "h5r9+x": {
+    "context": "sort shipping methods by zone, section header",
+    "string": "Envio por zona"
+  },
+  "h65vZI": {
+    "context": "times voucher used",
+    "string": "Usado"
+  },
+  "h6MWxB": {
+    "context": "orderLine.productSku, subheader, order line metadata dialog",
+    "string": "SKU"
+  },
+  "h75GAF": {
+    "context": "voucher",
+    "string": "Contagem de Utilização"
+  },
+  "h7yWcT": {
+    "string": "Digite seu e-mail. Se corresponder a uma conta, enviaremos um link de redefinição em alguns minutos."
+  },
+  "h84DkG": {
+    "string": "Ir para explorar extensões"
+  },
+  "h9aBq7": {
+    "string": "Senha alterada"
+  },
+  "hASogc": {
+    "string": "Pedido atualizado"
+  },
+  "hAcUEl": {
+    "context": "product publication date label",
+    "string": "será publicado em {date}"
+  },
+  "hAoqp6": {
+    "string": "Falha ao salvar permissões. Atualize a página e tente novamente."
+  },
+  "hHOI7D": {
+    "context": "product type name",
+    "string": "Nome do Tipo"
+  },
+  "hJZwTS": {
+    "string": "Email address"
+  },
+  "hLOEeb": {
+    "context": "button",
+    "string": "Definir como endereço de cobrança padrão"
+  },
+  "hLSgWj": {
+    "context": "warehouse label number available of products",
+    "string": "{productCount} disponível neste local"
+  },
+  "hLUYBt": {
+    "context": "payment status",
+    "string": "Pendente"
+  },
+  "hM40BV": {
+    "context": "header",
+    "string": "Estrutura de tradução \"{menuItemName}\" - {languageCode}"
+  },
+  "hMRP6J": {
+    "string": "Endereço Padrão"
+  },
+  "hOxIeP": {
+    "string": "Disponibilidade"
+  },
+  "hPB89Y": {
+    "string": "Número de faturas para exibição"
+  },
+  "hQDWIw": {
+    "context": "modal header, editable product variant metadata",
+    "string": "Metadados da variante do produto"
+  },
+  "hS+ZjH": {
+    "context": "delete webhook",
+    "string": "Tem certeza de que deseja excluir este webhook?"
+  },
+  "hTLCC2": {
+    "context": "channel publication date",
+    "string": "Se tornará publicado em {date}"
+  },
+  "hVPucN": {
+    "string": "Modo Claro"
+  },
+  "hVwc73": {
+    "context": "extensions page subheader",
+    "string": "extensões"
+  },
+  "hWO1SD": {
+    "context": "order history message",
+    "string": "O rascunho do pedido foi criado"
+  },
+  "hX5PAb": {
+    "string": "Nenhum resultado encontrado"
+  },
+  "hYWxeg": {
+    "string": "A extensão solicita permissões que você não pode conceder ou que excedem seu escopo permitido. Revise o manifesto da extensão e suas permissões. {docsLink} ({errorCode})"
+  },
+  "hdcGSJ": {
+    "context": "button",
+    "string": "Suporte/FAQ"
+  },
+  "hh0xW7": {
+    "string": "Nome do Canal"
+  },
+  "hhXK05": {
+    "context": "Link label to navigate to the app page",
+    "string": "Abrir o aplicativo"
+  },
+  "hjEkEH": {
+    "string": "Todos os webhooks registrados por esta extensão. Em caso de falha na entrega do webhook, a lista de tentativas é exibida."
+  },
+  "hkENym": {
+    "string": "Cliente"
+  },
+  "hkSkNx": {
+    "string": "Pesquisar Clientes"
+  },
+  "hnBvH7": {
+    "context": "copied to clipboard alert title",
+    "string": "Copiado para a área de transferência"
+  },
+  "hnRRUe": {
+    "context": "docs link label",
+    "string": "Saiba mais..."
+  },
+  "hniz8Z": {
+    "string": "aqui"
+  },
+  "ho75Lr": {
+    "context": "status label deactivated",
+    "string": "Desativado"
+  },
+  "hpBWnU": {
+    "context": "Warning when scheduling a visible product for the future",
+    "string": "O produto será oculto até {date}."
+  },
+  "hpMcW8": {
+    "string": "Defina como os usuários poderão navegar pela sua loja"
+  },
+  "hptDxW": {
+    "context": "money",
+    "string": "para {money}"
+  },
+  "hqVMLQ": {
+    "context": "button",
+    "string": "Enviar"
+  },
+  "hrhqju": {
+    "string": "Você está atualmente logado usando um provedor de identidade externo. Fazer login por e-mail e senha pode resultar na perda de permissões e pode torná-lo incapaz de gerenciar a loja. Se você tiver problemas para autenticar, volte e entre em contato com o administrador da sua organização para obter assistência."
+  },
+  "ht9yOD": {
+    "context": "table head",
+    "string": "Nome da Coleção"
+  },
+  "htvX+Z": {
+    "string": "Negar"
+  },
+  "hw9Fah": {
+    "context": "button",
+    "string": "Enviar convite"
+  },
+  "hwSDOP": {
+    "context": "Previous page button",
+    "string": "Anterior"
+  },
+  "hwYzY9": {
+    "string": "Nota adicionada"
+  },
+  "hyAOPB": {
+    "string": "Usar plugin Avalara"
+  },
+  "hz+9ES": {
+    "context": "bulk activate label",
+    "string": "Ativar"
+  },
+  "hzSNj4": {
+    "string": "Painel de controle"
+  },
+  "i+JSEZ": {
+    "string": "{counter,plural,one {Tem certeza de que deseja cancelar este pedido?} other {Tem certeza de que deseja cancelar {displayQuantity} pedidos?}}"
+  },
+  "i+Vox0": {
+    "context": "invoice generating has finished, header",
+    "string": "Fatura Gerada"
+  },
+  "i/ZhxL": {
+    "context": "section header returned",
+    "string": "Cumprimento aguardando aprovação"
+  },
+  "i0AcKY": {
+    "context": "notification message after log in",
+    "string": "Só para você saber ... Você está no modo de demonstração. Você pode brincar com o painel de controle, mas não pode salvar as alterações."
+  },
+  "i0ou1B": {
+    "context": "Description for no variants error",
+    "string": "Este produto não tem variantes. Crie pelo menos uma variante antes que os clientes possam comprar."
+  },
+  "i3Hquc": {
+    "context": "tooltip for discount amount",
+    "string": "Valor do desconto"
+  },
+  "i3Mvj8": {
+    "context": "product attribute error",
+    "string": "Esta variação já existe"
+  },
+  "i3r9KP": {
+    "context": "Checkbox label for scheduling availability for a future date",
+    "string": "Agendar para mais tarde"
+  },
+  "i56GGQ": {
+    "context": "order refund amount",
+    "string": "Valor dos produtos substituídos"
+  },
+  "iAaYh4": {
+    "context": "Info box description for unavailable products",
+    "string": "Os clientes podem visualizar este produto, mas não podem adicioná-lo ao carrinho."
+  },
+  "iAvKNf": {
+    "context": "navigator help mode description",
+    "string": "Mostrar Ajuda"
+  },
+  "iBSq6l": {
+    "context": "sale start date",
+    "string": "Inicia"
+  },
+  "iBW3rG": {
+    "context": "button",
+    "string": "Aplicar"
+  },
+  "iEeIhY": {
+    "context": "draft order",
+    "string": "Cliente"
+  },
+  "iFM716": {
+    "context": "grant refund, refund card subtitle",
+    "string": "Quanto dinheiro você deseja devolver ao cliente pelo pedido?"
+  },
+  "iIPThY": {
+    "context": "onboarding title",
+    "string": "Vamos começar ({count}/{total})"
+  },
+  "iIfq2+": {
+    "context": "Transaction cancel button - return preauthorized amount to client",
+    "string": "Cancelar"
+  },
+  "iJrw63": {
+    "context": "section header",
+    "string": "Faturado ({quantity})"
+  },
+  "iK8hZU": {
+    "context": "activate app",
+    "string": "Você tem certeza de que deseja ativar esta extensão? A ativação começará a coletar eventos."
+  },
+  "iMJka8": {
+    "string": "Nenhuma página encontrada"
+  },
+  "iPg/Z+": {
+    "context": "Pagination info showing current range",
+    "string": "Mostrando {start}-{end} de {total}"
+  },
+  "iPk640": {
+    "context": "dialog header",
+    "string": "Seleção de mídia"
+  },
+  "iQxjow": {
+    "context": "section header",
+    "string": "Atributos de conteúdo"
+  },
+  "iUIn50": {
+    "context": "section notice",
+    "string": "Produtos não faturados serão devolvidos ao estoque"
+  },
+  "iUy2dx": {
+    "context": "vouchers section name",
+    "string": "Cupons"
+  },
+  "iWmfMe": {
+    "context": "button",
+    "string": "Criar promoção"
+  },
+  "iWyoZn": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza de que deseja cancelar a atribuição desta variante?} other {Tem certeza de que deseja cancelar a atribuição de variantes {displayQuantity}?}}"
+  },
+  "iYH3Y7": {
+    "context": "checkbox",
+    "string": "Substituir a taxa de imposto do tipo de produto"
+  },
+  "ibnmEd": {
+    "context": "voucher country range",
+    "string": "Países"
+  },
+  "icb1fc": {
+    "context": "tooltip",
+    "string": "As alocações de estoque ocorrem quando:"
+  },
+  "icz/jb": {
+    "context": "customer",
+    "string": "Data de Inscrição"
+  },
+  "if9gAZ": {
+    "context": "Transaction event status - unknown status, info without event data",
+    "string": "Info"
+  },
+  "iidznP": {
+    "context": "password login mode option description",
+    "string": "Todos os usuários podem fazer login com uma senha"
+  },
+  "iigydN": {
+    "string": "Com base em suas seleções, criaremos 8 produtos. Use esta etapa para personalizar o preço e os estoques de seus novos produtos."
+  },
+  "ij3dWD": {
+    "context": "custom extension page create, error message",
+    "string": "O nome da extensão é obrigatório"
+  },
+  "ij7olm": {
+    "context": "error message",
+    "string": "Este faturamento não pode ser cancelado"
+  },
+  "ikM00B": {
+    "context": "table column header",
+    "string": "Substituir"
+  },
+  "ikRuLs": {
+    "context": "translation progress",
+    "string": "{current} de {max}"
+  },
+  "imYtnq": {
+    "string": "Selecionado {number, plural, one {# item} other {# itens}}"
+  },
+  "imYxM9": {
+    "context": "header",
+    "string": "Informações do Aplicativo"
+  },
+  "inWs4U": {
+    "context": "attribute visibility in storefront",
+    "string": "Visível na vitrine"
+  },
+  "ipbT0Q": {
+    "context": "btn label",
+    "string": "Marcar tudo como feito"
+  },
+  "isM94c": {
+    "context": "create service token, button",
+    "string": "Criar"
+  },
+  "iue6mV": {
+    "context": "option label",
+    "string": "Manter endereço"
+  },
+  "ivJ1qt": {
+    "string": "Gerenciar grupos de premissões e suas permissões."
+  },
+  "ivTlck": {
+    "string": "Ir para extensões instaladas"
+  },
+  "ivmwpV": {
+    "context": "tab name",
+    "string": "Todos os tipos de produtos"
+  },
+  "ixjvkM": {
+    "string": "Nós criamos seu token padrão. Certifique-se de copiar seu novo token de acesso pessoal agora. Você não será capaz de vê-lo novamente."
+  },
+  "j+lQWT": {
+    "context": "error message when cut-off date is older than 30 days",
+    "string": "A data de corte não pode ser mais de 30 dias no passado"
+  },
+  "j+pYrh": {
+    "context": "order returned success message",
+    "string": "Produtos devolvidos"
+  },
+  "j/Oo0B": {
+    "context": "bulk actions button label",
+    "string": "Publicar"
+  },
+  "j/shmR": {
+    "context": "Shown when shipping zone count cannot be determined",
+    "string": "Zonas de envio: Desconhecido"
+  },
+  "j/vV0n": {
+    "context": "channel name",
+    "string": "Nome do Canal"
+  },
+  "j08fR9": {
+    "context": "Product collections",
+    "string": "Coleções"
+  },
+  "j0ugM4": {
+    "context": "Manage and Update your warehouse information",
+    "string": "Taxas de câmbio"
+  },
+  "j2fPVo": {
+    "string": "Pedido atualizado com sucesso"
+  },
+  "j2l6cL": {
+    "context": "checkbox label",
+    "string": "Definir período de validade do vale-presente"
+  },
+  "j3yE7I": {
+    "context": "order history message",
+    "string": "Número de rastreio foi enviado ao cliente"
+  },
+  "j5hGyJ": {
+    "context": "attribute is filterable in dashboard",
+    "string": "Filtrável no painel"
+  },
+  "j8PV7E": {
+    "context": "attribute values",
+    "string": "Valores"
+  },
+  "jABdx1": {
+    "string": "O rastreamento ativo de estoque calculará automaticamente as mudanças de estoque"
+  },
+  "jBu2yj": {
+    "context": "acre-inch unit",
+    "string": "acre-inch"
+  },
+  "jCYHA+": {
+    "string": "Abrir em Popup"
+  },
+  "jDIRQV": {
+    "context": "section header",
+    "string": "Sobre este aplicativo"
+  },
+  "jDWPin": {
+    "context": "remove failed installation dialog title",
+    "string": "Remover instalação falhada"
+  },
+  "jDovoJ": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi emitido"
+  },
+  "jFrdB5": {
+    "string": "Configurações do Produto"
+  },
+  "jGGnSZ": {
+    "context": "page header",
+    "string": "Endereço Primário"
+  },
+  "jGvclB": {
+    "string": "Referência da transação"
+  },
+  "jHJmjf": {
+    "string": "Sem resultados"
+  },
+  "jL3caQ": {
+    "context": "resent code success message",
+    "string": "Código reenviado ao cliente"
+  },
+  "jL7f0z": {
+    "string": "Nenhuma condição adicionada, clique no botão abaixo para criar uma"
+  },
+  "jMzyU8": {
+    "context": "tax classes card header",
+    "string": "Classes de imposto"
+  },
+  "jNSOSu": {
+    "context": "cancelled fulfillment, section header",
+    "string": "Reembolsado e Devolvido ({quantity})"
+  },
+  "jNoqH0": {
+    "string": "Criar promoção"
+  },
+  "jOgiMP": {
+    "string": "NÃO"
+  },
+  "jTifz+": {
+    "string": "Atributo criado com sucesso"
+  },
+  "jU9GPX": {
+    "context": "section header",
+    "string": "Organizar Conteúdo"
+  },
+  "jUuHVn": {
+    "context": "description",
+    "string": "Nenhum membro encontrado"
+  },
+  "jWna9Q": {
+    "string": "Nome do tipo de conteúdo"
+  },
+  "jXf/9p": {
+    "context": "product availability",
+    "string": "Ocultar em listagens de produtos"
+  },
+  "jZbT0O": {
+    "string": "Adicione título e descrição ao mecanismo de busca para facilitar a localização desta página"
+  },
+  "ja+tNj": {
+    "string": "solicita acesso a novas permissões."
+  },
+  "jd/LWa": {
+    "string": "Cupom se aplica a todos os países"
+  },
+  "jgURyO": {
+    "context": "product price",
+    "string": "Selecionar canal"
+  },
+  "jhh/D6": {
+    "string": "Menu título"
+  },
+  "jhyt3I": {
+    "context": "label for max capturable amount when partial authorization",
+    "string": "Máximo restante (autorizado)"
+  },
+  "jiXbx5": {
+    "context": "fulfillment status canceled",
+    "string": "Cancelado"
+  },
+  "jj3Cb8": {
+    "context": "informations about product prices etc, header",
+    "string": "Informações Financeiras"
+  },
+  "jm/spn": {
+    "string": "Redefinir"
+  },
+  "jm2YzF": {
+    "context": "description",
+    "string": "Use o Saleor Cloud para acessar as Extensões do Saleor"
+  },
+  "jmZSK1": {
+    "string": "O produto não está disponível nos canais selecionados"
+  },
+  "jmh0rV": {
+    "context": "no gift card products alert message",
+    "string": "{createGiftCardProduct} para começar a vender cartões-presente em sua loja."
+  },
+  "joN8sy": {
+    "string": "A extensão não possui permissões concedidas."
+  },
+  "jp2Jjs": {
+    "context": "automatic completion cut-off date description",
+    "string": "Somente checkouts criados nesta data ou depois serão concluídos automaticamente. Se não definido, o horário atual será usado. {link}"
+  },
+  "jqJqdE": {
+    "context": "VariantDetailsChannelsAvailabilityCard no items available",
+    "string": "Esta variante não está disponível em nenhum dos canais"
+  },
+  "jqnwW9": {
+    "context": "header",
+    "string": "Webhooks"
+  },
+  "jswILH": {
+    "context": "add attribute as column in product list table",
+    "string": "Adicionar às opções de Colunas"
+  },
+  "ju8zHP": {
+    "string": "Os códigos postais adicionados serão excluídos do uso destes métodos de entrega. Se nenhum for adicionado, todos os códigos postais poderão usar essa taxa de envio"
+  },
+  "juBV+h": {
+    "string": "Hora de Término"
+  },
+  "juxCV3": {
+    "context": "dialog header",
+    "string": "Atribuir produto"
+  },
+  "jvKNMP": {
+    "string": "Código de Desconto"
+  },
+  "jvo0vs": {
+    "string": "Salvar"
+  },
+  "jvz9Mr": {
+    "string": "Configurações do site atualizadas"
+  },
+  "jwTwhf": {
+    "context": "app privacy policy link",
+    "string": "Veja a política de privacidade desta extensão."
+  },
+  "jww7Wl": {
+    "context": "confirmation dialog title",
+    "string": "Gerar {count} variantes?"
+  },
+  "jxoMLL": {
+    "context": "product field",
+    "string": "Coleções"
+  },
+  "jyTwDR": {
+    "context": "product type is either simple or configurable",
+    "string": "Tipo"
+  },
+  "jyaAlB": {
+    "context": "button",
+    "string": "Criar coleção"
+  },
+  "jz2SlO": {
+    "context": "refunded fulfillment, section header",
+    "string": "Substituído"
+  },
+  "jzu97k": {
+    "context": "attribute product type",
+    "string": "Tipo de produto"
+  },
+  "k+HcTv": {
+    "context": "product type",
+    "string": "Tipo"
+  },
+  "k/mTEl": {
+    "context": "distance units type",
+    "string": "Distância"
+  },
+  "k0rGBI": {
+    "string": "Token de acesso é usado para autenticar contas de serviços"
+  },
+  "k20lqw": {
+    "string": "Fluxo legado detectado - selecione a estratégia de imposto no dropdown"
+  },
+  "k3EI/U": {
+    "context": "dialog header",
+    "string": "Excluir Zona de Envio"
+  },
+  "k4brJy": {
+    "string": "SKU"
+  },
+  "k5lHFp": {
+    "context": "app data privacy link",
+    "string": "Saiba mais sobre a privacidade de dados"
+  },
+  "k62BKw": {
+    "context": "select label",
+    "string": "Desmarcar"
+  },
+  "k6WDZl": {
+    "context": "attribute is visible",
+    "string": "Visível"
+  },
+  "k6kIUq": {
+    "context": "password login mode option",
+    "string": "Habilitado"
+  },
+  "k6sfZr": {
+    "context": "tooltip content when product is in preorder",
+    "string": "Este produto ainda está em pré-venda. Você poderá cumpri-lo após a data de lançamento."
+  },
+  "k8ZJ5L": {
+    "context": "number of products",
+    "string": "No de Produtos"
+  },
+  "k8bltk": {
+    "string": "Sem resultados"
+  },
+  "k9hf7F": {
+    "context": "total order price",
+    "string": "Total"
+  },
+  "kAAlGL": {
+    "string": "Regras"
+  },
+  "kAEQyV": {
+    "string": "OK"
+  },
+  "kAPaN6": {
+    "context": "empty metadata text",
+    "string": "Vazio"
+  },
+  "kBCNfL": {
+    "context": "Button to verify product availability via public API",
+    "string": "Verificar via API pública"
+  },
+  "kEAjZV": {
+    "context": "rich text attribute type",
+    "string": "Texto Rico"
+  },
+  "kErneR": {
+    "string": "Este cliente não tem nenhum endereço adicionado ao catálogo de endereços. Você pode adicionar um endereço usando o botão abaixo."
+  },
+  "kFQvXv": {
+    "string": "Você atingiu o limite do seu armazém, não poderá mais adicionar armazéns à sua loja. Se desejar aumentar seu limite, entre em contato com a equipe administrativa sobre como aumentar seus limites."
+  },
+  "kFYlu2": {
+    "string": "O sistema está no modo somente leitura. Alterações não foram salvas."
+  },
+  "kFkMoG": {
+    "context": "set balance dialog subtitle",
+    "string": "Como você gostaria de definir o saldo dos cartões. Quando você altera o saldo, ambos os valores serão alterados"
+  },
+  "kFkPWB": {
+    "string": "Número"
+  },
+  "kFsTMN": {
+    "string": "Excluir clientes"
+  },
+  "kG44rx": {
+    "context": "dialog header",
+    "string": "Despublicar modelos"
+  },
+  "kIcyUo": {
+    "context": "column header",
+    "string": "Slug"
+  },
+  "kIvvax": {
+    "string": "Pesquisar Produtos..."
+  },
+  "kJQczl": {
+    "context": "sales section name",
+    "string": "Vendas"
+  },
+  "kJYa8Y": {
+    "context": "grant refund, refund card calculated refund value",
+    "string": "Valor de reembolso selecionado:"
+  },
+  "kL3C+K": {
+    "context": "product variant inventory status",
+    "string": "Inventário"
+  },
+  "kMziE/": {
+    "string": "Referência do PSP"
+  },
+  "kN6SLs": {
+    "string": "Valor Min."
+  },
+  "kPIZ65": {
+    "context": "page header",
+    "string": "Pedido  #{orderNumber}"
+  },
+  "kQq6/o": {
+    "context": "info when addresses search is unsuccessful",
+    "string": "Nenhum resultado encontrado"
+  },
+  "kRnxj2": {
+    "context": "Suffix for show-more button when hidden problems include both active and critical",
+    "string": ", incluindo {active} ativo e {critical} crítico"
+  },
+  "kS5Qgk": {
+    "context": "used by label",
+    "string": "Usado por"
+  },
+  "kTr2o8": {
+    "string": "Nome do atributo"
+  },
+  "kVKTwC": {
+    "context": "order expiration card title",
+    "string": "Expiração do pedido"
+  },
+  "kVL3LM": {
+    "string": "Códigos de voucher"
+  },
+  "kVOslW": {
+    "context": "reason for discount label",
+    "string": "Motivo do desconto"
+  },
+  "kVTWtR": {
+    "context": "product updated at",
+    "string": "Ultima atualização"
+  },
+  "kWuOqa": {
+    "context": "badge for variant that already exists",
+    "string": "Existe"
+  },
+  "kXqn6A": {
+    "context": "table header column",
+    "string": "Cobrar impostos"
+  },
+  "kYYbrv": {
+    "context": "channel publication date",
+    "string": "Publicado desde {date}"
+  },
+  "kZfIl/": {
+    "string": "Estas são informações gerais sobre este tipo de conteúdo."
+  },
+  "kak5vT": {
+    "context": "order refund amount",
+    "string": "Valor dos produtos selecionados"
+  },
+  "kbezTI": {
+    "string": "A extensão não fornece uma descrição."
+  },
+  "kbkjEc": {
+    "context": "navigator catalog mode description",
+    "string": "Pesquisar no Catálogo"
+  },
+  "kc4c4d": {
+    "context": "product label",
+    "string": "Produto comprado para ganhar vale-presente"
+  },
+  "kcMVsB": {
+    "context": "balance amound missing error message",
+    "string": "O valor do saldo está faltando"
+  },
+  "kdK1YM": {
+    "context": "placeholder for SKU prefix input",
+    "string": "ex: CAMISA"
+  },
+  "kdRcqU": {
+    "string": "Pesquisar clientes..."
+  },
+  "kfvvnM": {
+    "string": "O valor fornecido não pode exceder o valor cobrado pela transação selecionada"
+  },
+  "kgVqk1": {
+    "string": "Nome da categoria"
+  },
+  "ki2FY7": {
+    "context": "Badge label for webhook delivery error problems",
+    "string": "Entrega do webhook"
+  },
+  "ki7Mr8": {
+    "context": "product export to csv file, header",
+    "string": "Configurações de Exportação"
+  },
+  "kkFOHD": {
+    "context": "gift card history message",
+    "string": "O cartão-presente foi reembolsado em um pedido"
+  },
+  "kn7jjd": {
+    "context": "section header",
+    "string": "Configurações gerais"
+  },
+  "knO/IN": {
+    "context": "delete model",
+    "string": "Você tem certeza de que deseja excluir {title}?"
+  },
+  "kny5j9": {
+    "context": "section title",
+    "string": "Login por senha"
+  },
+  "kp2IYP": {
+    "context": "option",
+    "string": "Tipo de produto de vale-presente"
+  },
+  "kpRxSA": {
+    "context": "Require email confirmation link",
+    "string": "Exigir link de confirmação de e-mail"
+  },
+  "kr1PlW": {
+    "string": "Expanda ou restrinja as permissões da extensão para acessar certas partes do sistema Saleor."
+  },
+  "krer6Z": {
+    "string": "Prévia de recursos"
+  },
+  "kuo4fW": {
+    "context": "dialog title",
+    "string": "Capturar transação manual"
+  },
+  "kv3FWU": {
+    "context": "btn label",
+    "string": "Ir para pedidos"
+  },
+  "kvSYZh": {
+    "context": "replacement created order history message description",
+    "string": "foi criado para produtos substituídos"
+  },
+  "l0a2tU": {
+    "context": "onboarding step description",
+    "string": "Ir para todos os produtos de onde você pode criar um novo produto e visualizá-lo em toda a lista de produtos. Veja o produto em GraphQL"
+  },
+  "l1/Hwb": {
+    "context": "invalid date in expirydate field header",
+    "string": "Data incorreta inserida"
+  },
+  "l1pZJx": {
+    "string": "Não totalmente autorizado"
+  },
+  "l2oVCF": {
+    "context": "attributes section name",
+    "string": "Atributos"
+  },
+  "l3iOju": {
+    "context": "transaction event type, transaction was refunded to client",
+    "string": "Reembolso"
+  },
+  "l4o0ar": {
+    "context": "voucher type order discount",
+    "string": "Voucher: {voucherName}"
+  },
+  "l5V0QT": {
+    "context": "boolean attribute type",
+    "string": "Boolean"
+  },
+  "l9ETHu": {
+    "context": "checkbox label description",
+    "string": "Você poderá entregar produtos sem capturar o pagamento do pedido."
+  },
+  "l9Lwjh": {
+    "context": "order return error title when cannot refund",
+    "string": "Não foi possível reembolsar produtos"
+  },
+  "lCEp2/": {
+    "context": "save button disabled tooltip",
+    "string": "Definir preços para todos os canais para salvar"
+  },
+  "lCPxtT": {
+    "context": "resend code label",
+    "string": "Reenviar código"
+  },
+  "lCxfDe": {
+    "context": "attribute properties regarding dashboard",
+    "string": "Propriedades do Painel de Controle"
+  },
+  "lDdWo9": {
+    "string": "Metadados de Cumprimento"
+  },
+  "lDdj6f": {
+    "context": "page header",
+    "string": "Criar modelo"
+  },
+  "lEG/12": {
+    "context": "Webhook subscription query card title",
+    "string": "Consulta de Assinatura"
+  },
+  "lF+VJQ": {
+    "context": "Shipment information card header",
+    "string": "Informações de envio"
+  },
+  "lG/MDw": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza que você quer deletar este atributo?} other {Tem certeza que você quer deletar {displayQuantity} atributos?}}"
+  },
+  "lGlDEH": {
+    "context": "header",
+    "string": "Membros do grupo"
+  },
+  "lHccsy": {
+    "context": "table head",
+    "string": "Nome da variante"
+  },
+  "lJP1iw": {
+    "context": "order",
+    "string": "Canal"
+  },
+  "lL1HTg": {
+    "string": "Pedido sinalizado como pago"
+  },
+  "lL3YJO": {
+    "context": "collection",
+    "string": "Publicado "
+  },
+  "lL57q7": {
+    "string": "Configurações do pedido atualizadas"
+  },
+  "lLKEMH": {
+    "string": "Use as configurações de reembolso para configurar os motivos disponíveis (permissões necessárias)"
+  },
+  "lLwtgs": {
+    "string": "As variações estão desativadas neste tipo de produto"
+  },
+  "lNZuWl": {
+    "string": "Todos os pedidos"
+  },
+  "lQRnYK": {
+    "context": "selectt all options",
+    "string": "Selecionar Tudo"
+  },
+  "lQofIt": {
+    "context": "Full badge label with optional critical count suffix",
+    "string": "{count, plural, one {{count} problema} other {{count} problemas}}{hasCritical, select, true {, incluindo {criticalCount} crítico} other {}}"
+  },
+  "lSOmbK": {
+    "context": "fulfillment status fulfilled",
+    "string": "Cumprido"
+  },
+  "lT5MYM": {
+    "context": "dialog title",
+    "string": "Cancelar atribuição de usuários"
+  },
+  "lTrKHs": {
+    "string": "Ir para produtos"
+  },
+  "lUvX5F": {
+    "string": "Imagem adicionada"
+  },
+  "lVZ5n7": {
+    "context": "variant attribute",
+    "string": "Atributo"
+  },
+  "lVwmf5": {
+    "context": "total price of ordered products",
+    "string": "Total"
+  },
+  "lW5uJO": {
+    "context": "money",
+    "string": "de {money}"
+  },
+  "lXq4EE": {
+    "context": "checkbox",
+    "string": "Reembolso de envio: {currency} {amount}"
+  },
+  "lZC/1a": {
+    "string": "maior que {value}"
+  },
+  "lZTwh4": {
+    "string": "Recurso"
+  },
+  "la9cZ4": {
+    "string": " Taxa de imposto"
+  },
+  "labkPK": {
+    "context": "search gift card placeholder",
+    "string": "Pesquisar cartões-presente, e.g {exampleGiftCardCode}"
+  },
+  "lb5uDM": {
+    "context": "metadata edit form, error message",
+    "string": "A chave de metadados não pode estar vazia"
+  },
+  "lct0qd": {
+    "string": "Esta lista exibe todos os atributos que serão atribuídos às páginas que possuem este tipo de página atribuído."
+  },
+  "lehGc9": {
+    "context": "section header",
+    "string": "Variantes elegíveis"
+  },
+  "lfXze9": {
+    "string": "Excluir vouchers"
+  },
+  "lgateT": {
+    "context": "Warning when no stock in channel warehouses",
+    "string": "Sem estoque nos armazéns para \"{channelName}\""
+  },
+  "lhfPkc": {
+    "context": "variant stocks section subtitle",
+    "string": "Atribuir os estoques será possível após o produto ser salvo."
+  },
+  "li1BBk": {
+    "context": "export items as csv file",
+    "string": "Arquivo CSV"
+  },
+  "liLrVs": {
+    "context": "save filter tab, header",
+    "string": "Salvar Pesquisa Personalizada"
+  },
+  "ljwv+L": {
+    "context": "discount value label",
+    "string": "Valor do desconto"
+  },
+  "ll2dE6": {
+    "context": "PageTypeDeleteWarningDialog multiple assigned items description",
+    "string": "Você tem certeza de que deseja excluir os tipos de página selecionados? Se você removê-los, não será capaz de atribuí-los às páginas criadas."
+  },
+  "llBnr+": {
+    "string": "Nome do Depósito"
+  },
+  "llC1q8": {
+    "context": "button",
+    "string": "App home page"
+  },
+  "lm9NSK": {
+    "context": "password reset, button",
+    "string": "Envie um e-mail com link de redefinição"
+  },
+  "lnQAos": {
+    "context": "header",
+    "string": "Impostos"
+  },
+  "lnteBJ": {
+    "context": "country rates list label for the default rate",
+    "string": "Taxa padrão do país"
+  },
+  "loEfAh": {
+    "context": "onboarding completed message",
+    "string": "Onboarding concluído 🎉"
+  },
+  "lqIzC8": {
+    "string": "Este campo precisa ser único"
+  },
+  "lqkgFU": {
+    "context": "webhook input help text",
+    "string": "A chave secreta é usada para criar uma assinatura de hash com cada payload. *campo opcional"
+  },
+  "lra7Ej": {
+    "string": "Aplicar preço único a todos os SKUs"
+  },
+  "lrq8O6": {
+    "context": "order refund amount, input label",
+    "string": "Montante"
+  },
+  "ltSmln": {
+    "string": "Zona de envio excluída"
+  },
+  "lw9WIk": {
+    "context": "deleted multiple attributes",
+    "string": "Atributos excluídos com sucesso"
+  },
+  "lwjzVj": {
+    "string": "Editar pedido"
+  },
+  "lz7o8y": {
+    "context": "tooltip when generate button is disabled because over variant limit",
+    "string": "Não é possível criar mais de {limit} variantes de uma só vez"
+  },
+  "lzdvwp": {
+    "context": "field is optional",
+    "string": "Opcional"
+  },
+  "m0Dz+2": {
+    "string": "Por favor, configure uma nova senha para sua conta. Repita sua nova senha para ter certeza de que será capaz de lembrá-la."
+  },
+  "m19JfL": {
+    "string": "Visualizar e atualizar plugins e suas configurações."
+  },
+  "m2Jb3P": {
+    "string": "Você não tem permissão para gerenciar tokens de autenticação. Entre em contato com seu administrador para obter acesso."
+  },
+  "m6IBe5": {
+    "context": "invoice number prefix",
+    "string": "Fatura"
+  },
+  "m7EwFg": {
+    "context": "warning when preview is truncated due to too many combinations",
+    "string": "Sua seleção criaria {total} variantes. Você pode gerar até {limit} de cada vez."
+  },
+  "m8cjcK": {
+    "context": "add authorization key error",
+    "string": "Já existe uma chave de autorização com este tipo"
+  },
+  "m9I/YK": {
+    "context": "Shown when there are no available failed delivery logs for a webhook event.",
+    "string": "Os logs de entregas falhadas não estão disponíveis"
+  },
+  "m9Q2yf": {
+    "string": "Configurações do plugin atualizadas"
+  },
+  "m9ndUn": {
+    "context": "Link label to navigate to webhook settings for an app",
+    "string": "Verificar webhooks"
+  },
+  "mAabef": {
+    "context": "checkbox label",
+    "string": "O grupo tem acesso total à loja"
+  },
+  "mBSBtn": {
+    "string": "Correspondência de prefixo"
+  },
+  "mCP0UD": {
+    "context": "order draft creation date",
+    "string": "Data"
+  },
+  "mDgOmP": {
+    "context": "channel publication status",
+    "string": "Visível"
+  },
+  "mE+fru": {
+    "context": "tag filter label",
+    "string": "Tags"
+  },
+  "mFC5Rq": {
+    "string": "Atribuir Armazéns"
+  },
+  "mFr9YY": {
+    "context": "configuration section name for refund settings",
+    "string": "Configurações de Reembolsos"
+  },
+  "mGiA6q": {
+    "context": "modal button upload",
+    "string": "Upload"
+  },
+  "mIRBuW": {
+    "string": "Está publicado"
+  },
+  "mIUNgR": {
+    "context": "button",
+    "string": "Criar Zona de Envio"
+  },
+  "mLZMb6": {
+    "context": "ChannelsSection select field label",
+    "string": "Canal"
+  },
+  "mMOskm": {
+    "string": "Abrir detalhes do produto"
+  },
+  "mQtoRO": {
+    "context": "taxes title",
+    "string": "Impostos (IVA incluído)"
+  },
+  "mSCZd4": {
+    "context": "Webhook details asynchronous events",
+    "string": "Assíncrono"
+  },
+  "mSLr9d": {
+    "context": "voucher code, button",
+    "string": "Gerar Código"
+  },
+  "mSS92b": {
+    "string": "Regra sem título"
+  },
+  "mTEqYL": {
+    "context": "NoChannels content",
+    "string": "Sem canais para atribuir. Por favor, primeiro atribua-os ao produto."
+  },
+  "mUb8Gt": {
+    "context": "section header",
+    "string": "Impostos"
+  },
+  "mWQt3s": {
+    "string": "No de Produtos"
+  },
+  "mWYRZY": {
+    "context": "order history message",
+    "string": "Produtos foram adicionados ao pedido"
+  },
+  "mX7zJJ": {
+    "context": "header",
+    "string": "Criar Página"
+  },
+  "mYs3tb": {
+    "string": "O preço do produto não pode ser inferior a 0."
+  },
+  "mZrAiu": {
+    "context": "extension installation page, label for manifest URL input",
+    "string": "Fornecer URL do Manifesto"
+  },
+  "maxT+q": {
+    "context": "save button",
+    "string": "Confirmar pedido"
+  },
+  "mbOuGl": {
+    "context": "customer gift cards card issue button",
+    "string": "Emitir novo cartão"
+  },
+  "mbj1J5": {
+    "context": "bulk issue gift cards success alert description",
+    "string": "Os {cardsAmount} solicitados foram emitidos com sucesso"
+  },
+  "md326v": {
+    "string": "{amount, plural,one {Um pagamento para capturar} other {{amount} pagamentos para capturar}}"
+  },
+  "me585h": {
+    "context": "navigator section header",
+    "string": "Ações rápidas"
+  },
+  "mgFyBA": {
+    "string": "Este nome deve ser único"
+  },
+  "mkBgDe": {
+    "string": "Tipos de produto excluídos"
+  },
+  "mm0CXe": {
+    "string": "Você deve alterar sua senha todo mês para evitar problemas de segurança"
+  },
+  "mmcHeH": {
+    "string": "Valor de Desconto"
+  },
+  "mqwLmD": {
+    "string": "Menu atualizado"
+  },
+  "mr9jbO": {
+    "string": "Língua Preferida"
+  },
+  "msbMCT": {
+    "context": "Error when no variant is in channel",
+    "string": "Nenhuma variante listada neste canal"
+  },
+  "mslSpp": {
+    "context": "resend code to customer title",
+    "string": "Reenviar código ao cliente"
+  },
+  "mvDujQ": {
+    "context": "Description when product is visible in listings",
+    "string": "Aparece em páginas de categoria, coleções e resultados de pesquisa."
+  },
+  "mvVmbJ": {
+    "string": "Instalar extensão a partir do manifesto"
+  },
+  "mxGY7T": {
+    "context": "status pill for no authorization",
+    "string": "Sem Autorização"
+  },
+  "mxtAFx": {
+    "string": "Tem certeza de que deseja excluir o rascunho #{orderNumber}?"
+  },
+  "myyWNp": {
+    "context": "dialog header",
+    "string": "Adicionar Produto"
+  },
+  "mzASqs": {
+    "context": "days after label",
+    "string": "Dias após a emissão"
+  },
+  "n+Gwbu": {
+    "string": "Descontos"
+  },
+  "n02c9W": {
+    "context": "product variant price",
+    "string": "Preço"
+  },
+  "n0RwMK": {
+    "string": "Defina os tipos de produtos que você vende"
+  },
+  "n0w2ZT": {
+    "context": "label for currently selected warehouse",
+    "string": "atualmente selecionado"
+  },
+  "n25d+d": {
+    "context": "WarehousesSection select field add text",
+    "string": "Adicionar Novo Depósito"
+  },
+  "n3+6w5": {
+    "context": "input helper text",
+    "string": "Seu cliente não poderá comprar uma quantidade maior por finalização de compra do que a indicada aqui."
+  },
+  "n51nG4": {
+    "context": "Description for no stock warning",
+    "string": "Adicione estoque a pelo menos um armazém atribuído a este canal."
+  },
+  "n5vskv": {
+    "context": "customer's address book, header",
+    "string": "Catálogo de Endereços de {fullName}"
+  },
+  "n7Fg8i": {
+    "string": "Venda criada com sucesso"
+  },
+  "n7GIKB": {
+    "context": "dialog header",
+    "string": "Cancelar atribuição de produto da venda"
+  },
+  "n97Ii0": {
+    "context": "export selected items to csv file",
+    "string": "Vales-presente selecionados ({number})"
+  },
+  "n9JOI3": {
+    "context": "money amount input label",
+    "string": "Insira o valor"
+  },
+  "nABmvC": {
+    "string": "Número de linhas"
+  },
+  "nBzIBG": {
+    "string": "Excluir grupo de permissões"
+  },
+  "nEWp+k": {
+    "context": "quantity of ordered products",
+    "string": "Quantidade"
+  },
+  "nEixpu": {
+    "context": "table action",
+    "string": "Ações"
+  },
+  "nFTvQW": {
+    "context": "expiration date label",
+    "string": "Data de validade"
+  },
+  "nG1+Cz": {
+    "context": "staff members status active",
+    "string": "Ativo"
+  },
+  "nHmugP": {
+    "context": "order history message",
+    "string": "Faturados {quantidade} itens"
+  },
+  "nIrjSR": {
+    "context": "section header",
+    "string": "Instalações em Andamento"
+  },
+  "nIuKz3": {
+    "context": "Refund status none",
+    "string": "Rascunho"
+  },
+  "nIwoHa": {
+    "context": "delete app",
+    "string": "Ao excluir {name}, você removerá a instalação da extensão. Se você estiver pagando pela assinatura da extensão, lembre-se de cancelar a assinatura da extensão no Marketplace do Saleor."
+  },
+  "nJ0tek": {
+    "context": "tab name",
+    "string": "Todos os pedidos em rascunho"
+  },
+  "nK68Sg": {
+    "context": "model availability date label",
+    "string": "Definir data de disponibilidade"
+  },
+  "nKjLjT": {
+    "context": "error message",
+    "string": "Slug deve ser único para cada depósito"
+  },
+  "nKwgxY": {
+    "context": "select label",
+    "string": "Nome do canal"
+  },
+  "nLML8Y": {
+    "string": "Endereço de Entrega Padrão"
+  },
+  "nMojhT": {
+    "context": "Clear filters button text",
+    "string": "Redefinir"
+  },
+  "nNeWAx": {
+    "context": "dialog header",
+    "string": "Excluir Forma de Envio"
+  },
+  "nOo0oL": {
+    "context": "error message",
+    "string": "Itens insuficientes para faturar"
+  },
+  "nQQVdc": {
+    "string": "Ir para vouchers"
+  },
+  "nRiOg+": {
+    "string": "Desculpe, página não encontada"
+  },
+  "nSMe3f": {
+    "context": "Refund in progress transaction amount, data display header",
+    "string": "Reembolso pendente"
+  },
+  "nTF6tG": {
+    "context": "number of order",
+    "string": "Núm. do Pedido"
+  },
+  "nUp0Lp": {
+    "context": "tab label for variant selection attributes",
+    "string": "Atributos de seleção"
+  },
+  "nX2pCU": {
+    "context": "window title",
+    "string": "Criar cliente"
+  },
+  "nXGVlP": {
+    "string": "Taxa de envio criada"
+  },
+  "nYD7NT": {
+    "string": "Transação #{index} em {date}"
+  },
+  "nZDQbr": {
+    "context": "column header",
+    "string": "Nome do cliente"
+  },
+  "nayZY0": {
+    "context": "returned event title",
+    "string": "Produtos foram devolvidos por"
+  },
+  "nb2FlN": {
+    "string": "Extensões"
+  },
+  "nf3XSt": {
+    "context": "attribute internal name",
+    "string": "Slug"
+  },
+  "nfbabo": {
+    "context": "channel publication date",
+    "string": "Estará disponível em {date}"
+  },
+  "nfgSR+": {
+    "context": "Error when product has no variants",
+    "string": "Nenhuma variante criada"
+  },
+  "ng0ZDW": {
+    "context": "label, input for amount to refund in transaction",
+    "string": "Valor do reembolso"
+  },
+  "ngAgBy": {
+    "context": "tax class rates list label when no countries are assigned",
+    "string": "Não há países usando esta classe de imposto ainda, use a aba {tab} para atribuir taxas de imposto."
+  },
+  "ngSJ7N": {
+    "context": "alert title",
+    "string": "Sua consulta de assinatura requer as seguintes permissões:"
+  },
+  "ninItd": {
+    "string": "Criar cliente"
+  },
+  "njBulj": {
+    "context": "check to require attribute to have value",
+    "string": "Valor Necessário"
+  },
+  "njUQPz": {
+    "context": "shipping method price range",
+    "string": "Faixa de valor"
+  },
+  "nki0o/": {
+    "context": "replaced products list title",
+    "string": "Produtos substituídos"
+  },
+  "nngeI3": {
+    "context": "amount title",
+    "string": "Valor reembolsado"
+  },
+  "no3Ygn": {
+    "string": "Tem certeza de que deseja excluir o valor \"{name}\"? Se você excluí-lo, não poderá atribuí-lo a nenhum dos produtos com o atributo \"{attributeName}\"."
+  },
+  "nudPsY": {
+    "context": "metadata field name, header",
+    "string": "Campo"
+  },
+  "nvSJNR": {
+    "context": "discount reason input lavel",
+    "string": "Razão"
+  },
+  "nwcJVT": {
+    "context": "When enabled, all transactions would require an additional step to be charged.",
+    "string": "Quando ativado, todas as transações exigiriam um passo adicional para serem cobradas. ({link})"
+  },
+  "nwnwJ0": {
+    "context": "payment status",
+    "string": "Refused"
+  },
+  "nwvQPg": {
+    "context": "section header",
+    "string": "Empresa"
+  },
+  "ny4zrH": {
+    "context": "dialog title",
+    "string": "Excluir Depósito"
+  },
+  "nyhf9b": {
+    "context": "Add filter button text",
+    "string": "+ Adicionar filtro"
+  },
+  "o/4OCR": {
+    "string": "O envio já foi reembolsado"
+  },
+  "o5GUx9": {
+    "string": "Saldo devedor"
+  },
+  "o5KXAN": {
+    "context": "delete webhook",
+    "string": "Tem certeza de que deseja excluir {name}?"
+  },
+  "o6260f": {
+    "context": "attributes, section header",
+    "string": "Seleção de Atributos da Variação"
+  },
+  "o68j+t": {
+    "string": "Pesquisar membros da equipe..."
+  },
+  "o7ePJQ": {
+    "string": "Ir para clientes"
+  },
+  "o8S0Ac": {
+    "context": "usage limit uses left caption",
+    "string": "Usos restantes"
+  },
+  "o8f4Sg": {
+    "context": "disabled option description",
+    "string": "Não é possível cumprir até que o pagamento seja capturado"
+  },
+  "oB0y5Y": {
+    "context": "order status",
+    "string": "Não faturado"
+  },
+  "oChkS4": {
+    "context": "success message",
+    "string": "Variações criadas com sucesso"
+  },
+  "oEFc87": {
+    "context": "Warning when no shipping zones configured",
+    "string": "Sem zonas de envio"
+  },
+  "oHbgcK": {
+    "context": "PageTypeDeleteWarningDialog title",
+    "string": "Excluir página {selectedTypesCount,plural,one{type} other{types}}"
+  },
+  "oIMMcO": {
+    "context": "no warehouses info",
+    "string": "Não existem depósito configurados para sua loja. Você pode configurar variações sem fornecer quantidades em estoque."
+  },
+  "oIS3NK": {
+    "context": "button",
+    "string": "Mostrar mais"
+  },
+  "oIvtua": {
+    "context": "attribute's editor component",
+    "string": "Tipo de entrada do catálogo para o proprietário da loja"
+  },
+  "oJkeS6": {
+    "string": "Código do Atributo"
+  },
+  "oL7VUz": {
+    "string": "Metadados do pedido"
+  },
+  "oLMXDv": {
+    "context": "order status",
+    "string": "Pronto para faturar"
+  },
+  "oOFrUd": {
+    "context": "export products to csv file, button",
+    "string": "exportar produtos"
+  },
+  "oQ27V4": {
+    "context": "order history message",
+    "string": "Order placed information was sent to customer"
+  },
+  "oQY0a2": {
+    "string": "Endereço linha 2"
+  },
+  "oQhFlK": {
+    "context": "refunded fulfillment, section header",
+    "string": "Reembolsado ({quantity})"
+  },
+  "oUWADl": {
+    "string": "Não"
+  },
+  "oUWXLO": {
+    "context": "header",
+    "string": "Página de tradução \"{pageName}\" - {languageCode}"
+  },
+  "oVDZUb": {
+    "context": "tab name",
+    "string": "Todos Tipos de Página"
+  },
+  "oX2TAb": {
+    "string": "Selecionar presentes"
+  },
+  "oYGfnY": {
+    "string": "CEP"
+  },
+  "oYV+Ru": {
+    "context": "staff members status deactivated",
+    "string": "Inativo"
+  },
+  "oZFssJ": {
+    "context": "tooltip when generate button is disabled because required attributes are not filled",
+    "string": "Preencha todos os atributos obrigatórios na aba Atributos Obrigatórios"
+  },
+  "obHpf0": {
+    "string": "Nenhuma extensão encontrada"
+  },
+  "oboeOT": {
+    "string": "Adicionar as seguintes permissões"
+  },
+  "odpDdj": {
+    "context": "order history message",
+    "string": "Itens foram vendidos a mais"
+  },
+  "oegjWf": {
+    "context": "attribute values list: no search results",
+    "string": "Nenhum valor corresponde à sua pesquisa"
+  },
+  "of/+iV": {
+    "context": "transaction event type, refund was reversed, funds are back to store account",
+    "string": "Reembolso revertido"
+  },
+  "ofT0HH": {
+    "context": "Info box description for unpublished products",
+    "string": "Os clientes não podem encontrar ou visualizar este produto."
+  },
+  "ofewGR": {
+    "string": "Ir para pedidos"
+  },
+  "oiuwOl": {
+    "context": "button",
+    "string": "Atribuir"
+  },
+  "ojHyj3": {
+    "context": "discount value label",
+    "string": "Valor do desconto"
+  },
+  "opIDox": {
+    "context": "unassign product from sale and save, button",
+    "string": "Cancelar atribuição e salvar"
+  },
+  "orvpWh": {
+    "string": "Voltar"
+  },
+  "osPBn1": {
+    "context": "currency filter label",
+    "string": "Moeda"
+  },
+  "owCz2y": {
+    "context": "message when matrix view cannot be shown",
+    "string": "A visualização em matriz requer exatamente 2 atributos com valores selecionados"
+  },
+  "p+UDec": {
+    "context": "payment status",
+    "string": "Pagamento"
+  },
+  "p/EWEZ": {
+    "context": "channels variants availability dialog title",
+    "string": "Gerenciar canais"
+  },
+  "p/Fd7s": {
+    "context": "unassign products from shipping rate and save, button",
+    "string": "Cancelar atribuição e salvar"
+  },
+  "p/m4dD": {
+    "context": "onboarding step title",
+    "string": "Convidar membros da equipe"
+  },
+  "p0SUJj": {
+    "string": "Não se preocupe, vamos consertar isso em breve. Tente atualizar a página ou voltar ao painel."
+  },
+  "p12BmC": {
+    "context": "transaction refund tiles disabled transaction",
+    "string": "Esta transação não é reembolsável."
+  },
+  "p3eRUm": {
+    "context": "indicator that feature is in preview mode",
+    "string": "Visualização"
+  },
+  "p4X/0H": {
+    "context": "button, assign variants to sale and save",
+    "string": "Atribuir e salvar"
+  },
+  "p4zuQp": {
+    "context": "product no longer exists error title",
+    "string": "O produto não existe mais"
+  },
+  "p6ugX0": {
+    "context": "button to keep order",
+    "string": "Manter pedido"
+  },
+  "p9bXAy": {
+    "context": "default transaction name",
+    "string": "Transação"
+  },
+  "pA8Mlv": {
+    "context": "alert",
+    "string": "Staff Member limit reached"
+  },
+  "pAwBtz": {
+    "string": "Valor da recompensa"
+  },
+  "pBTTtU": {
+    "context": "product kind",
+    "string": "Tipo de produto"
+  },
+  "pC6/1z": {
+    "string": "Formato de manifesto inválido"
+  },
+  "pCjZEC": {
+    "context": "Error when channel is not active",
+    "string": "Canal \"{channelName}\" está inativo"
+  },
+  "pCy5EP": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi ativado"
+  },
+  "pEf/m+": {
+    "string": "Não há prévias no momento. Fique atento!"
+  },
+  "pFVX6g": {
+    "string": "Variante com esses atributos já existe"
+  },
+  "pGDYG5": {
+    "context": "search label",
+    "string": "Pesquisar Países"
+  },
+  "pGwvpX": {
+    "context": "status",
+    "string": "Desativado"
+  },
+  "pJ5/7G": {
+    "string": "Fechar e ocultar todas as dicas"
+  },
+  "pMAlSC": {
+    "context": "Shown when a value cannot be determined due to permissions",
+    "string": "Desconhecido"
+  },
+  "pMXWrd": {
+    "context": "Label for available for purchase toggle",
+    "string": "Disponível para compra"
+  },
+  "pNrF72": {
+    "context": "tab name",
+    "string": "Todos os Cupons"
+  },
+  "pNxrLQ": {
+    "string": "Tipo de modelo criado"
+  },
+  "pOUOnw": {
+    "context": "tab name",
+    "string": "Todos os vouchers"
+  },
+  "pRYGUR": {
+    "context": "section description",
+    "string": "Este endereço será usado para gerar faturas e calcular taxas de envio. O endereço de e-mail fornecido aqui será usado como endereço de contato para seus clientes."
+  },
+  "pSFOFy": {
+    "context": "relative time in days",
+    "string": "{days}d atrás"
+  },
+  "pSb46V": {
+    "context": "dialog header",
+    "string": "Criar estrutura"
+  },
+  "pSqXo6": {
+    "string": "Pedido Relacionado"
+  },
+  "pTpx0p": {
+    "context": "order history message",
+    "string": "Fatura nº {invoiceNumber} foi gerada por {generatedBy}"
+  },
+  "pURrk1": {
+    "context": "order status",
+    "string": "Status"
+  },
+  "pVFoOk": {
+    "string": "Tem certeza de que deseja excluir {collectionName}?"
+  },
+  "pWClYm": {
+    "context": "card title",
+    "string": "Configurações padrão"
+  },
+  "paa4m0": {
+    "string": "Tipo de produto criado com sucesso"
+  },
+  "pbGIUg": {
+    "context": "sales channel",
+    "string": "Canal"
+  },
+  "pc36KX": {
+    "context": "PageTypeDeleteWarningDialog multiple consent label",
+    "string": "Sim, eu quero excluir esses tipos de modelo e modelos atribuídos"
+  },
+  "pdJlXC": {
+    "string": "Veja todos os resultados de pesquisa global"
+  },
+  "pepgIN": {
+    "string": "Escolha o Tipo de Modelo cujos Modelos estendidos servirão como motivos de reembolso."
+  },
+  "pgTwKM": {
+    "context": "section header",
+    "string": "Atributos do modelo"
+  },
+  "phAZoj": {
+    "string": "Coleção"
+  },
+  "phIGQ1": {
+    "context": "Canceled transaction amount, data display header",
+    "string": "Cancelado"
+  },
+  "pkUbrL": {
+    "string": "Informações Gerais"
+  },
+  "pkjXPD": {
+    "context": "order status",
+    "string": "Completo"
+  },
+  "ppLwx3": {
+    "context": "number of categories",
+    "string": "Categorias ({quantity})"
+  },
+  "pr/aHj": {
+    "context": "success gift card disable message",
+    "string": "Cartão-presente desativado"
+  },
+  "pr513b": {
+    "context": "ordered products",
+    "string": "{quantity} itens"
+  },
+  "ps+h1G": {
+    "context": "checkbox label description",
+    "string": "A data de validade será definida automaticamente assim que o cartão-presente for emitido"
+  },
+  "ps0WUQ": {
+    "string": "Núm. do Pedido"
+  },
+  "psmnv9": {
+    "string": "Editar permissões"
+  },
+  "ptPPVk": {
+    "string": "Nenhuma linguagem encontrada"
+  },
+  "puALFo": {
+    "context": "notes about customer, header",
+    "string": "Notas"
+  },
+  "puRlnN": {
+    "context": "card subtitle",
+    "string": "Preços inseridos"
+  },
+  "puYVLm": {
+    "context": "relative time in hours",
+    "string": "{hours}h atrás"
+  },
+  "puikeb": {
+    "context": "button",
+    "string": "Excluir Endereço"
+  },
+  "pwqwcy": {
+    "context": "error message",
+    "string": "Preço máximo não pode ser menor que o mínimo"
+  },
+  "pyiyxe": {
+    "context": "button",
+    "string": "Criar modelo"
+  },
+  "pzSF+b": {
+    "context": "voucher usage limit, header",
+    "string": "Limite de Uso"
+  },
+  "q+gCyP": {
+    "context": "order payment",
+    "string": "Valor reembolsado"
+  },
+  "q/FMPM": {
+    "context": "dialog header",
+    "string": "Publicar modelos"
+  },
+  "q1shey": {
+    "context": "key-value field input",
+    "string": "Chave"
+  },
+  "q3IT3J": {
+    "context": "extensions list has been removed",
+    "string": "Extensão removida"
+  },
+  "q4EmsW": {
+    "string": "Total:"
+  },
+  "q5I8Ac": {
+    "string": "Ocorreu um erro inesperado do GraphQL. ({errorCode})"
+  },
+  "q5Lfp4": {
+    "context": "tooltip",
+    "string": "O pedido contém produtos que têm \"Rastrear inventário\" ativado."
+  },
+  "q7bXR4": {
+    "string": "Resumo de pagamentos"
+  },
+  "q7v0W7": {
+    "context": "save draft button",
+    "string": "Salvar rascunho"
+  },
+  "q8ep2I": {
+    "context": "dialog header",
+    "string": "Deletar clientes"
+  },
+  "qACBaj": {
+    "string": "Ocorreu um erro inesperado. ({errorCode})"
+  },
+  "qC6HKe": {
+    "string": "Desconto criado"
+  },
+  "qCH2eZ": {
+    "context": "header",
+    "string": "Adicionar Valor ao Campo de Autorização"
+  },
+  "qDwvZ4": {
+    "string": "Erro desconhecido"
+  },
+  "qEJT8e": {
+    "string": "Nova senha deve conter ao menos 8 caracteres"
+  },
+  "qEZ463": {
+    "context": "export selected items to csv file",
+    "string": "Produtos selecionados ({number})"
+  },
+  "qGwKT/": {
+    "string": "Extensão desativada. Ative a extensão nas configurações."
+  },
+  "qIVtUd": {
+    "context": "Modal header showing total problem count for an app",
+    "string": "Todos os problemas ({count})"
+  },
+  "qIgdO6": {
+    "string": "Personalizar Filtro"
+  },
+  "qJedl0": {
+    "context": "product label",
+    "string": "Publicado "
+  },
+  "qKiqXs": {
+    "context": "Date suffix for toggle controls",
+    "string": "desde {date}"
+  },
+  "qL9Oi9": {
+    "string": "Título da Estrutura"
+  },
+  "qLOBff": {
+    "context": "dialog header",
+    "string": "Excluir Endereço"
+  },
+  "qLaeSH": {
+    "context": "Number of countries and territories covered by shipping",
+    "string": "{count} países/territórios cobertos"
+  },
+  "qLbse5": {
+    "context": "button",
+    "string": "Sair"
+  },
+  "qMB6d2": {
+    "context": "weight",
+    "string": "para {value} {unit}"
+  },
+  "qMEm+l": {
+    "string": "Pesquisar Extensões..."
+  },
+  "qNcoRY": {
+    "context": "notes about customer header",
+    "string": "Notas"
+  },
+  "qNeXG1": {
+    "context": "User registration",
+    "string": "Registro de usuário"
+  },
+  "qOXgxv": {
+    "context": "gift card history message",
+    "string": "O cartão-presente foi reembolsado no pedido {orderLink}"
+  },
+  "qPSWmL": {
+    "string": "Digite o uso"
+  },
+  "qPXvFH": {
+    "context": "order history message",
+    "string": "O desconto do produto foi removido"
+  },
+  "qQih8j": {
+    "context": "voucher status scheduled",
+    "string": "Agendado"
+  },
+  "qRMXUE": {
+    "context": "card header",
+    "string": "Modo de login por senha"
+  },
+  "qRmntJ": {
+    "context": "extensions list ready to be used",
+    "string": "{name} está pronto para ser usado"
+  },
+  "qSCmIG": {
+    "string": "menor que {value}"
+  },
+  "qT0qr/": {
+    "context": "attribute page type",
+    "string": "Tipo de página"
+  },
+  "qT6YYk": {
+    "context": "order line total price",
+    "string": "Total"
+  },
+  "qVT7rt": {
+    "context": "Badge label showing number of errors",
+    "string": "{count, plural, one {{count} erro} other {{count} erros}}"
+  },
+  "qYukJi": {
+    "context": "Status when product is partially configured",
+    "string": "Agendado"
+  },
+  "qZB1cn": {
+    "string": "Este Tipo de Modelo ainda não tem modelos criados."
+  },
+  "qZHHed": {
+    "context": "stock exceeded dialog title",
+    "string": "Estoque insuficiente"
+  },
+  "qa/dDe": {
+    "context": "GraphiQL Playground in the dev mode panel",
+    "string": "Playground"
+  },
+  "qank7+": {
+    "string": "Continuar com SSO"
+  },
+  "qbFKVI": {
+    "context": "notification, form submitted",
+    "string": "Reembolso para o pedido #{orderNumber} foi concedido"
+  },
+  "qbcNjQ": {
+    "context": "table header column",
+    "string": "Nome do imposto"
+  },
+  "qbmeUI": {
+    "context": "dialog header",
+    "string": "Excluir rascunhos de pedido"
+  },
+  "qbqMpk": {
+    "context": "product variant preorder threshold",
+    "string": "Em pré-encomenda"
+  },
+  "qddy2Z": {
+    "context": "order history message",
+    "string": "A fatura foi enviada ao cliente por {sentBy} "
+  },
+  "qf/m5l": {
+    "string": "Tem certeza que você deseja deletar a zona {shippingZoneName}?"
+  },
+  "qf8OtW": {
+    "string": "Continuar com o Saleor Cloud"
+  },
+  "qgQeVW": {
+    "string": "Gerar Códigos de Voucher"
+  },
+  "qkRuT0": {
+    "context": "attribute type",
+    "string": "Atributo de Produto"
+  },
+  "qkUBLC": {
+    "string": "Ver logs"
+  },
+  "qkt/Km": {
+    "context": "bulk delete label",
+    "string": "Excluir"
+  },
+  "qlfssi": {
+    "context": "label for remaining amount customer owes",
+    "string": "Saldo devedor"
+  },
+  "qov29K": {
+    "context": "dialog content",
+    "string": "Selecione um dos endereços do cliente ou adicione um novo endereço: "
+  },
+  "qpQ0uB": {
+    "context": "product publication date",
+    "string": "Não publicado"
+  },
+  "qrWOxx": {
+    "string": "Nenhum membro encontrado"
+  },
+  "qtF0Ft": {
+    "context": "transaction event type, amount was authorized, but not captured",
+    "string": "Autorização"
+  },
+  "qu/hXD": {
+    "string": "Selecionado {number} itens"
+  },
+  "qu8b3v": {
+    "context": "PageTypeDeleteWarningDialog multiple consent label",
+    "string": "Sim, quero excluir esses tipos de páginas e as páginas atribuídas"
+  },
+  "quV5zH": {
+    "context": "dialog title",
+    "string": "Excluir Token"
+  },
+  "qwp4zK": {
+    "context": "Health check subtitle when product can be purchased",
+    "string": "O produto é visível na loja e disponível para compra"
+  },
+  "qy/XqL": {
+    "string": "Selecionar transação"
+  },
+  "qyJtWy": {
+    "string": "Mostrar menos"
+  },
+  "qzDwLa": {
+    "context": "Invalid url value",
+    "string": "URL inválido"
+  },
+  "r+8q4B": {
+    "context": "error message",
+    "string": "Apenas rascunhos de pedidos podem ser editados"
+  },
+  "r+dgiv": {
+    "string": "Impostos"
+  },
+  "r0hgpM": {
+    "context": "product publication date",
+    "string": "Será publicado em {date}"
+  },
+  "r1aQ2f": {
+    "context": "dialog header",
+    "string": "Cancelar atribuição de atributo do tipo de produto"
+  },
+  "r2dojI": {
+    "context": "checkbox label",
+    "string": "Restrict order weight"
+  },
+  "r2i5Fn": {
+    "context": "PageTypeDeleteWarningDialog multiple assigned items description",
+    "string": "Você tem certeza de que deseja excluir os tipos de modelo selecionados? Se você removê-los, não poderá atribuí-los aos modelos criados."
+  },
+  "r4UnCw": {
+    "string": "Ao emitir um reembolso concedido, selecione a transação à qual deseja aplicar o reembolso."
+  },
+  "r4g/vD": {
+    "context": "search modal billing title",
+    "string": "Endereço de cobrança"
+  },
+  "r5h6qc": {
+    "context": "model type name",
+    "string": "Nome do Tipo de Modelo"
+  },
+  "r7uSVR": {
+    "context": "model seo options description",
+    "string": "Adicione título e descrição do mecanismo de busca para facilitar a localização deste modelo"
+  },
+  "r86alc": {
+    "context": "button",
+    "string": "Copiado"
+  },
+  "rCy3Fe": {
+    "context": "invalid date in expirydate field content",
+    "string": "Não é possível criar vale-presente com data de validade vencida"
+  },
+  "rH4pi3": {
+    "context": "page header",
+    "string": "Retornar e substituir produtos"
+  },
+  "rHQmCt": {
+    "context": "column picker section header",
+    "string": "Personalizado"
+  },
+  "rHXF43": {
+    "string": "Aqui está o resumo das variações que serão criadas. Você pode alterar os preços, estocar um SKU para cada um criado."
+  },
+  "rHoRbE": {
+    "context": "Status label when object is unpublished in a channel",
+    "string": "Não publicado"
+  },
+  "rIJbNC": {
+    "string": "Use variações para produtos que tenham uma variedade de versões, por exemplo diferentes tamanhos ou cores"
+  },
+  "rJ3lkW": {
+    "context": "VariantDetailsChannelsAvailabilityCard item subtitle published",
+    "string": "Publicado desde {publicationDate}"
+  },
+  "rKf4LU": {
+    "context": "dialog title",
+    "string": "Deletar atributos"
+  },
+  "rLnEAj": {
+    "context": "Health check error when product not available",
+    "string": "Incapaz de verificar"
+  },
+  "rNzkIt": {
+    "context": "dialog content",
+    "string": "Tem certeza de que deseja excluir {saleName}?"
+  },
+  "rPX1f2": {
+    "context": "section title",
+    "string": "Informações da Empresa"
+  },
+  "rQOS7K": {
+    "context": "status label active",
+    "string": "Ativo"
+  },
+  "rUnw7n": {
+    "string": "Configurar comportamento de reembolsos"
+  },
+  "rVIlBs": {
+    "context": "page header with order number",
+    "string": "Pedido  #{orderNumber}"
+  },
+  "rVaB7c": {
+    "context": "attribute values, variant creation step",
+    "string": "Selecione os Valores"
+  },
+  "rZMT44": {
+    "context": "created channels counter",
+    "string": "{count}/{max} canais utilizados"
+  },
+  "rZf1qL": {
+    "context": "bulk variant create error",
+    "string": "SKUs devem ser únicos"
+  },
+  "ra2O4j": {
+    "string": "Excluir pedidos de rascunho"
+  },
+  "rbkmfG": {
+    "context": "button",
+    "string": "Excluir variação"
+  },
+  "rbrahO": {
+    "string": "Fechar"
+  },
+  "rccigC": {
+    "context": "option label prefix for using a typed email address",
+    "string": "Usar e-mail:"
+  },
+  "reP5Uf": {
+    "context": "global config plugin status popup description",
+    "string": "Plug-ins globais são definidos em todos os canais do seu comércio eletrônico. Apenas o status é mostrado para esses tipos de plug-ins"
+  },
+  "rfvBAF": {
+    "context": "select all options, button",
+    "string": "Selecionar Tudo"
+  },
+  "rhSI1/": {
+    "string": "Modelo"
+  },
+  "ri3kK9": {
+    "context": "order placement date",
+    "string": "Data"
+  },
+  "rjy9/k": {
+    "context": "button",
+    "string": "Adicionar Endereço"
+  },
+  "rl1t+o": {
+    "context": "expires in label",
+    "string": "Expira em"
+  },
+  "roQH8c": {
+    "context": "Description when product is not visible in listings",
+    "string": "Os clientes ainda podem acessá-lo via link direto."
+  },
+  "rpFdD1": {
+    "string": "Pesquisar Tipo de Produto"
+  },
+  "rqiCWU": {
+    "string": "Alterações salvas"
+  },
+  "rqtV5d": {
+    "context": "order status",
+    "string": "Pronto para capturar"
+  },
+  "rr8fyf": {
+    "context": "header",
+    "string": "Principais produtos"
+  },
+  "rrbzZt": {
+    "string": "Subcategoria não encontrada"
+  },
+  "rs815i": {
+    "context": "text field label",
+    "string": "Nome do grupo"
+  },
+  "rvk9ls": {
+    "context": "attribute can be used only in variants",
+    "string": "Variação Apenas"
+  },
+  "rwOx2s": {
+    "string": "Forneça uma referência de transação usando a entrada abaixo:"
+  },
+  "rxNddi": {
+    "string": "Página inicial"
+  },
+  "rxlJJ/": {
+    "context": "grant refund table, column header",
+    "string": "Produto"
+  },
+  "ryAyPr": {
+    "string": "A fatura solicitada foi gerada. Ela foi adicionada ao topo da lista de faturas nesta visualização. Aproveite!"
+  },
+  "rzhcpD": {
+    "context": "set expiry date selected label",
+    "string": "Defina a data de validade do vale-presente"
+  },
+  "s/sTT6": {
+    "string": "Se vazio, a pré-visualização será auto-gerada."
+  },
+  "s17U7u": {
+    "context": "discount type",
+    "string": "Porcentagem"
+  },
+  "s1IQuN": {
+    "context": "resend button label",
+    "string": "Reenviar"
+  },
+  "s2y5eG": {
+    "context": "Status label",
+    "string": "Status"
+  },
+  "s3jmO9": {
+    "context": "input label",
+    "string": "Notas de razão"
+  },
+  "s3xi3B": {
+    "context": "extension form app name field label",
+    "string": "Nome da Extensão"
+  },
+  "s40PZt": {
+    "string": "Nome de Venda"
+  },
+  "s51tHd": {
+    "context": "limit voucher",
+    "string": "Limite de Usuários"
+  },
+  "s5Imt5": {
+    "context": "button",
+    "string": "Editar SEO do site"
+  },
+  "s5v6m0": {
+    "context": "order",
+    "string": "Vale-presente solicitado"
+  },
+  "s6lW8R": {
+    "context": "option label",
+    "string": "Alterar endereço"
+  },
+  "s6oAC+": {
+    "context": "search label",
+    "string": "Pesquisar produtos"
+  },
+  "s8FlDW": {
+    "context": "hide error log label in notification",
+    "string": "Ocultar registro"
+  },
+  "s8e+7y": {
+    "string": "Atributo atualizado"
+  },
+  "s97tLq": {
+    "string": "Pesquisar coleções"
+  },
+  "s9sOcC": {
+    "context": "button",
+    "string": "OK"
+  },
+  "sAqzEK": {
+    "context": "no products placeholder",
+    "string": "Nenhum produto disponível"
+  },
+  "sDMNfc": {
+    "context": "bulk issue structure item",
+    "string": "Emissão em massa"
+  },
+  "sE7fI/": {
+    "context": "allow legacy gift card use label",
+    "string": "Permitir uso de cartão-presente legado"
+  },
+  "sEjRyz": {
+    "context": "voucher type order discount",
+    "string": "Cupom"
+  },
+  "sFynTT": {
+    "context": "grant refund, refund card title",
+    "string": "Reembolso"
+  },
+  "sG0w22": {
+    "context": "dialog title",
+    "string": "Deletar categorias"
+  },
+  "sGDsFP": {
+    "context": "header name input",
+    "string": "Deve corresponder a `x-*`, `authorization*`, ou `brokerproperties`."
+  },
+  "sHON47": {
+    "context": "refunded products list title",
+    "string": "Produtos reembolsados"
+  },
+  "sK1FPw": {
+    "context": "categories section name",
+    "string": "Categorias"
+  },
+  "sOlOZB": {
+    "context": "gift cards page subheader",
+    "string": "Saiba mais sobre {giftCards}"
+  },
+  "sQMS4n": {
+    "context": "Tooltip for the dismiss problem button",
+    "string": "Forçar limpar este erro. Use se você souber o que está fazendo"
+  },
+  "sR0urA": {
+    "context": "dialog content",
+    "string": "Tem certeza de que deseja excluir {name}?"
+  },
+  "sS5aVm": {
+    "context": "voucher discount type",
+    "string": "Envio Grátis"
+  },
+  "sW9IyX": {
+    "context": "dialog header",
+    "string": "Atribuir Categoria"
+  },
+  "sWvBZa": {
+    "string": "Endereço criado"
+  },
+  "sXSde1": {
+    "context": "link to docs in add custom extensions page subheader",
+    "string": "formato do manifesto"
+  },
+  "sZ27WU": {
+    "context": "error message",
+    "string": "Apenas pagamentos previamente autorizados podem ser anulados"
+  },
+  "sZ4enl": {
+    "string": "Exclui resultados que correspondem ao termo"
+  },
+  "saKXY3": {
+    "context": "product label",
+    "string": "Não publicado"
+  },
+  "scHVdW": {
+    "context": "button",
+    "string": "Atribuir produto"
+  },
+  "scTuDZ": {
+    "string": "Salvar pesquisa como preset"
+  },
+  "sdA14A": {
+    "context": "Status label when object is published in a channel",
+    "string": "Publicado "
+  },
+  "se5+j/": {
+    "context": "transaction refund tiles transaction name",
+    "string": "Transação"
+  },
+  "sedoZ3": {
+    "context": "VariantDetailsChannelsAvailabilityCard title",
+    "string": "Disponibilidade"
+  },
+  "sf6FMK": {
+    "context": "dialog search placeholder",
+    "string": "Pesquisar por nome de categoria, etc...."
+  },
+  "sfEbeB": {
+    "string": "Você vai marcar este pedido como pago."
+  },
+  "sfErC+": {
+    "string": "Nome do Cupom"
+  },
+  "shmSDX": {
+    "context": "no products placeholder",
+    "string": "Nenhum produto está disponível no canal atribuído a este pedido."
+  },
+  "sidKce": {
+    "context": "delete channel",
+    "string": "Todas as informações do pedido deste canal precisam ser movidas para um canal diferente. Por favor selecione os pedidos do canal que devem ser movidos para :."
+  },
+  "sjRXXz": {
+    "string": "O pedido nº {orderId} foi feito a partir do rascunho por {userEmail}"
+  },
+  "skEK/i": {
+    "context": "section header",
+    "string": "Atributos da Variação"
+  },
+  "skPoVe": {
+    "context": "button",
+    "string": "Aceitar"
+  },
+  "skklRz": {
+    "context": "table header column",
+    "string": "Mostrar preços brutos na vitrine"
+  },
+  "slKV5G": {
+    "context": "variant creation step",
+    "string": "Resumo"
+  },
+  "sn2awN": {
+    "context": "ExitFormPrompt cancel button",
+    "string": "Descartar mudanças"
+  },
+  "snUby7": {
+    "context": "header",
+    "string": "Detalhes sem nome do webhook"
+  },
+  "spjKeI": {
+    "string": "Cumprimento aprovado"
+  },
+  "stjHjY": {
+    "context": "error message",
+    "string": "Código promocional já existe"
+  },
+  "suAexp": {
+    "context": "aria label for list view button",
+    "string": "Visualização em lista"
+  },
+  "svK+kv": {
+    "string": "{counter,plural,one {Tem certeza de que deseja excluir este menu?} other {Tem certeza de que deseja excluir {displayQuantity} menus?}}"
+  },
+  "sw8Wl2": {
+    "context": "variant pricing section subtitle",
+    "string": "There is no channel to define prices for. You need to first add variant to channels to define prices."
+  },
+  "swOKYO": {
+    "string": "Descubra as últimas melhorias, novos recursos, correções e melhorias de desempenho que tornam sua experiência no painel ainda melhor."
+  },
+  "sy+pv5": {
+    "string": "E-mail"
+  },
+  "szXISP": {
+    "context": "permission group name",
+    "string": "Nome do Grupo de Permissão"
+  },
+  "t/R8nK": {
+    "context": "ShippingZoneSettingsCard title",
+    "string": "Configurações"
+  },
+  "t1Bd7E": {
+    "string": "Pagamento capturado"
+  },
+  "t1scMK": {
+    "string": "Configurações de reembolsos"
+  },
+  "t3aiWF": {
+    "context": "section header",
+    "string": "Produtos Excluídos"
+  },
+  "t4hWFu": {
+    "context": "Shown while verification is in progress",
+    "string": "Verificando..."
+  },
+  "t7UwLY": {
+    "context": "voucher status",
+    "string": "Expirado"
+  },
+  "t84lbb": {
+    "context": "empty list message",
+    "string": "Você ainda não atribuiu nenhum membro a este grupo de permissões."
+  },
+  "t9a9GQ": {
+    "string": "Nós criamos seu token. Certifique-se de copiar seu novo token de acesso pessoal agora. Você não será capaz de vê-lo novamente."
+  },
+  "tA5HJx": {
+    "context": "webhook input help text",
+    "string": "a chave é utilizada para criar uma assinatura hash em cada requisição. * campo opcional"
+  },
+  "tCLTCb": {
+    "context": "tab name",
+    "string": "Todos os produtos"
+  },
+  "tEdFmZ": {
+    "context": "notification title",
+    "string": "System update required"
+  },
+  "tI7/Ib": {
+    "string": "Extensão solicitou permissões que não estão disponíveis no Saleor."
+  },
+  "tIc2/h": {
+    "context": "input helper text, search attributes",
+    "string": "Pesquisar por nome do atributo"
+  },
+  "tIc6ZH": {
+    "string": "Ir para métodos de envio"
+  },
+  "tKxCld": {
+    "context": "set balance dialog title label",
+    "string": "Definir saldo"
+  },
+  "tLM9Jr": {
+    "string": "A operação não pode ser realizada no momento. Isso pode ser devido a uma instalação pendente com o mesmo identificador. {docsLink} ({errorCode})"
+  },
+  "tQuE1q": {
+    "string": "Selecione os canais que deseja para {contentType} esteja disponível em"
+  },
+  "tQxBXs": {
+    "context": "PageTypeDeleteWarningDialog single assigned items description",
+    "string": "Você está prestes a excluir o tipo de página <b>{typeName}</b>. Ele está atribuído a {assignedItemsCount} {assignedItemsCount,plural,one{página} other{páginas}}. Excluir este tipo de página também excluirá essas páginas. Tem certeza de que deseja fazer isso?"
+  },
+  "tR+UuE": {
+    "string": "Usuário não existe. Por favor, verifique seu e-mail na URL"
+  },
+  "tS2K/N": {
+    "context": "radio option for capturing order total",
+    "string": "Total do pedido"
+  },
+  "tTtoKd": {
+    "context": "error message",
+    "string": "Desculpe, seu nome de usuário e/ou senha estão incorretos. Por favor, tente novamente."
+  },
+  "tTuCYj": {
+    "context": "all gift cards label",
+    "string": "Todos os vales-presente"
+  },
+  "tUlsq+": {
+    "string": "Translating"
+  },
+  "tV+Dcm": {
+    "string": "País padrão"
+  },
+  "tV5QlB": {
+    "string": "Coleções excluídas"
+  },
+  "tVybuM": {
+    "context": "WarehouseSettings local warehouse label",
+    "string": "Somente estoque local"
+  },
+  "tWbE34": {
+    "string": "Hora Início"
+  },
+  "tXIgmR": {
+    "context": "balance curreny missing error message",
+    "string": "A moeda do saldo está faltando"
+  },
+  "tZ+8E3": {
+    "context": "spinner aria label on login page",
+    "string": "Carregando métodos de login"
+  },
+  "tZ/9Sl": {
+    "string": "Convidar usuário/membro da equipe"
+  },
+  "tZnV8L": {
+    "context": "Header row stock label",
+    "string": "Estoque"
+  },
+  "taS/08": {
+    "context": "variant stocks section subtitle",
+    "string": "Atribua esta variante a um canal no gerenciador de canais de produtos para definir a alocação de armazéns"
+  },
+  "taX/V3": {
+    "context": "order total amount",
+    "string": "Total"
+  },
+  "tf+OkY": {
+    "context": "link to edit variant metadata",
+    "string": "Editar na página da variante"
+  },
+  "tiY7bx": {
+    "string": "Adicionar novo produto"
+  },
+  "tl1/1E": {
+    "string": "Saiba mais sobre {orderManagement}"
+  },
+  "tlGXkh": {
+    "context": "input description",
+    "string": "Ilimitado"
+  },
+  "tmcdrp": {
+    "string": "ID:"
+  },
+  "tmrBDK": {
+    "string": "Transação manual ({amount}) foi criada"
+  },
+  "toDL5R": {
+    "context": "order status",
+    "string": "Rascunho"
+  },
+  "tqJwfo": {
+    "context": "button",
+    "string": "Definir data de término"
+  },
+  "tsL3IW": {
+    "context": "gift card history message",
+    "string": "O vale-presente foi enviado ao cliente"
+  },
+  "ttMauu": {
+    "context": "window title",
+    "string": "Criar coleção"
+  },
+  "tthToS": {
+    "string": "Desativado"
+  },
+  "ttk0w7": {
+    "context": "resend code to customer description",
+    "string": "O código do vale-presente será reenviado para o e-mail fornecido durante a finalização da compra. Você pode fornecer um endereço de e-mail diferente se desejar:"
+  },
+  "tuYPlG": {
+    "context": "minimum amount of spent money to activate voucher",
+    "string": "Gasto Mínimo"
+  },
+  "turLD8": {
+    "context": "Health check status when product cannot be purchased",
+    "string": "Os clientes não podem comprar este produto"
+  },
+  "tvpAXl": {
+    "context": "ordered product quantity",
+    "string": "Quantidade"
+  },
+  "txOXvy": {
+    "context": "checkbox label",
+    "string": "Defina o mesmo para endereço de entrega"
+  },
+  "tzMNF3": {
+    "string": "Status"
+  },
+  "u/hkKO": {
+    "context": "voucher has no requirements",
+    "string": "Nenhum"
+  },
+  "u/vOPu": {
+    "string": "Pago"
+  },
+  "u0S2be": {
+    "context": "order discount",
+    "string": "Desconto"
+  },
+  "u0V06N": {
+    "string": "Peso Máx. do Pedido"
+  },
+  "u24Ppd": {
+    "string": "Este atributo não pode ser atribuído a este tipo de produto"
+  },
+  "u34css": {
+    "context": "label for empty list in channels list",
+    "string": "Não há exceções para este canal"
+  },
+  "u3sYPH": {
+    "context": "independent of any particular day, eg. 11:35",
+    "string": "Time"
+  },
+  "u3wnIS": {
+    "context": "Health check label for isPublished field",
+    "string": "Visível na loja"
+  },
+  "u5c/tR": {
+    "context": "channels discount info",
+    "string": "Os canais que não têm descontos atribuídos usarão seu canal pai para definir o preço. O preço será convertido para a moeda do canal"
+  },
+  "u6V5I/": {
+    "context": "shipping zones configuration",
+    "string": "Alterar unidade de peso padrão"
+  },
+  "u6rPuc": {
+    "context": "warning message when some variants failed to create",
+    "string": "{success, plural, one {# variante} other {# variantes}} criadas, {failed, plural, one {# falhou} other {# falharam}}"
+  },
+  "u7ShY+": {
+    "context": "pill status for overcaptured outcome",
+    "string": "Sobrecarregado"
+  },
+  "u9/vj9": {
+    "context": "webhook input label",
+    "string": "URL alvo"
+  },
+  "u9WrRb": {
+    "string": "Adicionar Extensões Personalizadas"
+  },
+  "uCn/rd": {
+    "context": "dialog header",
+    "string": "Excluir Imagem"
+  },
+  "uD93er": {
+    "context": "dialog header",
+    "string": "Changed Customer"
+  },
+  "uGqPKY": {
+    "string": "Selecione um Tipo de Modelo. Todos os Modelos que estendem o tipo estarão disponíveis como razões de reembolso ao emitir um reembolso."
+  },
+  "uIPD1i": {
+    "context": "app has been removed",
+    "string": "Aplicativo removido com sucesso"
+  },
+  "uIYU0D": {
+    "context": "section header",
+    "string": "Permissões de extensão"
+  },
+  "uKlrEk": {
+    "context": "all selected items message",
+    "string": "Todos os {itemsName} disponíveis foram selecionados"
+  },
+  "uMpv1v": {
+    "string": "Faturamento cancelado com sucesso"
+  },
+  "uN88fb": {
+    "context": "button, submit form",
+    "string": "Retornar e Substituir produtos"
+  },
+  "uOC/uQ": {
+    "string": "Imagem atualizada"
+  },
+  "uQNm59": {
+    "context": "add header,button",
+    "string": "Adicionar cabeçalho de solicitação personalizado"
+  },
+  "uQk8gB": {
+    "context": "export all items to csv file",
+    "string": "Todos os cartões-presente ({number})"
+  },
+  "uRTj1Q": {
+    "context": "error message",
+    "string": "Fatura não encontrada"
+  },
+  "uRfta0": {
+    "context": "Enable email confirmation",
+    "string": "Ativar confirmação por e-mail"
+  },
+  "uT3VS+": {
+    "context": "promotion status",
+    "string": "Status"
+  },
+  "uT5L4h": {
+    "context": "cancel button label",
+    "string": "Cancelar"
+  },
+  "uULcph": {
+    "context": "header",
+    "string": "Envio"
+  },
+  "uUQ+Al": {
+    "context": "note about customer",
+    "string": "Nota"
+  },
+  "uUsZ7m": {
+    "context": "order payment",
+    "string": "Quantidade pré-autorizada"
+  },
+  "uVssds": {
+    "context": "product variant inventory",
+    "string": "{stockQuantity,plural,one {{stockQuantity} disponível} other {{stockQuantity} disponíveis}}"
+  },
+  "uX+Vg7": {
+    "string": "Voucher atualizado"
+  },
+  "ubasgL": {
+    "context": "order history message",
+    "string": "Pedido foi confirmado"
+  },
+  "ubd+Kj": {
+    "string": "Pesquisar por nome…"
+  },
+  "ubmFc8": {
+    "string": "Instalar"
+  },
+  "ucLtY8": {
+    "string": "Regras de desconto para produtos, coleções ou categorias."
+  },
+  "ucYPtV": {
+    "context": "variant attribute",
+    "string": "Escolha o atributo"
+  },
+  "uccjUM": {
+    "context": "Dry run objects",
+    "string": "Objetos"
+  },
+  "ud0w8h": {
+    "context": "number of postal code ranges",
+    "string": "{number} intervalos de códigos postais"
+  },
+  "udJUSa": {
+    "context": "Authorize {app name}",
+    "string": "Autorizar"
+  },
+  "uf1ttM": {
+    "string": "Valor da recompensa da regra é obrigatório"
+  },
+  "ufD5Jr": {
+    "string": "Tipo de Conteúdo"
+  },
+  "ufahVh": {
+    "context": "collection filter hidden",
+    "string": "Oculto"
+  },
+  "ufmuTp": {
+    "context": "button",
+    "string": "Excluir"
+  },
+  "ugnggZ": {
+    "string": "Menu criado."
+  },
+  "uiZoY3": {
+    "context": "Status when product is scheduled for future publication",
+    "string": "Agendado para {date}"
+  },
+  "uilt7q": {
+    "context": "issued cards amount label",
+    "string": "Cartões emitidos"
+  },
+  "ujFo4A": {
+    "context": "voucher start date",
+    "string": "Iniciado"
+  },
+  "ukdRUv": {
+    "context": "delete variant dialog subtitle",
+    "string": "{counter,plural,one {Are you sure you want to delete this variant?} other {Are you sure you want to delete {displayQuantity} variants?}}"
+  },
+  "ukjCvM": {
+    "context": "empty state prompt",
+    "string": "Selecione valores acima para gerar variantes"
+  },
+  "ulh3kf": {
+    "string": "Coleções"
+  },
+  "ulzM2V": {
+    "string": "Explore extensões disponíveis"
+  },
+  "umsU70": {
+    "string": "Pesquisar Tipo de Página"
+  },
+  "un+VWt": {
+    "string": "Pesquisar produtos"
+  },
+  "undefined": {
+    "context": "error message",
+    "string": "Status inválido"
+  },
+  "uo8NOT": {
+    "string": "desconhecido"
+  },
+  "uoKAmI": {
+    "string": "Adicionar novo pedido"
+  },
+  "uqxjSR": {
+    "context": "column picker section header",
+    "string": "Colunas"
+  },
+  "usSkzP": {
+    "context": "navigator order mode description",
+    "string": "Pesquisar Pedidos"
+  },
+  "usjqAQ": {
+    "context": "Badge showing number of issues in a channel",
+    "string": "{count, plural, one {# problema} other {# problemas}}"
+  },
+  "utaSh3": {
+    "context": "staff member's account",
+    "string": "Status"
+  },
+  "uwO3oC": {
+    "string": "Ocorreu um erro inesperado ao salvar a extensão."
+  },
+  "uwk5e9": {
+    "string": "Excluir produtos"
+  },
+  "uxPpRx": {
+    "context": "button",
+    "string": "Atribuir atributo"
+  },
+  "uxZZXx": {
+    "context": "option",
+    "string": "Criar múltiplas variantes via criador de variantes"
+  },
+  "uy+tB8": {
+    "context": "voucher status",
+    "string": "Status"
+  },
+  "uzAPCt": {
+    "context": "OrderPayment does not require shipping",
+    "string": "não aplica"
+  },
+  "v+Pkm+": {
+    "context": "field is optional",
+    "string": "*Opcional. Adicionar produtos à coleção ajuda os usuários a encontrá-lo."
+  },
+  "v/1VA6": {
+    "context": "add order note, button",
+    "string": "Enviar"
+  },
+  "v/tz3W": {
+    "context": "Summary of diagnostic issues found",
+    "string": "{errorCount, plural, =0 {} one {# problema} other {# problemas}}{hasWarnings, select, true {{hasErrors, select, true {, } other {}}} other {}}{warningCount, plural, =0 {} one {# aviso} other {# avisos}} encontrados"
+  },
+  "v01/tY": {
+    "context": "consent to send gift card to different address checkbox label",
+    "string": "Sim, quero enviar o vale-presente para um endereço diferente"
+  },
+  "v17Lly": {
+    "context": "label",
+    "string": "Prazo máximo de entrega"
+  },
+  "v1pNHW": {
+    "string": "Classe do Atributo"
+  },
+  "v1vJ77": {
+    "string": "Editar regra"
+  },
+  "v2+u4c": {
+    "context": "card subtitle",
+    "string": "Atribua e classifique os armazéns que serão usados neste canal (os armazéns podem ser atribuídos em vários canais)."
+  },
+  "v20Mra": {
+    "string": "Menus excluídos"
+  },
+  "v3WWK+": {
+    "string": "Status é inválido"
+  },
+  "v8UngX": {
+    "string": "Pesquisar armazéns..."
+  },
+  "v8e93p": {
+    "context": "hint for order total option",
+    "string": "Corresponde ao que o cliente deve"
+  },
+  "v9D1pm": {
+    "context": "automatic completion cut-off date info message",
+    "string": "Definir uma data limite não interromperá checkouts que já estão em processo de conclusão."
+  },
+  "vAxm7u": {
+    "string": "Você deve selecionar um canal primeiro e selecionar pelo menos um presente"
+  },
+  "vC8vyb": {
+    "context": "enabled status option label",
+    "string": "Habilitado"
+  },
+  "vCw7BP": {
+    "context": "requires activation checkbox label",
+    "string": "Requer ativação"
+  },
+  "vDnheO": {
+    "context": "gift card bulk create success dialog accept button",
+    "string": "Ok"
+  },
+  "vDp2tH": {
+    "context": "all structures",
+    "string": "Todas as estruturas"
+  },
+  "vEYtiq": {
+    "string": "Nome da Categoria"
+  },
+  "vEwjub": {
+    "context": "button",
+    "string": "Abrir no GraphiQL"
+  },
+  "vG57x5": {
+    "context": "card update success alert title",
+    "string": "Saldo do cartão atualizado"
+  },
+  "vGfmv8": {
+    "context": "card title, app install page, about privacy",
+    "string": "Informação"
+  },
+  "vLc9Td": {
+    "context": "Title for public API verification section",
+    "string": "Verificação da API pública"
+  },
+  "vM9quW": {
+    "context": "order payment",
+    "string": "Paid with Gift Card"
+  },
+  "vMo6/3": {
+    "string": "Rastreamento: {trackingNumber}"
+  },
+  "vN3qdA": {
+    "context": "button",
+    "string": "Desfazer"
+  },
+  "vNaDeR": {
+    "context": "number of countries",
+    "string": "{count, plural, one {# País} other {# Países}}"
+  },
+  "vONi+O": {
+    "string": "País"
+  },
+  "vP7g2+": {
+    "context": "error message",
+    "string": "URL não definida para uma fatura"
+  },
+  "vQunFc": {
+    "context": "gift card history message",
+    "string": "A data de validade do vale-presente foi atualizada por {expiryUpdatedBy}"
+  },
+  "vSLaZ7": {
+    "string": "Selecione um tipo de razão"
+  },
+  "vTN5DZ": {
+    "context": "button",
+    "string": "Descartar"
+  },
+  "vTPu1s": {
+    "string": "Código Quantidade (máx {maxCodes})"
+  },
+  "vTgRTZ": {
+    "context": "limit voucher",
+    "string": "Limitar a um uso por cliente"
+  },
+  "vUY6ir": {
+    "string": "O valor deve ser maior que 0 ao transferir fundos"
+  },
+  "vV9xwl": {
+    "context": "order line discount added title",
+    "string": "Desconto de {productName} foi adicionado"
+  },
+  "vVviA2": {
+    "string": "Estas permissões estão fora do seu escopo"
+  },
+  "vW3tb6": {
+    "context": "name",
+    "string": "Nome do Produto"
+  },
+  "vWTM6Y": {
+    "context": "customer gift cards card no cards subtitle",
+    "string": "Não há cartões-presente atribuídos a este cliente"
+  },
+  "vWapBZ": {
+    "context": "card title",
+    "string": "Peso do Pedido"
+  },
+  "vXA5xU": {
+    "context": "option description",
+    "string": "Use o criador de variantes para criar uma matriz de valores de atributos selecionados para criar variantes"
+  },
+  "vXCeIi": {
+    "string": "Falhou"
+  },
+  "vXFPD6": {
+    "context": "voucher discount type",
+    "string": "Quantia Fixa"
+  },
+  "vY17L8": {
+    "context": "window title",
+    "string": "Criar tipo de modelo"
+  },
+  "vY2lpx": {
+    "context": "channels availability text",
+    "string": "Disponível em {count} de {allCount, plural, one {# channel} outros {# channels}}"
+  },
+  "vYMZxh": {
+    "context": "delete custom app",
+    "string": "Ao excluir {name}, você excluirá todos os dados e webhooks relacionados a esta extensão."
+  },
+  "vZMs8f": {
+    "context": "default product variant indicator",
+    "string": "Padrão"
+  },
+  "vaFjs6": {
+    "string": "Nenhum armazém disponível para adicionar"
+  },
+  "vazr6V": {
+    "context": "Button label to open the full problems modal for an app",
+    "string": "Abrir problemas do aplicativo"
+  },
+  "vbop3G": {
+    "string": "Criar novo modelo"
+  },
+  "vcMnX2": {
+    "context": "unfulfilled fulfillment, section header",
+    "string": "Linhas de pedido não atendidas"
+  },
+  "vcwrgW": {
+    "string": "Nenhuma entidade traduzível encontrada"
+  },
+  "vdk01u": {
+    "context": "product type",
+    "string": "Não enviável"
+  },
+  "ve/Sph": {
+    "context": "there are more elements of list that are hidden",
+    "string": "e {number} mais"
+  },
+  "vf56In": {
+    "context": "address type",
+    "string": "Use um dos endereços do cliente"
+  },
+  "vfG+nh": {
+    "string": "Confirmar Senha"
+  },
+  "viFkCw": {
+    "context": "site settings section name",
+    "string": "Configurações do Site"
+  },
+  "vitgwA": {
+    "string": "Sintaxe de pesquisa"
+  },
+  "vjsfyn": {
+    "string": "Valor Máx."
+  },
+  "vkAWwY": {
+    "context": "gift card history message",
+    "string": "As tags dos vales-presente foram atualizadas"
+  },
+  "vlLyvk": {
+    "string": "{inputType} atributos não podem ser usados ​​como atributos de seleção de variantes."
+  },
+  "vlRrLz": {
+    "context": "Warning when user moves publication date to the future",
+    "string": "Isso despublicará o produto até {date}."
+  },
+  "vlVTmY": {
+    "string": "Produto removido"
+  },
+  "voRaz3": {
+    "context": "custom apps content",
+    "string": "Seus aplicativos personalizados serão mostrados aqui."
+  },
+  "vof5TR": {
+    "context": "button",
+    "string": "Criar categoria."
+  },
+  "vpTyL1": {
+    "context": "error message",
+    "string": "O valor fornecido não pode exceder o valor cobrado pela transação selecionada"
+  },
+  "vprU7C": {
+    "string": "Selecionar canais de pedidos visíveis"
+  },
+  "vqu+23": {
+    "context": "success notifier message",
+    "string": "Rascunho salvo"
+  },
+  "vsSdHA": {
+    "context": "Description for status when product has availability issues",
+    "string": "Tem problemas de disponibilidade"
+  },
+  "vuKrlW": {
+    "string": "estoque"
+  },
+  "vwA9Fq": {
+    "context": "notification",
+    "string": "Modelos selecionados foram excluídos."
+  },
+  "vwMO04": {
+    "context": "draft order",
+    "string": "Criado"
+  },
+  "vy7fjd": {
+    "context": "tab name",
+    "string": "Todas as Categorias"
+  },
+  "vyVVAW": {
+    "context": "generate variants button",
+    "string": "Gerar variantes"
+  },
+  "vz3yxp": {
+    "string": "Permissões de canais"
+  },
+  "vzce9B": {
+    "context": "customer gift cards card subtitle",
+    "string": "Apenas cinco cartões-presente mais recentes são mostrados aqui"
+  },
+  "vzgZ3U": {
+    "context": "card header",
+    "string": "Entrar"
+  },
+  "w+3Q3e": {
+    "context": "input label",
+    "string": "Tipo de produto"
+  },
+  "w+5Djm": {
+    "string": "Peso Mín. do Pedido"
+  },
+  "w+8BfK": {
+    "context": "button",
+    "string": "Editar Endereço "
+  },
+  "w067gF": {
+    "context": "refund section header",
+    "string": "Reembolsos"
+  },
+  "w2Cewo": {
+    "string": "Titulo do mecanismo de busca"
+  },
+  "w2eTzO": {
+    "context": "placed orders counter",
+    "string": "{count}/{max} orders"
+  },
+  "w3gxER": {
+    "string": "Rastreamento atualizado"
+  },
+  "w3sGrD": {
+    "string": "Insira qualquer informação extra sobre este cliente."
+  },
+  "w424P4": {
+    "context": "section header",
+    "string": "Informação da Extensão e Status"
+  },
+  "w4R/SO": {
+    "string": "Aplicativos Locais"
+  },
+  "w4ZVcj": {
+    "context": "Status when product is not visible",
+    "string": "Oculto"
+  },
+  "w6Gau0": {
+    "context": "deactivate named app",
+    "string": "Tem certeza que deseja desabilitar {name}? Seus dados serão mantidos até que você reative o aplicativo. Você ainda será cobrado pelo aplicativo."
+  },
+  "w6kcxY": {
+    "string": "O que acontece se eu aprovar?"
+  },
+  "w7jT4W": {
+    "string": "Nenhum canal selecionado"
+  },
+  "w9xgN9": {
+    "context": "see error log label in notification",
+    "string": "Ver log de erros"
+  },
+  "wAGThK": {
+    "context": "dialog header",
+    "string": "Excluir estruturas"
+  },
+  "wBGCR1": {
+    "context": "Badge shown when channel is marked for removal",
+    "string": "para remover"
+  },
+  "wBRaTi": {
+    "context": "no models placeholder",
+    "string": "Nenhum modelo disponível"
+  },
+  "wDUBLR": {
+    "context": "order refund amount",
+    "string": "Valor de reembolso proposto"
+  },
+  "wDyvFZ": {
+    "context": "Next page button",
+    "string": "Próximo"
+  },
+  "wFVOKJ": {
+    "string": "Ir para armazéns"
+  },
+  "wHdMAX": {
+    "context": "sale value, header",
+    "string": "Valor"
+  },
+  "wJep/X": {
+    "context": "refund amounts were settled",
+    "string": "Liquidado"
+  },
+  "wL7VAE": {
+    "string": "Ações"
+  },
+  "wL850U": {
+    "context": "draft order lines, section header",
+    "string": "Linhas de pedido"
+  },
+  "wLB8B3": {
+    "context": "column header",
+    "string": "Visibilidade"
+  },
+  "wNQzS/": {
+    "string": "O endereço primário deste cliente."
+  },
+  "wO9wb5": {
+    "string": "GitHub"
+  },
+  "wOaLvi": {
+    "context": "relative time",
+    "string": "agora mesmo"
+  },
+  "wOeIR4": {
+    "context": "order history message",
+    "string": "Reabastecidos {quantidade} itens"
+  },
+  "wQdR8M": {
+    "string": "Adicione título e descrição ao mecanismo de busca para facilitar a localização desta categoria"
+  },
+  "wTHjt3": {
+    "string": "Pesquisar Pedidos..."
+  },
+  "wUQCnQ": {
+    "context": "Save filters button text",
+    "string": "Salvar"
+  },
+  "wUWSv2": {
+    "string": "Produtos excluídos"
+  },
+  "wVjyOX": {
+    "string": "Totalmente autorizado"
+  },
+  "wWELJW": {
+    "context": "search results",
+    "string": "Nenhum produto encontrado"
+  },
+  "wWTUrM": {
+    "string": "Atividades não encontrada."
+  },
+  "wWYYBR": {
+    "context": "product variant inventory",
+    "string": "{numLocations,plural,one {{numAvailable} disponível em {numLocations} local} other {{numAvailable} disponíveis em {numLocations} locais}}"
+  },
+  "wXFttp": {
+    "context": "note on currency",
+    "string": "Nota: Apenas canais com moeda correspondente estão disponíveis."
+  },
+  "wabGCe": {
+    "context": "Tooltip line showing local timestamp of a problem event",
+    "string": "Local: {time}"
+  },
+  "wbjuR4": {
+    "string": "Nenhum webhook encontrado"
+  },
+  "wbsq7O": {
+    "string": "Uso"
+  },
+  "we4Lby": {
+    "string": "Informação"
+  },
+  "werrDz": {
+    "context": "refunded event title",
+    "string": "Produtos foram reembolsados"
+  },
+  "wgA48T": {
+    "context": "country selection",
+    "string": "Países de A a Z"
+  },
+  "whTEcF": {
+    "context": "link",
+    "string": "Desativar"
+  },
+  "wjKYSU": {
+    "context": "WarehousesSection subtitle",
+    "string": "Selecione o depósito de onde você enviará os produtos para esta zona de envio. O endereço do depósito também será usado para calcular impostos."
+  },
+  "wkeWw9": {
+    "context": "create refund title",
+    "string": "Criar reembolso com itens de linha"
+  },
+  "wlQTfb": {
+    "context": "go to next step, button",
+    "string": "Próximo"
+  },
+  "wlr0Si": {
+    "context": "button",
+    "string": "Criar Webhook"
+  },
+  "wmdHhD": {
+    "context": "button",
+    "string": "Criar Depósito"
+  },
+  "wmeRVH": {
+    "context": "dialog header",
+    "string": "Cancelar pedido #{orderNumber}"
+  },
+  "wn3di2": {
+    "string": "Esta senha é muito comumente usada"
+  },
+  "wo7tA9": {
+    "context": "automatic completion cut-off date checkbox label",
+    "string": "Data limite personalizada"
+  },
+  "wpAXKX": {
+    "context": "checkbox label description",
+    "string": "Todos os pedidos serão confirmados automaticamente e todos os pagamentos serão capturados."
+  },
+  "wpONQ2": {
+    "string": "Insira qualquer informação extra sobre este cliente."
+  },
+  "wpli4O": {
+    "context": "WarehouseSettings private stock label",
+    "string": "Estoque Privado"
+  },
+  "wsDF7X": {
+    "context": "product variant attribute entity type",
+    "string": "Variantes de produto"
+  },
+  "wxFwUW": {
+    "context": "marketplace button",
+    "string": "Visitar Marketplace"
+  },
+  "wyvzh9": {
+    "context": "dialog header",
+    "string": "Publicar Páginas"
+  },
+  "x/ZVlU": {
+    "string": "Produto"
+  },
+  "x/pIZ9": {
+    "context": "button",
+    "string": "Adicionar produto"
+  },
+  "x0n6YG": {
+    "string": "Este reembolso está sendo processado e não pode ser editado"
+  },
+  "x0wum5": {
+    "context": "home sidebar card title",
+    "string": "Informações da sua loja"
+  },
+  "x1k81A": {
+    "context": "order history message",
+    "string": "Itens foram atendidos"
+  },
+  "x2mg39": {
+    "context": "Transaction event description",
+    "string": "Usado no pedido"
+  },
+  "x3g4Ry": {
+    "context": "sale discount",
+    "string": "Valor de Desconto"
+  },
+  "x3leH4": {
+    "context": "ProductTypeDeleteWarningDialog title",
+    "string": "Deletar produto {selectedTypesCount,plural,one{type} other{types}}"
+  },
+  "x79cEk": {
+    "context": "dialog header",
+    "string": "Excluir estrutura"
+  },
+  "x8V/xS": {
+    "context": "attribute visibility in storefront",
+    "string": "Público"
+  },
+  "xAHOGV": {
+    "context": "dialog header",
+    "string": "Atribuir Variante"
+  },
+  "xB7BTp": {
+    "string": "SKU (Unidade de Manutenção de Estoque)"
+  },
+  "xBulM3": {
+    "string": "Defina recompensa e condições para o canal selecionado"
+  },
+  "xFSJR1": {
+    "context": "recent changes shortcut",
+    "string": "Novidades"
+  },
+  "xGC2Ge": {
+    "context": "grant refund, button",
+    "string": "Definir quantidades máximas"
+  },
+  "xHj9Qe": {
+    "context": "gift card settings header",
+    "string": "Gift Cards Configurações"
+  },
+  "xJEaxW": {
+    "string": "adicionado"
+  },
+  "xJQX5t": {
+    "string": "Nenhum membro da equipe encontrado"
+  },
+  "xKLf5H": {
+    "string": "Desenvolvido por {developer}"
+  },
+  "xNElry": {
+    "context": "Transaction card title with name",
+    "string": "Transação - {name}"
+  },
+  "xOEZjV": {
+    "context": "attribute's label",
+    "string": "Etiqueta Padrão"
+  },
+  "xPnZ0R": {
+    "context": "title",
+    "string": "detalhes"
+  },
+  "xQK2EC": {
+    "context": "tab name",
+    "string": "Todos os Clientes"
+  },
+  "xRbqcg": {
+    "context": "option",
+    "string": "Tipo de produto normal"
+  },
+  "xRkj2h": {
+    "string": "Tem certeza de que deseja excluir {categoryName}?"
+  },
+  "xTIKA/": {
+    "context": "PluginChannelConfigurationCell global title",
+    "string": "Global"
+  },
+  "xTyg+p": {
+    "string": "Nenhuma opção para selecionar"
+  },
+  "xUvWaP": {
+    "context": "subtotal price",
+    "string": "Subtotal"
+  },
+  "xVn5B0": {
+    "context": "added new attribute value",
+    "string": "Adicionar novo valor"
+  },
+  "xWEFrR": {
+    "context": "dialog content",
+    "string": "Este cliente não possui nenhum endereço no catálogo de endereços. Forneça o endereço para pedido:"
+  },
+  "xZhxBJ": {
+    "context": "dialog header",
+    "string": "Atribuir Pordutos"
+  },
+  "xco5tZ": {
+    "string": "Tem certeza de que deseja cancelar o faturamento? O cancelamento de um faturamento reabastecerá os produtos em um depósito selecionado."
+  },
+  "xeMcID": {
+    "string": "Armazém criado"
+  },
+  "xfGZsi": {
+    "context": "configuration section name",
+    "string": "Configuração"
+  },
+  "xfypNP": {
+    "context": "tooltip for variant selection column header",
+    "string": "Quando ativado, este atributo será usado para distinguir variantes na vitrine."
+  },
+  "xgPXGD": {
+    "string": "Clientes excluídos"
+  },
+  "xjpTLF": {
+    "context": "informations about product stock, header",
+    "string": "Informações de Estoque"
+  },
+  "xkjRu5": {
+    "context": "export products to csv file, dialog header",
+    "string": "Informações de Exportação"
+  },
+  "xl7Fag": {
+    "string": "Categoria criada"
+  },
+  "xmcVZ0": {
+    "string": "Pesquisar"
+  },
+  "xo5UIb": {
+    "context": "dialog title",
+    "string": "Eliminar categoria"
+  },
+  "xol6jX": {
+    "string": "Você não tem permissão para gerenciar pedidos"
+  },
+  "xoyCZ/": {
+    "context": "error message",
+    "string": "Valor impróprio"
+  },
+  "xqXYF+": {
+    "context": "section header",
+    "string": "Produtos Elegíveis"
+  },
+  "xrCRnH": {
+    "string": "Exemplo"
+  },
+  "xrF9JK": {
+    "string": "Nenhuma estrutura encontrada"
+  },
+  "xrKHS6": {
+    "string": "Sucesso"
+  },
+  "xrPv2K": {
+    "context": "by preposition",
+    "string": "by"
+  },
+  "xtUXnK": {
+    "context": "export all items to csv file",
+    "string": "Todos os produtos ({number})"
+  },
+  "xvKNkf": {
+    "context": "Info message when user sets a past publication date",
+    "string": "Esta data está no passado. O produto ficará visível imediatamente quando você salvar."
+  },
+  "xwEc8K": {
+    "string": "API"
+  },
+  "xxQxLE": {
+    "string": "Endereço de e-mail"
+  },
+  "xy66ru": {
+    "context": "custom preset delete, dialog header",
+    "string": "Excluir predefinição"
+  },
+  "y/UWBR": {
+    "string": "Não há endereço para exibição para este cliente"
+  },
+  "y/vChh": {
+    "context": "Suffix appended to problem count when critical problems exist",
+    "string": "incluindo {count} crítico"
+  },
+  "y08GTW": {
+    "string": "Canal é obrigatório"
+  },
+  "y1Z3or": {
+    "string": "Língua"
+  },
+  "y7mfbl": {
+    "string": "Atualmente, não há países atribuídos a esta zona de envio"
+  },
+  "y8E0iG": {
+    "context": "seo incomplete text",
+    "string": "Incompleto"
+  },
+  "y93ihJ": {
+    "context": "dialog title when opening generator with unsaved changes",
+    "string": "Alterações não salvas"
+  },
+  "y9cvqE": {
+    "context": "button",
+    "string": "Criar cupom"
+  },
+  "yAFaVK": {
+    "context": "Webhook details synchronous events",
+    "string": "Síncrono"
+  },
+  "yAgKyi": {
+    "string": "Webhook criado"
+  },
+  "yDkmX7": {
+    "context": "dialog content",
+    "string": "{counter,plural,one {Tem certeza que deseja excluir este produto?} other {Tem certeza que deseja excluir  {displayQuantity} produtos?}}"
+  },
+  "yEmwxD": {
+    "context": "publish page, button",
+    "string": "Publicado"
+  },
+  "yH56V+": {
+    "string": "Ooops!..."
+  },
+  "yHQQMQ": {
+    "context": "dialog header",
+    "string": "Páginas Não Publicadas"
+  },
+  "yHaQWG": {
+    "context": "variants selected label",
+    "string": "{variantsAmount} variantes selecionados"
+  },
+  "yHeZRQ": {
+    "string": "Falha na Exportação do Produto"
+  },
+  "yHwvLL": {
+    "context": "voucher uses",
+    "string": "Utilizações"
+  },
+  "yJqbYv": {
+    "context": "Asynchronous events description",
+    "string": "Webhook assíncrono envia carga útil e continua o processamento."
+  },
+  "yJynYK": {
+    "context": "discount value",
+    "string": "desconto"
+  },
+  "yKuba7": {
+    "context": "attribute can be searched in dashboard",
+    "string": "Pesquisavel"
+  },
+  "yMi8I8": {
+    "context": "dialog header",
+    "string": "Desativar aplicativo"
+  },
+  "yNb+dT": {
+    "context": "product type",
+    "string": "Produto simples"
+  },
+  "yOaNWB": {
+    "context": "delete shipping method",
+    "string": "Tem certeza de que deseja excluir {name}?"
+  },
+  "ySqncG": {
+    "context": "ExitFormPrompt keep editing button",
+    "string": "Continuar editando"
+  },
+  "ySqrUU": {
+    "context": "button",
+    "string": "Atribuir variantes"
+  },
+  "yT/GAp": {
+    "string": "Código de rastreamento"
+  },
+  "yT5zvU": {
+    "string": "{counter,plural,one {Você tem certeza que deseja deletar esta coleção?} other {Você tem certeza que deseja deletar {displayQuantity} coleções?}}"
+  },
+  "yatGsm": {
+    "context": "card title",
+    "string": "Valor do Pedido"
+  },
+  "ybaLoZ": {
+    "string": "Pesquisar canais"
+  },
+  "ycMLN9": {
+    "context": "warehouses section name",
+    "string": "Depósitos"
+  },
+  "ychKsb": {
+    "context": "error message",
+    "string": "O método de envio é obrigatório para este pedido"
+  },
+  "ycrTBX": {
+    "context": "table header channel col label",
+    "string": "Channel"
+  },
+  "yeX6fA": {
+    "context": "extensions page subheader",
+    "string": "Saiba mais sobre {extensions}"
+  },
+  "ygPAC7": {
+    "context": "Tooltip explaining the app-reported problem badge",
+    "string": "Esta mensagem vem do aplicativo"
+  },
+  "ygxco/": {
+    "context": "tooltip, submit form",
+    "string": "O cliente fez mais de uma transação. Você deve enviar o reembolso manualmente."
+  },
+  "yhq0gU": {
+    "context": "settings structure item",
+    "string": "Configurações"
+  },
+  "yhv3HX": {
+    "context": "voucher requirements, header",
+    "string": "Requisitos Mínimos"
+  },
+  "yi1HSj": {
+    "string": "({numberOfCharacters} de {maxCharacters} caracteres)"
+  },
+  "yivxZJ": {
+    "context": "order payment",
+    "string": "Pago com Cartão Presente: ({link})"
+  },
+  "ylobu9": {
+    "context": "assign reference to product, button",
+    "string": "Atribuir"
+  },
+  "ymo+cm": {
+    "context": "voucher discount",
+    "string": "Todos os produtos"
+  },
+  "ymvZrH": {
+    "context": "page models",
+    "string": "Modelos"
+  },
+  "yn7Stx": {
+    "context": "date group header",
+    "string": "Desconhecido"
+  },
+  "ypW4Mi": {
+    "context": "button refreshing page",
+    "string": "Atualizar a página"
+  },
+  "ys0jH2": {
+    "context": "channel publication status",
+    "string": "Publicado"
+  },
+  "ytKTTO": {
+    "context": "draft orders section name",
+    "string": "Rascunhos"
+  },
+  "yuiyES": {
+    "string": "Configurações Gerais"
+  },
+  "yyJcyW": {
+    "string": "O manifesto do aplicativo contém problemas. Você ainda pode instalá-lo, mas pode não funcionar corretamente. Veja os detalhes técnicos abaixo:"
+  },
+  "yzYXW/": {
+    "context": "header, dialog",
+    "string": "Criar Novo Depósito"
+  },
+  "z+wMgQ": {
+    "context": "window title",
+    "string": "Criar Variações"
+  },
+  "z/2AZY": {
+    "string": "Tipo de desconto"
+  },
+  "z/pKCq": {
+    "context": "structure name",
+    "string": "Nome"
+  },
+  "z0gGP+": {
+    "context": "number of attributes",
+    "string": "{number} Atributos"
+  },
+  "z1puMb": {
+    "context": "export items as csv or spreadsheet file",
+    "string": "Exportar como:"
+  },
+  "z1y9oL": {
+    "context": "file attribute type",
+    "string": "Arquivo"
+  },
+  "z3w/oL": {
+    "string": "Você deve fornecer um valor de quantidade"
+  },
+  "z45PdE": {
+    "context": "order status",
+    "string": "Expirado"
+  },
+  "z4qMx5": {
+    "string": "Abrir em uma nova aba"
+  },
+  "z8jo8h": {
+    "context": "button",
+    "string": "Ver produtos"
+  },
+  "z9c6/C": {
+    "string": "Obsoleto"
+  },
+  "z9f2oQ": {
+    "string": "Atualizações Recentes do Painel"
+  },
+  "z9wQ/U": {
+    "context": "no variant stock in warehouse",
+    "string": "Sem estoque"
+  },
+  "zCb8fX": {
+    "string": "Peso"
+  },
+  "zD7/M6": {
+    "context": "empty list message",
+    "string": "Use o botão Designar membros para fazer isso."
+  },
+  "zDvDnG": {
+    "context": "modal header",
+    "string": "A mídia do URL fornecido será mostrada na galeria de mídia. Você poderá definir a ordem da galeria."
+  },
+  "zHx85l": {
+    "context": "value input helper text",
+    "string": "Não pode ser maior que 100%"
+  },
+  "zIPK5M": {
+    "string": "Ativar razões de reembolso nas configurações"
+  },
+  "zJpP1T": {
+    "context": "create new structure, header",
+    "string": "Adicionar Item"
+  },
+  "zKEVOg": {
+    "context": "error message when required attributes are not filled",
+    "string": "Por favor, preencha todos os atributos obrigatórios antes de gerar variantes."
+  },
+  "zKOGkU": {
+    "context": "time during discount is active, header",
+    "string": "Datas Ativas"
+  },
+  "zKgsu9": {
+    "string": "Regra atualizada"
+  },
+  "zLtb4N": {
+    "context": "gift card removed success alert message",
+    "string": "{selectedItemsCount,plural,one {Vale-presente excluído com sucesso} other {Vales-presente excluídos com sucesso}}"
+  },
+  "zN0Eub": {
+    "context": "info message when hasVariants is false but variant attributes exist",
+    "string": "Este tipo de produto tem {count, plural, one {# atributo de variante} other {# atributos de variante}} definidos, mas 'O tipo de produto usa Atributos de Variante' está desativado. Edite o {productTypeLink} tipo de produto para ativar atributos de variante."
+  },
+  "zQX6xO": {
+    "context": "dialog header",
+    "string": "Excluir Aplicativo"
+  },
+  "zQnYKn": {
+    "context": "status section subtitle",
+    "string": "Status do canal"
+  },
+  "zQvVDJ": {
+    "string": "Todos"
+  },
+  "zR9Ozi": {
+    "context": "select all channels label",
+    "string": "Selecione todos os canais"
+  },
+  "zRIsjN": {
+    "string": "Saiba mais sobre {apiReference} e veja {apiGuide}"
+  },
+  "zRrcOG": {
+    "context": "order history message",
+    "string": "Pedido foi cancelado"
+  },
+  "zSDfq0": {
+    "string": "Usar taxa de imposto fixa"
+  },
+  "zSOvI0": {
+    "string": "Filtros"
+  },
+  "zT1CvH": {
+    "string": "Saiba mais sobre {extendingSaleor}"
+  },
+  "zTdwWM": {
+    "context": "money",
+    "string": "{fromMoney} - {toMoney}"
+  },
+  "zUHPnm": {
+    "context": "fulfillment status returned",
+    "string": "Devolvido"
+  },
+  "zWM89r": {
+    "context": "numeric attribute units of",
+    "string": "Unidades de"
+  },
+  "zWgbGg": {
+    "string": "Hoje"
+  },
+  "zY1K7Q": {
+    "context": "fulfillment status refunded and returned",
+    "string": "Reembolsado e Devolvido"
+  },
+  "zZCCqz": {
+    "context": "button",
+    "string": "Atribuir países"
+  },
+  "zb1rmx": {
+    "context": "alert message",
+    "string": "{country} não está disponível como destino de envio para este canal, verifique {configLink}."
+  },
+  "zb4eBO": {
+    "context": "order total price",
+    "string": "Total"
+  },
+  "zbJHl7": {
+    "context": "attribute type",
+    "string": "Conteúdo do Atributo"
+  },
+  "zehNKT": {
+    "string": "A regra tem erro, abra a regra para ver detalhes"
+  },
+  "zf48rQ": {
+    "context": "sum of captured amount of all transactions",
+    "string": "Total capturado"
+  },
+  "zfSKyx": {
+    "string": "Limpar histórico"
+  },
+  "zfjAc7": {
+    "context": "grant refund, card header",
+    "string": "Produtos não atendidos"
+  },
+  "zgqPGF": {
+    "context": "attribute list",
+    "string": "Atributo {name}"
+  },
+  "zhG4HQ": {
+    "context": "Action to configure channel",
+    "string": "Configurar canal"
+  },
+  "zhnwl6": {
+    "context": "save preset name",
+    "string": "Nome da predefinição"
+  },
+  "zjHH6b": {
+    "context": "sale start date",
+    "string": "Iniciado"
+  },
+  "zjZuhM": {
+    "context": "created gift card code label",
+    "string": "Este é o código de um vale-presente criado:"
+  },
+  "zjkAMs": {
+    "context": "header",
+    "string": "Venda de tradução \"{saleName}\" - {languageCode}"
+  },
+  "znbVYT": {
+    "context": "product available for purchase date",
+    "string": "Ficará disponível em {date}"
+  },
+  "zo5aT3": {
+    "string": "Metadados do Armazém"
+  },
+  "zoUlyR": {
+    "string": "Ir para tipos de produtos"
+  },
+  "zp9VHt": {
+    "context": "cta button label",
+    "string": "Explorar Atualizações"
+  },
+  "zqarUF": {
+    "context": "modal information under title",
+    "string": "Selecione um endereço que deseja usar na lista abaixo"
+  },
+  "zsz6LN": {
+    "context": "onboarding step description",
+    "string": "Revise o hub central para gerenciar todas as extensões disponíveis. Aqui, você pode supervisionar facilmente suas extensões e aprimorar o Saleor com soluções personalizadas usando webhooks e APIs."
+  },
+  "ztQgD8": {
+    "string": "Nenhum atributo encontrado"
+  },
+  "ztsvOP": {
+    "context": "tooltip for gift card amount",
+    "string": "Valor do cartão-presente utilizado"
+  },
+  "ztvvcm": {
+    "context": "swatch attribute type",
+    "string": "Tipo de amostra"
+  },
+  "zv9OGI": {
+    "string": "Nenhum modelo encontrado"
+  },
+  "zxs6G3": {
+    "string": "Gerencie como você enviará os pedidos"
+  },
+  "zyXcBP": {
+    "string": "Sorting by this column requires active filter: {filterName}"
+  },
+  "zyceue": {
+    "context": "placed order counter",
+    "string": "{count}/{max} pedidos"
+  },
+  "zzfj8H": {
+    "context": "label",
+    "string": "No refund"
+  }
 }


### PR DESCRIPTION
## Scope of the change

Added the missing translation keys from `defaultMessages` in comparison to `pt-BR.json`

1700 strings in total.

- [X] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
