### PR TITLE
fix(build): missing required git directory for releases

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -96,6 +96,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Create draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes the following error in the `gh release create` step ([link to logs](https://github.com/saleor/saleor-dashboard/actions/runs/25050248452/job/73375920013?pr=6543)):

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Implementation notes:
- `fetch-depth: 0` shouldn't be needed as we should only need to fetch the tag that we want to release (thus the default `fetch-depth: 1` should be sufficient)
- `persist-credentials: false` - shouldn't need to store the [git credentials](https://git-scm.com/docs/gitcredentials) as we are only creating a release which is a GitHub API call (thus `GITHUB_TOKEN` should be the only credential that's needed)


## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [x] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [x] I used analytics "trackEvent" for important events
