### PR TITLE
ProductDoctor: Add support for the new availability mode

### DIFF
--- a/.changeset/tender-impalas-tickle.md
+++ b/.changeset/tender-impalas-tickle.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+ProductDoctor: Add support for new availability mode introduced in Saleor 3.23

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -192,6 +192,10 @@
     "context": "expired on label",
     "string": "Expired on {date}"
   },
+  "/0QqzO": {
+    "context": "aria-label for the warning icon inside a channel issue badge",
+    "string": "Warning"
+  },
   "/0gMCW": {
     "string": "Try to refresh the page or go navigate to a different page and back."
   },
@@ -7326,6 +7330,10 @@
   "cY42ht": {
     "string": "Password cannot be entirely numeric"
   },
+  "cYjzDx": {
+    "context": "aria-label for the info icon inside an availability issue callout",
+    "string": "Information"
+  },
   "cZN5Jd": {
     "context": "Webhook details events",
     "string": "Events"
@@ -7617,6 +7625,10 @@
   "eWcvOc": {
     "context": "button",
     "string": "Choose file"
+  },
+  "eXcTEd": {
+    "context": "aria-label for the error icon inside an availability issue callout",
+    "string": "Error"
   },
   "eY+BKQ": {
     "string": "The extension manifest was not found. ({errorCode})"
@@ -8212,6 +8224,10 @@
     "context": "button",
     "string": "Apply"
   },
+  "iBY7aI": {
+    "context": "aria-label for the warning icon inside an availability issue callout",
+    "string": "Warning"
+  },
   "iEeIhY": {
     "context": "draft order",
     "string": "Customer"
@@ -8715,6 +8731,10 @@
   "kv3FWU": {
     "context": "btn label",
     "string": "Go to orders"
+  },
+  "kyOwDW": {
+    "context": "aria-label for the error icon inside a channel issue badge",
+    "string": "Error"
   },
   "l0a2tU": {
     "context": "onboarding step description",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -226,6 +226,10 @@
     "context": "button",
     "string": "Show"
   },
+  "/8a4cU": {
+    "context": "Description for stock-outside-channel-warehouses info",
+    "string": "This product has stock in warehouses that are not linked to this channel. Assign the warehouse to the channel for the stock to count toward availability."
+  },
   "/AbHy4": {
     "context": "creation label",
     "string": "Creation"
@@ -1583,6 +1587,10 @@
     "context": "link",
     "string": "View profile"
   },
+  "7CZ8Tp": {
+    "context": "Description for no shipping zones info when shop uses direct warehouse-channel stock availability",
+    "string": "Customers can browse and add this product to cart, but no shipping methods will be available at checkout. Add at least one shipping zone to this channel to enable shipping."
+  },
   "7Chrsf": {
     "string": "Passwords do not match"
   },
@@ -1694,6 +1702,10 @@
   "7qsOwa": {
     "context": "action",
     "string": "Include postal codes"
+  },
+  "7sSOgb": {
+    "context": "Indicator label shown when shop has Shop.useLegacyShippingZoneStockAvailability=true",
+    "string": "Stock availability uses shipping zones (legacy)"
   },
   "7scATx": {
     "context": "select title",
@@ -2361,6 +2373,10 @@
     "context": "header",
     "string": "Address Information"
   },
+  "BfhUcl": {
+    "context": "Indicator label shown when shop has Shop.useLegacyShippingZoneStockAvailability=false",
+    "string": "Stock availability uses direct warehouse-channel link"
+  },
   "Bkxrhw": {
     "context": "no webhooks message",
     "string": "No webhooks found"
@@ -2777,10 +2793,6 @@
   },
   "EAGfdH": {
     "string": "Page updated"
-  },
-  "EAKKtg": {
-    "context": "Description for no shipping zones warning",
-    "string": "Customers cannot checkout without shipping methods. Add shipping zones to this channel."
   },
   "EDihQs": {
     "string": "Staff member updated"
@@ -3246,6 +3258,10 @@
   "GVinbz": {
     "context": "column title",
     "string": "Value"
+  },
+  "GYBoVb": {
+    "context": "Tooltip explanation for legacy stock-availability mode",
+    "string": "Stock is considered available only when the warehouse is both assigned to this channel and covered by an active shipping zone for the destination address."
   },
   "GbBCmr": {
     "context": "window title",
@@ -5330,6 +5346,10 @@
   },
   "RrCui3": {
     "string": "Summary"
+  },
+  "Rt95cf": {
+    "context": "Info when channel has no shipping zones in direct stock-availability mode",
+    "string": "No shipping zones for \"{channelName}\""
   },
   "RyZd9J": {
     "context": "error message",
@@ -10161,6 +10181,10 @@
     "context": "radio option for capturing order total",
     "string": "Order total"
   },
+  "tSmJPv": {
+    "context": "Tooltip explanation for direct stock-availability mode",
+    "string": "Stock is considered available whenever the warehouse is assigned to this channel. Shipping zones only affect order fulfillment, not availability."
+  },
   "tTuCYj": {
     "context": "all gift cards label",
     "string": "All Gift Cards"
@@ -10378,6 +10402,10 @@
   "uY8rPp": {
     "context": "button label to cancel product removal",
     "string": "Keep product"
+  },
+  "uaZNZS": {
+    "context": "Info when product has stock only in warehouses not linked to the channel",
+    "string": "Stock is in warehouses not assigned to \"{channelName}\""
   },
   "ubasgL": {
     "context": "order history message",
@@ -10707,6 +10735,10 @@
   },
   "vuKrlW": {
     "string": "Stock"
+  },
+  "vuOZYs": {
+    "context": "Description for no shipping zones warning",
+    "string": "Without shipping zones, this product will appear unavailable to customers and orders cannot be shipped. Add at least one shipping zone to this channel."
   },
   "vwA9Fq": {
     "context": "notification",

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -16212,6 +16212,10 @@ export type GridWarehousesLazyQueryHookResult = ReturnType<typeof useGridWarehou
 export type GridWarehousesQueryResult = Apollo.QueryResult<Types.GridWarehousesQuery, Types.GridWarehousesQueryVariables>;
 export const ChannelDiagnosticsDocument = gql`
     query ChannelDiagnostics {
+  shop {
+    id
+    useLegacyShippingZoneStockAvailability
+  }
   channels {
     id
     name

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -13041,7 +13041,7 @@ export type GridWarehousesQuery = { __typename: 'Query', selectedWarehouses: { _
 export type ChannelDiagnosticsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ChannelDiagnosticsQuery = { __typename: 'Query', channels: Array<{ __typename: 'Channel', id: string, name: string, slug: string, currencyCode: string, isActive: boolean, warehouses: Array<{ __typename: 'Warehouse', id: string, name: string }> }> | null, shippingZones: { __typename: 'ShippingZoneCountableConnection', edges: Array<{ __typename: 'ShippingZoneCountableEdge', node: { __typename: 'ShippingZone', id: string, name: string, channels: Array<{ __typename: 'Channel', id: string }>, warehouses: Array<{ __typename: 'Warehouse', id: string, name: string }>, countries: Array<{ __typename: 'CountryDisplay', code: string, country: string }> } }> } | null };
+export type ChannelDiagnosticsQuery = { __typename: 'Query', shop: { __typename: 'Shop', id: string, useLegacyShippingZoneStockAvailability: boolean }, channels: Array<{ __typename: 'Channel', id: string, name: string, slug: string, currencyCode: string, isActive: boolean, warehouses: Array<{ __typename: 'Warehouse', id: string, name: string }> }> | null, shippingZones: { __typename: 'ShippingZoneCountableConnection', edges: Array<{ __typename: 'ShippingZoneCountableEdge', node: { __typename: 'ShippingZone', id: string, name: string, channels: Array<{ __typename: 'Channel', id: string }>, warehouses: Array<{ __typename: 'Warehouse', id: string, name: string }>, countries: Array<{ __typename: 'CountryDisplay', code: string, country: string }> } }> } | null };
 
 export type SetRefundReasonTypeMutationVariables = Exact<{
   modelTypeId: Scalars['ID'];

--- a/src/products/components/ProductDoctor/AvailabilityCard.test.tsx
+++ b/src/products/components/ProductDoctor/AvailabilityCard.test.tsx
@@ -1,0 +1,208 @@
+import Wrapper from "@test/wrapper";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { AvailabilityCard } from "./AvailabilityCard";
+import { type AvailabilityIssue, type DiagnosticsResult } from "./utils/types";
+
+// usePublicApiVerification hits the live API; stub it for isolated UI tests.
+jest.mock("./hooks/usePublicApiVerification", () => ({
+  usePublicApiVerification: () => ({
+    verifyChannel: jest.fn(),
+    getChannelResult: () => undefined,
+    isVerifying: false,
+    results: new Map(),
+    lastVerified: null,
+  }),
+}));
+
+const baseDiagnostics = (overrides: Partial<DiagnosticsResult> = {}): DiagnosticsResult => ({
+  issues: [],
+  channelSummaries: [
+    {
+      id: "channel-1",
+      name: "Default Channel",
+      slug: "default-channel",
+      currencyCode: "USD",
+      isActive: true,
+      isPublished: true,
+      publishedAt: "2024-01-01T00:00:00Z",
+      isAvailableForPurchase: true,
+      availableForPurchaseAt: "2024-01-01T00:00:00Z",
+      visibleInListings: true,
+      warehouseCount: 1,
+      warehouseNames: ["Main Warehouse"],
+      shippingZoneCount: 1,
+      shippingZoneNames: ["US"],
+      countryCount: 1,
+    },
+  ],
+  hasErrors: false,
+  hasWarnings: false,
+  isLoading: false,
+  permissions: {
+    canViewChannelWarehouses: true,
+    canViewShippingZones: true,
+    missingPermissions: [],
+  },
+  useLegacyShippingZoneStockAvailability: true,
+  ...overrides,
+});
+
+describe("AvailabilityCard / StockAvailabilityModeIndicator", () => {
+  it("renders the legacy mode indicator when shop uses shipping-zone stock availability", () => {
+    // Arrange
+    const diagnostics = baseDiagnostics({ useLegacyShippingZoneStockAvailability: true });
+
+    // Act
+    render(<AvailabilityCard diagnostics={diagnostics} totalChannelsCount={1} />, {
+      wrapper: Wrapper,
+    });
+
+    // Assert
+    const indicator = screen.getByTestId("stock-availability-mode-indicator");
+
+    expect(indicator).toHaveAttribute("data-test-mode", "legacy");
+    expect(indicator).toHaveTextContent(/legacy/i);
+  });
+
+  it("renders the direct mode indicator when shop uses direct warehouse-channel link", () => {
+    // Arrange
+    const diagnostics = baseDiagnostics({ useLegacyShippingZoneStockAvailability: false });
+
+    // Act
+    render(<AvailabilityCard diagnostics={diagnostics} totalChannelsCount={1} />, {
+      wrapper: Wrapper,
+    });
+
+    // Assert
+    const indicator = screen.getByTestId("stock-availability-mode-indicator");
+
+    expect(indicator).toHaveAttribute("data-test-mode", "direct");
+    expect(indicator).toHaveTextContent(/direct warehouse-channel/i);
+  });
+
+  it("does not render the indicator while diagnostics are loading", () => {
+    // Arrange
+    const diagnostics = baseDiagnostics({ isLoading: true, channelSummaries: [] });
+
+    // Act
+    render(<AvailabilityCard diagnostics={diagnostics} totalChannelsCount={1} />, {
+      wrapper: Wrapper,
+    });
+
+    // Assert - indicator only renders when channels list is shown
+    expect(screen.queryByTestId("stock-availability-mode-indicator")).toBeNull();
+  });
+});
+
+const makeIssue = (overrides: Partial<AvailabilityIssue> = {}): AvailabilityIssue => ({
+  id: "no-shipping-zones",
+  severity: "info",
+  channelId: "channel-1",
+  channelName: "Default Channel",
+  message: "No shipping zones",
+  description: "Customers can browse and add this product to cart, but...",
+  ...overrides,
+});
+
+describe("AvailabilityCard channel header severity gating", () => {
+  it("does not promote info-only issues into the channel issue badge", () => {
+    // Arrange - direct mode, single info advisory (e.g. no shipping zones)
+    const diagnostics = baseDiagnostics({
+      useLegacyShippingZoneStockAvailability: false,
+      issues: [makeIssue({ severity: "info" })],
+      hasErrors: false,
+      hasWarnings: false,
+    });
+
+    // Act
+    render(<AvailabilityCard diagnostics={diagnostics} totalChannelsCount={1} />, {
+      wrapper: Wrapper,
+    });
+
+    // Assert - no IssueBadge in the header
+    expect(screen.queryByTestId("channel-issue-badge")).toBeNull();
+
+    // Expand the channel accordion to inspect the issue callout in the body
+    fireEvent.click(screen.getByText("Default Channel"));
+
+    const callout = screen.getByTestId("availability-issue-callout");
+
+    expect(callout).toHaveAttribute("data-test-severity", "info");
+  });
+
+  it("still surfaces warnings via the channel issue badge", () => {
+    // Arrange - legacy mode, warning-level issue
+    const diagnostics = baseDiagnostics({
+      useLegacyShippingZoneStockAvailability: true,
+      issues: [makeIssue({ id: "no-stock", severity: "warning", message: "No stock" })],
+      hasErrors: false,
+      hasWarnings: true,
+    });
+
+    // Act
+    render(<AvailabilityCard diagnostics={diagnostics} totalChannelsCount={1} />, {
+      wrapper: Wrapper,
+    });
+
+    // Assert
+    const badge = screen.getByTestId("channel-issue-badge");
+
+    expect(badge).toHaveAttribute("data-test-type", "warning");
+    expect(badge).toHaveAttribute("data-test-count", "1");
+  });
+
+  it("counts only blocking issues in the channel issue badge when info issues co-exist", () => {
+    // Arrange - one warning, two info advisories on the same channel
+    const diagnostics = baseDiagnostics({
+      useLegacyShippingZoneStockAvailability: false,
+      issues: [
+        makeIssue({ id: "no-stock", severity: "warning", message: "No stock" }),
+        makeIssue({ id: "no-shipping-zones", severity: "info", message: "No shipping zones" }),
+        makeIssue({
+          id: "stock-outside-channel-warehouses",
+          severity: "info",
+          message: "Stranded stock",
+        }),
+      ],
+      hasErrors: false,
+      hasWarnings: true,
+    });
+
+    // Act
+    render(<AvailabilityCard diagnostics={diagnostics} totalChannelsCount={1} />, {
+      wrapper: Wrapper,
+    });
+
+    // Assert - badge count reflects the single blocking issue only
+    const badge = screen.getByTestId("channel-issue-badge");
+
+    expect(badge).toHaveAttribute("data-test-count", "1");
+    expect(badge).toHaveAttribute("data-test-type", "warning");
+  });
+
+  it("escalates to error styling when at least one issue is an error", () => {
+    // Arrange - mix of error and warning, plus info
+    const diagnostics = baseDiagnostics({
+      useLegacyShippingZoneStockAvailability: true,
+      issues: [
+        makeIssue({ id: "no-variants", severity: "error", message: "No variants" }),
+        makeIssue({ id: "no-stock", severity: "warning", message: "No stock" }),
+        makeIssue({ id: "no-shipping-zones", severity: "info", message: "Info only" }),
+      ],
+      hasErrors: true,
+      hasWarnings: true,
+    });
+
+    // Act
+    render(<AvailabilityCard diagnostics={diagnostics} totalChannelsCount={1} />, {
+      wrapper: Wrapper,
+    });
+
+    // Assert - badge type prefers error severity, count is the blocking total
+    const badge = screen.getByTestId("channel-issue-badge");
+
+    expect(badge).toHaveAttribute("data-test-type", "error");
+    expect(badge).toHaveAttribute("data-test-count", "2");
+  });
+});

--- a/src/products/components/ProductDoctor/AvailabilityCard.test.tsx
+++ b/src/products/components/ProductDoctor/AvailabilityCard.test.tsx
@@ -164,7 +164,7 @@ describe("AvailabilityCard channel header severity gating", () => {
     expect(within(badge).queryByTestId("product-doctor-issue-badge-count")).toBeNull();
   });
 
-  it("renders a visible count and the warning icon when multiple blocking issues exist alongside info advisories", () => {
+  it("renders a visible count and the warning icon when multiple header-worthy issues exist alongside info advisories", () => {
     // Arrange — two warnings + two info advisories on the same channel.
     const diagnostics = baseDiagnostics({
       useLegacyShippingZoneStockAvailability: false,
@@ -187,7 +187,7 @@ describe("AvailabilityCard channel header severity gating", () => {
       wrapper: Wrapper,
     });
 
-    // Assert — visible count reflects the two blocking issues only.
+    // Assert — visible count reflects the two header-worthy issues only.
     const badge = screen.getByTestId("channel-issue-badge");
 
     expect(within(badge).getByTestId("product-doctor-issue-badge-count")).toHaveTextContent("2");
@@ -196,7 +196,7 @@ describe("AvailabilityCard channel header severity gating", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the error icon when at least one blocking issue is an error", () => {
+  it("renders the error icon when at least one header issue is an error", () => {
     // Arrange — error + warning + info.
     const diagnostics = baseDiagnostics({
       useLegacyShippingZoneStockAvailability: true,
@@ -219,7 +219,7 @@ describe("AvailabilityCard channel header severity gating", () => {
 
     expect(within(badge).getByTestId("product-doctor-issue-badge-icon-error")).toBeInTheDocument();
     expect(within(badge).queryByTestId("product-doctor-issue-badge-icon-warning")).toBeNull();
-    // Visible count covers the two blocking issues (the info advisory is excluded).
+    // Visible count covers the two header-worthy issues (the info advisory is excluded).
     expect(within(badge).getByTestId("product-doctor-issue-badge-count")).toHaveTextContent("2");
   });
 });

--- a/src/products/components/ProductDoctor/AvailabilityCard.test.tsx
+++ b/src/products/components/ProductDoctor/AvailabilityCard.test.tsx
@@ -1,5 +1,5 @@
 import Wrapper from "@test/wrapper";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 
 import { AvailabilityCard } from "./AvailabilityCard";
 import { type AvailabilityIssue, type DiagnosticsResult } from "./utils/types";
@@ -49,7 +49,7 @@ const baseDiagnostics = (overrides: Partial<DiagnosticsResult> = {}): Diagnostic
 });
 
 describe("AvailabilityCard / StockAvailabilityModeIndicator", () => {
-  it("renders the legacy mode indicator when shop uses shipping-zone stock availability", () => {
+  it("renders the legacy mode label when shop uses shipping-zone stock availability", () => {
     // Arrange
     const diagnostics = baseDiagnostics({ useLegacyShippingZoneStockAvailability: true });
 
@@ -58,14 +58,12 @@ describe("AvailabilityCard / StockAvailabilityModeIndicator", () => {
       wrapper: Wrapper,
     });
 
-    // Assert
-    const indicator = screen.getByTestId("stock-availability-mode-indicator");
-
-    expect(indicator).toHaveAttribute("data-test-mode", "legacy");
-    expect(indicator).toHaveTextContent(/legacy/i);
+    // Assert — mode is communicated to the user via visible copy.
+    expect(screen.getByText(/uses shipping zones \(legacy\)/i)).toBeInTheDocument();
+    expect(screen.queryByText(/direct warehouse-channel/i)).toBeNull();
   });
 
-  it("renders the direct mode indicator when shop uses direct warehouse-channel link", () => {
+  it("renders the direct mode label when shop uses the direct warehouse-channel link", () => {
     // Arrange
     const diagnostics = baseDiagnostics({ useLegacyShippingZoneStockAvailability: false });
 
@@ -75,10 +73,8 @@ describe("AvailabilityCard / StockAvailabilityModeIndicator", () => {
     });
 
     // Assert
-    const indicator = screen.getByTestId("stock-availability-mode-indicator");
-
-    expect(indicator).toHaveAttribute("data-test-mode", "direct");
-    expect(indicator).toHaveTextContent(/direct warehouse-channel/i);
+    expect(screen.getByText(/direct warehouse-channel/i)).toBeInTheDocument();
+    expect(screen.queryByText(/uses shipping zones \(legacy\)/i)).toBeNull();
   });
 
   it("does not render the indicator while diagnostics are loading", () => {
@@ -90,8 +86,9 @@ describe("AvailabilityCard / StockAvailabilityModeIndicator", () => {
       wrapper: Wrapper,
     });
 
-    // Assert - indicator only renders when channels list is shown
-    expect(screen.queryByTestId("stock-availability-mode-indicator")).toBeNull();
+    // Assert — neither label is rendered (indicator shows only with the channels list).
+    expect(screen.queryByText(/uses shipping zones \(legacy\)/i)).toBeNull();
+    expect(screen.queryByText(/direct warehouse-channel/i)).toBeNull();
   });
 });
 
@@ -105,9 +102,18 @@ const makeIssue = (overrides: Partial<AvailabilityIssue> = {}): AvailabilityIssu
   ...overrides,
 });
 
+/**
+ * Channel header severity gating — these tests assert what the user actually
+ * sees: which icon is rendered (queried by accessible name), whether a count
+ * number is visible, and whether the badge appears at all.
+ *
+ * The pure selection/escalation logic that drives the props is unit-tested
+ * separately in `utils/issueBadge.test.ts`; here we only verify the
+ * UI consequences.
+ */
 describe("AvailabilityCard channel header severity gating", () => {
-  it("does not promote info-only issues into the channel issue badge", () => {
-    // Arrange - direct mode, single info advisory (e.g. no shipping zones)
+  it("does not render the issue badge for info-only advisories", () => {
+    // Arrange — direct mode, single info advisory.
     const diagnostics = baseDiagnostics({
       useLegacyShippingZoneStockAvailability: false,
       issues: [makeIssue({ severity: "info" })],
@@ -120,19 +126,20 @@ describe("AvailabilityCard channel header severity gating", () => {
       wrapper: Wrapper,
     });
 
-    // Assert - no IssueBadge in the header
+    // Assert — no IssueBadge in the header.
     expect(screen.queryByTestId("channel-issue-badge")).toBeNull();
 
-    // Expand the channel accordion to inspect the issue callout in the body
+    // Expand the channel accordion and verify the info-style icon is rendered
+    // for the issue callout (this is what the user perceives — Info icon
+    // rather than warning/error iconography).
     fireEvent.click(screen.getByText("Default Channel"));
 
-    const callout = screen.getByTestId("availability-issue-callout");
-
-    expect(callout).toHaveAttribute("data-test-severity", "info");
+    expect(screen.getByTestId("product-doctor-issue-callout-icon-info")).toBeInTheDocument();
+    expect(screen.getByLabelText("Information")).toBeInTheDocument();
   });
 
-  it("still surfaces warnings via the channel issue badge", () => {
-    // Arrange - legacy mode, warning-level issue
+  it("surfaces a single warning via the channel issue badge with no visible count", () => {
+    // Arrange — legacy mode, one warning-level issue.
     const diagnostics = baseDiagnostics({
       useLegacyShippingZoneStockAvailability: true,
       issues: [makeIssue({ id: "no-stock", severity: "warning", message: "No stock" })],
@@ -145,19 +152,25 @@ describe("AvailabilityCard channel header severity gating", () => {
       wrapper: Wrapper,
     });
 
-    // Assert
+    // Assert — the warning icon is shown inside the badge…
     const badge = screen.getByTestId("channel-issue-badge");
 
-    expect(badge).toHaveAttribute("data-test-type", "warning");
-    expect(badge).toHaveAttribute("data-test-count", "1");
+    expect(
+      within(badge).getByTestId("product-doctor-issue-badge-icon-warning"),
+    ).toBeInTheDocument();
+    // …no error icon is shown…
+    expect(within(badge).queryByTestId("product-doctor-issue-badge-icon-error")).toBeNull();
+    // …and there is no visible count number (count text only renders for >1).
+    expect(within(badge).queryByTestId("product-doctor-issue-badge-count")).toBeNull();
   });
 
-  it("counts only blocking issues in the channel issue badge when info issues co-exist", () => {
-    // Arrange - one warning, two info advisories on the same channel
+  it("renders a visible count and the warning icon when multiple blocking issues exist alongside info advisories", () => {
+    // Arrange — two warnings + two info advisories on the same channel.
     const diagnostics = baseDiagnostics({
       useLegacyShippingZoneStockAvailability: false,
       issues: [
         makeIssue({ id: "no-stock", severity: "warning", message: "No stock" }),
+        makeIssue({ id: "no-warehouses", severity: "warning", message: "No warehouses" }),
         makeIssue({ id: "no-shipping-zones", severity: "info", message: "No shipping zones" }),
         makeIssue({
           id: "stock-outside-channel-warehouses",
@@ -174,15 +187,17 @@ describe("AvailabilityCard channel header severity gating", () => {
       wrapper: Wrapper,
     });
 
-    // Assert - badge count reflects the single blocking issue only
+    // Assert — visible count reflects the two blocking issues only.
     const badge = screen.getByTestId("channel-issue-badge");
 
-    expect(badge).toHaveAttribute("data-test-count", "1");
-    expect(badge).toHaveAttribute("data-test-type", "warning");
+    expect(within(badge).getByTestId("product-doctor-issue-badge-count")).toHaveTextContent("2");
+    expect(
+      within(badge).getByTestId("product-doctor-issue-badge-icon-warning"),
+    ).toBeInTheDocument();
   });
 
-  it("escalates to error styling when at least one issue is an error", () => {
-    // Arrange - mix of error and warning, plus info
+  it("renders the error icon when at least one blocking issue is an error", () => {
+    // Arrange — error + warning + info.
     const diagnostics = baseDiagnostics({
       useLegacyShippingZoneStockAvailability: true,
       issues: [
@@ -199,10 +214,12 @@ describe("AvailabilityCard channel header severity gating", () => {
       wrapper: Wrapper,
     });
 
-    // Assert - badge type prefers error severity, count is the blocking total
+    // Assert — error icon appears, warning icon does not.
     const badge = screen.getByTestId("channel-issue-badge");
 
-    expect(badge).toHaveAttribute("data-test-type", "error");
-    expect(badge).toHaveAttribute("data-test-count", "2");
+    expect(within(badge).getByTestId("product-doctor-issue-badge-icon-error")).toBeInTheDocument();
+    expect(within(badge).queryByTestId("product-doctor-issue-badge-icon-warning")).toBeNull();
+    // Visible count covers the two blocking issues (the info advisory is excluded).
+    expect(within(badge).getByTestId("product-doctor-issue-badge-count")).toHaveTextContent("2");
   });
 });

--- a/src/products/components/ProductDoctor/AvailabilityCard.tsx
+++ b/src/products/components/ProductDoctor/AvailabilityCard.tsx
@@ -7,7 +7,16 @@ import {
   type ProductChannelListingErrorFragment,
 } from "@dashboard/graphql";
 import { Accordion, Box, Button, Skeleton, Spinner, Text, Tooltip } from "@saleor/macaw-ui-next";
-import { CheckCircle, ChevronLeft, ChevronRight, Info, Search, X, XCircle } from "lucide-react";
+import {
+  CheckCircle,
+  ChevronLeft,
+  ChevronRight,
+  Info,
+  Layers,
+  Search,
+  X,
+  XCircle,
+} from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 
@@ -64,7 +73,15 @@ export const AvailabilityCard = ({
 
   const PAGE_SIZE = 10;
 
-  const { channelSummaries, issues, hasErrors, hasWarnings, isLoading, permissions } = diagnostics;
+  const {
+    channelSummaries,
+    issues,
+    hasErrors,
+    hasWarnings,
+    isLoading,
+    permissions,
+    useLegacyShippingZoneStockAvailability,
+  } = diagnostics;
 
   const verification = usePublicApiVerification(productId || "");
 
@@ -185,6 +202,10 @@ export const AvailabilityCard = ({
               errorCount={errorCount}
               warningCount={warningCount}
               permissions={permissions}
+            />
+
+            <StockAvailabilityModeIndicator
+              useLegacyShippingZoneStockAvailability={useLegacyShippingZoneStockAvailability}
             />
 
             {/* Search input - always visible when there are channels */}
@@ -400,6 +421,54 @@ const DiagnosticSummaryBanner = ({
         </Tooltip>
       )}
     </Box>
+  );
+};
+
+interface StockAvailabilityModeIndicatorProps {
+  useLegacyShippingZoneStockAvailability: boolean;
+}
+
+/**
+ * Renders a small one-line indicator informing the user which Saleor 3.23+
+ * stock-availability mode is currently active. The mode determines how the
+ * doctor and the public API resolve product availability, so surfacing it
+ * upfront prevents confusion when warnings differ between the two modes.
+ */
+const StockAvailabilityModeIndicator = ({
+  useLegacyShippingZoneStockAvailability,
+}: StockAvailabilityModeIndicatorProps) => {
+  const intl = useIntl();
+  const labelMessage = useLegacyShippingZoneStockAvailability
+    ? messages.stockAvailabilityModeLegacy
+    : messages.stockAvailabilityModeDirect;
+  const tooltipMessage = useLegacyShippingZoneStockAvailability
+    ? messages.stockAvailabilityModeLegacyTooltip
+    : messages.stockAvailabilityModeDirectTooltip;
+
+  return (
+    <Tooltip>
+      <Tooltip.Trigger>
+        <Box
+          display="flex"
+          alignItems="center"
+          gap={2}
+          __cursor="help"
+          data-test-id="stock-availability-mode-indicator"
+          data-test-mode={useLegacyShippingZoneStockAvailability ? "legacy" : "direct"}
+        >
+          <Layers size={14} color="var(--mu-colors-text-default2)" />
+          <Text size={2} color="default2">
+            {intl.formatMessage(labelMessage)}
+          </Text>
+        </Box>
+      </Tooltip.Trigger>
+      <Tooltip.Content>
+        <Tooltip.Arrow />
+        <Box padding={2} __maxWidth="350px">
+          <Text size={2}>{intl.formatMessage(tooltipMessage)}</Text>
+        </Box>
+      </Tooltip.Content>
+    </Tooltip>
   );
 };
 

--- a/src/products/components/ProductDoctor/AvailabilityCard.tsx
+++ b/src/products/components/ProductDoctor/AvailabilityCard.tsx
@@ -454,7 +454,6 @@ const StockAvailabilityModeIndicator = ({
           gap={2}
           __cursor="help"
           data-test-id="stock-availability-mode-indicator"
-          data-test-mode={useLegacyShippingZoneStockAvailability ? "legacy" : "direct"}
         >
           <Layers size={14} color="var(--mu-colors-text-default2)" />
           <Text size={2} color="default2">

--- a/src/products/components/ProductDoctor/AvailabilityChannelItem.tsx
+++ b/src/products/components/ProductDoctor/AvailabilityChannelItem.tsx
@@ -2,7 +2,7 @@ import { type ChannelOpts } from "@dashboard/components/ChannelsAvailabilityCard
 import { type ProductChannelListingErrorFragment } from "@dashboard/graphql";
 import { useCurrentDate } from "@dashboard/hooks/useCurrentDate";
 import { Accordion, Box, Button, Spinner, Text, Tooltip } from "@saleor/macaw-ui-next";
-import { AlertTriangle, ChevronDown, CircleAlert, Search } from "lucide-react";
+import { AlertTriangle, ChevronDown, CircleAlert, Info, Search } from "lucide-react";
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { Link } from "react-router-dom";
@@ -64,8 +64,18 @@ export const AvailabilityChannelItem = ({
   const intl = useIntl();
   const dateNow = useCurrentDate();
   const status = getAvailabilityStatus(originalSummary ?? summary, dateNow);
-  const hasIssues = issues.length > 0;
-  const issueErrorCount = issues.filter(i => i.severity === "error").length;
+  // "Blocking" issues (errors/warnings) drive the channel header state — they
+  // change the status label, dot color, and surface the issue badge. Info
+  // severity issues are advisories: they are still rendered in the body so
+  // users see the recommendation, but they should not promote the channel
+  // into a "has issues" visual state. This matches the top-level summary
+  // banner which counts only errors and warnings.
+  const blockingIssues = React.useMemo(
+    () => issues.filter(i => i.severity === "error" || i.severity === "warning"),
+    [issues],
+  );
+  const hasBlockingIssues = blockingIssues.length > 0;
+  const issueErrorCount = blockingIssues.filter(i => i.severity === "error").length;
   // Channel is effectively disabled if marked for removal or explicitly disabled
   const isEffectivelyDisabled = disabled || isMarkedForRemoval;
 
@@ -110,8 +120,9 @@ export const AvailabilityChannelItem = ({
   );
 
   const getStatusLabel = () => {
-    // When there are issues, show "Issues" status regardless of publication status
-    if (hasIssues) {
+    // Only blocking issues (errors/warnings) flip the channel into "Issues"
+    // status. Info-severity advisories don't change the headline state.
+    if (hasBlockingIssues) {
       return intl.formatMessage(messages.status_issues);
     }
 
@@ -126,8 +137,8 @@ export const AvailabilityChannelItem = ({
   };
 
   const getStatusDescription = () => {
-    // When there are issues, show issues description regardless of publication status
-    if (hasIssues) {
+    // Only blocking issues drive the description override (see getStatusLabel).
+    if (hasBlockingIssues) {
       return intl.formatMessage(messages.statusDescription_issues);
     }
 
@@ -174,7 +185,7 @@ export const AvailabilityChannelItem = ({
                 <Box>
                   <StatusDot
                     status={status}
-                    hasIssues={hasIssues}
+                    hasIssues={hasBlockingIssues}
                     issueType={issueErrorCount > 0 ? "error" : "warning"}
                   />
                 </Box>
@@ -188,9 +199,11 @@ export const AvailabilityChannelItem = ({
                   <Text size={1} color="default2">
                     {getStatusDescription()}
                   </Text>
-                  {hasIssues && (
+                  {hasBlockingIssues && (
                     <Text size={1} color={issueErrorCount > 0 ? "critical1" : "warning1"}>
-                      {intl.formatMessage(messages.channelHasIssues, { count: issues.length })}
+                      {intl.formatMessage(messages.channelHasIssues, {
+                        count: blockingIssues.length,
+                      })}
                     </Text>
                   )}
                 </Box>
@@ -206,8 +219,11 @@ export const AvailabilityChannelItem = ({
             >
               {summary.name}
             </Text>
-            {hasIssues && (
-              <IssueBadge count={issues.length} type={issueErrorCount > 0 ? "error" : "warning"} />
+            {hasBlockingIssues && (
+              <IssueBadge
+                count={blockingIssues.length}
+                type={issueErrorCount > 0 ? "error" : "warning"}
+              />
             )}
           </Box>
           <Box display="flex" alignItems="center" gap={2}>
@@ -412,14 +428,41 @@ interface IssueCalloutProps {
   issue: AvailabilityIssue;
 }
 
+type IssueSeverity = AvailabilityIssue["severity"];
+
+interface IssueVisuals {
+  Icon: typeof AlertTriangle;
+  /** macaw-ui color token applied to the icon. */
+  iconColor: "critical1" | "warning1" | "default2";
+  /** macaw-ui color token applied to the issue title. Info issues render the
+   *  title in default text color so they don't look like an actionable warning. */
+  titleColor: "critical1" | "warning1" | "default1";
+}
+
+const getIssueVisuals = (severity: IssueSeverity): IssueVisuals => {
+  switch (severity) {
+    case "error":
+      return { Icon: AlertTriangle, iconColor: "critical1", titleColor: "critical1" };
+    case "warning":
+      return { Icon: CircleAlert, iconColor: "warning1", titleColor: "warning1" };
+    case "info":
+      return { Icon: Info, iconColor: "default2", titleColor: "default1" };
+  }
+};
+
 const IssueCallout = ({ issue }: IssueCalloutProps) => {
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const isError = issue.severity === "error";
-  const Icon = isError ? AlertTriangle : CircleAlert;
-  const iconColor = isError ? "critical1" : "warning1";
+  const { Icon, iconColor, titleColor } = getIssueVisuals(issue.severity);
 
   return (
-    <Box display="flex" gap={2} alignItems="flex-start">
+    <Box
+      display="flex"
+      gap={2}
+      alignItems="flex-start"
+      data-test-id="availability-issue-callout"
+      data-test-issue-id={issue.id}
+      data-test-severity={issue.severity}
+    >
       <Box color={iconColor} flexShrink="0" paddingTop={0.5}>
         <Icon size={14} />
       </Box>
@@ -437,7 +480,7 @@ const IssueCallout = ({ issue }: IssueCalloutProps) => {
           __textAlign="left"
           onClick={() => setIsExpanded(!isExpanded)}
         >
-          <Text size={2} fontWeight="medium" color={iconColor}>
+          <Text size={2} fontWeight="medium" color={titleColor}>
             {issue.message}
           </Text>
           <ChevronDown

--- a/src/products/components/ProductDoctor/AvailabilityChannelItem.tsx
+++ b/src/products/components/ProductDoctor/AvailabilityChannelItem.tsx
@@ -26,7 +26,7 @@ import {
 import { AvailableForPurchaseSection } from "./sections/AvailableForPurchaseSection";
 import { PublishedSection } from "./sections/PublishedSection";
 import { VisibleInListingsSection } from "./sections/VisibleInListingsSection";
-import { getBlockingIssueBadgeProps } from "./utils/issueBadge";
+import { getHeaderIssueBadgeProps } from "./utils/issueBadge";
 import { type AvailabilityIssue, type ChannelSummary, type IssueSeverity } from "./utils/types";
 
 interface AvailabilityChannelItemProps {
@@ -65,15 +65,17 @@ export const AvailabilityChannelItem = ({
   const intl = useIntl();
   const dateNow = useCurrentDate();
   const status = getAvailabilityStatus(originalSummary ?? summary, dateNow);
-  // "Blocking" issues (errors/warnings) drive the channel header state — they
-  // change the status label, dot color, and surface the issue badge. Info
-  // severity issues are advisories: they are still rendered in the body so
-  // users see the recommendation, but they should not promote the channel
-  // into a "has issues" visual state. The selection rules and severity
-  // escalation live in `getBlockingIssueBadgeProps` so they can be tested in
-  // isolation from React.
-  const issueBadgeProps = React.useMemo(() => getBlockingIssueBadgeProps(issues), [issues]);
-  const hasBlockingIssues = issueBadgeProps !== null;
+  // Errors and warnings get promoted into the channel header — they change
+  // the status label, dot color, and surface the issue badge. Info severity
+  // issues are advisories: they are still rendered in the body so users see
+  // the recommendation, but they do not promote the channel into a "has
+  // issues" visual state. (Note: a "warning" is not blocking in plain
+  // English; it shares the header treatment with errors only because both
+  // are non-advisory and worth flagging up front.) The selection rules and
+  // severity escalation live in `getHeaderIssueBadgeProps` so they can be
+  // tested in isolation from React.
+  const issueBadgeProps = React.useMemo(() => getHeaderIssueBadgeProps(issues), [issues]);
+  const hasHeaderIssues = issueBadgeProps !== null;
   // Channel is effectively disabled if marked for removal or explicitly disabled
   const isEffectivelyDisabled = disabled || isMarkedForRemoval;
 
@@ -118,9 +120,10 @@ export const AvailabilityChannelItem = ({
   );
 
   const getStatusLabel = () => {
-    // Only blocking issues (errors/warnings) flip the channel into "Issues"
-    // status. Info-severity advisories don't change the headline state.
-    if (hasBlockingIssues) {
+    // Only header-worthy issues (errors and warnings) flip the channel into
+    // "Issues" status. Info-severity advisories don't change the headline
+    // state.
+    if (hasHeaderIssues) {
       return intl.formatMessage(messages.status_issues);
     }
 
@@ -135,8 +138,8 @@ export const AvailabilityChannelItem = ({
   };
 
   const getStatusDescription = () => {
-    // Only blocking issues drive the description override (see getStatusLabel).
-    if (hasBlockingIssues) {
+    // Only header-worthy issues drive the description override (see getStatusLabel).
+    if (hasHeaderIssues) {
       return intl.formatMessage(messages.statusDescription_issues);
     }
 
@@ -183,7 +186,7 @@ export const AvailabilityChannelItem = ({
                 <Box>
                   <StatusDot
                     status={status}
-                    hasIssues={hasBlockingIssues}
+                    hasIssues={hasHeaderIssues}
                     issueType={issueBadgeProps?.type ?? "warning"}
                   />
                 </Box>

--- a/src/products/components/ProductDoctor/AvailabilityChannelItem.tsx
+++ b/src/products/components/ProductDoctor/AvailabilityChannelItem.tsx
@@ -26,7 +26,8 @@ import {
 import { AvailableForPurchaseSection } from "./sections/AvailableForPurchaseSection";
 import { PublishedSection } from "./sections/PublishedSection";
 import { VisibleInListingsSection } from "./sections/VisibleInListingsSection";
-import { type AvailabilityIssue, type ChannelSummary } from "./utils/types";
+import { getBlockingIssueBadgeProps } from "./utils/issueBadge";
+import { type AvailabilityIssue, type ChannelSummary, type IssueSeverity } from "./utils/types";
 
 interface AvailabilityChannelItemProps {
   summary: ChannelSummary;
@@ -68,14 +69,11 @@ export const AvailabilityChannelItem = ({
   // change the status label, dot color, and surface the issue badge. Info
   // severity issues are advisories: they are still rendered in the body so
   // users see the recommendation, but they should not promote the channel
-  // into a "has issues" visual state. This matches the top-level summary
-  // banner which counts only errors and warnings.
-  const blockingIssues = React.useMemo(
-    () => issues.filter(i => i.severity === "error" || i.severity === "warning"),
-    [issues],
-  );
-  const hasBlockingIssues = blockingIssues.length > 0;
-  const issueErrorCount = blockingIssues.filter(i => i.severity === "error").length;
+  // into a "has issues" visual state. The selection rules and severity
+  // escalation live in `getBlockingIssueBadgeProps` so they can be tested in
+  // isolation from React.
+  const issueBadgeProps = React.useMemo(() => getBlockingIssueBadgeProps(issues), [issues]);
+  const hasBlockingIssues = issueBadgeProps !== null;
   // Channel is effectively disabled if marked for removal or explicitly disabled
   const isEffectivelyDisabled = disabled || isMarkedForRemoval;
 
@@ -186,7 +184,7 @@ export const AvailabilityChannelItem = ({
                   <StatusDot
                     status={status}
                     hasIssues={hasBlockingIssues}
-                    issueType={issueErrorCount > 0 ? "error" : "warning"}
+                    issueType={issueBadgeProps?.type ?? "warning"}
                   />
                 </Box>
               </Tooltip.Trigger>
@@ -199,10 +197,13 @@ export const AvailabilityChannelItem = ({
                   <Text size={1} color="default2">
                     {getStatusDescription()}
                   </Text>
-                  {hasBlockingIssues && (
-                    <Text size={1} color={issueErrorCount > 0 ? "critical1" : "warning1"}>
+                  {issueBadgeProps && (
+                    <Text
+                      size={1}
+                      color={issueBadgeProps.type === "error" ? "critical1" : "warning1"}
+                    >
                       {intl.formatMessage(messages.channelHasIssues, {
-                        count: blockingIssues.length,
+                        count: issueBadgeProps.count,
                       })}
                     </Text>
                   )}
@@ -219,11 +220,8 @@ export const AvailabilityChannelItem = ({
             >
               {summary.name}
             </Text>
-            {hasBlockingIssues && (
-              <IssueBadge
-                count={blockingIssues.length}
-                type={issueErrorCount > 0 ? "error" : "warning"}
-              />
+            {issueBadgeProps && (
+              <IssueBadge count={issueBadgeProps.count} type={issueBadgeProps.type} />
             )}
           </Box>
           <Box display="flex" alignItems="center" gap={2}>
@@ -428,8 +426,6 @@ interface IssueCalloutProps {
   issue: AvailabilityIssue;
 }
 
-type IssueSeverity = AvailabilityIssue["severity"];
-
 interface IssueVisuals {
   Icon: typeof AlertTriangle;
   /** macaw-ui color token applied to the icon. */
@@ -437,34 +433,55 @@ interface IssueVisuals {
   /** macaw-ui color token applied to the issue title. Info issues render the
    *  title in default text color so they don't look like an actionable warning. */
   titleColor: "critical1" | "warning1" | "default1";
+  /** Key into the messages catalog used as the icon's accessible name. */
+  iconLabelKey: "issueCalloutIconError" | "issueCalloutIconWarning" | "issueCalloutIconInfo";
+  /** Stable test-id for the icon node, used by component tests instead of a
+   *  data-test-severity attribute leaking onto the wrapper. */
+  iconTestId:
+    | "product-doctor-issue-callout-icon-error"
+    | "product-doctor-issue-callout-icon-warning"
+    | "product-doctor-issue-callout-icon-info";
 }
 
 const getIssueVisuals = (severity: IssueSeverity): IssueVisuals => {
   switch (severity) {
     case "error":
-      return { Icon: AlertTriangle, iconColor: "critical1", titleColor: "critical1" };
+      return {
+        Icon: AlertTriangle,
+        iconColor: "critical1",
+        titleColor: "critical1",
+        iconLabelKey: "issueCalloutIconError",
+        iconTestId: "product-doctor-issue-callout-icon-error",
+      };
     case "warning":
-      return { Icon: CircleAlert, iconColor: "warning1", titleColor: "warning1" };
+      return {
+        Icon: CircleAlert,
+        iconColor: "warning1",
+        titleColor: "warning1",
+        iconLabelKey: "issueCalloutIconWarning",
+        iconTestId: "product-doctor-issue-callout-icon-warning",
+      };
     case "info":
-      return { Icon: Info, iconColor: "default2", titleColor: "default1" };
+      return {
+        Icon: Info,
+        iconColor: "default2",
+        titleColor: "default1",
+        iconLabelKey: "issueCalloutIconInfo",
+        iconTestId: "product-doctor-issue-callout-icon-info",
+      };
   }
 };
 
 const IssueCallout = ({ issue }: IssueCalloutProps) => {
+  const intl = useIntl();
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const { Icon, iconColor, titleColor } = getIssueVisuals(issue.severity);
+  const { Icon, iconColor, titleColor, iconLabelKey, iconTestId } = getIssueVisuals(issue.severity);
+  const iconLabel = intl.formatMessage(messages[iconLabelKey]);
 
   return (
-    <Box
-      display="flex"
-      gap={2}
-      alignItems="flex-start"
-      data-test-id="availability-issue-callout"
-      data-test-issue-id={issue.id}
-      data-test-severity={issue.severity}
-    >
+    <Box display="flex" gap={2} alignItems="flex-start" data-test-id="availability-issue-callout">
       <Box color={iconColor} flexShrink="0" paddingTop={0.5}>
-        <Icon size={14} />
+        <Icon size={14} role="img" aria-label={iconLabel} data-test-id={iconTestId} />
       </Box>
       <Box display="flex" flexDirection="column" gap={1} __flex="1">
         <Box

--- a/src/products/components/ProductDoctor/hooks/useProductAvailabilityDiagnostics.test.tsx
+++ b/src/products/components/ProductDoctor/hooks/useProductAvailabilityDiagnostics.test.tsx
@@ -66,7 +66,13 @@ const createMockProduct = (overrides?: Partial<ProductDiagnosticData>): ProductD
   ...overrides,
 });
 
-const createMockChannelData = () => ({
+const createMockChannelData = (
+  overrides: { useLegacyShippingZoneStockAvailability?: boolean } = {},
+) => ({
+  shop: {
+    useLegacyShippingZoneStockAvailability:
+      overrides.useLegacyShippingZoneStockAvailability ?? true,
+  },
   channels: [
     {
       id: "channel-1",
@@ -410,5 +416,124 @@ describe("useProductAvailabilityDiagnostics", () => {
       expect.anything(),
       expect.objectContaining({ skip: true }),
     );
+  });
+
+  describe("useLegacyShippingZoneStockAvailability flag plumbing (Saleor 3.23+)", () => {
+    it("should forward legacy=true from the diagnostics query to runAvailabilityChecks", () => {
+      // Arrange
+      const product = createMockProduct();
+      const channelData = createMockChannelData({ useLegacyShippingZoneStockAvailability: true });
+
+      mockUseQuery.mockReturnValue({ data: channelData, loading: false, error: null });
+
+      // Act
+      renderHook(() => useProductAvailabilityDiagnostics({ product }), { wrapper });
+
+      // Assert
+      expect(mockRunAvailabilityChecks).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ useLegacyShippingZoneStockAvailability: true }),
+      );
+    });
+
+    it("should forward legacy=false when shop has direct mode enabled", () => {
+      // Arrange
+      const product = createMockProduct();
+      const channelData = createMockChannelData({ useLegacyShippingZoneStockAvailability: false });
+
+      mockUseQuery.mockReturnValue({ data: channelData, loading: false, error: null });
+
+      // Act
+      renderHook(() => useProductAvailabilityDiagnostics({ product }), { wrapper });
+
+      // Assert
+      expect(mockRunAvailabilityChecks).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ useLegacyShippingZoneStockAvailability: false }),
+      );
+    });
+
+    it("should default to legacy=true when the diagnostics query hasn't returned shop yet", () => {
+      // Arrange - shop missing from response (e.g. permission stripped or partial data)
+      const product = createMockProduct();
+      const channelData = {
+        ...createMockChannelData(),
+        shop: null,
+      };
+
+      mockUseQuery.mockReturnValue({ data: channelData, loading: false, error: null });
+
+      // Act
+      const { result } = renderHook(() => useProductAvailabilityDiagnostics({ product }), {
+        wrapper,
+      });
+
+      // Assert - the doctor should not silently switch to direct mode before
+      // the shop fragment resolves; legacy is the safer default.
+      expect(result.current.useLegacyShippingZoneStockAvailability).toBe(true);
+      expect(mockRunAvailabilityChecks).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ useLegacyShippingZoneStockAvailability: true }),
+      );
+    });
+
+    it("should expose useLegacyShippingZoneStockAvailability on the result for UI consumers", () => {
+      // Arrange
+      const product = createMockProduct();
+      const channelData = createMockChannelData({ useLegacyShippingZoneStockAvailability: false });
+
+      mockUseQuery.mockReturnValue({ data: channelData, loading: false, error: null });
+
+      // Act
+      const { result } = renderHook(() => useProductAvailabilityDiagnostics({ product }), {
+        wrapper,
+      });
+
+      // Assert
+      expect(result.current.useLegacyShippingZoneStockAvailability).toBe(false);
+    });
+
+    it("should expose the flag on early-return states (disabled / no product / loading)", () => {
+      // Arrange
+      const channelData = createMockChannelData({ useLegacyShippingZoneStockAvailability: false });
+
+      mockUseQuery.mockReturnValue({ data: channelData, loading: false, error: null });
+
+      // Act + Assert - null product
+      const { result: nullResult } = renderHook(
+        () => useProductAvailabilityDiagnostics({ product: null }),
+        { wrapper },
+      );
+
+      expect(nullResult.current.useLegacyShippingZoneStockAvailability).toBe(false);
+
+      // Act + Assert - disabled
+      const product = createMockProduct();
+      const { result: disabledResult } = renderHook(
+        () => useProductAvailabilityDiagnostics({ product, enabled: false }),
+        { wrapper },
+      );
+
+      expect(disabledResult.current.useLegacyShippingZoneStockAvailability).toBe(false);
+
+      // Act + Assert - loading (no data yet -> falls back to legacy)
+      mockUseQuery.mockReturnValue({ data: null, loading: true, error: null });
+
+      const { result: loadingResult } = renderHook(
+        () => useProductAvailabilityDiagnostics({ product }),
+        { wrapper },
+      );
+
+      expect(loadingResult.current.useLegacyShippingZoneStockAvailability).toBe(true);
+    });
   });
 });

--- a/src/products/components/ProductDoctor/hooks/useProductAvailabilityDiagnostics.test.tsx
+++ b/src/products/components/ProductDoctor/hooks/useProductAvailabilityDiagnostics.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from "@testing-library/react";
 import { IntlProvider } from "react-intl";
 
 import { runAvailabilityChecks } from "../utils/availabilityChecks";
+import { LEGACY_MODE_FALLBACK } from "../utils/constants";
 import { type ProductDiagnosticData } from "../utils/types";
 import { useProductAvailabilityDiagnostics } from "./useProductAvailabilityDiagnostics";
 
@@ -71,7 +72,7 @@ const createMockChannelData = (
 ) => ({
   shop: {
     useLegacyShippingZoneStockAvailability:
-      overrides.useLegacyShippingZoneStockAvailability ?? true,
+      overrides.useLegacyShippingZoneStockAvailability ?? LEGACY_MODE_FALLBACK,
   },
   channels: [
     {

--- a/src/products/components/ProductDoctor/hooks/useProductAvailabilityDiagnostics.ts
+++ b/src/products/components/ProductDoctor/hooks/useProductAvailabilityDiagnostics.ts
@@ -13,6 +13,14 @@ import {
   type ProductDiagnosticData,
 } from "../utils/types";
 
+/**
+ * Defaults to `true` (legacy mode) when the shop fragment in the diagnostics
+ * query hasn't loaded yet so we don't downgrade legacy behaviors prematurely
+ * on a fresh page load. Once the query resolves, the real value takes over
+ * and re-renders the diagnostics.
+ */
+const LEGACY_MODE_FALLBACK = true;
+
 interface UseProductAvailabilityDiagnosticsProps {
   product: ProductDiagnosticData | null | undefined;
   enabled?: boolean;
@@ -108,6 +116,13 @@ export function useProductAvailabilityDiagnostics({
       missingPermissions: [] as string[],
     };
 
+    // `Shop.useLegacyShippingZoneStockAvailability` (Saleor 3.23+) is fetched
+    // alongside the channel data in `channelDiagnosticsQuery`. Default to
+    // legacy until the query resolves so we don't transiently downgrade
+    // existing severity levels on first render.
+    const useLegacyShippingZoneStockAvailability =
+      channelData?.shop?.useLegacyShippingZoneStockAvailability ?? LEGACY_MODE_FALLBACK;
+
     if (!product || !enabled) {
       return {
         issues: [],
@@ -116,6 +131,7 @@ export function useProductAvailabilityDiagnostics({
         hasWarnings: false,
         isLoading: false,
         permissions: defaultPermissions,
+        useLegacyShippingZoneStockAvailability,
       };
     }
 
@@ -129,6 +145,7 @@ export function useProductAvailabilityDiagnostics({
         hasWarnings: false,
         isLoading: true,
         permissions: defaultPermissions,
+        useLegacyShippingZoneStockAvailability,
       };
     }
 
@@ -218,6 +235,7 @@ export function useProductAvailabilityDiagnostics({
           {
             skipWarehouseChecks: !hasFullChannelData || !basePermissions.canViewChannelWarehouses,
             skipShippingChecks: !hasFullChannelData || !basePermissions.canViewShippingZones,
+            useLegacyShippingZoneStockAvailability,
           },
         );
 
@@ -294,6 +312,7 @@ export function useProductAvailabilityDiagnostics({
       hasWarnings: issues.some(issue => issue.severity === "warning"),
       isLoading: false,
       permissions,
+      useLegacyShippingZoneStockAvailability,
     };
   }, [product, channelData, loading, enabled, intl, basePermissions]);
 

--- a/src/products/components/ProductDoctor/hooks/useProductAvailabilityDiagnostics.ts
+++ b/src/products/components/ProductDoctor/hooks/useProductAvailabilityDiagnostics.ts
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 
 import { runAvailabilityChecks } from "../utils/availabilityChecks";
+import { LEGACY_MODE_FALLBACK } from "../utils/constants";
 import {
   type AvailabilityIssue,
   type ChannelDiagnosticData,
@@ -12,14 +13,6 @@ import {
   type DiagnosticsResult,
   type ProductDiagnosticData,
 } from "../utils/types";
-
-/**
- * Defaults to `true` (legacy mode) when the shop fragment in the diagnostics
- * query hasn't loaded yet so we don't downgrade legacy behaviors prematurely
- * on a fresh page load. Once the query resolves, the real value takes over
- * and re-renders the diagnostics.
- */
-const LEGACY_MODE_FALLBACK = true;
 
 interface UseProductAvailabilityDiagnosticsProps {
   product: ProductDiagnosticData | null | undefined;

--- a/src/products/components/ProductDoctor/messages.ts
+++ b/src/products/components/ProductDoctor/messages.ts
@@ -83,17 +83,31 @@ export const messages = defineMessages({
     description: "Description for no warehouses warning",
   },
 
-  // No shipping zones
+  // No shipping zones (legacy mode: blocks purchase)
   noShippingZones: {
     id: "8W1v0N",
     defaultMessage: 'No shipping zones for "{channelName}"',
     description: "Warning when channel has no shipping zones",
   },
   noShippingZonesDescription: {
-    id: "EAKKtg",
+    id: "vuOZYs",
     defaultMessage:
-      "Customers cannot checkout without shipping methods. Add shipping zones to this channel.",
+      "Without shipping zones, this product will appear unavailable to customers and orders cannot be shipped. Add at least one shipping zone to this channel.",
     description: "Description for no shipping zones warning",
+  },
+
+  // No shipping zones (direct warehouse-channel mode: shipping-only impact)
+  noShippingZonesShippingOnly: {
+    id: "Rt95cf",
+    defaultMessage: 'No shipping zones for "{channelName}"',
+    description: "Info when channel has no shipping zones in direct stock-availability mode",
+  },
+  noShippingZonesShippingOnlyDescription: {
+    id: "7CZ8Tp",
+    defaultMessage:
+      "Customers can browse and add this product to cart, but no shipping methods will be available at checkout. Add at least one shipping zone to this channel to enable shipping.",
+    description:
+      "Description for no shipping zones info when shop uses direct warehouse-channel stock availability",
   },
 
   // No stock
@@ -118,6 +132,19 @@ export const messages = defineMessages({
     id: "QfK+5Q",
     defaultMessage: "Warehouses with stock are not assigned to any shipping zone in this channel.",
     description: "Description for warehouse not in zone warning",
+  },
+
+  // Stock exists but in warehouses not assigned to the channel
+  stockOutsideChannelWarehouses: {
+    id: "uaZNZS",
+    defaultMessage: 'Stock is in warehouses not assigned to "{channelName}"',
+    description: "Info when product has stock only in warehouses not linked to the channel",
+  },
+  stockOutsideChannelWarehousesDescription: {
+    id: "/8a4cU",
+    defaultMessage:
+      "This product has stock in warehouses that are not linked to this channel. Assign the warehouse to the channel for the stock to count toward availability.",
+    description: "Description for stock-outside-channel-warehouses info",
   },
 
   // Actions
@@ -520,6 +547,32 @@ export const messages = defineMessages({
     id: "azych5",
     defaultMessage: "All channels configured correctly",
     description: "Message when no diagnostic issues found",
+  },
+
+  // Stock availability mode indicator (Saleor 3.23+)
+  stockAvailabilityModeLegacy: {
+    id: "7sSOgb",
+    defaultMessage: "Stock availability uses shipping zones (legacy)",
+    description:
+      "Indicator label shown when shop has Shop.useLegacyShippingZoneStockAvailability=true",
+  },
+  stockAvailabilityModeLegacyTooltip: {
+    id: "GYBoVb",
+    defaultMessage:
+      "Stock is considered available only when the warehouse is both assigned to this channel and covered by an active shipping zone for the destination address.",
+    description: "Tooltip explanation for legacy stock-availability mode",
+  },
+  stockAvailabilityModeDirect: {
+    id: "BfhUcl",
+    defaultMessage: "Stock availability uses direct warehouse-channel link",
+    description:
+      "Indicator label shown when shop has Shop.useLegacyShippingZoneStockAvailability=false",
+  },
+  stockAvailabilityModeDirectTooltip: {
+    id: "tSmJPv",
+    defaultMessage:
+      "Stock is considered available whenever the warehouse is assigned to this channel. Shipping zones only affect order fulfillment, not availability.",
+    description: "Tooltip explanation for direct stock-availability mode",
   },
   issuesSummary: {
     id: "v/tz3W",

--- a/src/products/components/ProductDoctor/messages.ts
+++ b/src/products/components/ProductDoctor/messages.ts
@@ -585,6 +585,36 @@ export const messages = defineMessages({
     defaultMessage: "{count, plural, one {# issue} other {# issues}}",
     description: "Badge showing number of issues in a channel",
   },
+  // Accessible (aria-label) names for the issue badge variants. They are the
+  // textual equivalent of the rendered icon for assistive technology, and
+  // also serve as a stable query handle in tests.
+  issueBadgeIconError: {
+    id: "kyOwDW",
+    defaultMessage: "Error",
+    description: "aria-label for the error icon inside a channel issue badge",
+  },
+  issueBadgeIconWarning: {
+    id: "/0QqzO",
+    defaultMessage: "Warning",
+    description: "aria-label for the warning icon inside a channel issue badge",
+  },
+  // Accessible names for the per-issue callout icons rendered inside the
+  // expanded channel body. Same idea as `issueBadgeIcon*`.
+  issueCalloutIconError: {
+    id: "eXcTEd",
+    defaultMessage: "Error",
+    description: "aria-label for the error icon inside an availability issue callout",
+  },
+  issueCalloutIconWarning: {
+    id: "iBY7aI",
+    defaultMessage: "Warning",
+    description: "aria-label for the warning icon inside an availability issue callout",
+  },
+  issueCalloutIconInfo: {
+    id: "cYjzDx",
+    defaultMessage: "Information",
+    description: "aria-label for the info icon inside an availability issue callout",
+  },
   configurationTitle: {
     id: "f71A+Y",
     defaultMessage: "Delivery configuration",

--- a/src/products/components/ProductDoctor/primitives.tsx
+++ b/src/products/components/ProductDoctor/primitives.tsx
@@ -157,22 +157,36 @@ export const IssueBadge = ({ count, type }: IssueBadgeProps) => {
   const intl = useIntl();
   const iconColor =
     type === "error" ? "var(--mu-colors-text-critical1)" : "var(--mu-colors-text-warning1)";
-  const title = intl.formatMessage(messages.channelHasIssues, { count });
+  const accessibleName = intl.formatMessage(messages.channelHasIssues, { count });
+  const iconLabel = intl.formatMessage(
+    type === "error" ? messages.issueBadgeIconError : messages.issueBadgeIconWarning,
+  );
 
   return (
     <Box
       display="flex"
       alignItems="center"
-      title={title}
+      title={accessibleName}
+      aria-label={accessibleName}
       position="relative"
       data-test-id="channel-issue-badge"
-      data-test-count={count}
-      data-test-type={type}
     >
       {type === "error" ? (
-        <AlertTriangle size={16} color={iconColor} />
+        <AlertTriangle
+          size={16}
+          color={iconColor}
+          role="img"
+          aria-label={iconLabel}
+          data-test-id="product-doctor-issue-badge-icon-error"
+        />
       ) : (
-        <CircleAlert size={16} color={iconColor} />
+        <CircleAlert
+          size={16}
+          color={iconColor}
+          role="img"
+          aria-label={iconLabel}
+          data-test-id="product-doctor-issue-badge-icon-warning"
+        />
       )}
       {count > 1 && (
         <Text
@@ -183,6 +197,7 @@ export const IssueBadge = ({ count, type }: IssueBadgeProps) => {
           __top="-4px"
           __right="-6px"
           __fontSize="10px"
+          data-test-id="product-doctor-issue-badge-count"
         >
           {count}
         </Text>

--- a/src/products/components/ProductDoctor/primitives.tsx
+++ b/src/products/components/ProductDoctor/primitives.tsx
@@ -160,7 +160,15 @@ export const IssueBadge = ({ count, type }: IssueBadgeProps) => {
   const title = intl.formatMessage(messages.channelHasIssues, { count });
 
   return (
-    <Box display="flex" alignItems="center" title={title} position="relative">
+    <Box
+      display="flex"
+      alignItems="center"
+      title={title}
+      position="relative"
+      data-test-id="channel-issue-badge"
+      data-test-count={count}
+      data-test-type={type}
+    >
       {type === "error" ? (
         <AlertTriangle size={16} color={iconColor} />
       ) : (

--- a/src/products/components/ProductDoctor/utils/availabilityChecks.test.ts
+++ b/src/products/components/ProductDoctor/utils/availabilityChecks.test.ts
@@ -259,4 +259,231 @@ describe("runAvailabilityChecks", () => {
       expect(shippingIssue).toBeUndefined();
     });
   });
+
+  describe("direct warehouse-channel stock availability mode (Saleor 3.23+)", () => {
+    it("should NOT emit warehouse-not-in-zone in direct mode (would be a false positive)", () => {
+      // Arrange - stock is in a warehouse linked to the channel but missing from shipping zones
+      const product = createProduct({ isShippingRequired: true });
+      const channelData = createChannelData({
+        shippingZones: [
+          {
+            id: "zone-1",
+            name: "Zone 1",
+            countries: [{ code: "US", country: "United States" }],
+            warehouses: [{ id: "warehouse-other", name: "Other Warehouse" }],
+          },
+        ],
+      });
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl, {
+        useLegacyShippingZoneStockAvailability: false,
+      });
+
+      // Assert
+      const zoneIssue = issues.find(i => i.id === "warehouse-not-in-zone");
+
+      expect(zoneIssue).toBeUndefined();
+    });
+
+    it("should still emit warehouse-not-in-zone in legacy mode for the same data", () => {
+      // Arrange - identical to the previous test, but legacy mode active
+      const product = createProduct({ isShippingRequired: true });
+      const channelData = createChannelData({
+        shippingZones: [
+          {
+            id: "zone-1",
+            name: "Zone 1",
+            countries: [{ code: "US", country: "United States" }],
+            warehouses: [{ id: "warehouse-other", name: "Other Warehouse" }],
+          },
+        ],
+      });
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl, {
+        useLegacyShippingZoneStockAvailability: true,
+      });
+
+      // Assert
+      const zoneIssue = issues.find(i => i.id === "warehouse-not-in-zone");
+
+      expect(zoneIssue).toBeDefined();
+      expect(zoneIssue?.severity).toBe("warning");
+    });
+
+    it("should downgrade no-shipping-zones to info severity in direct mode", () => {
+      // Arrange
+      const product = createProduct({ isShippingRequired: true });
+      const channelData = createChannelData({ shippingZones: [] });
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl, {
+        useLegacyShippingZoneStockAvailability: false,
+      });
+
+      // Assert
+      const shippingIssue = issues.find(i => i.id === "no-shipping-zones");
+
+      expect(shippingIssue).toBeDefined();
+      expect(shippingIssue?.severity).toBe("info");
+      // Direct-mode copy reflects that browsing/cart works but no shipping
+      // methods are available at checkout — it does NOT claim the product is
+      // unavailable, since direct mode reports it as available.
+      expect(shippingIssue?.description).toMatch(/no shipping methods will be available/i);
+      expect(shippingIssue?.description).not.toMatch(/appear unavailable/i);
+    });
+
+    it("should keep no-shipping-zones at warning severity in legacy mode", () => {
+      // Arrange
+      const product = createProduct({ isShippingRequired: true });
+      const channelData = createChannelData({ shippingZones: [] });
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl, {
+        useLegacyShippingZoneStockAvailability: true,
+      });
+
+      // Assert
+      const shippingIssue = issues.find(i => i.id === "no-shipping-zones");
+
+      expect(shippingIssue).toBeDefined();
+      expect(shippingIssue?.severity).toBe("warning");
+      // Legacy-mode copy emphasizes the primary blocker: the product appears
+      // unavailable to customers (the resolver intersects shipping zones with
+      // warehouses), and orders also cannot be shipped.
+      expect(shippingIssue?.description).toMatch(/appear unavailable/i);
+      expect(shippingIssue?.description).toMatch(/cannot be shipped/i);
+    });
+
+    it("should NOT emit no-shipping-zones at all when product is non-shippable, even in direct mode", () => {
+      // Arrange - digital product, shouldn't surface shipping advice in any mode
+      const product = createProduct({ isShippingRequired: false });
+      const channelData = createChannelData({ shippingZones: [] });
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl, {
+        useLegacyShippingZoneStockAvailability: false,
+      });
+
+      // Assert
+      const shippingIssue = issues.find(i => i.id === "no-shipping-zones");
+
+      expect(shippingIssue).toBeUndefined();
+    });
+
+    it("should default to legacy behavior when no options are provided", () => {
+      // Arrange
+      const product = createProduct({ isShippingRequired: true });
+      const channelData = createChannelData({ shippingZones: [] });
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl);
+
+      // Assert - legacy severity preserved for unconfigured callers
+      const shippingIssue = issues.find(i => i.id === "no-shipping-zones");
+
+      expect(shippingIssue?.severity).toBe("warning");
+    });
+  });
+
+  describe("checkStockOutsideChannelWarehouses (info)", () => {
+    it("should emit info when stock is in a warehouse not assigned to the channel", () => {
+      // Arrange - stock in warehouse-2, but channel is wired to warehouse-1
+      const product = createProduct({
+        variants: [
+          {
+            id: "variant-1",
+            name: "Variant A",
+            channelListings: [{ channel: { id: "channel-1" }, price: { amount: 10 } }],
+            stocks: [{ warehouse: { id: "warehouse-2" }, quantity: 5 }],
+          },
+        ],
+      });
+      const channelData = createChannelData({
+        warehouses: [{ id: "warehouse-1", name: "Channel Warehouse" }],
+      });
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl);
+
+      // Assert
+      const issue = issues.find(i => i.id === "stock-outside-channel-warehouses");
+
+      expect(issue).toBeDefined();
+      expect(issue?.severity).toBe("info");
+    });
+
+    it("should NOT emit when stock exists in a channel warehouse", () => {
+      // Arrange - stock in the channel-linked warehouse, all good
+      const product = createProduct(); // variant-1 -> warehouse-1, qty 100
+      const channelData = createChannelData(); // channel -> warehouse-1
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl);
+
+      // Assert
+      const issue = issues.find(i => i.id === "stock-outside-channel-warehouses");
+
+      expect(issue).toBeUndefined();
+    });
+
+    it("should NOT emit when there is no positive stock anywhere", () => {
+      // Arrange
+      const product = createProduct({
+        variants: [
+          {
+            id: "variant-1",
+            name: "Variant A",
+            channelListings: [{ channel: { id: "channel-1" }, price: { amount: 10 } }],
+            stocks: [{ warehouse: { id: "warehouse-2" }, quantity: 0 }],
+          },
+        ],
+      });
+      const channelData = createChannelData();
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl);
+
+      // Assert
+      const issue = issues.find(i => i.id === "stock-outside-channel-warehouses");
+
+      expect(issue).toBeUndefined();
+    });
+
+    it("should be skipped together with other warehouse checks when skipWarehouseChecks is true", () => {
+      // Arrange
+      const product = createProduct({
+        variants: [
+          {
+            id: "variant-1",
+            name: "Variant A",
+            channelListings: [{ channel: { id: "channel-1" }, price: { amount: 10 } }],
+            stocks: [{ warehouse: { id: "warehouse-2" }, quantity: 5 }],
+          },
+        ],
+      });
+      const channelData = createChannelData();
+      const channelListing = product.channelListings[0];
+
+      // Act
+      const issues = runAvailabilityChecks(product, channelData, channelListing, mockIntl, {
+        skipWarehouseChecks: true,
+      });
+
+      // Assert
+      const issue = issues.find(i => i.id === "stock-outside-channel-warehouses");
+
+      expect(issue).toBeUndefined();
+    });
+  });
 });

--- a/src/products/components/ProductDoctor/utils/availabilityChecks.ts
+++ b/src/products/components/ProductDoctor/utils/availabilityChecks.ts
@@ -2,6 +2,7 @@ import { channelUrl } from "@dashboard/channels/urls";
 import { type IntlShape } from "react-intl";
 
 import { messages } from "../messages";
+import { LEGACY_MODE_FALLBACK } from "./constants";
 import {
   type AvailabilityIssue,
   type ChannelDiagnosticData,
@@ -431,7 +432,7 @@ export function runAvailabilityChecks(
   options?: CheckOptions,
 ): AvailabilityIssue[] {
   const useLegacyShippingZoneStockAvailability =
-    options?.useLegacyShippingZoneStockAvailability ?? true;
+    options?.useLegacyShippingZoneStockAvailability ?? LEGACY_MODE_FALLBACK;
 
   const context: CheckContext = {
     product,

--- a/src/products/components/ProductDoctor/utils/availabilityChecks.ts
+++ b/src/products/components/ProductDoctor/utils/availabilityChecks.ts
@@ -13,6 +13,14 @@ interface CheckContext {
   channelData: ChannelDiagnosticData;
   channelListing: ProductDiagnosticData["channelListings"][0];
   intl: IntlShape;
+  /**
+   * Whether the shop is configured with the legacy shipping-zone-based stock
+   * availability behavior. Saleor 3.23 introduced a "direct warehouse-channel"
+   * mode (Shop.useLegacyShippingZoneStockAvailability=false) where shipping
+   * zones no longer affect stock availability, only the channel-warehouse link
+   * does. Some checks become misleading or lose meaning in direct mode.
+   */
+  useLegacyShippingZoneStockAvailability: boolean;
 }
 
 type CheckFunction = (context: CheckContext) => AvailabilityIssue | null;
@@ -138,10 +146,28 @@ const checkNoWarehouses: CheckFunction = ({ channelData, intl }) => {
 };
 
 /**
- * Check if channel has no shipping zones assigned
+ * Check if channel has no shipping zones assigned.
+ *
+ * In legacy mode (`useLegacyShippingZoneStockAvailability=true`), the absence
+ * of shipping zones blocks customers from purchasing because the legacy stock
+ * availability resolver intersects channel warehouses with shipping-zone
+ * warehouses. Severity = warning.
+ *
+ * In direct mode (`useLegacyShippingZoneStockAvailability=false`), the product
+ * appears as available via the public API regardless of shipping zones — but
+ * the order still cannot be fulfilled without a shipping method. Severity =
+ * info, with shipping-only copy.
  */
-const checkNoShippingZones: CheckFunction = ({ channelData, intl }) => {
-  if (!channelData.shippingZones || channelData.shippingZones.length === 0) {
+const checkNoShippingZones: CheckFunction = ({
+  channelData,
+  intl,
+  useLegacyShippingZoneStockAvailability,
+}) => {
+  if (channelData.shippingZones && channelData.shippingZones.length > 0) {
+    return null;
+  }
+
+  if (useLegacyShippingZoneStockAvailability) {
     return {
       id: "no-shipping-zones",
       severity: "warning",
@@ -156,7 +182,18 @@ const checkNoShippingZones: CheckFunction = ({ channelData, intl }) => {
     };
   }
 
-  return null;
+  return {
+    id: "no-shipping-zones",
+    severity: "info",
+    channelId: channelData.id,
+    channelName: channelData.name,
+    message: intl.formatMessage(messages.noShippingZonesShippingOnly, {
+      channelName: channelData.name,
+    }),
+    description: intl.formatMessage(messages.noShippingZonesShippingOnlyDescription),
+    actionLabel: intl.formatMessage(messages.configureChannel),
+    actionUrl: channelUrl(channelData.id),
+  };
 };
 
 /**
@@ -196,9 +233,26 @@ const checkNoStock: CheckFunction = ({ product, channelData, intl }) => {
 };
 
 /**
- * Check if warehouses with stock are not in any shipping zone
+ * Check if warehouses with stock are not in any shipping zone.
+ *
+ * Only meaningful under legacy mode, where stock availability is gated by the
+ * intersection of channel warehouses and shipping-zone warehouses. Under the
+ * direct warehouse-channel mode (Saleor 3.23+ when
+ * `useLegacyShippingZoneStockAvailability=false`) shipping zones do not affect
+ * `Product.isAvailable` / `quantityAvailable`, so this signal is no longer a
+ * purchase blocker and would produce a false positive that contradicts the
+ * public API verification.
  */
-const checkWarehouseNotInShippingZone: CheckFunction = ({ product, channelData, intl }) => {
+const checkWarehouseNotInShippingZone: CheckFunction = ({
+  product,
+  channelData,
+  intl,
+  useLegacyShippingZoneStockAvailability,
+}) => {
+  if (!useLegacyShippingZoneStockAvailability) {
+    return null;
+  }
+
   if (!product.variants || product.variants.length === 0) {
     return null;
   }
@@ -259,6 +313,64 @@ const checkWarehouseNotInShippingZone: CheckFunction = ({ product, channelData, 
 };
 
 /**
+ * Surface "stranded" stock: variant has stock in warehouses, but none of those
+ * warehouses are assigned to the current channel. This is the most common
+ * pitfall when migrating to direct warehouse-channel mode (the warehouse needs
+ * to be linked to the channel to count toward stock availability) and is also
+ * useful context under legacy mode, where it explains why `checkNoStock` fired.
+ *
+ * Severity is info — it complements (rather than replaces) the existing
+ * `no-stock` warning by pointing at a concrete fix.
+ */
+const checkStockOutsideChannelWarehouses: CheckFunction = ({ product, channelData, intl }) => {
+  if (!product.variants || product.variants.length === 0) {
+    return null;
+  }
+
+  if (!channelData.warehouses) {
+    return null;
+  }
+
+  const channelWarehouseIds = new Set(channelData.warehouses.map(w => w.id));
+
+  // Collect every warehouse that holds positive stock of any variant.
+  const warehousesWithStock = new Set<string>();
+
+  product.variants.forEach(variant => {
+    variant.stocks?.forEach(stock => {
+      if (stock.quantity > 0) {
+        warehousesWithStock.add(stock.warehouse.id);
+      }
+    });
+  });
+
+  if (warehousesWithStock.size === 0) {
+    return null;
+  }
+
+  const hasStockInChannelWarehouse = Array.from(warehousesWithStock).some(id =>
+    channelWarehouseIds.has(id),
+  );
+
+  if (hasStockInChannelWarehouse) {
+    return null;
+  }
+
+  return {
+    id: "stock-outside-channel-warehouses",
+    severity: "info",
+    channelId: channelData.id,
+    channelName: channelData.name,
+    message: intl.formatMessage(messages.stockOutsideChannelWarehouses, {
+      channelName: channelData.name,
+    }),
+    description: intl.formatMessage(messages.stockOutsideChannelWarehousesDescription),
+    actionLabel: intl.formatMessage(messages.configureChannel),
+    actionUrl: channelUrl(channelData.id),
+  };
+};
+
+/**
  * Checks that don't require warehouse/shipping permissions
  */
 const coreChecks: CheckFunction[] = [
@@ -271,7 +383,11 @@ const coreChecks: CheckFunction[] = [
 /**
  * Checks that require warehouse visibility
  */
-const warehouseChecks: CheckFunction[] = [checkNoWarehouses, checkNoStock];
+const warehouseChecks: CheckFunction[] = [
+  checkNoWarehouses,
+  checkNoStock,
+  checkStockOutsideChannelWarehouses,
+];
 
 /**
  * Checks that require shipping zone visibility
@@ -279,16 +395,29 @@ const warehouseChecks: CheckFunction[] = [checkNoWarehouses, checkNoStock];
 const shippingChecks: CheckFunction[] = [checkNoShippingZones, checkWarehouseNotInShippingZone];
 
 /**
- * Options to skip certain check categories.
- * These are typically set based on user permissions - if the user cannot view
- * warehouse or shipping zone data, the corresponding checks should be skipped
- * to avoid false positives from missing data.
+ * Options controlling which checks run and how they interpret the data.
+ *
+ * `skipWarehouseChecks` / `skipShippingChecks` are typically set based on the
+ * current user's permissions — when the user cannot read warehouse or shipping
+ * zone data, those checks must be skipped to avoid false positives caused by
+ * missing input.
+ *
+ * `useLegacyShippingZoneStockAvailability` mirrors the
+ * `Shop.useLegacyShippingZoneStockAvailability` flag introduced in Saleor 3.23.
+ * It changes how some checks reason about stock availability:
+ *  - legacy (true): stock visibility is gated by shipping zones; the
+ *    `warehouse-not-in-zone` check applies, and missing shipping zones block
+ *    purchases.
+ *  - direct (false): stock visibility is gated only by the channel-warehouse
+ *    link; shipping zones only affect order fulfillment, not availability.
+ *
+ * Defaults to `true` to preserve the historical behavior for callers that
+ * have not yet been updated.
  */
-interface CheckSkipOptions {
-  /** Skip warehouse/stock checks (set when user lacks warehouse view permissions) */
+export interface CheckOptions {
   skipWarehouseChecks?: boolean;
-  /** Skip shipping zone checks (set when user lacks shipping zone view permissions) */
   skipShippingChecks?: boolean;
+  useLegacyShippingZoneStockAvailability?: boolean;
 }
 
 /**
@@ -299,13 +428,17 @@ export function runAvailabilityChecks(
   channelData: ChannelDiagnosticData,
   channelListing: ProductDiagnosticData["channelListings"][0],
   intl: IntlShape,
-  skipOptions?: CheckSkipOptions,
+  options?: CheckOptions,
 ): AvailabilityIssue[] {
+  const useLegacyShippingZoneStockAvailability =
+    options?.useLegacyShippingZoneStockAvailability ?? true;
+
   const context: CheckContext = {
     product,
     channelData,
     channelListing,
     intl,
+    useLegacyShippingZoneStockAvailability,
   };
 
   const issues: AvailabilityIssue[] = [];
@@ -323,7 +456,7 @@ export function runAvailabilityChecks(
   // Note: Warehouse checks run for ALL products (including non-shippable) because:
   // - Non-shippable products may still track inventory (e.g., activation codes, digital license keys)
   // - If a product doesn't track inventory, variant.stocks will be empty and checks will pass
-  if (!skipOptions?.skipWarehouseChecks) {
+  if (!options?.skipWarehouseChecks) {
     for (const check of warehouseChecks) {
       const issue = check(context);
 
@@ -336,7 +469,7 @@ export function runAvailabilityChecks(
   // Run shipping checks only if:
   // 1. We have permission (skipShippingChecks is not set)
   // 2. Product requires shipping (non-shippable products don't need shipping configuration)
-  const shouldRunShippingChecks = !skipOptions?.skipShippingChecks && product.isShippingRequired;
+  const shouldRunShippingChecks = !options?.skipShippingChecks && product.isShippingRequired;
 
   if (shouldRunShippingChecks) {
     for (const check of shippingChecks) {

--- a/src/products/components/ProductDoctor/utils/constants.ts
+++ b/src/products/components/ProductDoctor/utils/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Default for `Shop.useLegacyShippingZoneStockAvailability` when the shop
+ * fragment hasn't loaded yet (or wasn't passed by a caller).
+ *
+ * Set to `true` so that, until we know otherwise, the doctor renders the
+ * legacy-mode severity levels and copy and we don't transiently downgrade
+ * warnings on a fresh page load.
+ *
+ * This is the single place to flip the doctor-wide default once the new
+ * direct warehouse-channel mode becomes the standard — every consumer in
+ * the ProductDoctor folder that needs a fallback reads from here, so the
+ * change is one line.
+ */
+export const LEGACY_MODE_FALLBACK = true;

--- a/src/products/components/ProductDoctor/utils/issueBadge.test.ts
+++ b/src/products/components/ProductDoctor/utils/issueBadge.test.ts
@@ -1,4 +1,4 @@
-import { getBlockingIssueBadgeProps } from "./issueBadge";
+import { getHeaderIssueBadgeProps } from "./issueBadge";
 import { type AvailabilityIssue } from "./types";
 
 const issue = (overrides: Partial<AvailabilityIssue> = {}): AvailabilityIssue => ({
@@ -11,14 +11,14 @@ const issue = (overrides: Partial<AvailabilityIssue> = {}): AvailabilityIssue =>
   ...overrides,
 });
 
-describe("getBlockingIssueBadgeProps", () => {
+describe("getHeaderIssueBadgeProps", () => {
   it("returns null when there are no issues at all", () => {
-    expect(getBlockingIssueBadgeProps([])).toBeNull();
+    expect(getHeaderIssueBadgeProps([])).toBeNull();
   });
 
-  it("returns null when issues are info-only (info is advisory, not blocking)", () => {
+  it("returns null when issues are info-only (info is advisory, not header-worthy)", () => {
     expect(
-      getBlockingIssueBadgeProps([
+      getHeaderIssueBadgeProps([
         issue({ id: "no-shipping-zones", severity: "info" }),
         issue({ id: "stock-outside-channel-warehouses", severity: "info" }),
       ]),
@@ -26,22 +26,22 @@ describe("getBlockingIssueBadgeProps", () => {
   });
 
   it("counts a single warning and reports type=warning", () => {
-    expect(getBlockingIssueBadgeProps([issue({ severity: "warning" })])).toEqual({
+    expect(getHeaderIssueBadgeProps([issue({ severity: "warning" })])).toEqual({
       count: 1,
       type: "warning",
     });
   });
 
   it("counts a single error and reports type=error", () => {
-    expect(getBlockingIssueBadgeProps([issue({ severity: "error" })])).toEqual({
+    expect(getHeaderIssueBadgeProps([issue({ severity: "error" })])).toEqual({
       count: 1,
       type: "error",
     });
   });
 
-  it("ignores info issues when summing the count alongside blocking issues", () => {
+  it("ignores info issues when summing the count alongside header issues", () => {
     expect(
-      getBlockingIssueBadgeProps([
+      getHeaderIssueBadgeProps([
         issue({ id: "no-stock", severity: "warning" }),
         issue({ id: "no-shipping-zones", severity: "info" }),
         issue({ id: "stock-outside-channel-warehouses", severity: "info" }),
@@ -49,9 +49,9 @@ describe("getBlockingIssueBadgeProps", () => {
     ).toEqual({ count: 1, type: "warning" });
   });
 
-  it("escalates type to error when at least one blocking issue is an error", () => {
+  it("escalates type to error when at least one header issue is an error", () => {
     expect(
-      getBlockingIssueBadgeProps([
+      getHeaderIssueBadgeProps([
         issue({ id: "no-variants", severity: "error" }),
         issue({ id: "no-stock", severity: "warning" }),
         issue({ id: "no-shipping-zones", severity: "info" }),
@@ -59,9 +59,9 @@ describe("getBlockingIssueBadgeProps", () => {
     ).toEqual({ count: 2, type: "error" });
   });
 
-  it("counts only blocking issues, even when several errors and warnings co-exist", () => {
+  it("counts only header-worthy issues, even when several errors and warnings co-exist", () => {
     expect(
-      getBlockingIssueBadgeProps([
+      getHeaderIssueBadgeProps([
         issue({ severity: "error" }),
         issue({ severity: "error" }),
         issue({ severity: "warning" }),

--- a/src/products/components/ProductDoctor/utils/issueBadge.test.ts
+++ b/src/products/components/ProductDoctor/utils/issueBadge.test.ts
@@ -1,0 +1,72 @@
+import { getBlockingIssueBadgeProps } from "./issueBadge";
+import { type AvailabilityIssue } from "./types";
+
+const issue = (overrides: Partial<AvailabilityIssue> = {}): AvailabilityIssue => ({
+  id: "no-stock",
+  severity: "warning",
+  channelId: "channel-1",
+  channelName: "Default Channel",
+  message: "msg",
+  description: "desc",
+  ...overrides,
+});
+
+describe("getBlockingIssueBadgeProps", () => {
+  it("returns null when there are no issues at all", () => {
+    expect(getBlockingIssueBadgeProps([])).toBeNull();
+  });
+
+  it("returns null when issues are info-only (info is advisory, not blocking)", () => {
+    expect(
+      getBlockingIssueBadgeProps([
+        issue({ id: "no-shipping-zones", severity: "info" }),
+        issue({ id: "stock-outside-channel-warehouses", severity: "info" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("counts a single warning and reports type=warning", () => {
+    expect(getBlockingIssueBadgeProps([issue({ severity: "warning" })])).toEqual({
+      count: 1,
+      type: "warning",
+    });
+  });
+
+  it("counts a single error and reports type=error", () => {
+    expect(getBlockingIssueBadgeProps([issue({ severity: "error" })])).toEqual({
+      count: 1,
+      type: "error",
+    });
+  });
+
+  it("ignores info issues when summing the count alongside blocking issues", () => {
+    expect(
+      getBlockingIssueBadgeProps([
+        issue({ id: "no-stock", severity: "warning" }),
+        issue({ id: "no-shipping-zones", severity: "info" }),
+        issue({ id: "stock-outside-channel-warehouses", severity: "info" }),
+      ]),
+    ).toEqual({ count: 1, type: "warning" });
+  });
+
+  it("escalates type to error when at least one blocking issue is an error", () => {
+    expect(
+      getBlockingIssueBadgeProps([
+        issue({ id: "no-variants", severity: "error" }),
+        issue({ id: "no-stock", severity: "warning" }),
+        issue({ id: "no-shipping-zones", severity: "info" }),
+      ]),
+    ).toEqual({ count: 2, type: "error" });
+  });
+
+  it("counts only blocking issues, even when several errors and warnings co-exist", () => {
+    expect(
+      getBlockingIssueBadgeProps([
+        issue({ severity: "error" }),
+        issue({ severity: "error" }),
+        issue({ severity: "warning" }),
+        issue({ severity: "info" }),
+      ]),
+    ).toEqual({ count: 3, type: "error" });
+  });
+});

--- a/src/products/components/ProductDoctor/utils/issueBadge.ts
+++ b/src/products/components/ProductDoctor/utils/issueBadge.ts
@@ -1,0 +1,55 @@
+import { type AvailabilityIssue } from "./types";
+
+/**
+ * The "blocking" severity types that drive the channel issue badge —
+ * informational advisories are intentionally excluded so that purely
+ * advisory hints (e.g. "stock is in warehouses not assigned to this
+ * channel") do not flip a channel into a "has issues" visual state.
+ */
+export type BlockingIssueType = "error" | "warning";
+
+export interface IssueBadgeProps {
+  count: number;
+  type: BlockingIssueType;
+}
+
+/**
+ * Compute the props that the channel header IssueBadge should render for a
+ * given list of per-channel availability issues.
+ *
+ * Rules:
+ *  - Only `error` and `warning` issues count toward the badge ("blocking"
+ *    issues). `info` advisories are surfaced inside the channel body but do
+ *    not promote the channel into the "has issues" header state.
+ *  - When there are no blocking issues, returns `null` and the caller should
+ *    not render a badge at all.
+ *  - When at least one blocking issue is an error, the badge type is escalated
+ *    to `"error"` so the icon and color reflect the most severe state.
+ *
+ * Pure function — no React, no intl. Intended for direct unit-testing of the
+ * calculation logic separately from the rendered UI.
+ */
+export function getBlockingIssueBadgeProps(
+  issues: readonly AvailabilityIssue[],
+): IssueBadgeProps | null {
+  let count = 0;
+  let hasError = false;
+
+  for (const issue of issues) {
+    if (issue.severity === "error") {
+      count += 1;
+      hasError = true;
+    } else if (issue.severity === "warning") {
+      count += 1;
+    }
+  }
+
+  if (count === 0) {
+    return null;
+  }
+
+  return {
+    count,
+    type: hasError ? "error" : "warning",
+  };
+}

--- a/src/products/components/ProductDoctor/utils/issueBadge.ts
+++ b/src/products/components/ProductDoctor/utils/issueBadge.ts
@@ -1,35 +1,38 @@
 import { type AvailabilityIssue } from "./types";
 
 /**
- * The "blocking" severity types that drive the channel issue badge —
- * informational advisories are intentionally excluded so that purely
- * advisory hints (e.g. "stock is in warehouses not assigned to this
- * channel") do not flip a channel into a "has issues" visual state.
+ * Severities that get promoted into the channel header badge.
+ *
+ * Note: in plain English a "warning" is *not* blocking — it advises caution
+ * but does not stop the user. Both `error` and `warning` are surfaced in the
+ * header here because they are non-advisory, action-worthy signals; `info`
+ * advisories stay inside the channel body. The shared header treatment is a
+ * UX choice, not a claim that warnings block anything.
  */
-export type BlockingIssueType = "error" | "warning";
+export type HeaderIssueType = "error" | "warning";
 
 export interface IssueBadgeProps {
   count: number;
-  type: BlockingIssueType;
+  type: HeaderIssueType;
 }
 
 /**
- * Compute the props that the channel header IssueBadge should render for a
+ * Compute the props that the channel header `IssueBadge` should render for a
  * given list of per-channel availability issues.
  *
  * Rules:
- *  - Only `error` and `warning` issues count toward the badge ("blocking"
- *    issues). `info` advisories are surfaced inside the channel body but do
- *    not promote the channel into the "has issues" header state.
- *  - When there are no blocking issues, returns `null` and the caller should
- *    not render a badge at all.
- *  - When at least one blocking issue is an error, the badge type is escalated
+ *  - Only `error` and `warning` issues count toward the badge. `info`
+ *    advisories are surfaced inside the channel body but do not promote the
+ *    channel into the "has issues" header state.
+ *  - When there are no header-worthy issues, returns `null` and the caller
+ *    should not render a badge at all.
+ *  - When at least one header issue is an error, the badge type is escalated
  *    to `"error"` so the icon and color reflect the most severe state.
  *
  * Pure function — no React, no intl. Intended for direct unit-testing of the
  * calculation logic separately from the rendered UI.
  */
-export function getBlockingIssueBadgeProps(
+export function getHeaderIssueBadgeProps(
   issues: readonly AvailabilityIssue[],
 ): IssueBadgeProps | null {
   let count = 0;

--- a/src/products/components/ProductDoctor/utils/types.ts
+++ b/src/products/components/ProductDoctor/utils/types.ts
@@ -1,4 +1,4 @@
-type IssueSeverity = "error" | "warning" | "info";
+export type IssueSeverity = "error" | "warning" | "info";
 
 export interface AvailabilityIssue {
   id: string;

--- a/src/products/components/ProductDoctor/utils/types.ts
+++ b/src/products/components/ProductDoctor/utils/types.ts
@@ -117,4 +117,9 @@ export interface DiagnosticsResult {
   hasWarnings: boolean;
   isLoading: boolean;
   permissions: DiagnosticsPermissions;
+  /**
+   * Mirrors `Shop.useLegacyShippingZoneStockAvailability` (Saleor 3.23+).
+   * Surfaced here so consuming UI can adapt copy without re-querying the shop.
+   */
+  useLegacyShippingZoneStockAvailability: boolean;
 }

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -268,9 +268,19 @@ export const defaultGraphiQLQuery = `query ProductDetails($id: ID!) {
  * Query for product availability diagnostics.
  * Fetches channel and shipping zone data needed to determine
  * if a product can be purchased in each channel.
+ *
+ * Also reads `Shop.useLegacyShippingZoneStockAvailability` (Saleor 3.23+) so
+ * the doctor can adapt severity/copy based on whether the shop uses legacy
+ * shipping-zone-based stock filtering or the direct warehouse-channel link.
+ * The field is scoped to this query (rather than the global ShopInfo) to
+ * avoid loading it on every authenticated session.
  */
 export const channelDiagnosticsQuery = gql`
   query ChannelDiagnostics {
+    shop {
+      id
+      useLegacyShippingZoneStockAvailability
+    }
     channels {
       id
       name


### PR DESCRIPTION
Saleor 3.23 introduced `Shop.useLegacyShippingZoneStockAvailability`. New installations default to the new direct warehouse↔channel stock model (false); existing installations keep the legacy shipping-zone-intersection model (true). The Product Doctor was so far only supporting the legacy semantics, so on direct-mode shops it raised false positives ("warehouse not in shipping zone") and labelled shipping-zone misconfiguration as a purchase blocker - when in direct mode it only blocks shipping.

This PR makes the doctor mode-aware and gives users explicit context about which mode is active.

https://github.com/user-attachments/assets/964d38db-f7c0-4a00-9fc6-c6ec10db08b0

