### PR TITLE
fix(build): missing environment variable

### DIFF
--- a/.github/workflows/deploy-cloud.yaml
+++ b/.github/workflows/deploy-cloud.yaml
@@ -134,7 +134,10 @@ jobs:
         env:
           DEPLOYMENT_BUCKET: ${{ secrets.AWS_CLOUD_EU_DEPLOYMENT_BUCKET }}
           CDN_DISTRIBUTIONS: ${{ secrets.AWS_CLOUD_EU_CDN_DISTRIBUTIONS }}
+          ENVIRONMENT: ${{ needs.build.outputs.ENVIRONMENT }}
         run: |
+          set -eu
+
           aws s3 sync build/dashboard "s3://${DEPLOYMENT_BUCKET}/${ENVIRONMENT}/static/"
           aws s3 cp build/dashboard/index.html "s3://${DEPLOYMENT_BUCKET}/${ENVIRONMENT}/"
 
@@ -149,7 +152,10 @@ jobs:
         env:
           DEPLOYMENT_BUCKET: ${{ secrets.AWS_CLOUD_US_DEPLOYMENT_BUCKET }}
           CDN_DISTRIBUTIONS: ${{ secrets.AWS_CLOUD_US_CDN_DISTRIBUTIONS }}
+          ENVIRONMENT: ${{ needs.build.outputs.ENVIRONMENT }}
         run: |
+          set -eu
+
           aws s3 sync build/dashboard "s3://${DEPLOYMENT_BUCKET}/${ENVIRONMENT}/static/"
           aws s3 cp build/dashboard/index.html "s3://${DEPLOYMENT_BUCKET}/${ENVIRONMENT}/"
 


### PR DESCRIPTION
`ENVIRONMENT` env var was missing which caused to upload using s3 to `s3://bucket//<dist-files>` where the `//` should have been `/<env>/`

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [x] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [x] I used analytics "trackEvent" for important events
