### PR TITLE
fix: include port in external host check for redirect actions

### DIFF
--- a/.changeset/plenty-mangos-pull.md
+++ b/.changeset/plenty-mangos-pull.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed `appBridge` redirects to treat different ports on the same domain as different origins (for example `localhost:3000` vs `localhost:8000`).

--- a/src/extensions/views/ViewManifestExtension/components/AppFrame/appActionsHandler.ts
+++ b/src/extensions/views/ViewManifestExtension/components/AppFrame/appActionsHandler.ts
@@ -29,7 +29,7 @@ const createResponseStatus = (actionId: string, ok: boolean): DispatchResponseEv
     ok,
   },
 });
-const isExternalHost = (host: string) => new URL(host).hostname !== window.location.hostname;
+const isExternalHost = (host: string) => new URL(host).host !== window.location.host;
 const isLocalPath = (path: string) => path.startsWith("/");
 const useHandleNotificationAction = () => {
   const notify = useNotifier();


### PR DESCRIPTION
The \isExternalHost\ function only compared \hostname\, causing \localhost:3000\ and \localhost:9000\ to be treated as the same host. Changed to compare \.host\ which includes the port number.

Closes #5549