### PR TITLE
fix: simplify staff settings translation notice copy

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -7587,7 +7587,7 @@
     "string": "Not set"
   },
   "e822us": {
-    "string": "Please note, while all currency and date adjustments are complete, language translations are at varying degrees of completion."
+    "string": "Note: some languages might have incomplete translations that will be displayed in English."
   },
   "e8O72h": {
     "context": "password login mode option",


### PR DESCRIPTION
## Summary
Fixes #4409 — simplifies the verbose translation progress text on the Staff settings page.

## Change
`locale/defaultMessages.json` (key `e822us`):
```
- "Please note, while all currency and date adjustments are complete,
   language translations are at varying degrees of completion."
+ "Note: some languages might have incomplete translations that will
   be displayed in English."
```

## Type of Change
- [x] Copy / text improvement