### PR TITLE
Storybook coverage for macaw/material components

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { Button } from "./Button";
+
+const meta: Meta<typeof Button> = {
+  title: "Components/Button",
+  component: Button,
+  args: {
+    children: "Click me",
+    onClick: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {};
+
+export const Primary: Story = {
+  args: {
+    variant: "primary",
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: "secondary",
+  },
+};
+
+export const Tertiary: Story = {
+  args: {
+    variant: "tertiary",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const AsInternalLink: Story = {
+  args: {
+    href: "/products/",
+    children: "Go to products",
+  },
+};
+
+export const AsExternalLink: Story = {
+  args: {
+    href: "https://saleor.io",
+    children: "Visit Saleor",
+  },
+};

--- a/src/components/CardMenu/CardMenu.stories.tsx
+++ b/src/components/CardMenu/CardMenu.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Pencil, Trash2 } from "lucide-react";
+import { fn } from "storybook/test";
+
+import CardMenu from "./CardMenu";
+
+const meta: Meta<typeof CardMenu> = {
+  title: "Components/CardMenu",
+  component: CardMenu,
+  args: {
+    menuItems: [
+      { label: "Edit", onSelect: fn() },
+      { label: "Delete", onSelect: fn() },
+      { label: "Archive", onSelect: fn() },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CardMenu>;
+
+export const Default: Story = {};
+
+export const Outlined: Story = {
+  args: {
+    outlined: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const WithIcons: Story = {
+  args: {
+    showMenuIcon: true,
+    menuItems: [
+      { label: "Edit", onSelect: fn(), Icon: <Pencil size={16} /> },
+      { label: "Delete", onSelect: fn(), Icon: <Trash2 size={16} /> },
+    ],
+  },
+};
+
+export const WithDisabledItem: Story = {
+  args: {
+    menuItems: [
+      { label: "Edit", onSelect: fn() },
+      { label: "Delete", onSelect: fn(), disabled: true },
+    ],
+  },
+};
+
+export const WithLoadingItem: Story = {
+  args: {
+    menuItems: [
+      { label: "Edit", onSelect: fn() },
+      { label: "Processing...", onSelect: fn(), loading: true, withLoading: true },
+    ],
+  },
+};

--- a/src/components/CardTitle/CardTitle.stories.tsx
+++ b/src/components/CardTitle/CardTitle.stories.tsx
@@ -1,0 +1,61 @@
+import { Card } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentType } from "react";
+import { fn } from "storybook/test";
+
+import { Button } from "../Button/Button";
+import { CardTitle } from "./CardTitle";
+
+const meta: Meta<typeof CardTitle> = {
+  title: "Components/CardTitle",
+  component: CardTitle,
+  decorators: [
+    (Story: ComponentType) => (
+      <Card style={{ maxWidth: 640 }}>
+        <Story />
+      </Card>
+    ),
+  ],
+  args: {
+    title: "Section title",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CardTitle>;
+
+export const Default: Story = {};
+
+export const WithSubtitle: Story = {
+  args: {
+    subtitle: "Additional description for this section",
+  },
+};
+
+export const WithToolbar: Story = {
+  args: {
+    toolbar: (
+      <Button variant="secondary" onClick={fn()}>
+        Action
+      </Button>
+    ),
+  },
+};
+
+export const WithSubtitleAndToolbar: Story = {
+  args: {
+    subtitle: "Additional description",
+    toolbar: (
+      <Button variant="secondary" onClick={fn()}>
+        Action
+      </Button>
+    ),
+  },
+};
+
+export const CustomBackground: Story = {
+  args: {
+    backgroundColor: "default2",
+    subtitle: "Card title with alternative background colour",
+  },
+};

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import Checkbox from "./Checkbox";
+
+const meta: Meta<typeof Checkbox> = {
+  title: "Components/Checkbox",
+  component: Checkbox,
+  args: {
+    checked: false,
+    onChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Checkbox>;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    indeterminate: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    disabled: true,
+    checked: true,
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    helperText: "Helpful description for the checkbox",
+  },
+};
+
+export const Error: Story = {
+  args: {
+    error: true,
+    helperText: "This field is required",
+  },
+};

--- a/src/components/Chip/Chip.stories.tsx
+++ b/src/components/Chip/Chip.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import Chip from "./Chip";
+
+const meta: Meta<typeof Chip> = {
+  title: "Components/Chip",
+  component: Chip,
+  args: {
+    label: "Tag label",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Chip>;
+
+export const Default: Story = {};
+
+export const WithCloseButton: Story = {
+  args: {
+    onClose: fn(),
+  },
+};
+
+export const LongLabel: Story = {
+  args: {
+    label: "A much longer chip label that still fits on one line",
+    onClose: fn(),
+  },
+};

--- a/src/components/CollectionWithDividers/CollectionWithDividers.stories.tsx
+++ b/src/components/CollectionWithDividers/CollectionWithDividers.stories.tsx
@@ -1,0 +1,61 @@
+import { Text } from "@saleor/macaw-ui-next";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import CollectionWithDividers from "./CollectionWithDividers";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const items: Item[] = [
+  { id: "1", name: "First item" },
+  { id: "2", name: "Second item" },
+  { id: "3", name: "Third item" },
+];
+
+const meta: Meta<typeof CollectionWithDividers<Item>> = {
+  title: "Components/CollectionWithDividers",
+  component: CollectionWithDividers,
+  args: {
+    collection: items,
+    renderItem: (item: Item | undefined) => (
+      <div style={{ padding: "12px 16px" }}>
+        <Text>{item?.name}</Text>
+      </div>
+    ),
+  },
+  argTypes: {
+    renderItem: { table: { disable: true } },
+    renderEmpty: { table: { disable: true } },
+    DividerComponent: { table: { disable: true } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CollectionWithDividers<Item>>;
+
+export const Default: Story = {};
+
+export const WithOuterDividers: Story = {
+  args: {
+    withOuterDividers: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    collection: [],
+    renderEmpty: () => (
+      <div style={{ padding: "12px 16px" }}>
+        <Text color="default2">No items to display</Text>
+      </div>
+    ),
+  },
+};
+
+export const EmptyWithoutPlaceholder: Story = {
+  args: {
+    collection: [],
+  },
+};

--- a/src/components/ColorPicker/ColorPicker.stories.tsx
+++ b/src/components/ColorPicker/ColorPicker.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentProps, useState } from "react";
+import { fn } from "storybook/test";
+
+import { ColorPicker } from "./ColorPicker";
+
+type Props = ComponentProps<typeof ColorPicker>;
+
+const meta: Meta<typeof ColorPicker> = {
+  title: "Components/ColorPicker",
+  component: ColorPicker,
+  args: {
+    data: { value: "#3F51B5" },
+    errors: {},
+    onColorChange: fn(),
+    setError: fn(),
+    clearErrors: fn(),
+  },
+  argTypes: {
+    onColorChange: { table: { disable: true } },
+    setError: { table: { disable: true } },
+    clearErrors: { table: { disable: true } },
+  },
+  render: (args: Props) => {
+    const Wrapper = () => {
+      const [value, setValue] = useState((args.data as { value: string }).value);
+
+      return (
+        <ColorPicker
+          {...args}
+          data={{ value }}
+          onColorChange={hex => {
+            setValue(hex);
+            args.onColorChange(hex);
+          }}
+        />
+      );
+    };
+
+    return <Wrapper />;
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ColorPicker>;
+
+export const Default: Story = {};
+
+export const Error: Story = {
+  args: {
+    data: { value: "#zzz" },
+    errors: { value: "Invalid color value" },
+  },
+};

--- a/src/components/ControlledCheckbox.stories.tsx
+++ b/src/components/ControlledCheckbox.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentProps, useState } from "react";
+import { fn } from "storybook/test";
+
+import { ControlledCheckbox } from "./ControlledCheckbox";
+
+type Props = ComponentProps<typeof ControlledCheckbox>;
+
+const meta: Meta<typeof ControlledCheckbox> = {
+  title: "Components/ControlledCheckbox",
+  component: ControlledCheckbox,
+  args: {
+    name: "controlled-checkbox",
+    label: "Subscribe to newsletter",
+    checked: false,
+    onChange: fn(),
+  },
+  render: (args: Props) => {
+    const Wrapper = () => {
+      const [checked, setChecked] = useState(args.checked);
+
+      return (
+        <ControlledCheckbox
+          {...args}
+          checked={checked}
+          onChange={event => {
+            setChecked(event.target.value);
+            args.onChange(event);
+          }}
+        />
+      );
+    };
+
+    return <Wrapper />;
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ControlledCheckbox>;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+export const Indeterminate: Story = {
+  args: {
+    indeterminate: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    disabled: true,
+    checked: true,
+  },
+};

--- a/src/components/IconButtonTableCell/IconButtonTableCell.stories.tsx
+++ b/src/components/IconButtonTableCell/IconButtonTableCell.stories.tsx
@@ -1,0 +1,40 @@
+import { TableBody } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Trash2 } from "lucide-react";
+import { type ComponentType } from "react";
+import { fn } from "storybook/test";
+
+import { ResponsiveTable } from "../ResponsiveTable/ResponsiveTable";
+import TableRowLink from "../TableRowLink";
+import IconButtonTableCell from "./IconButtonTableCell";
+
+const meta: Meta<typeof IconButtonTableCell> = {
+  title: "Components/IconButtonTableCell",
+  component: IconButtonTableCell,
+  decorators: [
+    (Story: ComponentType) => (
+      <ResponsiveTable>
+        <TableBody>
+          <TableRowLink>
+            <Story />
+          </TableRowLink>
+        </TableBody>
+      </ResponsiveTable>
+    ),
+  ],
+  args: {
+    children: <Trash2 size={16} />,
+    onClick: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof IconButtonTableCell>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/src/components/ResponsiveTable/ResponsiveTable.stories.tsx
+++ b/src/components/ResponsiveTable/ResponsiveTable.stories.tsx
@@ -1,0 +1,69 @@
+import { TableBody, TableCell, TableHead, TableRow } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { ResponsiveTable } from "./ResponsiveTable";
+
+const rows = [
+  { id: "1", name: "Hoodie", price: "$45" },
+  { id: "2", name: "T-Shirt", price: "$20" },
+  { id: "3", name: "Sneakers", price: "$120" },
+];
+
+const tableContent = (
+  <>
+    <TableHead>
+      <TableRow>
+        <TableCell>Name</TableCell>
+        <TableCell>Price</TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {rows.map(row => (
+        <TableRow key={row.id}>
+          <TableCell>{row.name}</TableCell>
+          <TableCell>{row.price}</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </>
+);
+
+const meta: Meta<typeof ResponsiveTable> = {
+  title: "Components/ResponsiveTable",
+  component: ResponsiveTable,
+  args: {
+    children: tableContent,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ResponsiveTable>;
+
+export const Default: Story = {};
+
+export const WithSearch: Story = {
+  args: {
+    search: {
+      placeholder: "Search products",
+      onSearchChange: fn(),
+    },
+  },
+};
+
+export const SearchEmptyResults: Story = {
+  args: {
+    search: {
+      placeholder: "Search products",
+      initialValue: "missing",
+      onSearchChange: fn(),
+    },
+    filteredItemsCount: 0,
+  },
+};
+
+export const WithFooter: Story = {
+  args: {
+    footer: <div>1 - 3 of 3</div>,
+  },
+};

--- a/src/components/SortableTable/SortableHandle.stories.tsx
+++ b/src/components/SortableTable/SortableHandle.stories.tsx
@@ -1,0 +1,40 @@
+import { TableCell } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { ResponsiveTable } from "../ResponsiveTable/ResponsiveTable";
+import SortableHandle from "./SortableHandle";
+import { SortableTableBody } from "./SortableTableBody";
+import { SortableTableRow } from "./SortableTableRow";
+
+const meta: Meta<typeof SortableHandle> = {
+  title: "Components/SortableHandle",
+  component: SortableHandle,
+};
+
+export default meta;
+type Story = StoryObj<typeof SortableHandle>;
+
+export const Default: Story = {
+  render: () => (
+    <ResponsiveTable>
+      <SortableTableBody onSortEnd={fn()}>
+        <SortableTableRow index={0}>
+          <TableCell>Sortable row with handle</TableCell>
+        </SortableTableRow>
+      </SortableTableBody>
+    </ResponsiveTable>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <ResponsiveTable>
+      <SortableTableBody onSortEnd={fn()} disabled>
+        <SortableTableRow index={0}>
+          <TableCell>Disabled sortable row</TableCell>
+        </SortableTableRow>
+      </SortableTableBody>
+    </ResponsiveTable>
+  ),
+};

--- a/src/components/SortableTable/SortableTableBody.stories.tsx
+++ b/src/components/SortableTable/SortableTableBody.stories.tsx
@@ -1,0 +1,53 @@
+import { TableCell, TableHead, TableRow } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentProps } from "react";
+import { fn } from "storybook/test";
+
+import { ResponsiveTable } from "../ResponsiveTable/ResponsiveTable";
+import { SortableTableBody } from "./SortableTableBody";
+import { SortableTableRow } from "./SortableTableRow";
+
+const rows = [
+  { id: "1", label: "Item one" },
+  { id: "2", label: "Item two" },
+  { id: "3", label: "Item three" },
+];
+
+type Props = ComponentProps<typeof SortableTableBody>;
+
+const renderRows = () =>
+  rows.map((row, index) => (
+    <SortableTableRow key={row.id} index={index}>
+      <TableCell>{row.label}</TableCell>
+    </SortableTableRow>
+  ));
+
+const meta: Meta<typeof SortableTableBody> = {
+  title: "Components/SortableTableBody",
+  component: SortableTableBody,
+  args: {
+    onSortEnd: fn(),
+  },
+  render: (args: Props) => (
+    <ResponsiveTable>
+      <TableHead>
+        <TableRow>
+          <TableCell />
+          <TableCell>Label</TableCell>
+        </TableRow>
+      </TableHead>
+      <SortableTableBody {...args}>{renderRows()}</SortableTableBody>
+    </ResponsiveTable>
+  ),
+};
+
+export default meta;
+type Story = StoryObj<typeof SortableTableBody>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/src/components/SortableTable/SortableTableRow.stories.tsx
+++ b/src/components/SortableTable/SortableTableRow.stories.tsx
@@ -1,0 +1,42 @@
+import { TableCell } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { ResponsiveTable } from "../ResponsiveTable/ResponsiveTable";
+import { SortableTableBody } from "./SortableTableBody";
+import { SortableTableRow } from "./SortableTableRow";
+
+const meta: Meta<typeof SortableTableRow> = {
+  title: "Components/SortableTableRow",
+  component: SortableTableRow,
+};
+
+export default meta;
+type Story = StoryObj<typeof SortableTableRow>;
+
+export const Default: Story = {
+  render: () => (
+    <ResponsiveTable>
+      <SortableTableBody onSortEnd={fn()}>
+        <SortableTableRow index={0}>
+          <TableCell>Sortable row content</TableCell>
+        </SortableTableRow>
+        <SortableTableRow index={1}>
+          <TableCell>Second row</TableCell>
+        </SortableTableRow>
+      </SortableTableBody>
+    </ResponsiveTable>
+  ),
+};
+
+export const AsLink: Story = {
+  render: () => (
+    <ResponsiveTable>
+      <SortableTableBody onSortEnd={fn()}>
+        <SortableTableRow index={0} href="/products/123/">
+          <TableCell>Sortable link row</TableCell>
+        </SortableTableRow>
+      </SortableTableBody>
+    </ResponsiveTable>
+  ),
+};

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { Tab } from "./Tab";
+
+const DemoTab = Tab<string>("demo-tab");
+
+const meta: Meta<typeof DemoTab> = {
+  title: "Components/Tab",
+  component: DemoTab,
+  args: {
+    children: "Tab label",
+    isActive: false,
+    changeTab: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DemoTab>;
+
+export const Default: Story = {};
+
+export const Active: Story = {
+  args: {
+    isActive: true,
+  },
+};

--- a/src/components/TableCellAvatar/AvatarImage.stories.tsx
+++ b/src/components/TableCellAvatar/AvatarImage.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import AvatarImage from "./AvatarImage";
+
+const meta: Meta<typeof AvatarImage> = {
+  title: "Components/AvatarImage",
+  component: AvatarImage,
+};
+
+export default meta;
+type Story = StoryObj<typeof AvatarImage>;
+
+export const WithThumbnail: Story = {
+  args: {
+    thumbnail: "https://via.placeholder.com/40",
+  },
+};
+
+export const WithInitials: Story = {
+  args: {
+    initials: "AB",
+  },
+};
+
+export const EmptyPlaceholder: Story = {};

--- a/src/components/TableCellAvatar/TableCellAvatar.stories.tsx
+++ b/src/components/TableCellAvatar/TableCellAvatar.stories.tsx
@@ -1,0 +1,48 @@
+import { TableBody, TableCell } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentType } from "react";
+
+import { ResponsiveTable } from "../ResponsiveTable/ResponsiveTable";
+import TableRowLink from "../TableRowLink";
+import TableCellAvatar from "./TableCellAvatar";
+
+const meta: Meta<typeof TableCellAvatar> = {
+  title: "Components/TableCellAvatar",
+  component: TableCellAvatar,
+  decorators: [
+    (Story: ComponentType) => (
+      <ResponsiveTable>
+        <TableBody>
+          <TableRowLink>
+            <Story />
+            <TableCell>Row label</TableCell>
+          </TableRowLink>
+        </TableBody>
+      </ResponsiveTable>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof TableCellAvatar>;
+
+export const Default: Story = {
+  args: {
+    thumbnail: "https://via.placeholder.com/40",
+  },
+};
+
+export const WithInitials: Story = {
+  args: {
+    initials: "JD",
+  },
+};
+
+export const EmptyPlaceholder: Story = {};
+
+export const AlignRight: Story = {
+  args: {
+    thumbnail: "https://via.placeholder.com/40",
+    alignRight: true,
+  },
+};

--- a/src/components/TableCellHeader/TableCellHeader.stories.tsx
+++ b/src/components/TableCellHeader/TableCellHeader.stories.tsx
@@ -1,0 +1,69 @@
+import { TableHead, TableRow } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentType } from "react";
+import { fn } from "storybook/test";
+
+import { ResponsiveTable } from "../ResponsiveTable/ResponsiveTable";
+import TableCellHeader from "./TableCellHeader";
+
+const meta: Meta<typeof TableCellHeader> = {
+  title: "Components/TableCellHeader",
+  component: TableCellHeader,
+  decorators: [
+    (Story: ComponentType) => (
+      <ResponsiveTable>
+        <TableHead>
+          <TableRow>
+            <Story />
+          </TableRow>
+        </TableHead>
+      </ResponsiveTable>
+    ),
+  ],
+  args: {
+    children: "Column",
+    onClick: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TableCellHeader>;
+
+export const Default: Story = {};
+
+export const SortedAscending: Story = {
+  args: {
+    direction: "asc",
+  },
+};
+
+export const SortedDescending: Story = {
+  args: {
+    direction: "desc",
+  },
+};
+
+export const ArrowRight: Story = {
+  args: {
+    direction: "asc",
+    arrowPosition: "right",
+  },
+};
+
+export const NotSortable: Story = {
+  args: {
+    onClick: undefined,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const AlignedRight: Story = {
+  args: {
+    textAlign: "right",
+  },
+};

--- a/src/components/TableFilter/FilterTab.stories.tsx
+++ b/src/components/TableFilter/FilterTab.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentType } from "react";
+import { fn } from "storybook/test";
+
+import FilterTab from "./FilterTab";
+import FilterTabs from "./FilterTabs";
+
+const meta: Meta<typeof FilterTab> = {
+  title: "Components/FilterTab",
+  component: FilterTab,
+  decorators: [
+    (Story: ComponentType) => (
+      <FilterTabs currentTab={0}>
+        <Story />
+      </FilterTabs>
+    ),
+  ],
+  args: {
+    label: "All",
+    onClick: fn(),
+    value: 0,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FilterTab>;
+
+export const Default: Story = {};
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+};

--- a/src/components/TableFilter/FilterTabs.stories.tsx
+++ b/src/components/TableFilter/FilterTabs.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import FilterTab from "./FilterTab";
+import FilterTabs from "./FilterTabs";
+
+const meta: Meta<typeof FilterTabs> = {
+  title: "Components/FilterTabs",
+  component: FilterTabs,
+};
+
+export default meta;
+type Story = StoryObj<typeof FilterTabs>;
+
+const tabLabels = ["All", "Published", "Drafts", "Archived"];
+
+export const Default: Story = {
+  args: {
+    currentTab: 0,
+    children: tabLabels.map((label, index) => (
+      <FilterTab key={label} label={label} value={index} onClick={fn()} selected={index === 0} />
+    )),
+  },
+};
+
+export const NoTabSelected: Story = {
+  args: {
+    currentTab: undefined,
+    children: tabLabels.map((label, index) => (
+      <FilterTab key={label} label={label} value={index} onClick={fn()} />
+    )),
+  },
+};

--- a/src/components/TableHead/TableHead.stories.tsx
+++ b/src/components/TableHead/TableHead.stories.tsx
@@ -1,0 +1,84 @@
+import { TableCell } from "@material-ui/core";
+import { Button } from "@saleor/macaw-ui-next";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentType } from "react";
+import { fn } from "storybook/test";
+
+import { ResponsiveTable } from "../ResponsiveTable/ResponsiveTable";
+import TableHead from "./TableHead";
+
+const items = [
+  { id: "1", name: "Item 1" },
+  { id: "2", name: "Item 2" },
+  { id: "3", name: "Item 3" },
+];
+
+const meta: Meta<typeof TableHead> = {
+  title: "Components/TableHead",
+  component: TableHead,
+  decorators: [
+    (Story: ComponentType) => (
+      <ResponsiveTable>
+        <Story />
+      </ResponsiveTable>
+    ),
+  ],
+  args: {
+    colSpan: 3,
+    disabled: false,
+    selected: 0,
+    items,
+    toggleAll: fn(),
+    children: (
+      <>
+        <TableCell>Name</TableCell>
+        <TableCell>Status</TableCell>
+      </>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TableHead>;
+
+export const Default: Story = {};
+
+export const SomeSelected: Story = {
+  args: {
+    selected: 2,
+    toolbar: (
+      <Button variant="secondary" onClick={fn()}>
+        Bulk delete
+      </Button>
+    ),
+  },
+};
+
+export const AllSelected: Story = {
+  args: {
+    selected: items.length,
+    toolbar: (
+      <Button variant="secondary" onClick={fn()}>
+        Bulk delete
+      </Button>
+    ),
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};
+
+export const WithDragRows: Story = {
+  args: {
+    dragRows: true,
+  },
+};

--- a/src/components/TablePagination/TablePagination.stories.tsx
+++ b/src/components/TablePagination/TablePagination.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { TablePagination } from "./TablePagination";
+
+const meta: Meta<typeof TablePagination> = {
+  title: "Components/TablePagination",
+  component: TablePagination,
+  args: {
+    hasPreviousPage: true,
+    hasNextPage: true,
+    onPreviousPage: fn(),
+    onNextPage: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TablePagination>;
+
+export const Default: Story = {};
+
+export const FirstPage: Story = {
+  args: {
+    hasPreviousPage: false,
+    hasNextPage: true,
+  },
+};
+
+export const LastPage: Story = {
+  args: {
+    hasPreviousPage: true,
+    hasNextPage: false,
+  },
+};
+
+export const WithRowNumberSelect: Story = {
+  args: {
+    rowNumber: 20,
+    onRowNumberChange: fn(),
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    rowNumber: 20,
+    onRowNumberChange: fn(),
+  },
+};

--- a/src/components/TableRowLink/TableRowLink.stories.tsx
+++ b/src/components/TableRowLink/TableRowLink.stories.tsx
@@ -1,0 +1,58 @@
+import { TableBody, TableCell } from "@material-ui/core";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ComponentType } from "react";
+import { fn } from "storybook/test";
+
+import { ResponsiveTable } from "../ResponsiveTable/ResponsiveTable";
+import TableRowLink from "./TableRowLink";
+
+const meta: Meta<typeof TableRowLink> = {
+  title: "Components/TableRowLink",
+  component: TableRowLink,
+  decorators: [
+    (Story: ComponentType) => (
+      <ResponsiveTable>
+        <TableBody>
+          <Story />
+        </TableBody>
+      </ResponsiveTable>
+    ),
+  ],
+  args: {
+    children: (
+      <>
+        <TableCell>Cell A</TableCell>
+        <TableCell>Cell B</TableCell>
+      </>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TableRowLink>;
+
+export const Default: Story = {};
+
+export const WithClickHandler: Story = {
+  args: {
+    onClick: fn(),
+  },
+};
+
+export const AsInternalLink: Story = {
+  args: {
+    href: "/products/123/",
+  },
+};
+
+export const AsExternalLink: Story = {
+  args: {
+    href: "https://saleor.io",
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    selected: true,
+  },
+};


### PR DESCRIPTION
The long term goal is to remove material-ui and legacy macaw-ui from the codebase. To approach that amount of changes, LLMs are clear choice.

However, these are visual changes, so it's difficult to spot side effects and visual regressions (they can't be unit-tested easily). 

This PR adds visual coverage - a bunch of components using legacy libraries now are covered with storybook stories. Using visual regression testing (Chromatic) and manual comparison, we will be able to visually recognize upcoming changes.