### PR TITLE
Improve image handling

### DIFF
--- a/.changeset/product-media-edit-metadata.md
+++ b/.changeset/product-media-edit-metadata.md
@@ -1,5 +1,5 @@
 ---
-"saleor-dashboard": minor
+"saleor-dashboard": patch
 ---
 
 Product media edit page improvements: breadcrumb title with product name and media type, viewport-sized preview for images and embedded videos, and per-media metadata from a header button (same dialog pattern as product and variant). Metadata dialogs and other buttons using the shared save loader now show the Saleor throbber instead of a generic spinner.

--- a/.changeset/product-media-edit-metadata.md
+++ b/.changeset/product-media-edit-metadata.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": minor
+---
+
+Product media edit page improvements: breadcrumb title with product name and media type, viewport-sized preview for images and embedded videos, and per-media metadata from a header button (same dialog pattern as product and variant). Metadata dialogs and other buttons using the shared save loader now show the Saleor throbber instead of a generic spinner.

--- a/.changeset/product-media-handling.md
+++ b/.changeset/product-media-handling.md
@@ -1,0 +1,10 @@
+---
+"saleor-dashboard": patch
+---
+
+Improved product image gallery on the product details page:
+
+- Minimal drag-and-drop upload area when the gallery is empty, with a clear overlay when adding images to an existing gallery
+- Gallery order updates immediately after reordering images; a success notification confirms when the new order is saved
+- Success notification when images finish uploading
+- Confirmation step before deleting gallery media, with the removed image disappearing from the gallery right away

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -4000,6 +4000,10 @@
     "context": "voucher value",
     "string": "Value"
   },
+  "JV3DcT": {
+    "context": "success notification when product media gallery order is saved",
+    "string": "Media order updated"
+  },
   "JVaz1C": {
     "context": "window title",
     "string": "Create Webhook"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -300,6 +300,10 @@
     "context": "input label",
     "string": "Global threshold"
   },
+  "/jEC3m": {
+    "context": "product media gallery dropzone hint",
+    "string": "Drag and drop or click to upload"
+  },
   "/jJLYy": {
     "string": "Transactions"
   },
@@ -7412,6 +7416,10 @@
     "context": "section header",
     "string": "Refund Order"
   },
+  "bqSNm/": {
+    "context": "success notification when product media is uploaded",
+    "string": "Image added"
+  },
   "brkxbY": {
     "string": "There are no transactions to refund"
   },
@@ -9146,9 +9154,6 @@
   },
   "lTrKHs": {
     "string": "Go to products"
-  },
-  "lUvX5F": {
-    "string": "Image added"
   },
   "lVwmf5": {
     "context": "total price of ordered products",

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -338,6 +338,10 @@
     "context": "Badge shown when channel is newly added",
     "string": "new"
   },
+  "/uu/aV": {
+    "context": "product media delete dialog content",
+    "string": "Are you sure you want to delete this video?"
+  },
   "/vCXIP": {
     "string": "Translation"
   },
@@ -814,6 +818,10 @@
   "2eZn56": {
     "context": "customer gift cards empty state placeholder",
     "string": "This customer hasn't redeemed any gift cards yet. Newly issued cards appear here once they're used at checkout."
+  },
+  "2fZByy": {
+    "context": "product media metadata dialog header",
+    "string": "Media Metadata"
   },
   "2fgaAQ": {
     "context": "search input placeholder",
@@ -2929,6 +2937,10 @@
   "EGycu/": {
     "context": "voucher status active",
     "string": "Active"
+  },
+  "EHRXv4": {
+    "context": "product media detail page header",
+    "string": "Edit Image"
   },
   "EHsnZX": {
     "context": "dialog description",
@@ -5697,6 +5709,10 @@
     "context": "sale status",
     "string": "Status"
   },
+  "SwtcgX": {
+    "context": "product media alt text field label",
+    "string": "Alt text"
+  },
   "Sz6CRr": {
     "string": "Create new product"
   },
@@ -6682,6 +6698,10 @@
     "context": "expiry date label",
     "string": "Exact date"
   },
+  "YDIpJq": {
+    "context": "product media detail page header",
+    "string": "Edit Video"
+  },
   "YEIFiI": {
     "string": "Add new structure item to begin creating structure"
   },
@@ -7559,6 +7579,10 @@
   "ce5Hp1": {
     "string": "Failed to copy to clipboard"
   },
+  "cg1bRE": {
+    "context": "product media detail page, top-bar metadata button tooltip",
+    "string": "Edit media metadata"
+  },
   "cgsY/X": {
     "context": "page header",
     "string": "Create New Category"
@@ -7663,6 +7687,10 @@
   "dDCLFW": {
     "context": "alert message",
     "string": "Not available for sale this channel"
+  },
+  "dGlDp6": {
+    "context": "product media delete dialog header",
+    "string": "Delete Video"
   },
   "dGqEJ9": {
     "context": "search box placeholder",

--- a/src/components/ButtonWithLoader/ButtonWithLoader.test.tsx
+++ b/src/components/ButtonWithLoader/ButtonWithLoader.test.tsx
@@ -11,7 +11,7 @@ describe("ButtonWithLoader", () => {
     expect(screen.getByRole("button")).toHaveTextContent("Confirm");
   });
 
-  it("should render a button with loading spinner", () => {
+  it("should render a button with loading throbber", () => {
     // Arrange & Act
     render(<ButtonWithLoader transitionState="loading" />);
     // Assert

--- a/src/components/ButtonWithLoader/ButtonWithLoader.tsx
+++ b/src/components/ButtonWithLoader/ButtonWithLoader.tsx
@@ -1,5 +1,6 @@
+import { SaleorThrobber } from "@dashboard/components/Throbber";
 import { buttonMessages } from "@dashboard/intl";
-import { Box, Button, type ButtonProps, Spinner, sprinkles } from "@saleor/macaw-ui-next";
+import { Button, type ButtonProps, sprinkles } from "@saleor/macaw-ui-next";
 import { useIntl } from "react-intl";
 
 import { type ConfirmButtonTransitionState } from "../ConfirmButton";
@@ -18,12 +19,16 @@ export const ButtonWithLoader = ({
   const intl = useIntl();
   const isLoading = transitionState === "loading";
 
-  const renderSpinner = () => {
+  const renderLoader = () => {
     if (isLoading) {
       return (
-        <Box data-test-id="button-progress" display="flex" position="absolute">
-          <Spinner />
-        </Box>
+        <SaleorThrobber
+          size={20}
+          data-test-id="button-progress"
+          className={sprinkles({
+            position: "absolute",
+          })}
+        />
       );
     }
 
@@ -41,7 +46,7 @@ export const ButtonWithLoader = ({
       onClick={isLoading ? undefined : onClick}
       data-test-state={isLoading ? "loading" : "default"}
     >
-      {renderSpinner()}
+      {renderLoader()}
       <span
         className={sprinkles({
           opacity: isLoading ? "0" : "1",

--- a/src/components/ImageUpload/ImageUpload.tsx
+++ b/src/components/ImageUpload/ImageUpload.tsx
@@ -67,7 +67,7 @@ const ImageUpload = (props: ImageUploadProps) => {
   const classes = useStyles(props);
 
   return (
-    <Dropzone disableClick={disableClick} onDrop={onImageUpload}>
+    <Dropzone noClick={disableClick} onDrop={onImageUpload}>
       {({ isDragActive, getInputProps, getRootProps }) => (
         <>
           <div

--- a/src/components/MediaTile/MediaTile.tsx
+++ b/src/components/MediaTile/MediaTile.tsx
@@ -1,6 +1,7 @@
 import { IconButton } from "@dashboard/components/IconButton";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { MediaWithFallback } from "@dashboard/components/MediaWithFallback/MediaWithFallback";
+import { parseOembedData } from "@dashboard/products/utils/parseOembedData";
 import { makeStyles } from "@saleor/macaw-ui";
 import { vars } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
@@ -106,8 +107,7 @@ type MediaTileProps = MediaTileBaseProps &
 const MediaTile = (props: MediaTileProps) => {
   const { loading, onDelete, onEdit, editHref, media, disableOverlay = false } = props;
   const classes = useStyles(props);
-  const parsedMediaOembedData = media?.oembedData ? JSON.parse(media.oembedData) : null;
-  const mediaUrl = parsedMediaOembedData?.thumbnail_url || media.url;
+  const mediaUrl = parseOembedData(media.oembedData).thumbnail_url || media.url;
 
   return (
     <div className={classes.mediaContainer} data-test-id="product-image">

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -16068,6 +16068,7 @@ export const ProductMediaByIdDocument = gql`
     name
     mainImage: mediaById(id: $mediaId) {
       id
+      ...Metadata
       alt
       url
       type
@@ -16082,7 +16083,7 @@ export const ProductMediaByIdDocument = gql`
     }
   }
 }
-    `;
+    ${MetadataFragmentDoc}`;
 
 /**
  * __useProductMediaByIdQuery__

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -15180,9 +15180,16 @@ export const ProductMediaDeleteDocument = gql`
     errors {
       ...ProductError
     }
+    product {
+      id
+      media {
+        ...ProductMedia
+      }
+    }
   }
 }
-    ${ProductErrorFragmentDoc}`;
+    ${ProductErrorFragmentDoc}
+${ProductMediaFragmentDoc}`;
 export type ProductMediaDeleteMutationFn = Apollo.MutationFunction<Types.ProductMediaDeleteMutation, Types.ProductMediaDeleteMutationVariables>;
 
 /**

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -14849,9 +14849,16 @@ export const ProductMediaReorderDocument = gql`
     errors {
       ...ProductError
     }
+    product {
+      id
+      media {
+        ...ProductMedia
+      }
+    }
   }
 }
-    ${ProductErrorFragmentDoc}`;
+    ${ProductErrorFragmentDoc}
+${ProductMediaFragmentDoc}`;
 export type ProductMediaReorderMutationFn = Apollo.MutationFunction<Types.ProductMediaReorderMutation, Types.ProductMediaReorderMutationVariables>;
 
 /**

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -13009,7 +13009,7 @@ export type ProductMediaByIdQueryVariables = Exact<{
 }>;
 
 
-export type ProductMediaByIdQuery = { __typename: 'Query', product: { __typename: 'Product', id: string, name: string, mainImage: { __typename: 'ProductMedia', id: string, alt: string, url: string, type: ProductMediaType, oembedData: string } | null, media: Array<{ __typename: 'ProductMedia', id: string, url: string, alt: string, type: ProductMediaType, oembedData: string }> | null } | null };
+export type ProductMediaByIdQuery = { __typename: 'Query', product: { __typename: 'Product', id: string, name: string, mainImage: { __typename: 'ProductMedia', id: string, alt: string, url: string, type: ProductMediaType, oembedData: string, metadata: Array<{ __typename: 'MetadataItem', key: string, value: string }>, privateMetadata: Array<{ __typename: 'MetadataItem', key: string, value: string }> } | null, media: Array<{ __typename: 'ProductMedia', id: string, url: string, alt: string, type: ProductMediaType, oembedData: string }> | null } | null };
 
 export type GridAttributesQueryVariables = Exact<{
   ids: Array<Scalars['ID']> | Scalars['ID'];

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -12765,7 +12765,7 @@ export type ProductMediaReorderMutationVariables = Exact<{
 }>;
 
 
-export type ProductMediaReorderMutation = { __typename: 'Mutation', productMediaReorder: { __typename: 'ProductMediaReorder', errors: Array<{ __typename: 'ProductError', code: ProductErrorCode, field: string | null, message: string | null }> } | null };
+export type ProductMediaReorderMutation = { __typename: 'Mutation', productMediaReorder: { __typename: 'ProductMediaReorder', errors: Array<{ __typename: 'ProductError', code: ProductErrorCode, field: string | null, message: string | null }>, product: { __typename: 'Product', id: string, media: Array<{ __typename: 'ProductMedia', id: string, alt: string, sortOrder: number | null, url: string, type: ProductMediaType, oembedData: string }> | null } | null } | null };
 
 export type ProductVariantSetDefaultMutationVariables = Exact<{
   productId: Scalars['ID'];

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -12834,7 +12834,7 @@ export type ProductMediaDeleteMutationVariables = Exact<{
 }>;
 
 
-export type ProductMediaDeleteMutation = { __typename: 'Mutation', productMediaDelete: { __typename: 'ProductMediaDelete', errors: Array<{ __typename: 'ProductError', code: ProductErrorCode, field: string | null, message: string | null }> } | null };
+export type ProductMediaDeleteMutation = { __typename: 'Mutation', productMediaDelete: { __typename: 'ProductMediaDelete', errors: Array<{ __typename: 'ProductError', code: ProductErrorCode, field: string | null, message: string | null }>, product: { __typename: 'Product', id: string, media: Array<{ __typename: 'ProductMedia', id: string, alt: string, sortOrder: number | null, url: string, type: ProductMediaType, oembedData: string }> | null } | null } | null };
 
 export type ProductMediaUpdateMutationVariables = Exact<{
   id: Scalars['ID'];

--- a/src/products/components/ProductMedia/ProductMedia.module.css
+++ b/src/products/components/ProductMedia/ProductMedia.module.css
@@ -1,0 +1,70 @@
+.dropzone {
+  border-style: dashed;
+  border-width: 1px;
+  border-color: var(--mu-colors-border-default1);
+  border-radius: 6px;
+  cursor: pointer;
+  min-height: 120px;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.dropzone:hover {
+  border-color: var(--mu-colors-border-default2);
+}
+
+.dropzoneActive {
+  border-color: var(--mu-colors-border-default2);
+  background-color: var(--mu-colors-background-default2);
+}
+
+.dropzoneContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 16px;
+  text-align: center;
+}
+
+.galleryContainer {
+  position: relative;
+  min-height: 148px;
+}
+
+.dropLayer {
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+}
+
+.dropLayerActive {
+  z-index: 1;
+}
+
+.dropOverlay {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  border: 1px dashed var(--mu-colors-border-default2);
+  border-radius: 6px;
+  background-color: var(--mu-colors-background-default1);
+  pointer-events: none;
+}
+
+.mediaList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  transition: opacity 0.15s ease;
+}
+
+.mediaListDimmed {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.hiddenInput {
+  display: none;
+}

--- a/src/products/components/ProductMedia/ProductMedia.module.css
+++ b/src/products/components/ProductMedia/ProductMedia.module.css
@@ -32,14 +32,11 @@
   min-height: 148px;
 }
 
-.dropLayer {
+.dropOverlayWrapper {
   position: absolute;
   inset: 0;
-  border-radius: 6px;
-}
-
-.dropLayerActive {
   z-index: 1;
+  pointer-events: none;
 }
 
 .dropOverlay {

--- a/src/products/components/ProductMedia/ProductMedia.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.tsx
@@ -1,16 +1,18 @@
 // @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
-import ImageUpload from "@dashboard/components/ImageUpload";
 import MediaTile from "@dashboard/components/MediaTile";
 import { type ProductMediaFragment, ProductMediaType } from "@dashboard/graphql";
 import { type ReorderAction } from "@dashboard/types";
 import createMultiFileUploadHandler from "@dashboard/utils/handlers/multiFileUploadHandler";
-import { Box, Button, Dropdown, List, Skeleton, sprinkles, Text } from "@saleor/macaw-ui-next";
+import { Box, Button, Dropdown, List, Skeleton, Text } from "@saleor/macaw-ui-next";
+import clsx from "clsx";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { SortableContainer, SortableElement } from "react-sortable-hoc";
 
 import { messages } from "./messages";
+import styles from "./ProductMedia.module.css";
+import { ProductMediaGalleryDropzone } from "./ProductMediaGalleryDropzone";
 
 interface SortableMediaProps {
   media: {
@@ -177,43 +179,27 @@ const ProductMedia = (props: ProductMediaProps) => {
               <Skeleton />
             </Box>
           ) : media.length > 0 ? (
-            <>
-              <ImageUpload
-                className={sprinkles({
-                  height: "100%",
-                  width: "100%",
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                })}
-                isActiveClassName={sprinkles({ zIndex: "1" })}
-                disableClick={true}
-                hideUploadIcon={true}
-                iconContainerActiveClassName={sprinkles({ display: "block" })}
-                onImageUpload={handleImageUpload}
-              >
-                {({ isDragActive }) => (
-                  <MediaListContainer
-                    distance={20}
-                    helperClass="dragged"
-                    axis="xy"
-                    media={media}
-                    preview={imagesToUpload}
-                    onSortEnd={onImageReorder}
-                    className={sprinkles({
-                      display: "flex",
-                      gap: 5,
-                      flexWrap: "wrap",
-                      opacity: isDragActive ? "0.2" : "1",
-                    })}
-                    onDelete={onImageDelete}
-                    getEditHref={getImageEditUrl}
-                  />
-                )}
-              </ImageUpload>
-            </>
+            <ProductMediaGalleryDropzone
+              variant="gallery"
+              disableClick={true}
+              onImageUpload={handleImageUpload}
+            >
+              {({ isDragActive }) => (
+                <MediaListContainer
+                  distance={20}
+                  helperClass="dragged"
+                  axis="xy"
+                  media={media}
+                  preview={imagesToUpload}
+                  onSortEnd={onImageReorder}
+                  className={clsx(styles.mediaList, isDragActive && styles.mediaListDimmed)}
+                  onDelete={onImageDelete}
+                  getEditHref={getImageEditUrl}
+                />
+              )}
+            </ProductMediaGalleryDropzone>
           ) : (
-            <ImageUpload onImageUpload={handleImageUpload} />
+            <ProductMediaGalleryDropzone variant="empty" onImageUpload={handleImageUpload} />
           )}
         </Box>
       </DashboardCard.Content>

--- a/src/products/components/ProductMedia/ProductMedia.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.tsx
@@ -39,7 +39,7 @@ const MediaListContainer = SortableContainer<MediaListContainerProps>(
     <div {...props}>
       {media.map((mediaObj, index) => (
         <SortableMedia
-          key={`item-${index}`}
+          key={mediaObj.id}
           index={index}
           media={mediaObj}
           editHref={getEditHref(mediaObj.id)}

--- a/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
+++ b/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
@@ -1,0 +1,62 @@
+import Dropzone from "@dashboard/components/Dropzone";
+import { Text } from "@saleor/macaw-ui-next";
+import clsx from "clsx";
+import type * as React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { messages } from "./messages";
+import styles from "./ProductMedia.module.css";
+
+interface ProductMediaGalleryDropzoneProps {
+  onImageUpload: (files: FileList) => void;
+  disableClick?: boolean;
+  variant: "empty" | "gallery";
+  children?: (props: { isDragActive: boolean }) => React.ReactNode;
+}
+
+export const ProductMediaGalleryDropzone = ({
+  onImageUpload,
+  disableClick = false,
+  variant,
+  children,
+}: ProductMediaGalleryDropzoneProps) => (
+  <Dropzone disableClick={disableClick} onDrop={onImageUpload}>
+    {({ isDragActive, getInputProps, getRootProps }) => {
+      if (variant === "empty") {
+        return (
+          <div
+            {...getRootProps()}
+            className={clsx(styles.dropzone, isDragActive && styles.dropzoneActive)}
+            data-test-id="product-media-dropzone"
+          >
+            <input {...getInputProps()} className={styles.hiddenInput} accept="image/*" multiple />
+            <div className={styles.dropzoneContent}>
+              <Text size={2} color="default2">
+                <FormattedMessage {...messages.uploadHint} />
+              </Text>
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div className={styles.galleryContainer} data-test-id="product-media-gallery">
+          <div
+            {...getRootProps()}
+            className={clsx(styles.dropLayer, isDragActive && styles.dropLayerActive)}
+          >
+            <input {...getInputProps()} className={styles.hiddenInput} accept="image/*" multiple />
+            {isDragActive && (
+              <div className={styles.dropOverlay}>
+                <Text size={2} color="default2">
+                  <FormattedMessage {...messages.uploadHint} />
+                </Text>
+              </div>
+            )}
+          </div>
+          {children?.({ isDragActive })}
+        </div>
+      );
+    }}
+  </Dropzone>
+);

--- a/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
+++ b/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
@@ -2,6 +2,7 @@ import Dropzone from "@dashboard/components/Dropzone";
 import { Text } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
 import type * as React from "react";
+import type { DropzoneState } from "react-dropzone";
 import { FormattedMessage } from "react-intl";
 
 import { messages } from "./messages";
@@ -21,7 +22,7 @@ export const ProductMediaGalleryDropzone = ({
   children,
 }: ProductMediaGalleryDropzoneProps) => (
   <Dropzone noClick={disableClick} onDrop={onImageUpload}>
-    {({ isDragActive, getInputProps, getRootProps }) => {
+    {({ isDragActive, getInputProps, getRootProps }: DropzoneState) => {
       if (variant === "empty") {
         return (
           <div

--- a/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
+++ b/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
@@ -20,7 +20,7 @@ export const ProductMediaGalleryDropzone = ({
   variant,
   children,
 }: ProductMediaGalleryDropzoneProps) => (
-  <Dropzone disableClick={disableClick} onDrop={onImageUpload}>
+  <Dropzone noClick={disableClick} onDrop={onImageUpload}>
     {({ isDragActive, getInputProps, getRootProps }) => {
       if (variant === "empty") {
         return (

--- a/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
+++ b/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
@@ -40,21 +40,22 @@ export const ProductMediaGalleryDropzone = ({
       }
 
       return (
-        <div className={styles.galleryContainer} data-test-id="product-media-gallery">
-          <div
-            {...getRootProps()}
-            className={clsx(styles.dropLayer, isDragActive && styles.dropLayerActive)}
-          >
-            <input {...getInputProps()} className={styles.hiddenInput} accept="image/*" multiple />
-            {isDragActive && (
+        <div
+          {...getRootProps()}
+          className={styles.galleryContainer}
+          data-test-id="product-media-gallery"
+        >
+          <input {...getInputProps()} className={styles.hiddenInput} accept="image/*" multiple />
+          {children?.({ isDragActive })}
+          {isDragActive && (
+            <div className={styles.dropOverlayWrapper}>
               <div className={styles.dropOverlay}>
                 <Text size={2} color="default2">
                   <FormattedMessage {...messages.uploadHint} />
                 </Text>
               </div>
-            )}
-          </div>
-          {children?.({ isDragActive })}
+            </div>
+          )}
         </div>
       );
     }}

--- a/src/products/components/ProductMedia/messages.ts
+++ b/src/products/components/ProductMedia/messages.ts
@@ -21,4 +21,9 @@ export const messages = defineMessages({
     defaultMessage: "Upload URL",
     description: "modal button url upload",
   },
+  uploadHint: {
+    id: "/jEC3m",
+    defaultMessage: "Drag and drop or click to upload",
+    description: "product media gallery dropzone hint",
+  },
 });

--- a/src/products/components/ProductMediaMetadataDialog/ProductMediaMetadataDialog.test.tsx
+++ b/src/products/components/ProductMediaMetadataDialog/ProductMediaMetadataDialog.test.tsx
@@ -1,0 +1,98 @@
+import { type ProductMediaByIdQuery, ProductMediaType } from "@dashboard/graphql";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { ProductMediaMetadataDialog } from "./ProductMediaMetadataDialog";
+
+const mockOnSubmit = jest.fn();
+
+jest.mock("@dashboard/components/MetadataDialog/useHandleMetadataSubmit", () => ({
+  useHandleMetadataSubmit: jest.fn(() => ({
+    onSubmit: mockOnSubmit,
+    lastSubmittedData: undefined,
+    submitInProgress: false,
+  })),
+}));
+
+const mockMedia: NonNullable<NonNullable<ProductMediaByIdQuery["product"]>["mainImage"]> = {
+  __typename: "ProductMedia",
+  id: "media-id",
+  alt: "Alt text",
+  url: "https://example.com/image.jpg",
+  type: ProductMediaType.IMAGE,
+  oembedData: "{}",
+  metadata: [{ __typename: "MetadataItem", key: "media-key", value: "media-value" }],
+  privateMetadata: [{ __typename: "MetadataItem", key: "private-key", value: "private-value" }],
+};
+
+describe("ProductMediaMetadataDialog", () => {
+  const onCloseMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders dialog with correct title when open", () => {
+    // Arrange & Act
+    render(<ProductMediaMetadataDialog open={true} onClose={onCloseMock} media={mockMedia} />);
+
+    // Assert
+    expect(screen.getByText("Media Metadata")).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    // Arrange & Act
+    render(<ProductMediaMetadataDialog open={false} onClose={onCloseMock} media={mockMedia} />);
+
+    // Assert
+    expect(screen.queryByText("Media Metadata")).not.toBeInTheDocument();
+  });
+
+  it("closes when user clicks close button", () => {
+    // Arrange
+    render(<ProductMediaMetadataDialog open={true} onClose={onCloseMock} media={mockMedia} />);
+
+    // Act
+    fireEvent.click(screen.getByTestId("back"));
+
+    // Assert
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it("displays metadata when section is expanded", () => {
+    // Arrange
+    render(<ProductMediaMetadataDialog open={true} onClose={onCloseMock} media={mockMedia} />);
+
+    const metadataEditors = screen.getAllByTestId("metadata-editor");
+    const publicMetadataEditor = metadataEditors.find(
+      editor => editor.getAttribute("data-test-is-private") === "false",
+    )!;
+
+    // Act
+    fireEvent.click(within(publicMetadataEditor).getByTestId("expand"));
+
+    // Assert
+    expect(within(publicMetadataEditor).getByDisplayValue("media-key")).toBeInTheDocument();
+    expect(within(publicMetadataEditor).getByDisplayValue("media-value")).toBeInTheDocument();
+  });
+
+  it("normalizes missing privateMetadata to empty list", () => {
+    // Arrange
+    const { privateMetadata: _omitted, ...mediaWithoutPrivateMetadata } = mockMedia;
+
+    // Act
+    render(
+      <ProductMediaMetadataDialog
+        open={true}
+        onClose={onCloseMock}
+        media={
+          mediaWithoutPrivateMetadata as unknown as NonNullable<
+            NonNullable<ProductMediaByIdQuery["product"]>["mainImage"]
+          >
+        }
+      />,
+    );
+
+    // Assert
+    expect(screen.getAllByTestId("metadata-editor")).toHaveLength(2);
+  });
+});

--- a/src/products/components/ProductMediaMetadataDialog/ProductMediaMetadataDialog.tsx
+++ b/src/products/components/ProductMediaMetadataDialog/ProductMediaMetadataDialog.tsx
@@ -1,0 +1,86 @@
+import { MetadataDialog } from "@dashboard/components/MetadataDialog/MetadataDialog";
+import { useHandleMetadataSubmit } from "@dashboard/components/MetadataDialog/useHandleMetadataSubmit";
+import { useMetadataForm } from "@dashboard/components/MetadataDialog/useMetadataForm";
+import { mapFieldArrayToMetadataInput } from "@dashboard/components/MetadataDialog/validation";
+import { ProductMediaByIdDocument, type ProductMediaByIdQuery } from "@dashboard/graphql";
+import { useEffect } from "react";
+import { defineMessages, useIntl } from "react-intl";
+
+type ProductMediaMetadataDialogData = NonNullable<
+  NonNullable<ProductMediaByIdQuery["product"]>["mainImage"]
+>;
+
+interface ProductMediaMetadataDialogProps {
+  open: boolean;
+  onClose: () => void;
+  media: ProductMediaMetadataDialogData | undefined | null;
+}
+
+const messages = defineMessages({
+  title: {
+    id: "2fZByy",
+    defaultMessage: "Media Metadata",
+    description: "product media metadata dialog header",
+  },
+});
+
+export const ProductMediaMetadataDialog = ({
+  onClose,
+  open,
+  media,
+}: ProductMediaMetadataDialogProps) => {
+  const intl = useIntl();
+  const normalizedMedia = media
+    ? { ...media, privateMetadata: media.privateMetadata ?? [] }
+    : undefined;
+  const { onSubmit, lastSubmittedData, submitInProgress } = useHandleMetadataSubmit({
+    initialData: normalizedMedia,
+    onClose,
+    refetchDocument: ProductMediaByIdDocument,
+  });
+
+  const {
+    metadataFields,
+    privateMetadataFields,
+    metadataErrors,
+    privateMetadataErrors,
+    reset,
+    formIsDirty,
+    handleChange,
+    formData,
+  } = useMetadataForm({
+    graphqlData: normalizedMedia,
+    submitInProgress,
+    lastSubmittedData,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      reset();
+    }
+  }, [open, reset]);
+
+  return (
+    <MetadataDialog
+      open={open}
+      onClose={onClose}
+      onSave={async () => {
+        await onSubmit(formData);
+      }}
+      title={intl.formatMessage(messages.title)}
+      data={{
+        metadata: mapFieldArrayToMetadataInput(metadataFields),
+        privateMetadata: mapFieldArrayToMetadataInput(privateMetadataFields),
+      }}
+      onChange={handleChange}
+      loading={submitInProgress}
+      errors={{
+        metadata: metadataErrors.length ? metadataErrors.join(", ") : undefined,
+        privateMetadata: privateMetadataErrors.length
+          ? privateMetadataErrors.join(", ")
+          : undefined,
+      }}
+      formIsDirty={formIsDirty}
+    />
+  );
+};

--- a/src/products/components/ProductMediaNavigation/ProductMediaNavigation.tsx
+++ b/src/products/components/ProductMediaNavigation/ProductMediaNavigation.tsx
@@ -1,6 +1,7 @@
 // @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
 import { MediaWithFallback } from "@dashboard/components/MediaWithFallback/MediaWithFallback";
+import { parseOembedData } from "@dashboard/products/utils/parseOembedData";
 import { makeStyles } from "@saleor/macaw-ui";
 import { Skeleton, vars } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
@@ -76,8 +77,7 @@ const ProductMediaNavigation = (props: ProductMediaNavigationProps) => {
         ) : (
           <div className={classes.root}>
             {media.map(mediaObj => {
-              const mediaObjOembedData = JSON.parse(mediaObj?.oembedData);
-              const mediaUrl = mediaObjOembedData?.thumbnail_url || mediaObj.url;
+              const mediaUrl = parseOembedData(mediaObj.oembedData).thumbnail_url || mediaObj.url;
 
               return (
                 <div

--- a/src/products/components/ProductMediaNavigation/ProductMediaNavigation.tsx
+++ b/src/products/components/ProductMediaNavigation/ProductMediaNavigation.tsx
@@ -3,9 +3,11 @@ import { DashboardCard } from "@dashboard/components/Card";
 import { MediaWithFallback } from "@dashboard/components/MediaWithFallback/MediaWithFallback";
 import { parseOembedData } from "@dashboard/products/utils/parseOembedData";
 import { makeStyles } from "@saleor/macaw-ui";
-import { Skeleton, vars } from "@saleor/macaw-ui-next";
+import { Box, Skeleton, vars } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
 import { defineMessages, useIntl } from "react-intl";
+
+const skeletonThumbnailCount = 4;
 
 const messages = defineMessages({
   allMedia: {
@@ -36,6 +38,10 @@ const useStyles = makeStyles(
     },
     highlightedImageContainer: {
       border: `2px solid ${vars.colors.text.default1}`,
+    },
+    skeletonImageContainer: {
+      cursor: "default",
+      pointerEvents: "none",
     },
     root: {
       display: "grid",
@@ -73,7 +79,16 @@ const ProductMediaNavigation = (props: ProductMediaNavigationProps) => {
       </DashboardCard.Header>
       <DashboardCard.Content>
         {!media ? (
-          <Skeleton />
+          <div className={classes.root} data-test-id="product-media-navigation-skeleton">
+            {Array.from({ length: skeletonThumbnailCount }, (_, index) => (
+              <Box
+                key={index}
+                className={clsx(classes.imageContainer, classes.skeletonImageContainer)}
+              >
+                <Skeleton __width="100%" __height="100%" borderRadius={2} />
+              </Box>
+            ))}
+          </div>
         ) : (
           <div className={classes.root}>
             {media.map(mediaObj => {

--- a/src/products/components/ProductMediaNavigation/ProductMediaNavigation.tsx
+++ b/src/products/components/ProductMediaNavigation/ProductMediaNavigation.tsx
@@ -19,9 +19,6 @@ const useStyles = makeStyles(
     card: {
       marginBottom: theme.spacing(2),
     },
-    highlightedImageContainer: {
-      borderColor: theme.palette.primary.main,
-    },
     image: {
       height: "100%",
       objectFit: "contain",
@@ -36,6 +33,9 @@ const useStyles = makeStyles(
       overflow: "hidden",
       padding: theme.spacing(0.5),
       position: "relative",
+    },
+    highlightedImageContainer: {
+      border: `2px solid ${vars.colors.text.default1}`,
     },
     root: {
       display: "grid",

--- a/src/products/components/ProductMediaPage/ProductMediaPage.tsx
+++ b/src/products/components/ProductMediaPage/ProductMediaPage.tsx
@@ -9,8 +9,9 @@ import { MediaWithFallback } from "@dashboard/components/MediaWithFallback/Media
 import { Savebar } from "@dashboard/components/Savebar";
 import { ProductMediaType } from "@dashboard/graphql";
 import useNavigator from "@dashboard/hooks/useNavigator";
-import { commonMessages } from "@dashboard/intl";
+import { rippleProductMediaMetadata } from "@dashboard/products/ripples/productMediaMetadata";
 import { productUrl } from "@dashboard/products/urls";
+import { parseOembedData } from "@dashboard/products/utils/parseOembedData";
 import { TextField } from "@material-ui/core";
 import { makeStyles } from "@saleor/macaw-ui";
 import { Box, Skeleton, Text, vars } from "@saleor/macaw-ui-next";
@@ -48,6 +49,16 @@ const messages = defineMessages({
     id: "lzdvwp",
     defaultMessage: "Optional",
     description: "field is optional",
+  },
+  editMediaMetadata: {
+    id: "cg1bRE",
+    defaultMessage: "Edit media metadata",
+    description: "product media detail page, top-bar metadata button tooltip",
+  },
+  altText: {
+    id: "SwtcgX",
+    defaultMessage: "Alt text",
+    description: "product media alt text field label",
   },
 });
 // Fits below top nav + savebar, this card's header, and content padding.
@@ -150,6 +161,7 @@ interface ProductMediaPageProps {
   saveButtonBarState: ConfirmButtonTransitionState;
   onDelete: () => void;
   onRowClick: (id: string) => () => void;
+  onShowMetadata: () => void;
   onSubmit: (data: { description: string }) => void;
 }
 
@@ -163,6 +175,7 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
     saveButtonBarState,
     onDelete,
     onRowClick,
+    onShowMetadata,
     onSubmit,
   } = props;
   const classes = useStyles(props);
@@ -190,13 +203,21 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
                 </Box>
               )
             }
-          />
+          >
+            <TopNav.MetadataButton
+              onClick={onShowMetadata}
+              disabled={!mediaObj}
+              data-test-id="show-media-metadata"
+              title={intl.formatMessage(messages.editMediaMetadata)}
+              ripple={rippleProductMediaMetadata}
+            />
+          </TopNav>
           <Grid variant="inverted" className={classes.grid}>
             <div>
               <ProductMediaNavigation
                 disabled={disabled}
                 media={media}
-                highlighted={media ? mediaObj.id : undefined}
+                highlighted={mediaObj?.id}
                 onRowClick={onRowClick}
               />
               <DashboardCard>
@@ -208,7 +229,7 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
                 <DashboardCard.Content>
                   <TextField
                     name="description"
-                    label={intl.formatMessage(commonMessages.description)}
+                    label={intl.formatMessage(messages.altText)}
                     helperText={intl.formatMessage(messages.optional)}
                     disabled={disabled}
                     onChange={change}
@@ -240,7 +261,7 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
                         <div
                           className={classes.previewVideo}
                           dangerouslySetInnerHTML={{
-                            __html: JSON.parse(mediaObj?.oembedData)?.html,
+                            __html: parseOembedData(mediaObj.oembedData).html ?? "",
                           }}
                         />
                       )

--- a/src/products/components/ProductMediaPage/ProductMediaPage.tsx
+++ b/src/products/components/ProductMediaPage/ProductMediaPage.tsx
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { savebarHeight, topBarHeight } from "@dashboard/components/AppLayout/consts";
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import { DashboardCard } from "@dashboard/components/Card";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
@@ -12,8 +13,8 @@ import { commonMessages } from "@dashboard/intl";
 import { productUrl } from "@dashboard/products/urls";
 import { TextField } from "@material-ui/core";
 import { makeStyles } from "@saleor/macaw-ui";
-import { Skeleton, vars } from "@saleor/macaw-ui-next";
-import { defineMessages, useIntl } from "react-intl";
+import { Box, Skeleton, Text, vars } from "@saleor/macaw-ui-next";
+import { defineMessages, type IntlShape, useIntl } from "react-intl";
 
 import ProductMediaNavigation from "../ProductMediaNavigation";
 
@@ -22,6 +23,16 @@ const messages = defineMessages({
     id: "Ihp4D3",
     defaultMessage: "Edit Media",
     description: "header",
+  },
+  editImage: {
+    id: "EHRXv4",
+    defaultMessage: "Edit Image",
+    description: "product media detail page header",
+  },
+  editVideo: {
+    id: "YDIpJq",
+    defaultMessage: "Edit Video",
+    description: "product media detail page header",
   },
   mediaInformation: {
     id: "9RvXNg",
@@ -39,27 +50,87 @@ const messages = defineMessages({
     description: "field is optional",
   },
 });
+// Fits below top nav + savebar, this card's header, and content padding.
+const previewStageHeight = `calc(100vh - ${topBarHeight} - ${savebarHeight} - 120px)`;
+
 const useStyles = makeStyles(
   theme => ({
-    image: {
-      height: "100%",
-      objectFit: "contain",
-      width: "100%",
+    grid: {
+      alignItems: "start",
     },
-    imageContainer: {
-      "& iframe": {
-        width: "100%",
-        maxHeight: 420,
-      },
+    mediaViewColumn: {
+      alignSelf: "start",
+      position: "sticky",
+      top: theme.spacing(3),
+    },
+    previewStage: {
+      alignItems: "center",
       border: `1px solid ${vars.colors.border.default1}`,
       borderRadius: theme.spacing(),
-      margin: `0 auto ${theme.spacing(2)}px`,
-      width: "100%",
+      boxSizing: "border-box",
+      display: "flex",
+      height: previewStageHeight,
+      justifyContent: "center",
+      maxHeight: previewStageHeight,
+      overflow: "visible",
       padding: theme.spacing(2),
+      width: "100%",
+    },
+    previewMedia: {
+      display: "block",
+      maxHeight: "100%",
+      maxWidth: "100%",
+      objectFit: "contain",
+    },
+    previewVideo: {
+      alignSelf: "center",
+      aspectRatio: "16 / 9",
+      flexShrink: 1,
+      height: "auto",
+      maxHeight: "100%",
+      maxWidth: "100%",
+      minWidth: 0,
+      position: "relative",
+      width: "100%",
+      // Provider oembed HTML (e.g. YouTube) uses a padding-bottom responsive wrapper.
+      "& > div": {
+        height: "100%",
+        overflow: "hidden",
+        paddingBottom: "0 !important",
+        position: "relative",
+        width: "100%",
+      },
+      "& iframe": {
+        border: 0,
+        display: "block",
+        height: "100%",
+        left: 0,
+        maxHeight: "none",
+        maxWidth: "none",
+        position: "absolute",
+        top: 0,
+        width: "100%",
+      },
+    },
+    previewSkeleton: {
+      height: "100%",
+      width: "100%",
     },
   }),
   { name: "ProductMediaPage" },
 );
+
+function getEditMediaTitle(mediaType: string | undefined, intl: IntlShape) {
+  if (mediaType === ProductMediaType.VIDEO) {
+    return intl.formatMessage(messages.editVideo);
+  }
+
+  if (mediaType === ProductMediaType.IMAGE) {
+    return intl.formatMessage(messages.editImage);
+  }
+
+  return intl.formatMessage(messages.editMedia);
+}
 
 interface ProductMediaPageProps {
   productId: string;
@@ -88,6 +159,7 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
     disabled,
     mediaObj,
     media,
+    product: productName,
     saveButtonBarState,
     onDelete,
     onRowClick,
@@ -101,8 +173,25 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
     <Form initial={{ description: mediaObj ? mediaObj.alt : "" }} onSubmit={onSubmit} confirmLeave>
       {({ change, data, submit }) => (
         <>
-          <TopNav href={productUrl(productId)} title={intl.formatMessage(messages.editMedia)} />
-          <Grid variant="inverted">
+          <TopNav
+            href={productUrl(productId)}
+            title={
+              disabled && !productName ? (
+                <Skeleton __width="200px" />
+              ) : (
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Text size={6} color="default2" ellipsis __maxWidth="200px" title={productName}>
+                    {productName}
+                  </Text>
+                  <Text size={6} color="default2">
+                    /
+                  </Text>
+                  <Text size={6}>{getEditMediaTitle(mediaObj?.type, intl)}</Text>
+                </Box>
+              )
+            }
+          />
+          <Grid variant="inverted" className={classes.grid}>
             <div>
               <ProductMediaNavigation
                 disabled={disabled}
@@ -130,7 +219,7 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
                 </DashboardCard.Content>
               </DashboardCard>
             </div>
-            <div>
+            <div className={classes.mediaViewColumn}>
               <DashboardCard>
                 <DashboardCard.Header>
                   <DashboardCard.Title>
@@ -138,27 +227,27 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
                   </DashboardCard.Title>
                 </DashboardCard.Header>
                 <DashboardCard.Content>
-                  {mediaObj ? (
-                    mediaObj?.type === ProductMediaType.IMAGE ? (
-                      <div className={classes.imageContainer}>
+                  <div className={classes.previewStage}>
+                    {mediaObj ? (
+                      mediaObj?.type === ProductMediaType.IMAGE ? (
                         <MediaWithFallback
                           key={mediaObj.url}
-                          className={classes.image}
+                          className={classes.previewMedia}
                           src={mediaObj.url}
                           alt={mediaObj.alt}
                         />
-                      </div>
+                      ) : (
+                        <div
+                          className={classes.previewVideo}
+                          dangerouslySetInnerHTML={{
+                            __html: JSON.parse(mediaObj?.oembedData)?.html,
+                          }}
+                        />
+                      )
                     ) : (
-                      <div
-                        className={classes.imageContainer}
-                        dangerouslySetInnerHTML={{
-                          __html: JSON.parse(mediaObj?.oembedData)?.html,
-                        }}
-                      />
-                    )
-                  ) : (
-                    <Skeleton />
-                  )}
+                      <Skeleton className={classes.previewSkeleton} />
+                    )}
+                  </div>
                 </DashboardCard.Content>
               </DashboardCard>
             </div>

--- a/src/products/components/ProductMediaPage/ProductMediaPage.tsx
+++ b/src/products/components/ProductMediaPage/ProductMediaPage.tsx
@@ -162,7 +162,7 @@ interface ProductMediaPageProps {
   onDelete: () => void;
   onRowClick: (id: string) => () => void;
   onShowMetadata: () => void;
-  onSubmit: (data: { description: string }) => void;
+  onSubmit: (data: { alt: string }) => void;
 }
 
 const ProductMediaPage = (props: ProductMediaPageProps) => {
@@ -183,7 +183,7 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
   const navigate = useNavigator();
 
   return (
-    <Form initial={{ description: mediaObj ? mediaObj.alt : "" }} onSubmit={onSubmit} confirmLeave>
+    <Form initial={{ alt: mediaObj?.alt ?? "" }} onSubmit={onSubmit} confirmLeave>
       {({ change, data, submit }) => (
         <>
           <TopNav
@@ -228,12 +228,12 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
                 </DashboardCard.Header>
                 <DashboardCard.Content>
                   <TextField
-                    name="description"
+                    name="alt"
                     label={intl.formatMessage(messages.altText)}
                     helperText={intl.formatMessage(messages.optional)}
                     disabled={disabled}
                     onChange={change}
-                    value={data.description}
+                    value={data.alt}
                     multiline
                     fullWidth
                   />

--- a/src/products/components/ProductMediaPage/ProductMediaPage.tsx
+++ b/src/products/components/ProductMediaPage/ProductMediaPage.tsx
@@ -45,11 +45,6 @@ const messages = defineMessages({
     defaultMessage: "Media View",
     description: "section header",
   },
-  optional: {
-    id: "lzdvwp",
-    defaultMessage: "Optional",
-    description: "field is optional",
-  },
   editMediaMetadata: {
     id: "cg1bRE",
     defaultMessage: "Edit media metadata",
@@ -230,7 +225,6 @@ const ProductMediaPage = (props: ProductMediaPageProps) => {
                   <TextField
                     name="alt"
                     label={intl.formatMessage(messages.altText)}
-                    helperText={intl.formatMessage(messages.optional)}
                     disabled={disabled}
                     onChange={change}
                     value={data.alt}

--- a/src/products/components/ProductVariantImageSelectDialog/ProductVariantMediaSelectDialog.tsx
+++ b/src/products/components/ProductVariantImageSelectDialog/ProductVariantMediaSelectDialog.tsx
@@ -4,6 +4,7 @@ import { DashboardModal } from "@dashboard/components/Modal";
 import { type ProductMediaFragment } from "@dashboard/graphql";
 import useModalDialogOpen from "@dashboard/hooks/useModalDialogOpen";
 import { buttonMessages } from "@dashboard/intl";
+import { parseOembedData } from "@dashboard/products/utils/parseOembedData";
 import { Box } from "@saleor/macaw-ui-next";
 import { useState } from "react";
 import { FormattedMessage } from "react-intl";
@@ -64,8 +65,7 @@ const ProductVariantMediaSelectDialog = (props: ProductVariantImageSelectDialogP
           {media
             ?.sort((prev, next) => (prev.sortOrder! > next.sortOrder! ? 1 : -1))
             .map(mediaObj => {
-              const parsedMediaOembedData = JSON.parse(mediaObj?.oembedData);
-              const mediaUrl = parsedMediaOembedData?.thumbnail_url || mediaObj.url;
+              const mediaUrl = parseOembedData(mediaObj.oembedData).thumbnail_url || mediaObj.url;
               const isSelected = selectedMedia?.includes(mediaObj.id);
 
               return (

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -193,6 +193,12 @@ export const productMediaDeleteMutation = gql`
       errors {
         ...ProductError
       }
+      product {
+        id
+        media {
+          ...ProductMedia
+        }
+      }
     }
   }
 `;

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -34,6 +34,12 @@ export const productMediaReorder = gql`
       errors {
         ...ProductError
       }
+      product {
+        id
+        media {
+          ...ProductMedia
+        }
+      }
     }
   }
 `;

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -174,6 +174,7 @@ export const productMediaQuery = gql`
       name
       mainImage: mediaById(id: $mediaId) {
         id
+        ...Metadata
         alt
         url
         type

--- a/src/products/ripples/productMediaMetadata.ts
+++ b/src/products/ripples/productMediaMetadata.ts
@@ -1,0 +1,14 @@
+import { type Ripple } from "@dashboard/ripples/types";
+
+export const rippleProductMediaMetadata: Ripple = {
+  type: "improvement",
+  ID: "product-media-metadata-header",
+  TTL_seconds: 60 * 60 * 24 * 7,
+  dateAdded: new Date(2026, 5, 3),
+  content: {
+    oneLiner: "Media metadata in header",
+    contextual: "Media metadata is now edited from this button, which opens a dedicated dialog.",
+    global:
+      "Product media items now have a header metadata button on the edit media page. You can manage public and private metadata for each image or video without leaving the preview.",
+  },
+};

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -172,7 +172,8 @@ export const productVariantAddUrl = (
 
 export const productImagePath = (productId: string, imageId: string) =>
   urlJoin(productSection, productId, "image", imageId);
-export type ProductImageUrlQueryParams = Dialog<"remove">;
+export type ProductImageUrlDialog = "remove" | "view-metadata";
+export type ProductImageUrlQueryParams = Dialog<ProductImageUrlDialog>;
 export const productImageUrl = (
   productId: string,
   imageId: string,

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -133,6 +133,7 @@ export const productListUrlWithProductType = (productType?: {
 export const productPath = (id: string) => urlJoin(productSection + id);
 export type ProductUrlDialog =
   | "remove"
+  | "remove-media"
   | "assign-attribute-value"
   | "view-metadata"
   | ChannelsAction;

--- a/src/products/utils/parseOembedData.test.ts
+++ b/src/products/utils/parseOembedData.test.ts
@@ -1,0 +1,30 @@
+import { parseOembedData } from "./parseOembedData";
+
+describe("parseOembedData", () => {
+  it("returns empty object when oembed data is missing", () => {
+    // Arrange & Act & Assert
+    expect(parseOembedData(undefined)).toEqual({});
+    expect(parseOembedData(null)).toEqual({});
+    expect(parseOembedData("")).toEqual({});
+  });
+
+  it("parses valid oembed json", () => {
+    // Arrange
+    const oembedData = JSON.stringify({
+      html: "<iframe></iframe>",
+      thumbnail_url: "https://example.com/thumb.jpg",
+    });
+
+    // Act
+    const result = parseOembedData(oembedData);
+
+    // Assert
+    expect(result.html).toBe("<iframe></iframe>");
+    expect(result.thumbnail_url).toBe("https://example.com/thumb.jpg");
+  });
+
+  it("returns empty object for invalid json", () => {
+    // Arrange & Act & Assert
+    expect(parseOembedData("not-json")).toEqual({});
+  });
+});

--- a/src/products/utils/parseOembedData.ts
+++ b/src/products/utils/parseOembedData.ts
@@ -29,6 +29,4 @@ export function parseOembedData(oembedData: string | null | undefined): ParsedOe
   } catch {
     return {};
   }
-
-  return {};
 }

--- a/src/products/utils/parseOembedData.ts
+++ b/src/products/utils/parseOembedData.ts
@@ -1,0 +1,34 @@
+export interface ParsedOembedData {
+  html?: string;
+  thumbnail_url?: string;
+}
+
+export function parseOembedData(oembedData: string | null | undefined): ParsedOembedData {
+  if (!oembedData) {
+    return {};
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(oembedData);
+
+    if (typeof parsed !== "object" || parsed === null) {
+      return {};
+    }
+
+    const result: ParsedOembedData = {};
+
+    if ("html" in parsed && typeof parsed.html === "string") {
+      result.html = parsed.html;
+    }
+
+    if ("thumbnail_url" in parsed && typeof parsed.thumbnail_url === "string") {
+      result.thumbnail_url = parsed.thumbnail_url;
+    }
+
+    return result;
+  } catch {
+    return {};
+  }
+
+  return {};
+}

--- a/src/products/views/ProductImage.tsx
+++ b/src/products/views/ProductImage.tsx
@@ -90,10 +90,10 @@ const ProductImage = ({ mediaId, productId, params }: ProductMediaProps) => {
 
   const handleDelete = () => deleteImage({ variables: { id: mediaId } });
   const handleImageClick = (id: string) => () => navigate(productImageUrl(productId, id));
-  const handleUpdate = (formData: { description: string }) => {
+  const handleUpdate = (formData: { alt: string }) => {
     updateImage({
       variables: {
-        alt: formData.description,
+        alt: formData.alt,
         id: mediaId,
       },
     });

--- a/src/products/views/ProductImage.tsx
+++ b/src/products/views/ProductImage.tsx
@@ -2,21 +2,47 @@
 import ActionDialog from "@dashboard/components/ActionDialog";
 import NotFoundPage from "@dashboard/components/NotFoundPage";
 import {
+  ProductMediaType,
   useProductMediaByIdQuery,
   useProductMediaDeleteMutation,
   useProductMediaUpdateMutation,
 } from "@dashboard/graphql";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { useNotifier } from "@dashboard/hooks/useNotifier";
-import { FormattedMessage, useIntl } from "react-intl";
+import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
+import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 
+import { ProductMediaMetadataDialog } from "../components/ProductMediaMetadataDialog/ProductMediaMetadataDialog";
 import ProductMediaPage from "../components/ProductMediaPage";
 import {
   productImageUrl,
+  type ProductImageUrlDialog,
   type ProductImageUrlQueryParams,
   productListUrl,
   productUrl,
 } from "../urls";
+
+const messages = defineMessages({
+  deleteImageTitle: {
+    id: "uCn/rd",
+    defaultMessage: "Delete Image",
+    description: "dialog header",
+  },
+  deleteVideoTitle: {
+    id: "dGlDp6",
+    defaultMessage: "Delete Video",
+    description: "product media delete dialog header",
+  },
+  deleteImageConfirmation: {
+    id: "VEext+",
+    defaultMessage: "Are you sure you want to delete this image?",
+  },
+  deleteVideoConfirmation: {
+    id: "/uu/aV",
+    defaultMessage: "Are you sure you want to delete this video?",
+    description: "product media delete dialog content",
+  },
+});
 
 interface ProductMediaProps {
   mediaId: string;
@@ -29,6 +55,10 @@ const ProductImage = ({ mediaId, productId, params }: ProductMediaProps) => {
   const notify = useNotifier();
   const intl = useIntl();
   const handleBack = () => navigate(productUrl(productId));
+  const [openModal, closeModal] = createDialogActionHandlers<
+    ProductImageUrlDialog,
+    ProductImageUrlQueryParams
+  >(navigate, params => productImageUrl(productId, mediaId, params), params);
   const { data, loading } = useProductMediaByIdQuery({
     displayLoader: true,
     variables: {
@@ -69,6 +99,7 @@ const ProductImage = ({ mediaId, productId, params }: ProductMediaProps) => {
     });
   };
   const mediaObj = data?.product?.mainImage;
+  const isVideo = mediaObj?.type === ProductMediaType.VIDEO;
 
   return (
     <>
@@ -86,24 +117,25 @@ const ProductImage = ({ mediaId, productId, params }: ProductMediaProps) => {
           )
         }
         onRowClick={handleImageClick}
+        onShowMetadata={() => openModal("view-metadata")}
         onSubmit={handleUpdate}
         saveButtonBarState={updateResult.status}
+      />
+      <ProductMediaMetadataDialog
+        open={params.action === "view-metadata" && !!mediaObj}
+        onClose={closeModal}
+        media={mediaObj}
       />
       <ActionDialog
         onClose={() => navigate(productImageUrl(productId, mediaId), { replace: true })}
         onConfirm={handleDelete}
         open={params.action === "remove"}
-        title={intl.formatMessage({
-          id: "uCn/rd",
-          defaultMessage: "Delete Image",
-          description: "dialog header",
-        })}
+        title={intl.formatMessage(isVideo ? messages.deleteVideoTitle : messages.deleteImageTitle)}
         variant="delete"
         confirmButtonState={deleteResult.status}
       >
         <FormattedMessage
-          id="VEext+"
-          defaultMessage="Are you sure you want to delete this image?"
+          {...(isVideo ? messages.deleteVideoConfirmation : messages.deleteImageConfirmation)}
         />
       </ActionDialog>
     </>

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -24,7 +24,7 @@ import {
 import { getSearchFetchMoreProps } from "@dashboard/hooks/makeTopLevelSearch/utils";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { useNotifier } from "@dashboard/hooks/useNotifier";
-import { errorMessages } from "@dashboard/intl";
+import { commonMessages, errorMessages } from "@dashboard/intl";
 import { useSearchAttributeValuesSuggestions } from "@dashboard/searches/useAttributeValueSearch";
 import useCategorySearch from "@dashboard/searches/useCategorySearch";
 import useCollectionSearch from "@dashboard/searches/useCollectionSearch";
@@ -111,7 +111,18 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
   });
   const [reorderProductImages, reorderProductImagesOpts] = useProductMediaReorderMutation({
     onCompleted: data => {
-      const errors = data.productMediaReorder?.errors ?? [];
+      const result = data.productMediaReorder;
+
+      if (!result) {
+        notify({
+          status: "error",
+          text: intl.formatMessage(commonMessages.somethingWentWrong),
+        });
+
+        return;
+      }
+
+      const { errors } = result;
 
       if (errors.length) {
         errors.forEach(error =>
@@ -185,7 +196,18 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
   >(navigate, params => productUrl(id, params), params);
   const [deleteProductImage, deleteProductImageOpts] = useProductMediaDeleteMutation({
     onCompleted: data => {
-      const errors = data.productMediaDelete?.errors ?? [];
+      const result = data.productMediaDelete;
+
+      if (!result) {
+        notify({
+          status: "error",
+          text: intl.formatMessage(commonMessages.somethingWentWrong),
+        });
+
+        return;
+      }
+
+      const { errors } = result;
 
       if (errors.length) {
         errors.forEach(error =>

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -37,7 +37,7 @@ import { getProductErrorMessage } from "@dashboard/utils/errors";
 import useAttributeValueSearchHandler from "@dashboard/utils/handlers/attributeValueSearchHandler";
 import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { useAssignAttributeValueDialogFilterChangeHandlers } from "../../../components/AssignAttributeValueDialog/useAssignAttributeValueDialogFilterChangeHandlers";
@@ -231,11 +231,15 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     },
   });
   const product = data?.product;
-  const mediaToDelete = useMemo(
-    () => product?.media?.find(media => media.id === params.id),
-    [params.id, product?.media],
-  );
-  const isVideoMediaToDelete = mediaToDelete?.type === ProductMediaType.VIDEO;
+  const [deleteMediaType, setDeleteMediaType] = useState<ProductMediaType | null>(null);
+
+  useEffect(() => {
+    if (params.action !== "remove-media") {
+      setDeleteMediaType(null);
+    }
+  }, [params.action]);
+
+  const isVideoMediaToDelete = deleteMediaType === ProductMediaType.VIDEO;
   const getAttributeValuesSuggestions = useSearchAttributeValuesSuggestions();
   const [createProductMedia, createProductMediaOpts] = useProductMediaCreateMutation({
     onCompleted: handleProductMediaCreateCompleted,
@@ -347,7 +351,12 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     },
     [bulkCreateVariants, id, intl, notify, refetch],
   );
-  const handleImageDelete = (mediaId: string) => () => openModal("remove-media", { id: mediaId });
+  const handleImageDelete = (mediaId: string) => () => {
+    const media = product?.media?.find(item => item.id === mediaId);
+
+    setDeleteMediaType(media?.type ?? null);
+    openModal("remove-media", { id: mediaId });
+  };
   const handleConfirmMediaDelete = () => {
     const mediaId = params.id;
     const currentMedia = product?.media;

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -10,6 +10,7 @@ import { WindowTitle } from "@dashboard/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA, VALUES_PAGINATE_BY } from "@dashboard/config";
 import {
   ErrorPolicyEnum,
+  type ProductMediaCreateMutation,
   type ProductMediaCreateMutationVariables,
   type ProductVariantBulkCreateInput,
   useProductDeleteMutation,
@@ -138,9 +139,10 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
       navigate(productListUrl());
     },
   });
-  const [createProductImage, createProductImageOpts] = useProductMediaCreateMutation({
-    onCompleted: data => {
-      const imageError = data.productMediaCreate.errors.find(
+  const handleProductMediaCreateCompleted = useCallback(
+    (data: ProductMediaCreateMutation) => {
+      const errors = data.productMediaCreate?.errors ?? [];
+      const imageError = errors.find(
         error => error.field === ("image" as keyof ProductMediaCreateMutationVariables),
       );
 
@@ -150,8 +152,30 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
           title: intl.formatMessage(errorMessages.imgageUploadErrorTitle),
           text: intl.formatMessage(errorMessages.imageUploadErrorText),
         });
+
+        return;
       }
+
+      if (errors.length) {
+        errors.forEach(error =>
+          notify({
+            status: "error",
+            text: getProductErrorMessage(error, intl),
+          }),
+        );
+
+        return;
+      }
+
+      notify({
+        status: "success",
+        text: intl.formatMessage(messages.mediaUploadSuccess),
+      });
     },
+    [intl, notify],
+  );
+  const [createProductImage, createProductImageOpts] = useProductMediaCreateMutation({
+    onCompleted: handleProductMediaCreateCompleted,
   });
   const [deleteProductImage] = useProductMediaDeleteMutation({
     onCompleted: () =>
@@ -171,26 +195,7 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
   const product = data?.product;
   const getAttributeValuesSuggestions = useSearchAttributeValuesSuggestions();
   const [createProductMedia, createProductMediaOpts] = useProductMediaCreateMutation({
-    onCompleted: data => {
-      const errors = data.productMediaCreate.errors;
-
-      if (errors.length) {
-        errors.map(error =>
-          notify({
-            status: "error",
-            text: getProductErrorMessage(error, intl),
-          }),
-        );
-      } else {
-        notify({
-          status: "success",
-          text: intl.formatMessage({
-            id: "lUvX5F",
-            defaultMessage: "Image added",
-          }),
-        });
-      }
-    },
+    onCompleted: handleProductMediaCreateCompleted,
   });
   const handleMediaUrlUpload = (mediaUrl: string) => {
     const variables = {

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -12,6 +12,7 @@ import {
   ErrorPolicyEnum,
   type ProductMediaCreateMutation,
   type ProductMediaCreateMutationVariables,
+  ProductMediaType,
   type ProductVariantBulkCreateInput,
   useProductDeleteMutation,
   useProductDetailsQuery,
@@ -177,22 +178,42 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
   const [createProductImage, createProductImageOpts] = useProductMediaCreateMutation({
     onCompleted: handleProductMediaCreateCompleted,
   });
-  const [deleteProductImage] = useProductMediaDeleteMutation({
-    onCompleted: () =>
+  const [bulkCreateVariants] = useProductVariantBulkCreateMutation();
+  const [openModal, closeModal] = createDialogActionHandlers<
+    ProductUrlDialog,
+    ProductUrlQueryParams
+  >(navigate, params => productUrl(id, params), params);
+  const [deleteProductImage, deleteProductImageOpts] = useProductMediaDeleteMutation({
+    onCompleted: data => {
+      const errors = data.productMediaDelete?.errors ?? [];
+
+      if (errors.length) {
+        errors.forEach(error =>
+          notify({
+            status: "error",
+            text: getProductErrorMessage(error, intl),
+          }),
+        );
+
+        return;
+      }
+
+      closeModal();
       notify({
         status: "success",
         text: intl.formatMessage({
           id: "Gi8zwc",
           defaultMessage: "Image deleted",
         }),
-      }),
+      });
+    },
   });
-  const [bulkCreateVariants] = useProductVariantBulkCreateMutation();
-  const [openModal, closeModal] = createDialogActionHandlers<
-    ProductUrlDialog,
-    ProductUrlQueryParams
-  >(navigate, params => productUrl(id, params), params);
   const product = data?.product;
+  const mediaToDelete = useMemo(
+    () => product?.media?.find(media => media.id === params.id),
+    [params.id, product?.media],
+  );
+  const isVideoMediaToDelete = mediaToDelete?.type === ProductMediaType.VIDEO;
   const getAttributeValuesSuggestions = useSearchAttributeValuesSuggestions();
   const [createProductMedia, createProductMediaOpts] = useProductMediaCreateMutation({
     onCompleted: handleProductMediaCreateCompleted,
@@ -304,7 +325,31 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     },
     [bulkCreateVariants, id, intl, notify, refetch],
   );
-  const handleImageDelete = (id: string) => () => deleteProductImage({ variables: { id } });
+  const handleImageDelete = (mediaId: string) => () => openModal("remove-media", { id: mediaId });
+  const handleConfirmMediaDelete = () => {
+    const mediaId = params.id;
+    const currentMedia = product?.media;
+
+    if (!mediaId || !product || !currentMedia) {
+      return;
+    }
+
+    deleteProductImage({
+      variables: { id: mediaId },
+      optimisticResponse: {
+        __typename: "Mutation",
+        productMediaDelete: {
+          __typename: "ProductMediaDelete",
+          errors: [],
+          product: {
+            __typename: "Product",
+            id: product.id,
+            media: currentMedia.filter(media => media.id !== mediaId),
+          },
+        },
+      },
+    });
+  };
   const [submit, submitOpts] = useProductUpdateHandler(product);
   const handleImageUpload = createImageUploadHandler(id, variables =>
     createProductImage({ variables }),
@@ -491,6 +536,22 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
         <FormattedMessage
           {...messages.deleteProductDialogSubtitle}
           values={{ name: product?.name }}
+        />
+      </ActionDialog>
+      <ActionDialog
+        open={params.action === "remove-media" && !!params.id}
+        onClose={closeModal}
+        confirmButtonState={deleteProductImageOpts.status}
+        onConfirm={handleConfirmMediaDelete}
+        variant="delete"
+        title={intl.formatMessage(
+          isVideoMediaToDelete ? messages.deleteMediaVideoTitle : messages.deleteMediaImageTitle,
+        )}
+      >
+        <FormattedMessage
+          {...(isVideoMediaToDelete
+            ? messages.deleteMediaVideoConfirmation
+            : messages.deleteMediaImageConfirmation)}
         />
       </ActionDialog>
     </>

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -107,7 +107,25 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
       productVariants: true,
     },
   });
-  const [reorderProductImages, reorderProductImagesOpts] = useProductMediaReorderMutation({});
+  const [reorderProductImages, reorderProductImagesOpts] = useProductMediaReorderMutation({
+    onCompleted: data => {
+      const errors = data.productMediaReorder?.errors ?? [];
+
+      if (errors.length) {
+        errors.forEach(error =>
+          notify({
+            status: "error",
+            text: getProductErrorMessage(error, intl),
+          }),
+        );
+      } else {
+        notify({
+          status: "success",
+          text: intl.formatMessage(messages.mediaReorderSuccess),
+        });
+      }
+    },
+  });
   const [deleteProduct, deleteProductOpts] = useProductDeleteMutation({
     onCompleted: () => {
       notify({
@@ -286,8 +304,8 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
   const handleImageUpload = createImageUploadHandler(id, variables =>
     createProductImage({ variables }),
   );
-  const handleImageReorder = createImageReorderHandler(product, variables =>
-    reorderProductImages({ variables }),
+  const handleImageReorder = createImageReorderHandler(product, options =>
+    reorderProductImages(options),
   );
   const handleAssignAttributeReferenceClick = (attribute: AttributeInput) =>
     navigate(

--- a/src/products/views/ProductUpdate/handlers/index.test.ts
+++ b/src/products/views/ProductUpdate/handlers/index.test.ts
@@ -48,8 +48,12 @@ describe("createImageReorderHandler", () => {
     const reorderProductImages = jest.fn();
     const product = createProductWithMedia(["media-a", "media-b", "media-c"]);
     const handler = createImageReorderHandler(product, reorderProductImages);
-    const [, mediaB, mediaC] = product.media;
-    const [mediaA] = product.media;
+
+    if (!product.media) {
+      throw new Error("Expected test product to have media");
+    }
+
+    const [mediaA, mediaB, mediaC] = product.media;
 
     // Act
     handler({ oldIndex: 0, newIndex: 2 });

--- a/src/products/views/ProductUpdate/handlers/index.test.ts
+++ b/src/products/views/ProductUpdate/handlers/index.test.ts
@@ -1,0 +1,78 @@
+import { type ProductFragment, ProductMediaType } from "@dashboard/graphql";
+
+import { createImageReorderHandler } from "./index";
+
+function createProductWithMedia(mediaIds: string[]): ProductFragment {
+  return {
+    id: "product-1",
+    media: mediaIds.map((id, sortOrder) => ({
+      __typename: "ProductMedia",
+      alt: "",
+      id,
+      oembedData: "{}",
+      sortOrder,
+      type: ProductMediaType.IMAGE,
+      url: `https://example.com/${id}.jpg`,
+    })),
+  } as ProductFragment;
+}
+
+describe("createImageReorderHandler", () => {
+  it("does not call reorder when product is undefined", () => {
+    // Arrange
+    const reorderProductImages = jest.fn();
+    const handler = createImageReorderHandler(undefined, reorderProductImages);
+
+    // Act
+    handler({ oldIndex: 0, newIndex: 1 });
+
+    // Assert
+    expect(reorderProductImages).not.toHaveBeenCalled();
+  });
+
+  it("does not call reorder when product has no media", () => {
+    // Arrange
+    const reorderProductImages = jest.fn();
+    const product = createProductWithMedia([]);
+    const handler = createImageReorderHandler(product, reorderProductImages);
+
+    // Act
+    handler({ oldIndex: 0, newIndex: 1 });
+
+    // Assert
+    expect(reorderProductImages).not.toHaveBeenCalled();
+  });
+
+  it("reorders media with variables and optimistic response", () => {
+    // Arrange
+    const reorderProductImages = jest.fn();
+    const product = createProductWithMedia(["media-a", "media-b", "media-c"]);
+    const handler = createImageReorderHandler(product, reorderProductImages);
+    const [, mediaB, mediaC] = product.media;
+    const [mediaA] = product.media;
+
+    // Act
+    handler({ oldIndex: 0, newIndex: 2 });
+
+    // Assert
+    expect(reorderProductImages).toHaveBeenCalledTimes(1);
+    expect(reorderProductImages).toHaveBeenCalledWith({
+      variables: {
+        mediaIds: ["media-b", "media-c", "media-a"],
+        productId: "product-1",
+      },
+      optimisticResponse: {
+        __typename: "Mutation",
+        productMediaReorder: {
+          __typename: "ProductMediaReorder",
+          errors: [],
+          product: {
+            __typename: "Product",
+            id: "product-1",
+            media: [mediaB, mediaC, mediaA],
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/products/views/ProductUpdate/handlers/index.ts
+++ b/src/products/views/ProductUpdate/handlers/index.ts
@@ -1,8 +1,10 @@
 // @ts-strict-ignore
+import { type MutationFunctionOptions } from "@apollo/client";
 import {
   type Node,
   type ProductFragment,
   type ProductMediaCreateMutationVariables,
+  type ProductMediaReorderMutation,
   type ProductMediaReorderMutationVariables,
   type ProductVariantReorderMutationFn,
 } from "@dashboard/graphql";
@@ -22,18 +24,47 @@ export function createImageUploadHandler(
     });
 }
 
+type ProductMediaReorderOptions = Pick<
+  MutationFunctionOptions<ProductMediaReorderMutation, ProductMediaReorderMutationVariables>,
+  "variables" | "optimisticResponse"
+>;
+
 /** @deprecated This component should use @dnd-kit instead of react-sortable-hoc */
 export function createImageReorderHandler(
   product: ProductFragment,
-  reorderProductImages: (variables: ProductMediaReorderMutationVariables) => void,
+  reorderProductImages: (options: ProductMediaReorderOptions) => void,
 ) {
   return ({ newIndex, oldIndex }: ReorderEvent) => {
-    let ids = product.media.map(image => image.id);
+    const media = product?.media;
 
-    ids = arrayMove(ids, oldIndex, newIndex);
+    if (!product || !media?.length) {
+      return;
+    }
+
+    const mediaIds = arrayMove(
+      media.map(image => image.id),
+      oldIndex,
+      newIndex,
+    );
+    const reorderedMedia = arrayMove([...media], oldIndex, newIndex);
+
     reorderProductImages({
-      mediaIds: ids,
-      productId: product.id,
+      variables: {
+        mediaIds,
+        productId: product.id,
+      },
+      optimisticResponse: {
+        __typename: "Mutation",
+        productMediaReorder: {
+          __typename: "ProductMediaReorder",
+          errors: [],
+          product: {
+            __typename: "Product",
+            id: product.id,
+            media: reorderedMedia,
+          },
+        },
+      },
     });
   };
 }

--- a/src/products/views/ProductUpdate/handlers/index.ts
+++ b/src/products/views/ProductUpdate/handlers/index.ts
@@ -31,7 +31,7 @@ type ProductMediaReorderOptions = Pick<
 
 /** @deprecated This component should use @dnd-kit instead of react-sortable-hoc */
 export function createImageReorderHandler(
-  product: ProductFragment,
+  product: ProductFragment | undefined,
   reorderProductImages: (options: ProductMediaReorderOptions) => void,
 ) {
   return ({ newIndex, oldIndex }: ReorderEvent) => {

--- a/src/products/views/ProductUpdate/messages.ts
+++ b/src/products/views/ProductUpdate/messages.ts
@@ -49,4 +49,23 @@ export const productUpdatePageMessages = defineMessages({
     defaultMessage: "Image added",
     description: "success notification when product media is uploaded",
   },
+  deleteMediaImageTitle: {
+    id: "uCn/rd",
+    defaultMessage: "Delete Image",
+    description: "dialog header",
+  },
+  deleteMediaVideoTitle: {
+    id: "dGlDp6",
+    defaultMessage: "Delete Video",
+    description: "product media delete dialog header",
+  },
+  deleteMediaImageConfirmation: {
+    id: "VEext+",
+    defaultMessage: "Are you sure you want to delete this image?",
+  },
+  deleteMediaVideoConfirmation: {
+    id: "/uu/aV",
+    defaultMessage: "Are you sure you want to delete this video?",
+    description: "product media delete dialog content",
+  },
 });

--- a/src/products/views/ProductUpdate/messages.ts
+++ b/src/products/views/ProductUpdate/messages.ts
@@ -44,4 +44,9 @@ export const productUpdatePageMessages = defineMessages({
     defaultMessage: "Media order updated",
     description: "success notification when product media gallery order is saved",
   },
+  mediaUploadSuccess: {
+    id: "bqSNm/",
+    defaultMessage: "Image added",
+    description: "success notification when product media is uploaded",
+  },
 });

--- a/src/products/views/ProductUpdate/messages.ts
+++ b/src/products/views/ProductUpdate/messages.ts
@@ -39,4 +39,9 @@ export const productUpdatePageMessages = defineMessages({
       "{success, plural, one {# variant} other {# variants}} created, {failed, plural, one {# failed} other {# failed}}",
     description: "warning message when some variants failed to create",
   },
+  mediaReorderSuccess: {
+    id: "JV3DcT",
+    defaultMessage: "Media order updated",
+    description: "success notification when product media gallery order is saved",
+  },
 });


### PR DESCRIPTION
**Gallery (product details)**
- Minimal drag-and-drop upload (empty state + overlay when the gallery already has images)
- Reorder reflects immediately; success toasts on reorder and upload
- Delete asks for confirmation; tile drops out of the gallery right away (optimistic cache)

**Media edit page**
- Larger image/video preview, clearer breadcrumb (product + media type)
- Per-media metadata dialog (same pattern as product/variant)
- Sidebar selection polish; removed redundant “Optional” on alt text


https://github.com/user-attachments/assets/47f3e554-a5aa-4595-88a4-d5e0d4888a61

