### PR TITLE
Add support for `table` block in EditorJS

### DIFF
--- a/.changeset/rich-text-tables.md
+++ b/.changeset/rich-text-tables.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Rich-text description editors now support tables. A new "Table" block is available in the editor toolbar across all rich-text fields (product, category, collection and page descriptions, discount and shipping rate descriptions, rich-text attribute values, and translations). Tables support a toggleable heading row, adding and removing rows and columns, and inline formatting (bold, italic, link, strikethrough) inside cells.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@editorjs/list": "2.0.8",
     "@editorjs/paragraph": "2.11.7",
     "@editorjs/quote": "2.7.6",
+    "@editorjs/table": "2.4.5",
     "@glideapps/glide-data-grid": "5.3.0",
     "@glideapps/glide-data-grid-cells": "5.3.0",
     "@graphiql/plugin-explorer": "^0.1.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       "@editorjs/quote":
         specifier: 2.7.6
         version: 2.7.6
+      "@editorjs/table":
+        specifier: 2.4.5
+        version: 2.4.5
       "@glideapps/glide-data-grid":
         specifier: 5.3.0
         version: 5.3.0(lodash@4.18.1)(marked@4.3.0)(react-dom@18.3.1(react@18.3.1))(react-responsive-carousel@3.2.23)(react@18.3.1)
@@ -1325,6 +1328,12 @@ packages:
         integrity: sha512-s6H2KXhLz2rgbMZSkRm8dsMJvyUNZsEjxobBEg9ztdrb1B2H3pEzY6iTwI4XUPJWJ3c3qRKwV4TrO3J5jUdoQA==,
       }
 
+  "@codexteam/icons@0.0.6":
+    resolution:
+      {
+        integrity: sha512-L7Q5PET8PjKcBT5wp7VR+FCjwCi5PUp7rd/XjsgQ0CI5FJz0DphyHGRILMuDUdCW2MQT9NHbVr4QP31vwAkS/A==,
+      }
+
   "@codexteam/icons@0.3.3":
     resolution:
       {
@@ -1441,6 +1450,12 @@ packages:
     resolution:
       {
         integrity: sha512-D01KUMSDj2r+6Z+xjDkQqI+y6URpeHCvj0+P4pah+GtkG040lWjFb2H4pgHFXuol2cbfyAoraYSw85fuPheCvw==,
+      }
+
+  "@editorjs/table@2.4.5":
+    resolution:
+      {
+        integrity: sha512-pF48R2wc5m0c+N+RjtCLXBGZd23Rl7EjfSFpmcSViwNsu5RwMgYGrEiQ8mzVh98mbvYQwXm/NYBi9DEUUs970A==,
       }
 
   "@emnapi/core@1.8.1":
@@ -14467,6 +14482,8 @@ snapshots:
 
   "@codexteam/icons@0.0.5": {}
 
+  "@codexteam/icons@0.0.6": {}
+
   "@codexteam/icons@0.3.3": {}
 
   "@cspotcode/source-map-support@0.8.1":
@@ -14541,6 +14558,10 @@ snapshots:
     dependencies:
       "@codexteam/icons": 0.3.3
       "@editorjs/dom": 0.0.5
+
+  "@editorjs/table@2.4.5":
+    dependencies:
+      "@codexteam/icons": 0.0.6
 
   "@emnapi/core@1.8.1":
     dependencies:

--- a/src/components/RichTextEditor/RichTextEditor.stories.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.stories.tsx
@@ -1,6 +1,6 @@
 import { type OutputData } from "@editorjs/editorjs";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { type ComponentProps, type ComponentType, useRef } from "react";
+import { type ComponentProps, type ComponentType, useRef, useState } from "react";
 
 import fixtures from "./fixtures.json";
 import RichTextEditor from "./RichTextEditor";
@@ -9,12 +9,74 @@ const defaultValue = fixtures.richTextEditor as unknown as OutputData;
 
 type Props = ComponentProps<typeof RichTextEditor>;
 
+const layout: Record<string, React.CSSProperties> = {
+  container: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: 24,
+  },
+  editor: {
+    flex: 1,
+    minWidth: 0,
+  },
+  preview: {
+    flex: "0 0 320px",
+    position: "sticky",
+    top: 24,
+    border: "1px solid rgba(128, 128, 128, 0.3)",
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  previewTitle: {
+    fontFamily: "monospace",
+    fontSize: 12,
+    fontWeight: 600,
+    padding: "8px 12px",
+    borderBottom: "1px solid rgba(128, 128, 128, 0.3)",
+    opacity: 0.7,
+  },
+  pre: {
+    margin: 0,
+    padding: 12,
+    fontSize: 11,
+    lineHeight: 1.5,
+    maxHeight: 480,
+    overflow: "auto",
+    whiteSpace: "pre-wrap",
+    wordBreak: "break-word",
+  },
+};
+
+// Wraps the editor with a live preview of the saved EditorJS blocks. The editor's
+// onChange fires on every edit, so the panel mirrors exactly what gets persisted —
+// handy for inspecting block shapes (e.g. the table block) while editing.
+const EditorWithLivePreview = (args: Props): React.ReactElement => {
+  const ref = useRef(null);
+  const [data, setData] = useState<OutputData | undefined>(args.defaultValue);
+
+  return (
+    <div style={layout.container}>
+      <div style={layout.editor}>
+        <RichTextEditor {...args} editorRef={ref} onChange={setData} />
+      </div>
+      <aside style={layout.preview}>
+        <div style={layout.previewTitle}>Live blocks</div>
+        <pre style={layout.pre}>
+          {data?.blocks?.length
+            ? JSON.stringify(data.blocks, null, 2)
+            : "// Start typing to see blocks"}
+        </pre>
+      </aside>
+    </div>
+  );
+};
+
 const meta: Meta<typeof RichTextEditor> = {
   title: "Components/RichTextEditor",
   component: RichTextEditor,
   decorators: [
     (Story: ComponentType) => (
-      <div style={{ maxWidth: 720, padding: 24 }}>
+      <div style={{ maxWidth: 1100, padding: 24 }}>
         <Story />
       </div>
     ),
@@ -31,15 +93,7 @@ const meta: Meta<typeof RichTextEditor> = {
     onBlur: { table: { disable: true } },
     onInitialize: { table: { disable: true } },
   },
-  render: (args: Props) => {
-    const Wrapper = () => {
-      const ref = useRef(null);
-
-      return <RichTextEditor {...args} editorRef={ref} />;
-    };
-
-    return <Wrapper />;
-  },
+  render: (args: Props): React.ReactElement => <EditorWithLivePreview {...args} />,
 };
 
 export default meta;

--- a/src/components/RichTextEditor/consts.ts
+++ b/src/components/RichTextEditor/consts.ts
@@ -6,6 +6,7 @@ import Header from "@editorjs/header";
 import List from "@editorjs/list";
 import Paragraph from "@editorjs/paragraph";
 import Quote from "@editorjs/quote";
+import Table from "@editorjs/table";
 import createGenericInlineTool from "editorjs-inline-tool";
 
 const inlineToolbar = ["link", "bold", "italic", "strikethrough"];
@@ -27,6 +28,15 @@ export const tools: Record<string, ToolConstructable | ToolSettings> = {
   quote: {
     class: Quote,
     inlineToolbar,
+  },
+  table: {
+    // @ts-expect-error Type mismatch between editorjs libraries (@editorjs/table and @editorjs/editorjs)
+    class: Table,
+    inlineToolbar,
+    config: {
+      rows: 2,
+      cols: 2,
+    },
   },
   paragraph: {
     // @ts-expect-error Type mismatch between editorjs libraries (@editorjs/list and @editorjs/editorjs)

--- a/src/components/RichTextEditor/fixtures.json
+++ b/src/components/RichTextEditor/fixtures.json
@@ -67,6 +67,18 @@
             "In tincidunt, dui vitae suscipit sodales, lacus justo porttitor nulla<br>"
           ]
         }
+      },
+      {
+        "type": "table",
+        "data": {
+          "withHeadings": true,
+          "stretched": false,
+          "content": [
+            ["Kine", "Pigs", "Chicken"],
+            ["1 pcs", "3 pcs", "12 pcs"],
+            ["100$", "200$", "150$"]
+          ]
+        }
       }
     ],
     "version": "2.19.0"

--- a/src/components/RichTextEditor/styles.ts
+++ b/src/components/RichTextEditor/styles.ts
@@ -90,7 +90,9 @@ const useStyles = makeStyles(
           backgroundColor: vars.colors.background.default1,
         },
         "& .ce-popover__items": {
-          overflowY: "hidden",
+          // Adding the Table tool pushed the toolbox past the popover's max-height.
+          // Allow the list to scroll instead of clipping the overflowing items.
+          overflowY: "auto",
         },
         "& .ce-popover__item": {
           ...hover,
@@ -119,21 +121,32 @@ const useStyles = makeStyles(
           backgroundColor: vars.colors.background.default1,
         },
         // @editorjs/table theming overrides.
-        // The plugin ships hardcoded light-theme colors; these scaffolds map its
-        // `.tc-*` classes onto macaw vars so tables read correctly in light and dark mode.
-        // The row/column settings popover mounts inside the editor holder (not document.body),
-        // so it is themed here rather than in the "@global" block.
-        // TODO(theme): fill in colors/borders and verify both light and dark mode.
-        "& .tc-wrap": {},
-        "& .tc-table": {},
-        "& .tc-row": {},
-        "& .tc-cell": {},
-        "& .tc-row--heading": {},
-        "& .tc-cell--selected": {},
-        "& .tc-add-row": {},
-        "& .tc-add-column": {},
-        "& .tc-popover": {},
-        "& .tc-popover__item": {},
+        // The plugin hardcodes light-theme colors and exposes them as CSS custom
+        // properties scoped to .tc-wrap / .tc-popover / .tc-toolbox. As with the
+        // .ce-popover block above, we override the vars (not the elements) so the
+        // table reads correctly in light and dark mode. The row/column settings
+        // popover mounts inside the editor holder, so it is themed here, not in "@global".
+        "& .tc-wrap": {
+          "--color-background": vars.colors.background.default1,
+          "--color-border": vars.colors.border.default1,
+          "--color-text-secondary": vars.colors.text.default2,
+          // Cell content is contenteditable and otherwise falls back to the browser
+          // default (black), unreadable on a dark surface — pin it to the theme text color.
+          color: vars.colors.text.default1,
+        },
+        // Row/column drag handle ("::" dots). The hovered color is hardcoded near-black,
+        // invisible in dark mode.
+        "& .tc-toolbox": {
+          "--toggler-dots-color": vars.colors.text.default2,
+          "--toggler-dots-color-hovered": vars.colors.text.default1,
+        },
+        // Row/column settings menu.
+        "& .tc-popover": {
+          "--color-background": vars.colors.background.default1,
+          "--color-border": vars.colors.border.default1,
+          "--color-background-hover": vars.colors.background.default1Hovered,
+          color: vars.colors.text.default1,
+        },
       },
       root: {
         border: `1px solid ${vars.colors.border.default1}`,

--- a/src/components/RichTextEditor/styles.ts
+++ b/src/components/RichTextEditor/styles.ts
@@ -139,6 +139,10 @@ const useStyles = makeStyles(
         "& .tc-toolbox": {
           "--toggler-dots-color": vars.colors.text.default2,
           "--toggler-dots-color-hovered": vars.colors.text.default1,
+          // The toolbox (z-index:1, position:absolute) forms a stacking context below the
+          // sticky header row (.tc-row:first-child, z-index:2), so its settings popover gets
+          // covered by the header. Lift the whole toolbox above the header.
+          zIndex: 3,
         },
         // Row/column settings menu.
         "& .tc-popover": {

--- a/src/components/RichTextEditor/styles.ts
+++ b/src/components/RichTextEditor/styles.ts
@@ -118,6 +118,22 @@ const useStyles = makeStyles(
         "& .cdx-search-field": {
           backgroundColor: vars.colors.background.default1,
         },
+        // @editorjs/table theming overrides.
+        // The plugin ships hardcoded light-theme colors; these scaffolds map its
+        // `.tc-*` classes onto macaw vars so tables read correctly in light and dark mode.
+        // The row/column settings popover mounts inside the editor holder (not document.body),
+        // so it is themed here rather than in the "@global" block.
+        // TODO(theme): fill in colors/borders and verify both light and dark mode.
+        "& .tc-wrap": {},
+        "& .tc-table": {},
+        "& .tc-row": {},
+        "& .tc-cell": {},
+        "& .tc-row--heading": {},
+        "& .tc-cell--selected": {},
+        "& .tc-add-row": {},
+        "& .tc-add-column": {},
+        "& .tc-popover": {},
+        "& .tc-popover__item": {},
       },
       root: {
         border: `1px solid ${vars.colors.border.default1}`,


### PR DESCRIPTION
core
https://github.com/saleor/saleor/pull/19280

<img width="2312" height="1180" alt="CleanShot 2026-06-03 at 16 14 40@2x" src="https://github.com/user-attachments/assets/8a759504-d3ca-4681-9101-37a3773a5222" />

