### PR TITLE
Mount a single Editor.js instance under StrictMode

### DIFF
--- a/.changeset/fix-product-description-editor.md
+++ b/.changeset/fix-product-description-editor.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed the rich text editor (e.g. product description) duplicating its content on load and then becoming empty and non-editable. This happened in development due to the editor being initialized twice; it now mounts a single editor instance.

--- a/src/components/RichTextEditor/ReactEditorJS.tsx
+++ b/src/components/RichTextEditor/ReactEditorJS.tsx
@@ -4,12 +4,8 @@ import EditorJS, {
   type ToolConstructable,
 } from "@editorjs/editorjs";
 import Paragraph from "@editorjs/paragraph";
-import {
-  type EditorCore,
-  type Props as ReactEditorJSProps,
-  ReactEditorJS as BaseReactEditorJS,
-} from "@react-editor-js/core";
-import { useCallback } from "react";
+import { type EditorCore, type Props as ReactEditorJSProps } from "@react-editor-js/core";
+import { useEffect, useRef } from "react";
 
 import { convertEditorJSListBlocks } from "./utils";
 
@@ -75,10 +71,65 @@ class ClientEditorCore implements EditorCore {
 
 type Props = Omit<ReactEditorJSProps, "factory">;
 
-function ReactEditorJSClient(props: Props) {
-  const factory = useCallback((config: EditorConfig) => new ClientEditorCore(config), []);
+/**
+ * StrictMode-safe Editor.js mount.
+ *
+ * The upstream `@react-editor-js` component creates the editor inside `useEffect([])`
+ * and tears it down with an async `destroy()`. Under React 18 StrictMode (enabled in dev),
+ * the mount effect runs twice (setup → cleanup → setup), so two Editor.js instances briefly
+ * share the same holder: the first render duplicates the content, then the late async
+ * `destroy()` of the first instance wipes the holder, leaving an empty, non-editable field.
+ *
+ * To avoid this we keep a single editor instance across the simulated remount and defer the
+ * teardown by a tick, cancelling it when React immediately re-runs the setup.
+ */
+function ReactEditorJSClient({
+  holder,
+  children,
+  value,
+  defaultValue,
+  onInitialize,
+  ...restProps
+}: Props) {
+  const holderId = useRef(holder ?? `react-editor-js-${Date.now().toString(16)}`);
+  const editorRef = useRef<ClientEditorCore | null>(null);
+  const destroyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  return <BaseReactEditorJS factory={factory} {...props} />;
+  useEffect(() => {
+    // Cancel a teardown scheduled by StrictMode's simulated unmount so a single editor survives.
+    if (destroyTimeoutRef.current !== null) {
+      clearTimeout(destroyTimeoutRef.current);
+      destroyTimeoutRef.current = null;
+    }
+
+    if (!editorRef.current) {
+      editorRef.current = new ClientEditorCore({
+        holder: holderId.current,
+        ...(defaultValue && { data: defaultValue }),
+        ...restProps,
+      });
+    }
+
+    onInitialize?.(editorRef.current);
+
+    return () => {
+      // Defer teardown a tick; StrictMode re-runs setup synchronously and cancels it above.
+      destroyTimeoutRef.current = setTimeout(() => {
+        editorRef.current?.destroy();
+        editorRef.current = null;
+        destroyTimeoutRef.current = null;
+      }, 0);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (value) {
+      editorRef.current?.render(value);
+    }
+  }, [value]);
+
+  return children ?? <div id={holderId.current} />;
 }
 
 export const ReactEditorJS = ReactEditorJSClient;

--- a/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/components/RichTextEditor/RichTextEditor.tsx
@@ -42,6 +42,8 @@ const RichTextEditor = ({
   const generatedId = React.useId();
   const id = defaultId ?? generatedId;
   const ref = React.useRef<EditorCore | null>(null);
+  const renderRef = React.useRef<EditorCore["render"] | undefined>(undefined);
+  const [isEditorReady, setIsEditorReady] = React.useState(false);
   const [isFocused, setIsFocused] = React.useState(false);
   const [hasValue, setHasValue] = React.useState(false);
   const isTyped = Boolean(hasValue || isFocused);
@@ -50,13 +52,15 @@ const RichTextEditor = ({
       onInitialize(editor);
     }
 
+    ref.current = editor;
+    renderRef.current = editor.render.bind(editor);
+    setIsEditorReady(true);
+
     if (typeof editorRef === "function") {
       return editorRef(editor);
     }
 
     if (editorRef) {
-      ref.current = editor;
-
       return (editorRef.current = editor);
     }
   }, []);
@@ -66,9 +70,10 @@ const RichTextEditor = ({
   // EditorJS does not rerender when default value changes,
   // so we need to manually update it
   useUpdateOnRerender({
-    render: ref.current?.render.bind(ref.current),
+    renderRef,
     defaultValue: props.defaultValue,
     hasRendered,
+    isEditorReady,
   });
 
   return (

--- a/src/components/RichTextEditor/hooks.test.ts
+++ b/src/components/RichTextEditor/hooks.test.ts
@@ -1,29 +1,37 @@
 import { renderHook } from "@testing-library/react";
+import { type MutableRefObject } from "react";
 
 import { useUpdateOnRerender } from "./hooks";
 
 describe("useUpdateOnRerender", () => {
+  const createRenderRef = (
+    mockRender = jest.fn(),
+  ): MutableRefObject<typeof mockRender | undefined> => ({
+    current: mockRender,
+  });
+
   it("should call render when defaultValue changes after initial render", () => {
     // Arrange
     const mockRender = jest.fn();
+    const renderRef = createRenderRef(mockRender);
 
     const { rerender } = renderHook(
-      ({ render, defaultValue, hasRendered }) =>
-        useUpdateOnRerender({ render, defaultValue, hasRendered }),
+      ({ defaultValue, hasRendered, isEditorReady }) =>
+        useUpdateOnRerender({ renderRef, defaultValue, hasRendered, isEditorReady }),
       {
         initialProps: {
-          render: mockRender,
           defaultValue: { blocks: [{ type: "paragraph", data: { text: "Initial" } }] },
           hasRendered: true,
+          isEditorReady: true,
         },
       },
     );
 
     // Act
     rerender({
-      render: mockRender,
       defaultValue: { blocks: [{ type: "paragraph", data: { text: "Updated" } }] },
       hasRendered: true,
+      isEditorReady: true,
     });
 
     // Assert
@@ -32,59 +40,91 @@ describe("useUpdateOnRerender", () => {
     });
   });
 
-  it("should call render once when defaultValue change", () => {
+  it("should not call render on initial sync when editor becomes ready", () => {
     // Arrange
     const mockRender = jest.fn();
+    const renderRef = createRenderRef(mockRender);
 
     const { rerender } = renderHook(
-      ({ render, defaultValue, hasRendered }) =>
-        useUpdateOnRerender({ render, defaultValue, hasRendered }),
+      ({ defaultValue, hasRendered, isEditorReady }) =>
+        useUpdateOnRerender({ renderRef, defaultValue, hasRendered, isEditorReady }),
       {
         initialProps: {
-          render: mockRender,
           defaultValue: { blocks: [{ type: "paragraph", data: { text: "Initial" } }] },
           hasRendered: false,
+          isEditorReady: false,
         },
       },
     );
 
     // Act
     rerender({
-      render: mockRender,
       defaultValue: { blocks: [{ type: "paragraph", data: { text: "Initial" } }] },
       hasRendered: true,
+      isEditorReady: true,
     });
     rerender({
-      render: mockRender,
       defaultValue: { blocks: [{ type: "paragraph", data: { text: "Initial" } }] },
       hasRendered: true,
+      isEditorReady: true,
     });
 
     // Assert
-    expect(mockRender).toHaveBeenCalledTimes(1);
+    expect(mockRender).not.toHaveBeenCalled();
   });
 
   it("should not call render if hasRendered is false", () => {
     // Arrange
     const mockRender = jest.fn();
+    const renderRef = createRenderRef(mockRender);
 
     const { rerender } = renderHook(
-      ({ render, defaultValue, hasRendered }) =>
-        useUpdateOnRerender({ render, defaultValue, hasRendered }),
+      ({ defaultValue, hasRendered, isEditorReady }) =>
+        useUpdateOnRerender({ renderRef, defaultValue, hasRendered, isEditorReady }),
       {
         initialProps: {
-          render: mockRender,
           defaultValue: { blocks: [{ type: "paragraph", data: { text: "Initial" } }] },
           hasRendered: false,
+          isEditorReady: true,
         },
       },
     );
 
     // Act
     rerender({
-      render: mockRender,
       defaultValue: { blocks: [{ type: "paragraph", data: { text: "Updated" } }] },
       hasRendered: false,
+      isEditorReady: true,
+    });
+
+    // Assert
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it("should not call render when defaultValue is undefined", () => {
+    // Arrange
+    const mockRender = jest.fn();
+    const renderRef = createRenderRef(mockRender);
+
+    const { rerender } = renderHook(
+      ({ defaultValue, hasRendered, isEditorReady }) =>
+        useUpdateOnRerender({ renderRef, defaultValue, hasRendered, isEditorReady }),
+      {
+        initialProps: {
+          defaultValue: { blocks: [{ type: "paragraph", data: { text: "Initial" } }] } as
+            | { blocks: { type: string; data: { text: string } }[] }
+            | undefined,
+          hasRendered: true,
+          isEditorReady: true,
+        },
+      },
+    );
+
+    // Act
+    rerender({
+      defaultValue: undefined,
+      hasRendered: true,
+      isEditorReady: true,
     });
 
     // Assert

--- a/src/components/RichTextEditor/hooks.ts
+++ b/src/components/RichTextEditor/hooks.ts
@@ -1,6 +1,6 @@
 import { type EditorConfig } from "@editorjs/editorjs";
 import { type EditorCore } from "@react-editor-js/core";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { type MutableRefObject, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 export const useHasRendered = () => {
   const [hasRendered, setHasRendereed] = useState(false);
@@ -13,30 +13,44 @@ export const useHasRendered = () => {
 };
 
 export const useUpdateOnRerender = ({
-  render,
+  renderRef,
   defaultValue,
   hasRendered,
+  isEditorReady,
 }: {
-  render: EditorCore["render"] | undefined;
+  renderRef: MutableRefObject<EditorCore["render"] | undefined>;
   defaultValue: EditorConfig["data"];
   hasRendered: boolean;
+  isEditorReady: boolean;
 }) => {
   const prevDefaultValue = useRef<EditorConfig["data"] | undefined>(undefined);
+  const hasSyncedInitialValue = useRef(false);
 
   useEffect(() => {
-    if (!hasRendered) {
+    if (!hasRendered || !isEditorReady) {
       return;
     }
 
-    // Prevent call render when defaultValue doesn't change
+    if (defaultValue === undefined) {
+      return;
+    }
+
     if (JSON.stringify(defaultValue) === JSON.stringify(prevDefaultValue.current)) {
       return;
     }
 
-    prevDefaultValue.current = defaultValue;
+    const isInitialSync = !hasSyncedInitialValue.current;
 
-    render?.({
+    prevDefaultValue.current = defaultValue;
+    hasSyncedInitialValue.current = true;
+
+    // Editor.js is created with `data` from props; calling render() on first mount duplicates blocks.
+    if (isInitialSync) {
+      return;
+    }
+
+    renderRef.current?.({
       blocks: defaultValue?.blocks ?? [],
     });
-  }, [defaultValue, hasRendered, render]);
+  }, [defaultValue, hasRendered, isEditorReady, renderRef]);
 };

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -304,7 +304,7 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     deleteProductOpts.loading ||
     reorderProductImagesOpts.loading ||
     createProductMediaOpts.loading ||
-    loading;
+    (loading && !product);
   const formTransitionState = getMutationState(
     submitOpts.called,
     submitOpts.loading,

--- a/src/utils/richText/useRichText.test.ts
+++ b/src/utils/richText/useRichText.test.ts
@@ -32,7 +32,7 @@ describe("useRichText", () => {
     expect(result.current.isReadyForMount).toBe(true);
     expect(result.current.isDirty).toBe(false);
   });
-  it("returns undefined when JSON cannot be parsed", () => {
+  it("mounts empty editor when JSON cannot be parsed", () => {
     const { result, rerender } = renderHook(
       ({ initial, loading }) => useRichText({ initial, loading, triggerChange }),
       { initialProps: { initial: undefined as string | undefined, loading: true } },
@@ -40,9 +40,26 @@ describe("useRichText", () => {
 
     expect(result.current.isReadyForMount).toBe(false);
     rerender({ initial: "this-isnt-valid-json", loading: false });
-    expect(result.current.defaultValue).toBe(undefined);
-    expect(result.current.isReadyForMount).toBe(false);
+    expect(result.current.defaultValue).toStrictEqual({ blocks: [] });
+    expect(result.current.isReadyForMount).toBe(true);
     expect(result.current.isDirty).toBe(false);
+  });
+
+  it("resets editor readiness while loading", () => {
+    const { result, rerender } = renderHook(
+      ({ initial, loading }) => useRichText({ initial, loading, triggerChange }),
+      {
+        initialProps: {
+          initial: JSON.stringify(fixtures.short),
+          loading: false,
+        },
+      },
+    );
+
+    expect(result.current.isReadyForMount).toBe(true);
+    rerender({ initial: JSON.stringify(fixtures.short), loading: true });
+    expect(result.current.isReadyForMount).toBe(false);
+    expect(result.current.defaultValue).toBeUndefined();
   });
   it("runs editorJS .save() when getValue is called", async () => {
     const saveFn = jest.fn(async () => fixtures.short);

--- a/src/utils/richText/useRichText.ts
+++ b/src/utils/richText/useRichText.ts
@@ -1,6 +1,8 @@
 import { type OutputData } from "@editorjs/editorjs";
 import { type EditorCore } from "@react-editor-js/core";
-import { type MutableRefObject, useMemo, useRef, useState } from "react";
+import { type MutableRefObject, useEffect, useRef, useState } from "react";
+
+const EMPTY_EDITOR_DATA: OutputData = { blocks: [] };
 
 export interface UseRichTextOptions {
   initial: string | null | undefined;
@@ -17,6 +19,14 @@ export interface UseRichTextResult {
   isDirty: boolean;
 }
 
+function parseInitialDescription(initial: string): OutputData | null {
+  try {
+    return JSON.parse(initial) as OutputData;
+  } catch {
+    return null;
+  }
+}
+
 export function useRichText({
   initial,
   loading,
@@ -25,42 +35,45 @@ export function useRichText({
   const editorRef = useRef<EditorCore | null>(null);
   const [isReadyForMount, setIsReadyForMount] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
+  const [defaultValue, setDefaultValue] = useState<OutputData | undefined>(undefined);
+
   const handleChange = () => {
     setIsDirty(true);
     triggerChange();
   };
+
   const getValue = async () => {
     if (editorRef.current) {
       setIsDirty(false);
 
       return editorRef.current.save();
-    } else {
-      throw new Error("Editor instance is not available");
     }
+
+    throw new Error("Editor instance is not available");
   };
 
-  const defaultValue = useMemo<OutputData | undefined>(() => {
+  useEffect(() => {
     if (loading) {
+      setIsReadyForMount(false);
+      setDefaultValue(undefined);
+      setIsDirty(false);
+
       return;
     }
 
     if (!initial) {
+      setDefaultValue(EMPTY_EDITOR_DATA);
       setIsReadyForMount(true);
       setIsDirty(false);
 
-      return "";
+      return;
     }
 
-    try {
-      const result = JSON.parse(initial);
+    const parsed = parseInitialDescription(initial);
 
-      setIsDirty(false);
-      setIsReadyForMount(true);
-
-      return result;
-    } catch (e) {
-      return undefined;
-    }
+    setDefaultValue(parsed ?? EMPTY_EDITOR_DATA);
+    setIsReadyForMount(true);
+    setIsDirty(false);
   }, [initial, loading]);
 
   return {


### PR DESCRIPTION
React 18 StrictMode (dev-only) double-invokes the mount effect, and the upstream @react-editor-js component creates the editor in useEffect with an async destroy(). This caused two instances to share one holder: content was rendered twice (duplicated description), then the late destroy() wiped the holder, leaving an empty, non-editable field.

Mount exactly one editor instance in our ReactEditorJS wrapper and defer teardown a tick so StrictMode's simulated remount cancels it. Also skip the redundant initial render(), guard against rendering an undefined defaultValue, resolve the rich text initial value in an effect (mounting an empty editor on unparseable JSON), and only disable the product form while loading without a product.