### PR TITLE
Replace order details datagrid spinners with subtle skeleton bars

### DIFF
--- a/src/components/Datagrid/customCells/SkeletonCell.tsx
+++ b/src/components/Datagrid/customCells/SkeletonCell.tsx
@@ -1,0 +1,75 @@
+import {
+  type CustomCell,
+  type CustomRenderer,
+  type GridCell,
+  GridCellKind,
+} from "@glideapps/glide-data-grid";
+
+export type SkeletonCellVariant = "default" | "narrow";
+
+export interface SkeletonCellProps {
+  readonly kind: "skeleton-cell";
+  readonly variant: SkeletonCellVariant;
+}
+
+export type SkeletonCell = CustomCell<SkeletonCellProps>;
+
+const SKELETON_HEIGHT = 12;
+const SKELETON_RADIUS = 4;
+
+const drawRoundedRect = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+): void => {
+  if ("roundRect" in ctx) {
+    ctx.beginPath();
+    ctx.roundRect(x, y, width, height, radius);
+    ctx.fill();
+  }
+};
+
+const drawSkeletonBar = (
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  fillStyle: string,
+): void => {
+  ctx.fillStyle = fillStyle;
+  drawRoundedRect(ctx, x, y, width, SKELETON_HEIGHT, SKELETON_RADIUS);
+};
+
+export const skeletonCellRenderer: CustomRenderer<SkeletonCell> = {
+  kind: GridCellKind.Custom,
+  isMatch: (cell: CustomCell): cell is SkeletonCell =>
+    (cell.data as SkeletonCellProps | undefined)?.kind === "skeleton-cell",
+  draw: (args, cell) => {
+    const { rect, ctx, theme } = args;
+    const padding = theme.cellHorizontalPadding ?? 8;
+    const fillStyle = theme.accentLight;
+    const barY = rect.y + (rect.height - SKELETON_HEIGHT) / 2;
+    const widthRatio = cell.data.variant === "narrow" ? 0.35 : 0.6;
+    const barWidth = Math.max(24, (rect.width - padding * 2) * widthRatio);
+
+    drawSkeletonBar(ctx, rect.x + padding, barY, barWidth, fillStyle);
+
+    return true;
+  },
+};
+
+export function skeletonCell(variant: SkeletonCellVariant = "default"): GridCell {
+  return {
+    kind: GridCellKind.Custom,
+    allowOverlay: false,
+    readonly: true,
+    copyData: "",
+    data: {
+      kind: "skeleton-cell",
+      variant,
+    },
+  };
+}

--- a/src/components/Datagrid/customCells/useCustomCellRenderers.ts
+++ b/src/components/Datagrid/customCells/useCustomCellRenderers.ts
@@ -9,6 +9,7 @@ import { moneyCellRenderer } from "./Money/MoneyCell";
 import { moneyDiscountedCellRenderer } from "./Money/MoneyDiscountedCell";
 import { numberCellRenderer } from "./NumberCell";
 import { pillCellRenderer } from "./PillCell";
+import { skeletonCellRenderer } from "./SkeletonCell";
 import { statusCellRenderer } from "./StatusCell";
 import { thumbnailCellRenderer } from "./ThumbnailCell";
 
@@ -25,6 +26,7 @@ export function useCustomCellRenderers() {
       numberCellRenderer(locale),
       dateCellRenderer(locale),
       dropdownCellRenderer,
+      skeletonCellRenderer,
       thumbnailCellRenderer,
       ...customRenderers,
     ],

--- a/src/orders/components/OrderDetailsDatagrid/datagrid.ts
+++ b/src/orders/components/OrderDetailsDatagrid/datagrid.ts
@@ -2,12 +2,15 @@
 import {
   booleanCell,
   buttonCell,
-  loadingCell,
   moneyCell,
   moneyDiscountedCell,
   readonlyTextCell,
   thumbnailCell,
 } from "@dashboard/components/Datagrid/customCells/cells";
+import {
+  skeletonCell,
+  type SkeletonCellVariant,
+} from "@dashboard/components/Datagrid/customCells/SkeletonCell";
 import { type GetCellContentOpts } from "@dashboard/components/Datagrid/Datagrid";
 import { type AvailableColumn } from "@dashboard/components/Datagrid/types";
 import { type Locale } from "@dashboard/components/Locale";
@@ -87,6 +90,14 @@ export const isPriceBreakdownColumn = (
 ): columnId is PriceBreakdownColumnId =>
   PRICE_BREAKDOWN_COLUMN_IDS.includes(columnId as PriceBreakdownColumnId);
 
+const getSkeletonVariant = (columnId: string | undefined): SkeletonCellVariant => {
+  if (columnId === "quantity") {
+    return "narrow";
+  }
+
+  return "default";
+};
+
 export const createGetCellContent =
   ({
     columns,
@@ -102,11 +113,16 @@ export const createGetCellContent =
       ? { ...readonlyOptions, cursor: "pointer" }
       : readonlyOptions;
 
+    const columnId = columns[column]?.id;
+
     if (loading) {
-      return loadingCell();
+      if (isFirstColumn(column)) {
+        return readonlyTextCell("", false);
+      }
+
+      return skeletonCell(getSkeletonVariant(columnId));
     }
 
-    const columnId = columns[column]?.id;
     const rowData = added.includes(row) ? undefined : data[getDatagridRowDataIndex(row, removed)];
 
     if (!rowData || !columnId) {


### PR DESCRIPTION
Use skeleton cells for order fulfillment loading states and keep the left padding separator column empty so the placeholder row aligns cleanly.