### PR TITLE
chore: bump codecov to v6.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           npm run lint
           git diff --exit-code ./src
-      
+
       - name: Knip for unused files, dependencies and exports
         run: npm run knip
 
@@ -75,7 +75,7 @@ jobs:
           npm run test:ci
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: saleor/saleor-dashboard


### PR DESCRIPTION
Port of #6623

Part of ENG-1621 - updates the action to https://github.com/codecov/codecov-action/releases/tag/v6.0.1, which fixes some security issues

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
