### PR TITLE
Fix return/replace refund excluding lines from waiting fulfillments

### DIFF
--- a/.changeset/great-pots-refuse.md
+++ b/.changeset/great-pots-refuse.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed an issue where the Return/Replace flow excluded order lines from the granted refund when their fulfillment was waiting for approval. Previously, only shipping costs were sent to the payment provider in such cases - now the refund correctly includes both the returned items and shipping.

--- a/src/orders/views/OrderReturn/useRefundWithinReturn.test.ts
+++ b/src/orders/views/OrderReturn/useRefundWithinReturn.test.ts
@@ -1,4 +1,93 @@
-import { type GrantRefundInputLine, squashLines } from "./useRefundWithinReturn";
+import { type FormsetQuantityData } from "@dashboard/orders/components/OrderReturnPage/form";
+
+import {
+  type GrantRefundInputLine,
+  prepareGrantRefundLines,
+  squashLines,
+} from "./useRefundWithinReturn";
+
+const getQuantityLine = ({
+  id,
+  orderLineId,
+  value,
+}: {
+  id: string;
+  orderLineId: string;
+  value: number;
+}): FormsetQuantityData[number] => ({
+  id,
+  label: "",
+  value,
+  data: {
+    isFulfillment: true,
+    isRefunded: false,
+    orderLineId,
+  },
+});
+
+describe("prepareGrantRefundLines", () => {
+  it("includes fulfilled, waiting for approval and unfulfilled lines in the refund payload", () => {
+    // Arrange
+    const fulfilledItemsQuantities: FormsetQuantityData = [
+      getQuantityLine({ id: "fulfillment-line-1", orderLineId: "order-line-1", value: 2 }),
+    ];
+    const waitingItemsQuantities: FormsetQuantityData = [
+      getQuantityLine({ id: "fulfillment-line-2", orderLineId: "order-line-2", value: 1 }),
+    ];
+    const unfulfilledItemsQuantities: FormsetQuantityData = [
+      getQuantityLine({ id: "order-line-3", orderLineId: "order-line-3", value: 3 }),
+    ];
+
+    // Act
+    const result = prepareGrantRefundLines({
+      fulfilledItemsQuantities,
+      waitingItemsQuantities,
+      unfulfilledItemsQuantities,
+    });
+
+    // Assert
+    expect(result).toEqual([
+      { id: "order-line-1", quantity: 2 },
+      { id: "order-line-2", quantity: 1 },
+      { id: "order-line-3", quantity: 3 },
+    ]);
+  });
+  it("maps waiting for approval lines to order line ids", () => {
+    // Arrange
+    const waitingItemsQuantities: FormsetQuantityData = [
+      getQuantityLine({ id: "fulfillment-line-1", orderLineId: "order-line-1", value: 4 }),
+    ];
+
+    // Act
+    const result = prepareGrantRefundLines({
+      fulfilledItemsQuantities: [],
+      waitingItemsQuantities,
+      unfulfilledItemsQuantities: [],
+    });
+
+    // Assert
+    expect(result).toEqual([{ id: "order-line-1", quantity: 4 }]);
+  });
+  it("squashes lines referencing the same order line", () => {
+    // Arrange
+    const fulfilledItemsQuantities: FormsetQuantityData = [
+      getQuantityLine({ id: "fulfillment-line-1", orderLineId: "order-line-1", value: 2 }),
+    ];
+    const waitingItemsQuantities: FormsetQuantityData = [
+      getQuantityLine({ id: "fulfillment-line-2", orderLineId: "order-line-1", value: 1 }),
+    ];
+
+    // Act
+    const result = prepareGrantRefundLines({
+      fulfilledItemsQuantities,
+      waitingItemsQuantities,
+      unfulfilledItemsQuantities: [],
+    });
+
+    // Assert
+    expect(result).toEqual([{ id: "order-line-1", quantity: 3 }]);
+  });
+});
 
 describe("squashLines", () => {
   it("merges items with the same ID", () => {

--- a/src/orders/views/OrderReturn/useRefundWithinReturn.ts
+++ b/src/orders/views/OrderReturn/useRefundWithinReturn.ts
@@ -39,16 +39,7 @@ export function useRefundWithinReturn({
             amount: formData.amount,
             transactionId: formData.transactionId,
             reason: "",
-            lines: squashLines([
-              ...formData.fulfilledItemsQuantities.map(line => ({
-                id: line.data.orderLineId,
-                quantity: line.value,
-              })),
-              ...formData.unfulfilledItemsQuantities.map(({ id, value }) => ({
-                id,
-                quantity: value,
-              })),
-            ]),
+            lines: prepareGrantRefundLines(formData),
             grantRefundForShipping: formData.refundShipmentCosts,
           },
         })
@@ -79,6 +70,29 @@ export function useRefundWithinReturn({
     grantRefundResponseOrderData,
   };
 }
+
+export const prepareGrantRefundLines = (
+  formData: Pick<
+    OrderReturnFormData,
+    "fulfilledItemsQuantities" | "waitingItemsQuantities" | "unfulfilledItemsQuantities"
+  >,
+): GrantRefundInputLine[] =>
+  squashLines([
+    // Fulfillment lines (fulfilled and waiting for approval) use formset ids pointing
+    // to fulfillment lines - map them to order line ids required by the grant refund mutation
+    ...formData.fulfilledItemsQuantities.map(line => ({
+      id: line.data.orderLineId,
+      quantity: line.value,
+    })),
+    ...formData.waitingItemsQuantities.map(line => ({
+      id: line.data.orderLineId,
+      quantity: line.value,
+    })),
+    ...formData.unfulfilledItemsQuantities.map(({ id, value }) => ({
+      id,
+      quantity: value,
+    })),
+  ]);
 
 export const squashLines = (items: GrantRefundInputLine[]): GrantRefundInputLine[] =>
   Object.values(


### PR DESCRIPTION
Grant refund mutation payload was built only from fulfilled and unfulfilled items, dropping lines from fulfillments in "waiting for approval" state. As the amount is derived from lines on the backend, the refund collapsed to shipping costs only (ENG-1636).

https://linear.app/saleor/issue/ENG-1636

port to main: https://github.com/saleor/saleor-dashboard/pull/6642