### PR TITLE
Add dev-only permission debugger for UI preview and debug staff sessions

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,6 +6,9 @@ APP_MOUNT_URI=/
 SALEOR_CLOUD_APP_DOMAIN=saleor.app
 LOCALE_CODE="EN"
 
+# Dev-only permission debugger (local `pnpm dev` only; excluded from production builds)
+# VITE_ENABLE_PERMISSIONS_DEBUGGER=true
+
 # Multi-schema support (optional)
 # Set to "true" to use staging schema instead of main schema
 # See docs/multi-schema.md

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,8 @@ Create or edit `.env` file in a root directory or set environment variables with
 
 - `DEPRECATED_SALEOR_VERSION_TIMESTAMP` - Optional. ISO date or timestamp (e.g. `2026-09-01`) shown in the deprecation banner as the automatic upgrade date. Only the date is rendered. Required together with `DEPRECATED_SALEOR_VERSION`.
 
+- `VITE_ENABLE_PERMISSIONS_DEBUGGER` - Optional. Set to `true` to enable the local dev permission debugger widget when running `pnpm dev`. Requires a development server (`vite` dev mode); production builds always use a no-op stub and do not bundle the debugger code.
+
 ## Fetching schema
 
 By default dashboard will use `fetch-schema` script from package.json to get Saleor schema from specific branch e.g `main` for unstable one. If you need to generate types based on your own schema use `fetch-local-schema` that will fetch it from `API_URL`.

--- a/src/__dev__/permissionOverride/DebugStaffPermissionsList.tsx
+++ b/src/__dev__/permissionOverride/DebugStaffPermissionsList.tsx
@@ -1,0 +1,55 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+import useShop from "@dashboard/hooks/useShop";
+import { Box, Text } from "@saleor/macaw-ui-next";
+import { useMemo } from "react";
+
+import { getPermissionLabel } from "./allPermissions";
+import styles from "./DevPermissionOverride.module.css";
+
+interface DebugStaffPermissionsListProps {
+  permissions: PermissionEnum[];
+}
+
+export const DebugStaffPermissionsList = ({
+  permissions,
+}: DebugStaffPermissionsListProps): JSX.Element => {
+  const shop = useShop();
+
+  const permissionNameByCode = useMemo(() => {
+    const map = new Map<PermissionEnum, string>();
+
+    shop?.permissions?.forEach(permission => {
+      map.set(permission.code, permission.name);
+    });
+
+    return map;
+  }, [shop?.permissions]);
+
+  const sortedPermissions = useMemo(
+    () => [...permissions].sort((left, right) => left.localeCompare(right)),
+    [permissions],
+  );
+
+  if (sortedPermissions.length === 0) {
+    return (
+      <Text size={1} color="default2">
+        No permissions assigned.
+      </Text>
+    );
+  }
+
+  return (
+    <Box className={styles.profilePermissions}>
+      {sortedPermissions.map(code => (
+        <Text key={code} size={1} color="default2">
+          {getPermissionLabel(code, permissionNameByCode).replace(/\.$/, "")}
+          <Text as="span" size={1} fontFamily="Geist Mono" color="default2">
+            {" "}
+            · {code}
+          </Text>
+        </Text>
+      ))}
+    </Box>
+  );
+};

--- a/src/__dev__/permissionOverride/DevDebugSessionView.tsx
+++ b/src/__dev__/permissionOverride/DevDebugSessionView.tsx
@@ -1,0 +1,67 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { Box, Button, Input, Text } from "@saleor/macaw-ui-next";
+
+import { DebugStaffPermissionsList } from "./DebugStaffPermissionsList";
+import { type DebugStaffProfile } from "./debugStaffProfileStore";
+import styles from "./DevPermissionOverride.module.css";
+
+interface DevDebugSessionViewProps {
+  activeDebugProfile: DebugStaffProfile | null;
+  baseEmail: string;
+  isWorking: boolean;
+  message: string | null;
+  onPasswordChange: (value: string) => void;
+  onSwitchBack: () => void;
+  password: string;
+  realUserEmail: string;
+  status: "idle" | "working" | "success" | "error";
+}
+
+export const DevDebugSessionView = ({
+  activeDebugProfile,
+  baseEmail,
+  isWorking,
+  message,
+  onPasswordChange,
+  onSwitchBack,
+  password,
+  realUserEmail,
+  status,
+}: DevDebugSessionViewProps): JSX.Element => (
+  <Box display="flex" flexDirection="column" gap={3} className={styles.tabContent}>
+    <Box display="flex" flexDirection="column" gap={1}>
+      <Text size={2} fontWeight="medium" color="critical1">
+        Logged in as debug user
+      </Text>
+      <Text size={1} fontFamily="Geist Mono" wordBreak="break-all">
+        {realUserEmail}
+      </Text>
+      <Text size={1} color="default2">
+        Real JWT — apps and API see this user&apos;s permissions.
+      </Text>
+      {activeDebugProfile && (
+        <DebugStaffPermissionsList permissions={activeDebugProfile.permissions} />
+      )}
+    </Box>
+
+    <Input
+      size="small"
+      type="password"
+      name="password"
+      autoComplete="current-password"
+      placeholder="Your original account password"
+      value={password}
+      onChange={event => onPasswordChange(event.target.value)}
+    />
+
+    {message && (
+      <Text size={1} color={status === "error" ? "critical1" : "default2"}>
+        {message}
+      </Text>
+    )}
+
+    <Button size="small" variant="secondary" disabled={isWorking} onClick={onSwitchBack}>
+      {isWorking ? "Working…" : `Back to ${baseEmail || "my account"}`}
+    </Button>
+  </Box>
+);

--- a/src/__dev__/permissionOverride/DevDebugStaffStepIndicator.tsx
+++ b/src/__dev__/permissionOverride/DevDebugStaffStepIndicator.tsx
@@ -1,0 +1,39 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { Box, Text } from "@saleor/macaw-ui-next";
+
+const STEP_LABELS = ["Permissions", "Create", "Password", "Log in"] as const;
+
+export type DebugStaffFlowStep = 1 | 2 | 3 | 4;
+
+interface DevDebugStaffStepIndicatorProps {
+  currentStep: DebugStaffFlowStep;
+}
+
+export const DevDebugStaffStepIndicator = ({
+  currentStep,
+}: DevDebugStaffStepIndicatorProps): JSX.Element => (
+  <Box display="flex" flexWrap="wrap" gap={1} alignItems="center">
+    {STEP_LABELS.map((label, index) => {
+      const step = (index + 1) as DebugStaffFlowStep;
+      const isComplete = step < currentStep;
+      const isCurrent = step === currentStep;
+
+      return (
+        <Box key={label} display="flex" alignItems="center" gap={1}>
+          {index > 0 && (
+            <Text size={1} color="default2">
+              →
+            </Text>
+          )}
+          <Text
+            size={1}
+            fontWeight={isCurrent ? "bold" : "regular"}
+            color={isComplete ? "default1" : isCurrent ? "default1" : "default2"}
+          >
+            {isComplete ? `✓ ${label}` : `${step}. ${label}`}
+          </Text>
+        </Box>
+      );
+    })}
+  </Box>
+);

--- a/src/__dev__/permissionOverride/DevPanelStatusHeader.tsx
+++ b/src/__dev__/permissionOverride/DevPanelStatusHeader.tsx
@@ -1,0 +1,58 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { Box, Text } from "@saleor/macaw-ui-next";
+
+import { type DebugStaffProfile } from "./debugStaffProfileStore";
+
+interface DevPanelStatusHeaderProps {
+  activeDebugProfile: DebugStaffProfile | null;
+  isDebugSession: boolean;
+  isUiOverrideActive: boolean;
+  overrideCount: number;
+  userEmail: string | undefined;
+}
+
+export const DevPanelStatusHeader = ({
+  activeDebugProfile,
+  isDebugSession,
+  isUiOverrideActive,
+  overrideCount,
+  userEmail,
+}: DevPanelStatusHeaderProps): JSX.Element => {
+  if (isDebugSession) {
+    return (
+      <Box display="flex" flexDirection="column" gap={0.5}>
+        <Text size={2} fontWeight="medium" color="critical1">
+          Logged in as debug user
+        </Text>
+        <Text size={1} fontFamily="Geist Mono" wordBreak="break-all">
+          {userEmail}
+        </Text>
+        <Text size={1} color="default2">
+          {activeDebugProfile
+            ? `${activeDebugProfile.permissions.length} permissions · real JWT session`
+            : "Real JWT — apps and API see this user's permissions."}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (isUiOverrideActive) {
+    return (
+      <Box display="flex" flexDirection="column" gap={0.5}>
+        <Text size={2} fontWeight="medium" color="critical1">
+          UI permission preview active
+        </Text>
+        <Text size={1} color="default2">
+          {overrideCount} permissions · dashboard UI only, not API
+          {userEmail ? ` · you: ${userEmail}` : ""}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Text size={1} color="default2">
+      {userEmail ? `You: ${userEmail} · UI: real permissions` : "UI: real permissions"}
+    </Text>
+  );
+};

--- a/src/__dev__/permissionOverride/DevPanelWarningCallout.tsx
+++ b/src/__dev__/permissionOverride/DevPanelWarningCallout.tsx
@@ -1,0 +1,33 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
+import { getStatusColor } from "@dashboard/misc";
+import { Box, Text, useTheme } from "@saleor/macaw-ui-next";
+import { CircleAlert } from "lucide-react";
+import { type ReactNode } from "react";
+
+interface DevPanelWarningCalloutProps {
+  children: ReactNode;
+}
+
+export const DevPanelWarningCallout = ({ children }: DevPanelWarningCalloutProps): JSX.Element => {
+  const { theme } = useTheme();
+  const backgroundColor = getStatusColor({ status: "warning", currentTheme: theme }).base;
+
+  return (
+    <Box
+      display="flex"
+      alignItems="flex-start"
+      gap={2}
+      padding={2}
+      borderRadius={3}
+      __backgroundColor={backgroundColor}
+    >
+      <Box color="warning1" __lineHeight="0" flexShrink="0" __marginTop="1px">
+        <CircleAlert size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />
+      </Box>
+      <Text size={1} color="default1">
+        {children}
+      </Text>
+    </Box>
+  );
+};

--- a/src/__dev__/permissionOverride/DevPermissionOverride.module.css
+++ b/src/__dev__/permissionOverride/DevPermissionOverride.module.css
@@ -1,0 +1,133 @@
+.panel {
+  width: 440px;
+  max-width: calc(100vw - 24px);
+}
+
+.tabPanel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.tabList {
+  display: flex;
+  border-bottom: 1px solid var(--mu-colors-border-default1);
+}
+
+.tab {
+  flex: 1;
+  padding: 10px 12px;
+  margin-bottom: -1px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--mu-colors-text-default2);
+  text-align: center;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.tab:hover {
+  color: var(--mu-colors-text-default1);
+  background-color: var(--mu-colors-background-default2);
+}
+
+.tab[aria-selected="true"] {
+  color: var(--mu-colors-text-default1);
+  border-bottom-color: var(--mu-colors-text-default1);
+  background-color: transparent;
+}
+
+.panelBody {
+  height: min(70vh, 520px);
+  box-sizing: border-box;
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tabContent {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tabBodyScroll {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  gap: 8px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.permissionList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.savedPresetPill {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--mu-colors-border-default1);
+  border-radius: 6px;
+  overflow: hidden;
+  background-color: var(--mu-colors-background-default1);
+}
+
+.savedPresetApply {
+  border: none;
+  background: transparent;
+  padding: 4px 8px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+  cursor: pointer;
+  color: var(--mu-colors-text-default1);
+}
+
+.savedPresetApply:hover {
+  background-color: var(--mu-colors-background-default2);
+}
+
+.savedPresetRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-left: 1px solid var(--mu-colors-border-default1);
+  background: transparent;
+  padding: 4px 8px;
+  min-width: 28px;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--mu-colors-text-default2);
+}
+
+.savedPresetRemove:hover {
+  background-color: var(--mu-colors-background-default2);
+  color: var(--mu-colors-text-default1);
+}
+
+.profilePermissions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 88px;
+  overflow-y: auto;
+}

--- a/src/__dev__/permissionOverride/DevPermissionOverride.tsx
+++ b/src/__dev__/permissionOverride/DevPermissionOverride.tsx
@@ -1,0 +1,163 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+//
+// Floating widget that lets a developer impersonate a subset of permissions
+// without re-logging in. It writes through to localStorage and triggers
+// re-renders for every consumer of `useUser` / `useUserPermissions` /
+// `RequirePermissions` / `SectionRoute`, because the override is applied at
+// the `useUser` layer.
+//
+// Mounted from `src/index.tsx` when VITE_ENABLE_PERMISSIONS_DEBUGGER=true
+// (dev server only). Production builds alias to a stub and do not bundle this.
+import { Box, Button, Text } from "@saleor/macaw-ui-next";
+import { useMemo } from "react";
+
+import { isDebugStaffEmail } from "./debugStaffEmail";
+import { debugStaffProfileStore } from "./debugStaffProfileStore";
+import { DevPanelStatusHeader } from "./DevPanelStatusHeader";
+import styles from "./DevPermissionOverride.module.css";
+import { DevRealSessionTab } from "./DevRealSessionTab";
+import { DevUiPreviewTab } from "./DevUiPreviewTab";
+import { type DevPanelTab, useDevPermissionPanel } from "./useDevPermissionPanel";
+import { usePermissionOverride } from "./usePermissionOverride";
+import { useRealUser } from "./useRealUser";
+
+const TAB_LABELS: Record<DevPanelTab, string> = {
+  "ui-preview": "UI preview",
+  "real-session": "Real session",
+};
+
+export const DevPermissionOverride = (): JSX.Element => {
+  const override = usePermissionOverride();
+  const realUser = useRealUser().user;
+  const { open, pageInvite, setOpen, setTab, tab } = useDevPermissionPanel();
+
+  const realPermissionCodes = useMemo(
+    () => realUser?.userPermissions?.map(permission => permission.code) ?? [],
+    [realUser?.userPermissions],
+  );
+
+  const selectedPermissions = override ?? realPermissionCodes;
+  const isUiOverrideActive = override !== null;
+  const isDebugSession = isDebugStaffEmail(realUser?.email);
+  const onDebugSetPasswordPage = pageInvite !== null && isDebugStaffEmail(pageInvite.email);
+
+  const fabLabel = useMemo(() => {
+    if (onDebugSetPasswordPage) {
+      return "dev · set-password";
+    }
+
+    if (isDebugSession) {
+      return "dev · debug session";
+    }
+
+    if (isUiOverrideActive) {
+      return `dev · UI: ${override?.length ?? 0}`;
+    }
+
+    return "dev tools";
+  }, [isDebugSession, isUiOverrideActive, onDebugSetPasswordPage, override?.length]);
+
+  const activeDebugProfile = useMemo(() => {
+    const email = realUser?.email;
+
+    if (!isDebugSession || !email) {
+      return null;
+    }
+
+    return debugStaffProfileStore.getByDebugEmail(email);
+  }, [isDebugSession, realUser?.email]);
+
+  return (
+    <Box
+      position="fixed"
+      __bottom="12px"
+      __right="12px"
+      __zIndex="9999"
+      display="flex"
+      flexDirection="column"
+      alignItems="flex-end"
+      gap={2}
+    >
+      {open && (
+        <Box
+          backgroundColor="default1"
+          borderColor={isUiOverrideActive || isDebugSession ? "critical1" : "default1"}
+          borderStyle="solid"
+          borderWidth={1}
+          borderRadius={4}
+          padding={4}
+          display="flex"
+          flexDirection="column"
+          gap={3}
+          className={styles.panel}
+          __boxShadow="0 8px 24px rgba(0,0,0,0.18)"
+        >
+          <Box display="flex" flexDirection="column" gap={1}>
+            <Box display="flex" justifyContent="space-between" alignItems="center" gap={2}>
+              <Text size={3} fontWeight="bold">
+                Dev tools
+              </Text>
+              <Button size="small" variant="tertiary" onClick={() => setOpen(false)}>
+                Close
+              </Button>
+            </Box>
+            <DevPanelStatusHeader
+              activeDebugProfile={activeDebugProfile}
+              isDebugSession={isDebugSession}
+              isUiOverrideActive={isUiOverrideActive}
+              overrideCount={override?.length ?? 0}
+              userEmail={realUser?.email}
+            />
+          </Box>
+
+          <Box className={styles.tabPanel}>
+            <div className={styles.tabList} role="tablist" aria-label="Dev tools sections">
+              {(Object.keys(TAB_LABELS) as DevPanelTab[]).map(tabId => (
+                <button
+                  key={tabId}
+                  type="button"
+                  role="tab"
+                  aria-selected={tab === tabId}
+                  className={styles.tab}
+                  onClick={() => setTab(tabId)}
+                >
+                  {TAB_LABELS[tabId]}
+                </button>
+              ))}
+            </div>
+
+            <Box className={styles.panelBody} role="tabpanel" aria-label={TAB_LABELS[tab]}>
+              {tab === "ui-preview" ? (
+                <DevUiPreviewTab
+                  onSwitchTab={setTab}
+                  override={override}
+                  realPermissionCodes={realPermissionCodes}
+                />
+              ) : (
+                <DevRealSessionTab
+                  onSwitchTab={setTab}
+                  pageInvite={pageInvite}
+                  selectedPermissions={selectedPermissions}
+                />
+              )}
+            </Box>
+          </Box>
+
+          <Text size={1} color="default2">
+            Dev builds only · metadata in localStorage · passwords in browser
+          </Text>
+        </Box>
+      )}
+
+      <Button
+        size="small"
+        variant={
+          isUiOverrideActive || isDebugSession || onDebugSetPasswordPage ? "error" : "secondary"
+        }
+        onClick={() => setOpen(prev => !prev)}
+      >
+        {fabLabel}
+      </Button>
+    </Box>
+  );
+};

--- a/src/__dev__/permissionOverride/DevPermissionPresets.tsx
+++ b/src/__dev__/permissionOverride/DevPermissionPresets.tsx
@@ -1,0 +1,198 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+import { Box, Button, Input, Text } from "@saleor/macaw-ui-next";
+import { useEffect, useState } from "react";
+
+import { ALL_SALEOR_PERMISSIONS } from "./allPermissions";
+import styles from "./DevPermissionOverride.module.css";
+import { type PermissionPreset } from "./permissionPresetStore";
+import { usePermissionPresets } from "./usePermissionPresets";
+
+interface SavedPresetPillProps {
+  onApply: (permissions: PermissionEnum[]) => void;
+  onRemove: (hash: string) => void;
+  preset: PermissionPreset;
+}
+
+const SavedPresetPill = ({ onApply, onRemove, preset }: SavedPresetPillProps): JSX.Element => (
+  <span className={styles.savedPresetPill}>
+    <button
+      type="button"
+      className={styles.savedPresetApply}
+      onClick={() => onApply(preset.permissions)}
+    >
+      {preset.name} ({preset.permissions.length})
+    </button>
+    <button
+      type="button"
+      className={styles.savedPresetRemove}
+      aria-label={`Delete preset ${preset.name}`}
+      onClick={() => onRemove(preset.hash)}
+    >
+      ×
+    </button>
+  </span>
+);
+
+const BUILT_IN_PRESETS: Array<{ id: string; label: string; permissions: PermissionEnum[] }> = [
+  { id: "all", label: "All", permissions: ALL_SALEOR_PERMISSIONS },
+  { id: "none", label: "None", permissions: [] },
+];
+
+interface DevPermissionPresetsProps {
+  onApply: (permissions: PermissionEnum[]) => void;
+  realPermissionCodes: PermissionEnum[];
+  selectedPermissions: PermissionEnum[] | null;
+}
+
+export const DevPermissionPresets = ({
+  onApply,
+  realPermissionCodes,
+  selectedPermissions,
+}: DevPermissionPresetsProps): JSX.Element => {
+  const { findPresetByPermissions, presets, removePreset, savePreset } = usePermissionPresets();
+  const [presetName, setPresetName] = useState("");
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isSaveFormOpen, setIsSaveFormOpen] = useState(false);
+  const [matchingPresetName, setMatchingPresetName] = useState<string | null>(null);
+
+  const canSave = selectedPermissions !== null;
+  const canSaveSelection = canSave && matchingPresetName === null;
+
+  useEffect(
+    function syncMatchingPresetName() {
+      if (!canSave || !selectedPermissions) {
+        return;
+      }
+
+      let cancelled = false;
+
+      void findPresetByPermissions(selectedPermissions).then(existing => {
+        if (!cancelled) {
+          setMatchingPresetName(existing?.name ?? null);
+        }
+      });
+
+      return () => {
+        cancelled = true;
+      };
+    },
+    [canSave, findPresetByPermissions, selectedPermissions],
+  );
+
+  const showSaveForm = canSave && isSaveFormOpen;
+  const displayMatchingPresetName = canSave ? matchingPresetName : null;
+
+  const handleSavePreset = async (): Promise<void> => {
+    if (!selectedPermissions) {
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveMessage(null);
+
+    const result = await savePreset(presetName, selectedPermissions);
+
+    if (result.status === "saved") {
+      setPresetName("");
+      setSaveMessage(null);
+      setIsSaveFormOpen(false);
+      setMatchingPresetName(presetName.trim());
+    } else if (result.status === "duplicate") {
+      setSaveMessage(`Already saved as "${result.name}".`);
+    } else {
+      setSaveMessage("Enter a preset name.");
+    }
+
+    setIsSaving(false);
+  };
+
+  const closeSaveForm = (): void => {
+    setIsSaveFormOpen(false);
+    setPresetName("");
+    setSaveMessage(null);
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={1}>
+      <Text size={1} color="default2" fontWeight="medium">
+        Presets
+      </Text>
+      <Box display="flex" flexWrap="wrap" gap={1} alignItems="center">
+        <Button size="small" variant="secondary" onClick={() => onApply(realPermissionCodes)}>
+          Real user ({realPermissionCodes.length})
+        </Button>
+        {BUILT_IN_PRESETS.map(preset => (
+          <Button
+            key={preset.id}
+            size="small"
+            variant="secondary"
+            onClick={() => onApply(preset.permissions)}
+          >
+            {preset.label}
+          </Button>
+        ))}
+        {presets.map(preset => (
+          <SavedPresetPill
+            key={preset.hash}
+            preset={preset}
+            onApply={onApply}
+            onRemove={removePreset}
+          />
+        ))}
+        <Button
+          size="small"
+          variant="tertiary"
+          disabled={!canSaveSelection || showSaveForm}
+          onClick={() => setIsSaveFormOpen(true)}
+        >
+          Save selected
+        </Button>
+      </Box>
+      {!canSave && (
+        <Text size={1} color="default2">
+          Select permissions first to save a preset.
+        </Text>
+      )}
+      {displayMatchingPresetName && (
+        <Text size={1} color="default2">
+          Matches saved preset &quot;{displayMatchingPresetName}&quot;.
+        </Text>
+      )}
+      {showSaveForm && (
+        <Box display="flex" flexDirection="column" gap={1}>
+          <Input
+            size="small"
+            placeholder="Preset name…"
+            value={presetName}
+            disabled={isSaving}
+            autoFocus
+            onChange={event => {
+              setPresetName(event.target.value);
+              setSaveMessage(null);
+            }}
+          />
+          <Box display="flex" flexWrap="wrap" gap={1} alignItems="center">
+            <Button
+              size="small"
+              variant="secondary"
+              disabled={isSaving || !presetName.trim()}
+              onClick={() => void handleSavePreset()}
+            >
+              {isSaving ? "Saving…" : "Save preset"}
+            </Button>
+            <Button size="small" variant="tertiary" disabled={isSaving} onClick={closeSaveForm}>
+              Cancel
+            </Button>
+            {saveMessage && (
+              <Text size={1} color="critical1">
+                {saveMessage}
+              </Text>
+            )}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/src/__dev__/permissionOverride/DevRealSessionTab.tsx
+++ b/src/__dev__/permissionOverride/DevRealSessionTab.tsx
@@ -1,0 +1,431 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+import { Box, Button, Input, Text } from "@saleor/macaw-ui-next";
+import { useCallback, useMemo, useState } from "react";
+
+import { DebugStaffPermissionsList } from "./DebugStaffPermissionsList";
+import {
+  getDebugStaffProfileStatus,
+  getDebugStaffProfileStatusLabel,
+} from "./debugStaffProfileStatus";
+import { type DebugStaffProfile } from "./debugStaffProfileStore";
+import { DevDebugSessionView } from "./DevDebugSessionView";
+import { type DebugStaffFlowStep, DevDebugStaffStepIndicator } from "./DevDebugStaffStepIndicator";
+import styles from "./DevPermissionOverride.module.css";
+import { DevStaffPasswordSetup } from "./DevStaffPasswordSetup";
+import { useDebugStaffSession } from "./useDebugStaffSession";
+import { type DevPanelTab } from "./useDevPermissionPanel";
+import { type CapturedNewPasswordPageInvite } from "./useNewPasswordPageInvite";
+
+type FlowView = "home" | "flow";
+
+interface DevRealSessionTabProps {
+  onSwitchTab: (tab: DevPanelTab) => void;
+  pageInvite: CapturedNewPasswordPageInvite | null;
+  selectedPermissions: PermissionEnum[];
+}
+
+interface InviteFlowTarget {
+  profile: DebugStaffProfile | null;
+  step: DebugStaffFlowStep;
+}
+
+export const DevRealSessionTab = ({
+  onSwitchTab,
+  pageInvite,
+  selectedPermissions,
+}: DevRealSessionTabProps): JSX.Element => {
+  const session = useDebugStaffSession({ selectedPermissions });
+  const [flowView, setFlowView] = useState<FlowView>("home");
+  const [flowStep, setFlowStep] = useState<DebugStaffFlowStep>(1);
+  const [activeProfile, setActiveProfile] = useState<DebugStaffProfile | null>(null);
+  const [dismissedInviteEmail, setDismissedInviteEmail] = useState<string | null>(null);
+
+  const isWorking = session.status === "working";
+
+  const inviteFlowTarget = useMemo((): InviteFlowTarget | null => {
+    if (!pageInvite || session.isDebugSession || pageInvite.email === dismissedInviteEmail) {
+      return null;
+    }
+
+    const profile =
+      session.findProfileByEmail(pageInvite.email) ??
+      (session.preview?.debugEmail === pageInvite.email && session.preview.savedProfile
+        ? session.preview.savedProfile
+        : null);
+
+    if (profile) {
+      return { profile, step: 3 };
+    }
+
+    if (session.preview?.debugEmail === pageInvite.email) {
+      return { profile: null, step: 3 };
+    }
+
+    return null;
+  }, [dismissedInviteEmail, pageInvite, session]);
+
+  const isFlowView = !session.isDebugSession && (flowView === "flow" || inviteFlowTarget !== null);
+  const effectiveFlowStep = inviteFlowTarget?.step ?? flowStep;
+  const effectiveActiveProfile = inviteFlowTarget?.profile ?? activeProfile;
+
+  const startNewUserFlow = useCallback(() => {
+    session.clearMessage();
+    setActiveProfile(null);
+    setFlowStep(1);
+    setFlowView("flow");
+  }, [session]);
+
+  const openProfileFlow = useCallback(
+    (profile: DebugStaffProfile, step: DebugStaffFlowStep) => {
+      session.clearMessage();
+      setActiveProfile(profile);
+      setFlowStep(step);
+      setFlowView("flow");
+    },
+    [session],
+  );
+
+  const cancelFlow = useCallback(() => {
+    if (pageInvite) {
+      setDismissedInviteEmail(pageInvite.email);
+    }
+
+    setFlowView("home");
+  }, [pageInvite]);
+
+  const resolveFlowProfile = (): DebugStaffProfile | null => {
+    const debugEmail = effectiveActiveProfile?.debugEmail ?? session.preview?.debugEmail;
+
+    if (!debugEmail) {
+      return null;
+    }
+
+    return (
+      effectiveActiveProfile ??
+      session.findProfileByEmail(debugEmail) ??
+      session.preview?.savedProfile ??
+      null
+    );
+  };
+
+  const handleCreate = async (): Promise<void> => {
+    const result = await session.createDebugStaff();
+
+    if (result.status === "error") {
+      return;
+    }
+
+    setActiveProfile(result.profile);
+    setFlowStep(result.needsPassword ? 3 : 4);
+    setFlowView("flow");
+  };
+
+  const handleContinueFromPassword = (): void => {
+    const profile = resolveFlowProfile();
+
+    if (!profile) {
+      return;
+    }
+
+    const updated = session.markProfilePasswordReady(profile);
+
+    setActiveProfile(updated);
+    setFlowStep(4);
+    setFlowView("flow");
+  };
+
+  const handleLogin = async (): Promise<void> => {
+    const profile = resolveFlowProfile();
+
+    if (!profile) {
+      return;
+    }
+
+    setActiveProfile(profile);
+    await session.loginDebugStaff(profile);
+  };
+
+  if (session.isDebugSession) {
+    const activeDebugProfile = session.savedProfiles.find(
+      profile => profile.debugEmail === session.realUserEmail,
+    );
+
+    return (
+      <DevDebugSessionView
+        activeDebugProfile={activeDebugProfile ?? null}
+        baseEmail={session.baseEmail}
+        isWorking={isWorking}
+        message={session.message}
+        onPasswordChange={session.handlePasswordChange}
+        onSwitchBack={() => void session.switchBackToOriginalUser()}
+        password={session.password}
+        realUserEmail={session.realUserEmail}
+        status={session.status}
+      />
+    );
+  }
+
+  if (isFlowView) {
+    const debugEmail = effectiveActiveProfile?.debugEmail ?? session.preview?.debugEmail;
+    const passwordUsername =
+      effectiveActiveProfile?.debugEmail ?? session.preview?.debugEmail ?? "";
+
+    return (
+      <Box display="flex" flexDirection="column" gap={3} className={styles.tabContent}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" gap={2}>
+          <DevDebugStaffStepIndicator currentStep={effectiveFlowStep} />
+          <Button size="small" variant="tertiary" onClick={cancelFlow}>
+            Cancel
+          </Button>
+        </Box>
+
+        <Box display="flex" flexDirection="column" gap={3} className={styles.tabBodyScroll}>
+          {effectiveFlowStep === 1 && (
+            <Box display="flex" flexDirection="column" gap={2}>
+              <Text size={1} color="default2">
+                From UI preview: {selectedPermissions.length} selected
+              </Text>
+              <Text size={1} color="default2">
+                Will grant {session.grantablePermissions.length} permission
+                {session.grantablePermissions.length === 1 ? "" : "s"}
+                {session.skippedPermissions.length > 0
+                  ? ` (${session.skippedPermissions.length} skipped — not held by your account)`
+                  : ""}
+                .
+              </Text>
+              <Button size="small" variant="tertiary" onClick={() => onSwitchTab("ui-preview")}>
+                Edit permissions in UI preview
+              </Button>
+              {!session.hasManageStaff && (
+                <Text size={1} color="critical1">
+                  MANAGE_STAFF is required.
+                </Text>
+              )}
+              <Button
+                size="small"
+                variant="secondary"
+                disabled={!session.hasManageStaff || session.grantablePermissions.length === 0}
+                onClick={() => {
+                  if (session.preview?.savedProfile) {
+                    setActiveProfile(session.preview.savedProfile);
+                  }
+
+                  setFlowStep(2);
+                  setFlowView("flow");
+                }}
+              >
+                Continue
+              </Button>
+            </Box>
+          )}
+
+          {effectiveFlowStep === 2 && (
+            <Box display="flex" flexDirection="column" gap={2}>
+              <Text size={1} color="default2" fontWeight="medium">
+                Debug user
+              </Text>
+              <Text size={2} fontFamily="Geist Mono" wordBreak="break-all">
+                {session.isResolvingPreview ? "Resolving…" : (debugEmail ?? "—")}
+              </Text>
+              {effectiveActiveProfile &&
+              getDebugStaffProfileStatus(effectiveActiveProfile) === "ready-to-login" ? (
+                <Text size={1} color="default2">
+                  Staff already exists for this permission set.
+                </Text>
+              ) : (
+                <Text size={1} color="default2">
+                  Creates a staff account and sends an invite email (Mailhog locally).
+                </Text>
+              )}
+              {session.message && (
+                <Text size={1} color={session.status === "error" ? "critical1" : "default2"}>
+                  {session.message}
+                </Text>
+              )}
+              <Box display="flex" flexWrap="wrap" gap={1}>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  disabled={isWorking || !session.hasManageStaff || !debugEmail}
+                  onClick={() => void handleCreate()}
+                >
+                  {isWorking ? "Working…" : "Create & send invite"}
+                </Button>
+                {effectiveActiveProfile &&
+                  getDebugStaffProfileStatus(effectiveActiveProfile) === "ready-to-login" && (
+                    <Button
+                      size="small"
+                      variant="tertiary"
+                      onClick={() => {
+                        setFlowStep(4);
+                        setFlowView("flow");
+                      }}
+                    >
+                      Skip to log in
+                    </Button>
+                  )}
+                {effectiveActiveProfile &&
+                  getDebugStaffProfileStatus(effectiveActiveProfile) === "needs-password" && (
+                    <Button
+                      size="small"
+                      variant="tertiary"
+                      onClick={() => {
+                        setFlowStep(3);
+                        setFlowView("flow");
+                      }}
+                    >
+                      Continue to password
+                    </Button>
+                  )}
+              </Box>
+            </Box>
+          )}
+
+          {effectiveFlowStep === 3 && debugEmail && (
+            <DevStaffPasswordSetup
+              debugEmail={debugEmail}
+              pageInvite={pageInvite?.email === debugEmail ? pageInvite : null}
+              onContinue={handleContinueFromPassword}
+            />
+          )}
+
+          {effectiveFlowStep === 4 && resolveFlowProfile() && (
+            <Box display="flex" flexDirection="column" gap={2}>
+              <Text size={1} color="default2">
+                Log in with the password you set for this debug user.
+              </Text>
+              <Input
+                size="small"
+                type="email"
+                name="username"
+                autoComplete="username"
+                readOnly
+                value={passwordUsername}
+                aria-label="Login email"
+              />
+              <Input
+                size="small"
+                type="password"
+                name="password"
+                autoComplete="current-password"
+                placeholder="Debug user password"
+                value={session.password}
+                onChange={event => session.handlePasswordChange(event.target.value)}
+              />
+              {session.message && (
+                <Text size={1} color={session.status === "error" ? "critical1" : "default2"}>
+                  {session.message}
+                </Text>
+              )}
+              <Button
+                size="small"
+                variant="secondary"
+                disabled={isWorking}
+                onClick={() => void handleLogin()}
+              >
+                {isWorking ? "Working…" : "Log in as debug user"}
+              </Button>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3} className={styles.tabContent}>
+      <Box display="flex" flexDirection="column" gap={1}>
+        <Text size={2} fontWeight="medium">
+          Real session
+        </Text>
+        <Text size={1} color="default2">
+          Creates a staff account and logs you in so app JWTs match the selected permissions.
+        </Text>
+      </Box>
+
+      {!session.hasManageStaff && (
+        <Text size={1} color="critical1">
+          MANAGE_STAFF is required.
+        </Text>
+      )}
+
+      {session.savedProfiles.length > 0 ? (
+        <Box display="flex" flexDirection="column" gap={2} className={styles.tabBodyScroll}>
+          <Text size={1} color="default2" fontWeight="medium">
+            Saved debug users
+          </Text>
+          {session.savedProfiles.map(profile => {
+            const profileStatus = getDebugStaffProfileStatus(profile);
+
+            return (
+              <Box
+                key={profile.hash}
+                padding={2}
+                borderWidth={1}
+                borderStyle="solid"
+                borderColor="default1"
+                borderRadius={3}
+                display="flex"
+                flexDirection="column"
+                gap={2}
+              >
+                <Box display="flex" flexDirection="column" gap={0.5}>
+                  <Text size={1} fontFamily="Geist Mono" wordBreak="break-all">
+                    {profile.debugEmail}
+                  </Text>
+                  <Text size={1} color="default2">
+                    {getDebugStaffProfileStatusLabel(profileStatus)}
+                  </Text>
+                  <DebugStaffPermissionsList permissions={profile.permissions} />
+                </Box>
+                <Box display="flex" flexWrap="wrap" gap={1}>
+                  {profileStatus === "needs-password" ? (
+                    <Button
+                      size="small"
+                      variant="secondary"
+                      onClick={() => openProfileFlow(profile, 3)}
+                    >
+                      Set password
+                    </Button>
+                  ) : (
+                    <Button
+                      size="small"
+                      variant="secondary"
+                      disabled={isWorking || !session.hasManageStaff}
+                      onClick={() => openProfileFlow(profile, 4)}
+                    >
+                      Log in
+                    </Button>
+                  )}
+                  <Button
+                    size="small"
+                    variant="tertiary"
+                    onClick={() => session.removeSavedProfile(profile)}
+                  >
+                    Forget
+                  </Button>
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      ) : (
+        <Box className={styles.tabBodyScroll}>
+          <Text size={1} color="default2">
+            No saved debug users yet.
+          </Text>
+        </Box>
+      )}
+
+      <Button
+        size="small"
+        variant="secondary"
+        disabled={!session.hasManageStaff}
+        onClick={startNewUserFlow}
+      >
+        + New debug user
+      </Button>
+    </Box>
+  );
+};

--- a/src/__dev__/permissionOverride/DevStaffPasswordSetup.tsx
+++ b/src/__dev__/permissionOverride/DevStaffPasswordSetup.tsx
@@ -1,0 +1,90 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { Box, Button, Input, Text } from "@saleor/macaw-ui-next";
+
+import { useDebugStaffPasswordSetup } from "./useDebugStaffPasswordSetup";
+import { type CapturedNewPasswordPageInvite } from "./useNewPasswordPageInvite";
+
+interface DevStaffPasswordSetupProps {
+  debugEmail: string;
+  onContinue: () => void;
+  pageInvite: CapturedNewPasswordPageInvite | null;
+}
+
+export const DevStaffPasswordSetup = ({
+  debugEmail,
+  onContinue,
+  pageInvite,
+}: DevStaffPasswordSetupProps): JSX.Element => {
+  const {
+    confirmedFromCurrentPage,
+    handleInviteInputChange,
+    inviteInput,
+    openSetPasswordPage,
+    parsedInvite,
+    resendInviteEmail,
+    resendMessage,
+    resendStatus,
+  } = useDebugStaffPasswordSetup({ debugEmail, pageInvite });
+
+  const isResending = resendStatus === "working";
+
+  return (
+    <Box display="flex" flexDirection="column" gap={2}>
+      {confirmedFromCurrentPage ? (
+        <Text size={1} color="default1">
+          Invite link confirmed on this page. Set the password in the form behind this panel, then
+          continue.
+        </Text>
+      ) : (
+        <Text size={1} color="default2">
+          Open the invite link from Mailhog, set a password, then continue to log in.
+        </Text>
+      )}
+
+      {!confirmedFromCurrentPage && (
+        <Input
+          size="small"
+          placeholder="Paste /new-password/ link or token…"
+          value={inviteInput}
+          onChange={event => handleInviteInputChange(event.target.value)}
+        />
+      )}
+
+      {parsedInvite && parsedInvite.email !== debugEmail && (
+        <Text size={1} color="critical1">
+          Email in link ({parsedInvite.email}) does not match this debug user.
+        </Text>
+      )}
+
+      <Box display="flex" flexWrap="wrap" gap={1}>
+        {!confirmedFromCurrentPage && (
+          <Button
+            size="small"
+            variant="secondary"
+            disabled={!parsedInvite || parsedInvite.email !== debugEmail}
+            onClick={openSetPasswordPage}
+          >
+            Open set-password page
+          </Button>
+        )}
+        <Button
+          size="small"
+          variant="tertiary"
+          disabled={isResending}
+          onClick={() => void resendInviteEmail()}
+        >
+          {isResending ? "Sending…" : "Resend invite"}
+        </Button>
+        <Button size="small" variant="secondary" onClick={onContinue}>
+          Continue to log in
+        </Button>
+      </Box>
+
+      {resendMessage && (
+        <Text size={1} color={resendStatus === "error" ? "critical1" : "default2"}>
+          {resendMessage}
+        </Text>
+      )}
+    </Box>
+  );
+};

--- a/src/__dev__/permissionOverride/DevUiPreviewTab.tsx
+++ b/src/__dev__/permissionOverride/DevUiPreviewTab.tsx
@@ -1,0 +1,161 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+import useShop from "@dashboard/hooks/useShop";
+import { Box, Button, Checkbox, Input, Text } from "@saleor/macaw-ui-next";
+import { useMemo, useState } from "react";
+
+import { ALL_SALEOR_PERMISSIONS, getPermissionLabel } from "./allPermissions";
+import { DevPanelWarningCallout } from "./DevPanelWarningCallout";
+import styles from "./DevPermissionOverride.module.css";
+import { DevPermissionPresets } from "./DevPermissionPresets";
+import { permissionOverrideStore } from "./store";
+import { type DevPanelTab } from "./useDevPermissionPanel";
+
+interface DevUiPreviewTabProps {
+  onSwitchTab: (tab: DevPanelTab) => void;
+  override: PermissionEnum[] | null;
+  realPermissionCodes: PermissionEnum[];
+}
+
+export const DevUiPreviewTab = ({
+  onSwitchTab,
+  override,
+  realPermissionCodes,
+}: DevUiPreviewTabProps): JSX.Element => {
+  const shop = useShop();
+  const [search, setSearch] = useState("");
+  const isActive = override !== null;
+  const effectiveCount = override?.length ?? realPermissionCodes.length;
+
+  const permissionNameByCode = useMemo(() => {
+    const map = new Map<PermissionEnum, string>();
+
+    shop?.permissions?.forEach(permission => {
+      map.set(permission.code, permission.name);
+    });
+
+    return map;
+  }, [shop?.permissions]);
+
+  const filteredPermissions = useMemo(() => {
+    const query = search.trim().toLowerCase();
+
+    if (!query) {
+      return ALL_SALEOR_PERMISSIONS;
+    }
+
+    return ALL_SALEOR_PERMISSIONS.filter(code => {
+      const label = getPermissionLabel(code, permissionNameByCode);
+
+      return code.toLowerCase().includes(query) || label.toLowerCase().includes(query);
+    });
+  }, [permissionNameByCode, search]);
+
+  const applyPermissions = (permissions: PermissionEnum[]): void => {
+    if (permissions.length === 0) {
+      permissionOverrideStore.clearOverride();
+
+      return;
+    }
+
+    permissionOverrideStore.setOverride(permissions);
+  };
+
+  const handlePermissionChange = (
+    code: PermissionEnum,
+    checked: boolean | "indeterminate",
+  ): void => {
+    if (checked !== true) {
+      if (override === null) {
+        return;
+      }
+
+      const next = override.filter(permission => permission !== code);
+
+      applyPermissions(next);
+
+      return;
+    }
+
+    const current = override ?? [];
+
+    if (current.includes(code)) {
+      return;
+    }
+
+    applyPermissions([...current, code]);
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={3} className={styles.tabContent}>
+      <Box display="flex" flexDirection="column" gap={1}>
+        <Box display="flex" justifyContent="space-between" alignItems="center" gap={2}>
+          <Text size={2} fontWeight="medium">
+            {isActive
+              ? `Override active — ${override?.length ?? 0} permissions`
+              : "Using real API permissions"}
+          </Text>
+          {isActive && (
+            <Button
+              size="small"
+              variant="tertiary"
+              onClick={() => permissionOverrideStore.clearOverride()}
+            >
+              Reset
+            </Button>
+          )}
+        </Box>
+        <Text size={1} color="default2">
+          Dashboard UI only — menus, routes, and guards.
+        </Text>
+        <DevPanelWarningCallout>Does not change JWTs or app tokens.</DevPanelWarningCallout>
+      </Box>
+
+      <DevPermissionPresets
+        onApply={applyPermissions}
+        realPermissionCodes={realPermissionCodes}
+        selectedPermissions={override}
+      />
+
+      <Input
+        size="small"
+        placeholder="Filter permissions…"
+        value={search}
+        onChange={event => setSearch(event.target.value)}
+      />
+
+      <Box className={styles.permissionList}>
+        {filteredPermissions.length === 0 ? (
+          <Text size={2} color="default2">
+            No permissions match your filter.
+          </Text>
+        ) : (
+          filteredPermissions.map(code => {
+            const label = getPermissionLabel(code, permissionNameByCode);
+            const hasRealPermission = realPermissionCodes.includes(code);
+
+            return (
+              <Checkbox
+                key={code}
+                checked={override?.includes(code) ?? false}
+                onCheckedChange={checked => handlePermissionChange(code, checked)}
+              >
+                <Box display="flex" flexDirection="column" __marginTop="-2px">
+                  <Text size={2}>{label.replace(/\.$/, "")}</Text>
+                  <Text size={1} color={hasRealPermission ? "default1" : "default2"}>
+                    {code}
+                    {hasRealPermission ? " · granted by API" : ""}
+                  </Text>
+                </Box>
+              </Checkbox>
+            );
+          })
+        )}
+      </Box>
+
+      <Button size="small" variant="secondary" onClick={() => onSwitchTab("real-session")}>
+        Use {effectiveCount} permission{effectiveCount === 1 ? "" : "s"} in Real session →
+      </Button>
+    </Box>
+  );
+};

--- a/src/__dev__/permissionOverride/allPermissions.ts
+++ b/src/__dev__/permissionOverride/allPermissions.ts
@@ -1,0 +1,11 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { PermissionEnum } from "@dashboard/graphql";
+
+export const ALL_SALEOR_PERMISSIONS: PermissionEnum[] = Object.values(PermissionEnum).sort(
+  (left, right) => left.localeCompare(right),
+);
+
+export const getPermissionLabel = (
+  code: PermissionEnum,
+  nameByCode: ReadonlyMap<PermissionEnum, string>,
+): string => nameByCode.get(code) ?? code.replaceAll("_", " ").toLowerCase();

--- a/src/__dev__/permissionOverride/buildNewPasswordPageUrl.ts
+++ b/src/__dev__/permissionOverride/buildNewPasswordPageUrl.ts
@@ -1,0 +1,10 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { newPasswordUrl } from "@dashboard/auth/urls";
+import { getAppMountUriForRedirect } from "@dashboard/utils/urls";
+import urlJoin from "url-join";
+
+export const buildNewPasswordPageUrl = (email: string, token: string): string => {
+  const pathWithQuery = newPasswordUrl({ email, token }).replace(/^\//, "");
+
+  return urlJoin(window.location.origin, getAppMountUriForRedirect(), pathWithQuery);
+};

--- a/src/__dev__/permissionOverride/debugSessionStore.ts
+++ b/src/__dev__/permissionOverride/debugSessionStore.ts
@@ -1,0 +1,18 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+const ORIGINAL_USER_EMAIL_KEY = "dev:debugStaff:originalUserEmail";
+
+export const debugSessionStore = {
+  getOriginalUserEmail: (): string | null => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    return window.sessionStorage.getItem(ORIGINAL_USER_EMAIL_KEY);
+  },
+  setOriginalUserEmail: (email: string): void => {
+    window.sessionStorage.setItem(ORIGINAL_USER_EMAIL_KEY, email);
+  },
+  clearOriginalUserEmail: (): void => {
+    window.sessionStorage.removeItem(ORIGINAL_USER_EMAIL_KEY);
+  },
+};

--- a/src/__dev__/permissionOverride/debugStaffEmail.test.ts
+++ b/src/__dev__/permissionOverride/debugStaffEmail.test.ts
@@ -1,0 +1,29 @@
+import { buildDebugStaffEmail, getBaseStaffEmail, isDebugStaffEmail } from "./debugStaffEmail";
+
+describe("debugStaffEmail", () => {
+  it("detects debug staff emails", () => {
+    // Arrange // Act // Assert
+    expect(isDebugStaffEmail("admin+debugdev-12345678@saleor.io")).toBe(true);
+    expect(isDebugStaffEmail("mirek+dashboard+debugdev-abcdef12@saleor.io")).toBe(true);
+    expect(isDebugStaffEmail("admin@saleor.io")).toBe(false);
+    expect(isDebugStaffEmail(undefined)).toBe(false);
+  });
+
+  it("builds debug staff emails from base addresses with existing plus tags", () => {
+    // Arrange // Act // Assert
+    expect(buildDebugStaffEmail("mirek+dashboard@saleor.io", "abcdef12")).toBe(
+      "mirek+dashboard+debugdev-abcdef12@saleor.io",
+    );
+    expect(buildDebugStaffEmail("admin+debugdev-12345678@saleor.io", "abcdef12")).toBe(
+      "admin+debugdev-abcdef12@saleor.io",
+    );
+  });
+
+  it("restores the base staff email from a debug address", () => {
+    // Arrange // Act // Assert
+    expect(getBaseStaffEmail("mirek+dashboard+debugdev-abcdef12@saleor.io")).toBe(
+      "mirek+dashboard@saleor.io",
+    );
+    expect(getBaseStaffEmail("admin@saleor.io")).toBe("admin@saleor.io");
+  });
+});

--- a/src/__dev__/permissionOverride/debugStaffEmail.ts
+++ b/src/__dev__/permissionOverride/debugStaffEmail.ts
@@ -1,0 +1,31 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+const DEBUG_EMAIL_TAG_PATTERN = /\+debugdev-[a-f0-9]{8}$/i;
+
+export const isDebugStaffEmail = (email: string | undefined): boolean =>
+  !!email && /\+debugdev-[a-f0-9]{8}@/i.test(email);
+
+export const buildDebugStaffEmail = (baseEmail: string, hash: string): string => {
+  const atIndex = baseEmail.lastIndexOf("@");
+
+  if (atIndex <= 0) {
+    throw new Error("Cannot build debug staff email: invalid base email.");
+  }
+
+  const localPart = baseEmail.slice(0, atIndex).replace(DEBUG_EMAIL_TAG_PATTERN, "");
+  const domain = baseEmail.slice(atIndex + 1);
+
+  return `${localPart}+debugdev-${hash}@${domain}`;
+};
+
+export const getBaseStaffEmail = (email: string): string => {
+  const atIndex = email.lastIndexOf("@");
+
+  if (atIndex <= 0) {
+    return email;
+  }
+
+  const localPart = email.slice(0, atIndex).replace(DEBUG_EMAIL_TAG_PATTERN, "");
+  const domain = email.slice(atIndex + 1);
+
+  return `${localPart}@${domain}`;
+};

--- a/src/__dev__/permissionOverride/debugStaffGraphql.ts
+++ b/src/__dev__/permissionOverride/debugStaffGraphql.ts
@@ -1,0 +1,70 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { gql } from "@apollo/client";
+
+export const searchPermissionGroupByNameDocument = gql`
+  query DevSearchPermissionGroupByName($query: String!) {
+    permissionGroups(first: 5, filter: { search: $query }) {
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+export const searchStaffByEmailDocument = gql`
+  query DevSearchStaffByEmail($query: String!) {
+    staffUsers(first: 5, filter: { search: $query }) {
+      edges {
+        node {
+          id
+          email
+        }
+      }
+    }
+  }
+`;
+
+export const permissionGroupCreateDocument = gql`
+  mutation DevPermissionGroupCreate($input: PermissionGroupCreateInput!) {
+    permissionGroupCreate(input: $input) {
+      errors {
+        code
+        field
+        message
+      }
+      group {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const staffCreateDocument = gql`
+  mutation DevStaffCreate($input: StaffCreateInput!) {
+    staffCreate(input: $input) {
+      errors {
+        code
+        field
+        message
+      }
+      user {
+        id
+        email
+      }
+    }
+  }
+`;
+
+export const requestPasswordResetDocument = gql`
+  mutation DevRequestPasswordReset($email: String!, $redirectUrl: String!) {
+    requestPasswordReset(email: $email, redirectUrl: $redirectUrl) {
+      errors {
+        message
+      }
+    }
+  }
+`;

--- a/src/__dev__/permissionOverride/debugStaffInviteTokenStore.ts
+++ b/src/__dev__/permissionOverride/debugStaffInviteTokenStore.ts
@@ -1,0 +1,40 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+//
+// Short-lived invite tokens from staff onboarding emails. Dev convenience only.
+const STORAGE_KEY = "dev:debugStaffInviteTokens";
+
+type InviteTokenMap = Record<string, string>;
+
+const readAll = (): InviteTokenMap => {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+
+    return typeof parsed === "object" && parsed !== null ? (parsed as InviteTokenMap) : {};
+  } catch {
+    return {};
+  }
+};
+
+export const debugStaffInviteTokenStore = {
+  get: (debugEmail: string): string | null => readAll()[debugEmail] ?? null,
+  set: (debugEmail: string, token: string) => {
+    const next = { ...readAll(), [debugEmail]: token };
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  },
+  clear: (debugEmail: string) => {
+    const { [debugEmail]: _removed, ...rest } = readAll();
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(rest));
+  },
+};

--- a/src/__dev__/permissionOverride/debugStaffProfileStatus.test.ts
+++ b/src/__dev__/permissionOverride/debugStaffProfileStatus.test.ts
@@ -1,0 +1,32 @@
+import { PermissionEnum } from "@dashboard/graphql";
+
+import {
+  getDebugStaffProfileStatus,
+  getDebugStaffProfileStatusLabel,
+} from "./debugStaffProfileStatus";
+import { type DebugStaffProfile } from "./debugStaffProfileStore";
+
+const baseProfile: DebugStaffProfile = {
+  baseEmail: "admin@saleor.io",
+  debugEmail: "admin+debugdev-12345678@saleor.io",
+  hash: "12345678",
+  permissions: [PermissionEnum.MANAGE_ORDERS],
+  staffCreated: false,
+  lastUsedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("getDebugStaffProfileStatus", () => {
+  it("returns needs-password when staff invite is pending", () => {
+    // Arrange // Act // Assert
+    expect(getDebugStaffProfileStatus(baseProfile)).toBe("needs-password");
+    expect(getDebugStaffProfileStatusLabel("needs-password")).toBe("Needs password");
+  });
+
+  it("returns ready-to-login when staff exists", () => {
+    // Arrange // Act // Assert
+    expect(getDebugStaffProfileStatus({ ...baseProfile, staffCreated: true })).toBe(
+      "ready-to-login",
+    );
+    expect(getDebugStaffProfileStatusLabel("ready-to-login")).toBe("Ready to log in");
+  });
+});

--- a/src/__dev__/permissionOverride/debugStaffProfileStatus.ts
+++ b/src/__dev__/permissionOverride/debugStaffProfileStatus.ts
@@ -1,0 +1,16 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type DebugStaffProfile } from "./debugStaffProfileStore";
+
+export type DebugStaffProfileStatus = "needs-password" | "ready-to-login";
+
+export const getDebugStaffProfileStatus = (profile: DebugStaffProfile): DebugStaffProfileStatus =>
+  profile.staffCreated ? "ready-to-login" : "needs-password";
+
+export const getDebugStaffProfileStatusLabel = (status: DebugStaffProfileStatus): string => {
+  switch (status) {
+    case "needs-password":
+      return "Needs password";
+    case "ready-to-login":
+      return "Ready to log in";
+  }
+};

--- a/src/__dev__/permissionOverride/debugStaffProfileStore.ts
+++ b/src/__dev__/permissionOverride/debugStaffProfileStore.ts
@@ -1,0 +1,101 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+//
+// Stores debug staff profile metadata (email, permissions hash) for quick re-login.
+// Passwords are not stored — rely on the browser password manager instead.
+import { type PermissionEnum } from "@dashboard/graphql";
+
+const STORAGE_KEY = "dev:debugStaffProfiles";
+const EVENT_NAME = "dev:debugStaffProfiles:change";
+const MAX_PROFILES_PER_BASE_EMAIL = 8;
+
+export interface DebugStaffProfile {
+  baseEmail: string;
+  debugEmail: string;
+  hash: string;
+  permissions: PermissionEnum[];
+  staffCreated: boolean;
+  lastUsedAt: string;
+}
+
+const readAll = (): DebugStaffProfile[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+
+    return Array.isArray(parsed) ? (parsed as DebugStaffProfile[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+let cachedSnapshot = readAll();
+
+const notify = (): void => {
+  cachedSnapshot = readAll();
+  window.dispatchEvent(new Event(EVENT_NAME));
+};
+
+const writeAll = (profiles: DebugStaffProfile[]): void => {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+  notify();
+};
+
+export const debugStaffProfileStore = {
+  getSnapshot: (): DebugStaffProfile[] => cachedSnapshot,
+
+  subscribe: (listener: () => void): (() => void) => {
+    const handler = (): void => listener();
+
+    window.addEventListener(EVENT_NAME, handler);
+    window.addEventListener("storage", handler);
+
+    return () => {
+      window.removeEventListener(EVENT_NAME, handler);
+      window.removeEventListener("storage", handler);
+    };
+  },
+
+  getForBaseEmail: (baseEmail: string): DebugStaffProfile[] =>
+    cachedSnapshot
+      .filter(profile => profile.baseEmail === baseEmail)
+      .sort((left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt)),
+
+  getByDebugEmail: (debugEmail: string): DebugStaffProfile | null =>
+    cachedSnapshot.find(profile => profile.debugEmail === debugEmail) ?? null,
+
+  getByHash: (baseEmail: string, hash: string): DebugStaffProfile | null =>
+    cachedSnapshot.find(profile => profile.baseEmail === baseEmail && profile.hash === hash) ??
+    null,
+
+  upsert: (profile: DebugStaffProfile): DebugStaffProfile => {
+    const others = readAll().filter(
+      existing => !(existing.baseEmail === profile.baseEmail && existing.hash === profile.hash),
+    );
+    const sameBase = others
+      .filter(existing => existing.baseEmail === profile.baseEmail)
+      .sort((left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt))
+      .slice(0, MAX_PROFILES_PER_BASE_EMAIL - 1);
+
+    const rest = others.filter(existing => existing.baseEmail !== profile.baseEmail);
+    const saved = { ...profile, lastUsedAt: profile.lastUsedAt || new Date().toISOString() };
+
+    writeAll([saved, ...sameBase, ...rest]);
+
+    return saved;
+  },
+
+  remove: (baseEmail: string, hash: string): void => {
+    writeAll(
+      readAll().filter(profile => !(profile.baseEmail === baseEmail && profile.hash === hash)),
+    );
+  },
+};

--- a/src/__dev__/permissionOverride/ensureDebugStaffUser.ts
+++ b/src/__dev__/permissionOverride/ensureDebugStaffUser.ts
@@ -1,0 +1,185 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type ApolloClient } from "@apollo/client";
+import { newPasswordUrl } from "@dashboard/auth/urls";
+import { type PermissionEnum } from "@dashboard/graphql";
+import { getAppMountUriForRedirect } from "@dashboard/utils/urls";
+import urlJoin from "url-join";
+
+import { buildDebugStaffEmail } from "./debugStaffEmail";
+import {
+  permissionGroupCreateDocument,
+  searchPermissionGroupByNameDocument,
+  searchStaffByEmailDocument,
+  staffCreateDocument,
+} from "./debugStaffGraphql";
+import { buildPermissionGroupName, hashPermissions } from "./permissionsHash";
+
+interface GraphQLErrorField {
+  message: string | null;
+}
+
+interface SearchPermissionGroupByNameData {
+  permissionGroups?: {
+    edges?: Array<{ node: { id: string; name: string } }>;
+  } | null;
+}
+
+interface SearchStaffByEmailData {
+  staffUsers?: {
+    edges?: Array<{ node: { id: string; email: string } }>;
+  } | null;
+}
+
+interface PermissionGroupCreateData {
+  permissionGroupCreate?: {
+    errors: GraphQLErrorField[];
+    group?: { id: string; name: string } | null;
+  } | null;
+}
+
+interface StaffCreateData {
+  staffCreate?: {
+    errors: GraphQLErrorField[];
+    user?: { id: string; email: string } | null;
+  } | null;
+}
+
+interface EnsureDebugStaffUserInput {
+  apolloClient: ApolloClient<unknown>;
+  baseEmail: string;
+  permissions: PermissionEnum[];
+}
+
+export type EnsureDebugStaffUserResult =
+  | {
+      status: "ready";
+      debugEmail: string;
+      hash: string;
+      groupId: string;
+      staffCreated: boolean;
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+const getStaffPasswordRedirectUrl = (): string =>
+  urlJoin(window.location.origin, getAppMountUriForRedirect(), newPasswordUrl().replace(/\?/, ""));
+
+export const ensureDebugStaffUser = async ({
+  apolloClient,
+  baseEmail,
+  permissions,
+}: EnsureDebugStaffUserInput): Promise<EnsureDebugStaffUserResult> => {
+  try {
+    const hash = await hashPermissions(permissions);
+    const groupName = buildPermissionGroupName(hash);
+    const debugEmail = buildDebugStaffEmail(baseEmail, hash);
+
+    const groupSearch = await apolloClient.query<SearchPermissionGroupByNameData>({
+      query: searchPermissionGroupByNameDocument,
+      variables: { query: groupName },
+      fetchPolicy: "network-only",
+    });
+
+    const existingGroup = groupSearch.data?.permissionGroups?.edges?.find(
+      (edge: { node: { id: string; name: string } }) => edge.node.name === groupName,
+    )?.node;
+
+    let groupId = existingGroup?.id;
+
+    if (!groupId) {
+      const groupCreateResult = await apolloClient.mutate<PermissionGroupCreateData>({
+        mutation: permissionGroupCreateDocument,
+        variables: {
+          input: {
+            name: groupName,
+            addPermissions: permissions,
+            restrictedAccessToChannels: false,
+          },
+        },
+      });
+
+      const groupErrors = groupCreateResult.data?.permissionGroupCreate?.errors ?? [];
+
+      if (groupErrors.length > 0) {
+        return {
+          status: "error",
+          message: groupErrors
+            .map((error: GraphQLErrorField) => error.message)
+            .filter(Boolean)
+            .join(" "),
+        };
+      }
+
+      groupId = groupCreateResult.data?.permissionGroupCreate?.group?.id;
+
+      if (!groupId) {
+        return {
+          status: "error",
+          message: "Permission group was not created.",
+        };
+      }
+    }
+
+    const staffSearch = await apolloClient.query<SearchStaffByEmailData>({
+      query: searchStaffByEmailDocument,
+      variables: { query: debugEmail },
+      fetchPolicy: "network-only",
+    });
+
+    const existingStaff = staffSearch.data?.staffUsers?.edges?.find(
+      (edge: { node: { id: string; email: string } }) => edge.node.email === debugEmail,
+    )?.node;
+
+    if (existingStaff) {
+      return {
+        status: "ready",
+        debugEmail,
+        hash,
+        groupId,
+        staffCreated: false,
+      };
+    }
+
+    const staffCreateResult = await apolloClient.mutate<StaffCreateData>({
+      mutation: staffCreateDocument,
+      variables: {
+        input: {
+          email: debugEmail,
+          firstName: "Dev",
+          lastName: `Debug ${hash}`,
+          isActive: true,
+          addGroups: [groupId],
+          redirectUrl: getStaffPasswordRedirectUrl(),
+          metadata: [{ key: "dev:debugStaff", value: hash }],
+        },
+      },
+    });
+
+    const staffErrors = staffCreateResult.data?.staffCreate?.errors ?? [];
+
+    if (staffErrors.length > 0) {
+      return {
+        status: "error",
+        message: staffErrors
+          .map((error: GraphQLErrorField) => error.message)
+          .filter(Boolean)
+          .join(" "),
+      };
+    }
+
+    return {
+      status: "ready",
+      debugEmail,
+      hash,
+      groupId,
+      staffCreated: true,
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : "Failed to prepare debug staff user.",
+    };
+  }
+};

--- a/src/__dev__/permissionOverride/parseStaffInviteInput.ts
+++ b/src/__dev__/permissionOverride/parseStaffInviteInput.ts
@@ -1,0 +1,45 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+
+interface ParsedStaffInvite {
+  email: string;
+  token: string;
+}
+
+export const parseStaffInviteInput = (
+  input: string,
+  expectedEmail: string,
+): ParsedStaffInvite | null => {
+  const trimmed = input.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const fromUrl = tryParseInviteUrl(trimmed);
+
+  if (fromUrl) {
+    return fromUrl;
+  }
+
+  if (!trimmed.includes("@") && !trimmed.includes(" ")) {
+    return { email: expectedEmail, token: trimmed };
+  }
+
+  return null;
+};
+
+const tryParseInviteUrl = (value: string): ParsedStaffInvite | null => {
+  try {
+    const url = value.startsWith("/") ? new URL(value, window.location.origin) : new URL(value);
+    const email = url.searchParams.get("email");
+    const token = url.searchParams.get("token");
+
+    if (!email || !token) {
+      return null;
+    }
+
+    return { email, token };
+  } catch {
+    return null;
+  }
+};

--- a/src/__dev__/permissionOverride/permissionPresetStore.test.ts
+++ b/src/__dev__/permissionOverride/permissionPresetStore.test.ts
@@ -1,0 +1,33 @@
+import { PermissionEnum } from "@dashboard/graphql";
+
+import { permissionPresetStore } from "./permissionPresetStore";
+
+const samplePreset = {
+  hash: "abc12345",
+  name: "Orders only",
+  permissions: [PermissionEnum.MANAGE_ORDERS],
+  savedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("permissionPresetStore", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("prevents saving a preset with the same permission hash", () => {
+    // Arrange
+    expect(permissionPresetStore.upsert(samplePreset)).toBe(true);
+
+    // Act
+    const saved = permissionPresetStore.upsert({
+      ...samplePreset,
+      name: "Different label",
+      savedAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    // Assert
+    expect(saved).toBe(false);
+    expect(permissionPresetStore.getAll()).toHaveLength(1);
+    expect(permissionPresetStore.getByHash("abc12345")?.name).toBe("Orders only");
+  });
+});

--- a/src/__dev__/permissionOverride/permissionPresetStore.ts
+++ b/src/__dev__/permissionOverride/permissionPresetStore.ts
@@ -1,0 +1,86 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+
+const STORAGE_KEY = "dev:permissionPresets";
+const EVENT_NAME = "dev:permissionPresets:change";
+const MAX_PRESETS = 20;
+
+export interface PermissionPreset {
+  hash: string;
+  name: string;
+  permissions: PermissionEnum[];
+  savedAt: string;
+}
+
+const readAll = (): PermissionPreset[] => {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+
+    return Array.isArray(parsed) ? (parsed as PermissionPreset[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+const sortPresets = (presets: PermissionPreset[]): PermissionPreset[] =>
+  [...presets].sort((left, right) => right.savedAt.localeCompare(left.savedAt));
+
+let cachedSnapshot = sortPresets(readAll());
+
+const notify = (): void => {
+  cachedSnapshot = sortPresets(readAll());
+  window.dispatchEvent(new Event(EVENT_NAME));
+};
+
+const writeAll = (presets: PermissionPreset[]): void => {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+  notify();
+};
+
+export const permissionPresetStore = {
+  getSnapshot: (): PermissionPreset[] => cachedSnapshot,
+
+  subscribe: (listener: () => void): (() => void) => {
+    const handler = (): void => listener();
+
+    window.addEventListener(EVENT_NAME, handler);
+    window.addEventListener("storage", handler);
+
+    return () => {
+      window.removeEventListener(EVENT_NAME, handler);
+      window.removeEventListener("storage", handler);
+    };
+  },
+
+  getAll: (): PermissionPreset[] => cachedSnapshot,
+
+  getByHash: (hash: string): PermissionPreset | null =>
+    cachedSnapshot.find(preset => preset.hash === hash) ?? null,
+
+  upsert: (preset: PermissionPreset): boolean => {
+    if (permissionPresetStore.getByHash(preset.hash)) {
+      return false;
+    }
+
+    const others = readAll().filter(existing => existing.hash !== preset.hash);
+    const next = [preset, ...others].slice(0, MAX_PRESETS);
+
+    writeAll(next);
+
+    return true;
+  },
+
+  remove: (hash: string): void => {
+    writeAll(readAll().filter(preset => preset.hash !== hash));
+  },
+};

--- a/src/__dev__/permissionOverride/permissionsHash.ts
+++ b/src/__dev__/permissionOverride/permissionsHash.ts
@@ -1,0 +1,15 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+
+export const buildPermissionGroupName = (hash: string): string => `[dev] perms ${hash}`;
+
+export const hashPermissions = async (permissions: PermissionEnum[]): Promise<string> => {
+  const payload = [...permissions].sort().join(",");
+  const data = new TextEncoder().encode(payload);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashHex = Array.from(new Uint8Array(hashBuffer))
+    .map(byte => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+  return hashHex.slice(0, 8);
+};

--- a/src/__dev__/permissionOverride/readNewPasswordInviteFromLocation.test.ts
+++ b/src/__dev__/permissionOverride/readNewPasswordInviteFromLocation.test.ts
@@ -1,0 +1,35 @@
+import { readNewPasswordInviteFromLocation } from "./readNewPasswordInviteFromLocation";
+
+describe("readNewPasswordInviteFromLocation", () => {
+  it("parses email and token from a new-password URL", () => {
+    // Arrange
+    const pathname = "/dashboard/new-password/";
+    const search =
+      "?email=mirek%2Bdashboard%2Bdebugdev-73cadc85%40saleor.io&token=da0wbs-9cfb71899d6a5c2a4bffa0854e9fde76";
+
+    // Act
+    const result = readNewPasswordInviteFromLocation(pathname, search);
+
+    // Assert
+    expect(result).toEqual({
+      email: "mirek+dashboard+debugdev-73cadc85@saleor.io",
+      token: "da0wbs-9cfb71899d6a5c2a4bffa0854e9fde76",
+    });
+  });
+
+  it("returns null for other routes", () => {
+    // Arrange // Act
+    const result = readNewPasswordInviteFromLocation("/orders/", "?email=a@b.com&token=x");
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it("returns null when token is missing", () => {
+    // Arrange // Act
+    const result = readNewPasswordInviteFromLocation("/new-password/", "?email=debug@saleor.io");
+
+    // Assert
+    expect(result).toBeNull();
+  });
+});

--- a/src/__dev__/permissionOverride/readNewPasswordInviteFromLocation.ts
+++ b/src/__dev__/permissionOverride/readNewPasswordInviteFromLocation.ts
@@ -1,0 +1,31 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { newPasswordPath } from "@dashboard/auth/urls";
+import { parseQs } from "@dashboard/url-utils";
+
+export interface NewPasswordPageInvite {
+  email: string;
+  token: string;
+}
+
+export const readNewPasswordInviteFromLocation = (
+  pathname: string,
+  search: string,
+): NewPasswordPageInvite | null => {
+  const normalizedPath = pathname.endsWith("/") ? pathname : `${pathname}/`;
+
+  if (!normalizedPath.endsWith(newPasswordPath)) {
+    return null;
+  }
+
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  const params = parseQs(query) as { email?: string; token?: string };
+
+  if (!params.email || !params.token) {
+    return null;
+  }
+
+  return {
+    email: params.email,
+    token: params.token,
+  };
+};

--- a/src/__dev__/permissionOverride/resolveOriginalUserEmail.test.ts
+++ b/src/__dev__/permissionOverride/resolveOriginalUserEmail.test.ts
@@ -1,0 +1,25 @@
+import { resolveOriginalUserEmail } from "./resolveOriginalUserEmail";
+
+describe("resolveOriginalUserEmail", () => {
+  it("prefers the stored original email", () => {
+    // Arrange // Act // Assert
+    expect(resolveOriginalUserEmail("admin@saleor.io", "admin+debugdev-12345678@saleor.io")).toBe(
+      "admin@saleor.io",
+    );
+  });
+
+  it("derives the base email from the current debug session", () => {
+    // Arrange // Act // Assert
+    expect(resolveOriginalUserEmail(null, "mirek+dashboard+debugdev-abcdef12@saleor.io")).toBe(
+      "mirek+dashboard@saleor.io",
+    );
+  });
+
+  it("returns the current email for a normal session", () => {
+    // Arrange // Act // Assert
+    expect(resolveOriginalUserEmail(null, "mirek+dashboard@saleor.io")).toBe(
+      "mirek+dashboard@saleor.io",
+    );
+    expect(resolveOriginalUserEmail(null, undefined)).toBeNull();
+  });
+});

--- a/src/__dev__/permissionOverride/resolveOriginalUserEmail.ts
+++ b/src/__dev__/permissionOverride/resolveOriginalUserEmail.ts
@@ -1,0 +1,17 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { getBaseStaffEmail, isDebugStaffEmail } from "./debugStaffEmail";
+
+export const resolveOriginalUserEmail = (
+  storedOriginalEmail: string | null,
+  currentUserEmail: string | undefined,
+): string | null => {
+  if (storedOriginalEmail) {
+    return storedOriginalEmail;
+  }
+
+  if (currentUserEmail && isDebugStaffEmail(currentUserEmail)) {
+    return getBaseStaffEmail(currentUserEmail);
+  }
+
+  return currentUserEmail ?? null;
+};

--- a/src/__dev__/permissionOverride/store.ts
+++ b/src/__dev__/permissionOverride/store.ts
@@ -1,0 +1,75 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: temporary tool for testing customer
+// read-only access. Remove this entire `__dev__/permissionOverride/` folder
+// (and the override block in src/auth/useUser.ts, permissionOverrideBinding
+// files, vite alias, and the mount in src/index.tsx) before pushing upstream.
+// Enabled locally with VITE_ENABLE_PERMISSIONS_DEBUGGER=true (dev server only).
+//
+// Quick removal:
+//   git grep -l "DEV-ONLY-PERMISSION-OVERRIDE"
+//
+// The store is a thin localStorage-backed observable so `useSyncExternalStore`
+// can re-render permission consumers when the developer toggles a checkbox.
+import { PermissionEnum } from "@dashboard/graphql";
+
+const STORAGE_KEY = "dev:permissionOverride";
+const EVENT_NAME = "dev:permissionOverride:change";
+
+const isPermissionEnum = (value: string): value is PermissionEnum =>
+  Object.values(PermissionEnum).includes(value as PermissionEnum);
+
+const readFromStorage = (): PermissionEnum[] | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+
+  if (raw === null) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed.filter(
+      (value): value is PermissionEnum => typeof value === "string" && isPermissionEnum(value),
+    );
+  } catch {
+    return null;
+  }
+};
+
+let cachedSnapshot: PermissionEnum[] | null = readFromStorage();
+
+const notify = () => {
+  cachedSnapshot = readFromStorage();
+  window.dispatchEvent(new Event(EVENT_NAME));
+};
+
+export const permissionOverrideStore = {
+  getSnapshot: (): PermissionEnum[] | null => cachedSnapshot,
+  subscribe: (listener: () => void): (() => void) => {
+    const handler = () => listener();
+
+    window.addEventListener(EVENT_NAME, handler);
+    // Cross-tab sync: localStorage events fire in *other* tabs only.
+    window.addEventListener("storage", handler);
+
+    return () => {
+      window.removeEventListener(EVENT_NAME, handler);
+      window.removeEventListener("storage", handler);
+    };
+  },
+  setOverride: (permissions: PermissionEnum[]) => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(permissions));
+    notify();
+  },
+  clearOverride: () => {
+    window.localStorage.removeItem(STORAGE_KEY);
+    notify();
+  },
+};

--- a/src/__dev__/permissionOverride/useDebugStaffPasswordSetup.ts
+++ b/src/__dev__/permissionOverride/useDebugStaffPasswordSetup.ts
@@ -1,0 +1,143 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { useApolloClient } from "@apollo/client";
+import { getNewPasswordResetRedirectUrl } from "@dashboard/auth/utils";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { buildNewPasswordPageUrl } from "./buildNewPasswordPageUrl";
+import { requestPasswordResetDocument } from "./debugStaffGraphql";
+import { debugStaffInviteTokenStore } from "./debugStaffInviteTokenStore";
+import { parseStaffInviteInput } from "./parseStaffInviteInput";
+import { type CapturedNewPasswordPageInvite } from "./useNewPasswordPageInvite";
+
+interface RequestPasswordResetData {
+  requestPasswordReset?: {
+    errors: Array<{ message: string | null }>;
+  } | null;
+}
+
+interface UseDebugStaffPasswordSetupOptions {
+  debugEmail: string | undefined;
+  pageInvite: CapturedNewPasswordPageInvite | null;
+}
+
+export const useDebugStaffPasswordSetup = ({
+  debugEmail,
+  pageInvite,
+}: UseDebugStaffPasswordSetupOptions) => {
+  const apolloClient = useApolloClient();
+  const [inviteInput, setInviteInput] = useState("");
+  const [resendStatus, setResendStatus] = useState<"idle" | "working" | "success" | "error">(
+    "idle",
+  );
+  const [resendMessage, setResendMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (pageInvite && (!debugEmail || pageInvite.email === debugEmail)) {
+      setInviteInput(pageInvite.url);
+
+      return;
+    }
+
+    if (!debugEmail) {
+      setInviteInput("");
+
+      return;
+    }
+
+    const savedToken = debugStaffInviteTokenStore.get(debugEmail);
+
+    setInviteInput(savedToken ?? "");
+  }, [debugEmail, pageInvite]);
+
+  const parsedInvite = useMemo(() => {
+    if (!debugEmail) {
+      return null;
+    }
+
+    return parseStaffInviteInput(inviteInput, debugEmail);
+  }, [debugEmail, inviteInput]);
+
+  const setupUrl = useMemo(() => {
+    if (!parsedInvite) {
+      return null;
+    }
+
+    return buildNewPasswordPageUrl(parsedInvite.email, parsedInvite.token);
+  }, [parsedInvite]);
+
+  const handleInviteInputChange = useCallback(
+    (value: string) => {
+      setInviteInput(value);
+
+      if (!debugEmail) {
+        return;
+      }
+
+      const parsed = parseStaffInviteInput(value, debugEmail);
+
+      if (parsed?.token) {
+        debugStaffInviteTokenStore.set(debugEmail, parsed.token);
+      }
+    },
+    [debugEmail],
+  );
+
+  const openSetPasswordPage = useCallback(() => {
+    if (!setupUrl) {
+      return;
+    }
+
+    window.open(setupUrl, "_blank", "noopener,noreferrer");
+  }, [setupUrl]);
+
+  const resendInviteEmail = useCallback(async () => {
+    if (!debugEmail) {
+      return;
+    }
+
+    setResendStatus("working");
+    setResendMessage(null);
+
+    try {
+      const result = await apolloClient.mutate<RequestPasswordResetData>({
+        mutation: requestPasswordResetDocument,
+        variables: {
+          email: debugEmail,
+          redirectUrl: getNewPasswordResetRedirectUrl(),
+        },
+      });
+
+      const errors = result.data?.requestPasswordReset?.errors ?? [];
+
+      if (errors.length > 0) {
+        setResendStatus("error");
+        setResendMessage(
+          errors.map((error: { message: string | null }) => error.message).join(" "),
+        );
+
+        return;
+      }
+
+      setResendStatus("success");
+      setResendMessage("Invite email sent — paste the new link or token from Mailhog.");
+    } catch (error) {
+      setResendStatus("error");
+      setResendMessage(error instanceof Error ? error.message : "Failed to resend invite email.");
+    }
+  }, [apolloClient, debugEmail]);
+
+  const confirmedFromCurrentPage = Boolean(
+    pageInvite && debugEmail && pageInvite.email === debugEmail,
+  );
+
+  return {
+    confirmedFromCurrentPage,
+    handleInviteInputChange,
+    inviteInput,
+    openSetPasswordPage,
+    parsedInvite,
+    resendInviteEmail,
+    resendMessage,
+    resendStatus,
+  };
+};

--- a/src/__dev__/permissionOverride/useDebugStaffPreview.ts
+++ b/src/__dev__/permissionOverride/useDebugStaffPreview.ts
@@ -1,0 +1,58 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+import { useEffect, useState } from "react";
+
+import { buildDebugStaffEmail } from "./debugStaffEmail";
+import { debugStaffProfileStore } from "./debugStaffProfileStore";
+import { hashPermissions } from "./permissionsHash";
+
+interface DebugStaffPreview {
+  debugEmail: string;
+  hash: string;
+  savedProfile: ReturnType<typeof debugStaffProfileStore.getByHash>;
+}
+
+interface UseDebugStaffPreviewOptions {
+  baseEmail: string;
+  grantablePermissions: PermissionEnum[];
+  selectedPermissions: PermissionEnum[];
+}
+
+export const useDebugStaffPreview = ({
+  baseEmail,
+  grantablePermissions,
+  selectedPermissions,
+}: UseDebugStaffPreviewOptions) => {
+  const [preview, setPreview] = useState<DebugStaffPreview | null>(null);
+  const [isResolving, setIsResolving] = useState(false);
+
+  useEffect(() => {
+    if (!baseEmail) {
+      setPreview(null);
+      setIsResolving(false);
+
+      return;
+    }
+
+    let cancelled = false;
+
+    setIsResolving(true);
+
+    void (async () => {
+      const hash = await hashPermissions(grantablePermissions);
+      const debugEmail = buildDebugStaffEmail(baseEmail, hash);
+      const savedProfile = debugStaffProfileStore.getByHash(baseEmail, hash);
+
+      if (!cancelled) {
+        setPreview({ debugEmail, hash, savedProfile });
+        setIsResolving(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [baseEmail, grantablePermissions, selectedPermissions]);
+
+  return { preview, isResolving };
+};

--- a/src/__dev__/permissionOverride/useDebugStaffSession.ts
+++ b/src/__dev__/permissionOverride/useDebugStaffSession.ts
@@ -1,0 +1,338 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { useApolloClient } from "@apollo/client";
+import { PermissionEnum } from "@dashboard/graphql";
+import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
+
+import { debugSessionStore } from "./debugSessionStore";
+import { isDebugStaffEmail } from "./debugStaffEmail";
+import { type DebugStaffProfile, debugStaffProfileStore } from "./debugStaffProfileStore";
+import { ensureDebugStaffUser } from "./ensureDebugStaffUser";
+import { resolveOriginalUserEmail } from "./resolveOriginalUserEmail";
+import { permissionOverrideStore } from "./store";
+import { useDebugStaffPreview } from "./useDebugStaffPreview";
+import { useRealUser } from "./useRealUser";
+
+type DebugStaffSessionStatus = "idle" | "working" | "success" | "error";
+
+export interface UseDebugStaffSessionResult {
+  baseEmail: string;
+  clearMessage: () => void;
+  createDebugStaff: () => Promise<CreateDebugStaffResult>;
+  findProfileByEmail: (debugEmail: string) => DebugStaffProfile | null;
+  grantablePermissions: PermissionEnum[];
+  handlePasswordChange: (value: string) => void;
+  hasManageStaff: boolean;
+  isDebugSession: boolean;
+  isResolvingPreview: boolean;
+  loginDebugStaff: (profile: DebugStaffProfile) => Promise<boolean>;
+  markProfilePasswordReady: (profile: DebugStaffProfile) => DebugStaffProfile;
+  message: string | null;
+  password: string;
+  preview: ReturnType<typeof useDebugStaffPreview>["preview"];
+  realUserEmail: string;
+  removeSavedProfile: (profile: DebugStaffProfile) => void;
+  savedProfiles: DebugStaffProfile[];
+  skippedPermissions: PermissionEnum[];
+  status: DebugStaffSessionStatus;
+  switchBackToOriginalUser: () => Promise<boolean>;
+}
+
+interface UseDebugStaffSessionOptions {
+  selectedPermissions: PermissionEnum[];
+}
+
+export type CreateDebugStaffResult =
+  | {
+      status: "created";
+      profile: DebugStaffProfile;
+      needsPassword: true;
+    }
+  | {
+      status: "exists";
+      profile: DebugStaffProfile;
+      needsPassword: false;
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+export const useDebugStaffSession = ({
+  selectedPermissions,
+}: UseDebugStaffSessionOptions): UseDebugStaffSessionResult => {
+  const apolloClient = useApolloClient();
+  const { user, login } = useRealUser();
+  const [status, setStatus] = useState<DebugStaffSessionStatus>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [password, setPassword] = useState("");
+  const realUserEmail = user?.email ?? "";
+  const isDebugSession = isDebugStaffEmail(realUserEmail);
+  const baseEmail =
+    resolveOriginalUserEmail(
+      isDebugSession ? debugSessionStore.getOriginalUserEmail() : null,
+      realUserEmail || undefined,
+    ) ?? "";
+
+  const hasManageStaff = useMemo(
+    () =>
+      !!user?.userPermissions?.some(permission => permission.code === PermissionEnum.MANAGE_STAFF),
+    [user?.userPermissions],
+  );
+
+  const grantablePermissions = useMemo(() => {
+    const realCodes = new Set(user?.userPermissions?.map(permission => permission.code) ?? []);
+
+    return selectedPermissions.filter(code => realCodes.has(code));
+  }, [selectedPermissions, user?.userPermissions]);
+
+  const skippedPermissions = useMemo(() => {
+    const grantable = new Set(grantablePermissions);
+
+    return selectedPermissions.filter(code => !grantable.has(code));
+  }, [grantablePermissions, selectedPermissions]);
+
+  const { preview, isResolving } = useDebugStaffPreview({
+    baseEmail,
+    grantablePermissions,
+    selectedPermissions,
+  });
+
+  const allProfiles = useSyncExternalStore(
+    debugStaffProfileStore.subscribe,
+    debugStaffProfileStore.getSnapshot,
+    () => [],
+  );
+
+  const savedProfiles = useMemo(() => {
+    if (!baseEmail) {
+      return [];
+    }
+
+    return allProfiles
+      .filter(profile => profile.baseEmail === baseEmail)
+      .sort((left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt));
+  }, [allProfiles, baseEmail]);
+
+  const handlePasswordChange = useCallback((value: string) => {
+    setPassword(value);
+  }, []);
+
+  const clearMessage = useCallback(() => {
+    setMessage(null);
+    setStatus("idle");
+  }, []);
+
+  const persistProfile = useCallback((profile: Omit<DebugStaffProfile, "lastUsedAt">) => {
+    return debugStaffProfileStore.upsert({
+      ...profile,
+      lastUsedAt: new Date().toISOString(),
+    });
+  }, []);
+
+  const loginAsUser = useCallback(
+    async (email: string, userPassword: string) => {
+      if (!login) {
+        setStatus("error");
+        setMessage("Login is not available in this context.");
+
+        return false;
+      }
+
+      const result = await login(email, userPassword);
+
+      if (!result?.token || result.errors?.length) {
+        setStatus("error");
+        setMessage("Login failed. Check the password and try again.");
+
+        return false;
+      }
+
+      window.location.reload();
+
+      return true;
+    },
+    [login],
+  );
+
+  const createDebugStaff = useCallback(async (): Promise<CreateDebugStaffResult> => {
+    if (!hasManageStaff) {
+      const errorMessage = "MANAGE_STAFF is required to create debug staff users.";
+
+      setStatus("error");
+      setMessage(errorMessage);
+
+      return { status: "error", message: errorMessage };
+    }
+
+    if (!preview?.debugEmail) {
+      const errorMessage = "Could not resolve the debug user email.";
+
+      setStatus("error");
+      setMessage(errorMessage);
+
+      return { status: "error", message: errorMessage };
+    }
+
+    if (!baseEmail) {
+      const errorMessage = "Could not determine your staff email.";
+
+      setStatus("error");
+      setMessage(errorMessage);
+
+      return { status: "error", message: errorMessage };
+    }
+
+    setStatus("working");
+    setMessage(null);
+
+    const ensureResult = await ensureDebugStaffUser({
+      apolloClient,
+      baseEmail,
+      permissions: grantablePermissions,
+    });
+
+    if (ensureResult.status === "error") {
+      setStatus("error");
+      setMessage(ensureResult.message);
+
+      return { status: "error", message: ensureResult.message };
+    }
+
+    const profile = persistProfile({
+      baseEmail,
+      debugEmail: ensureResult.debugEmail,
+      hash: ensureResult.hash,
+      permissions: grantablePermissions,
+      staffCreated: !ensureResult.staffCreated,
+    });
+
+    permissionOverrideStore.clearOverride();
+    setStatus("success");
+    setMessage(null);
+
+    if (ensureResult.staffCreated) {
+      return { status: "created", profile, needsPassword: true };
+    }
+
+    return { status: "exists", profile, needsPassword: false };
+  }, [
+    apolloClient,
+    baseEmail,
+    grantablePermissions,
+    hasManageStaff,
+    persistProfile,
+    preview?.debugEmail,
+  ]);
+
+  const loginDebugStaff = useCallback(
+    async (profile: DebugStaffProfile) => {
+      if (!password.trim()) {
+        setStatus("error");
+        setMessage("Enter the debug user's password.");
+
+        return false;
+      }
+
+      if (!baseEmail) {
+        setStatus("error");
+        setMessage("Could not determine your staff email.");
+
+        return false;
+      }
+
+      setStatus("working");
+      setMessage(null);
+
+      persistProfile(profile);
+
+      if (!isDebugSession) {
+        debugSessionStore.setOriginalUserEmail(baseEmail);
+      }
+
+      permissionOverrideStore.clearOverride();
+
+      return loginAsUser(profile.debugEmail, password.trim());
+    },
+    [baseEmail, isDebugSession, loginAsUser, password, persistProfile],
+  );
+
+  const markProfilePasswordReady = useCallback(
+    (profile: DebugStaffProfile) => {
+      const updated = persistProfile({
+        ...profile,
+        staffCreated: true,
+      });
+
+      setStatus("success");
+      setMessage(null);
+
+      return updated;
+    },
+    [persistProfile],
+  );
+
+  const removeSavedProfile = useCallback((profile: DebugStaffProfile): void => {
+    debugStaffProfileStore.remove(profile.baseEmail, profile.hash);
+  }, []);
+
+  const switchBackToOriginalUser = useCallback(async (): Promise<boolean> => {
+    const originalEmail = resolveOriginalUserEmail(
+      debugSessionStore.getOriginalUserEmail(),
+      realUserEmail || undefined,
+    );
+
+    if (!originalEmail) {
+      setStatus("error");
+      setMessage("Could not determine your original account email. Log in manually.");
+
+      return false;
+    }
+
+    if (!password.trim()) {
+      setStatus("error");
+      setMessage("Enter your original account password.");
+
+      return false;
+    }
+
+    setStatus("working");
+    setMessage(null);
+
+    const success = await loginAsUser(originalEmail, password.trim());
+
+    if (success) {
+      debugSessionStore.clearOriginalUserEmail();
+    }
+
+    return success;
+  }, [loginAsUser, password, realUserEmail]);
+
+  const findProfileByEmail = useCallback(
+    (debugEmail: string): DebugStaffProfile | null =>
+      savedProfiles.find(profile => profile.debugEmail === debugEmail) ?? null,
+    [savedProfiles],
+  );
+
+  return {
+    baseEmail,
+    clearMessage,
+    createDebugStaff,
+    findProfileByEmail,
+    grantablePermissions,
+    handlePasswordChange,
+    hasManageStaff,
+    isDebugSession,
+    isResolvingPreview: isResolving,
+    loginDebugStaff,
+    markProfilePasswordReady,
+    message,
+    password,
+    preview,
+    realUserEmail,
+    removeSavedProfile,
+    savedProfiles,
+    skippedPermissions,
+    status,
+    switchBackToOriginalUser,
+  };
+};

--- a/src/__dev__/permissionOverride/useDevPermissionPanel.ts
+++ b/src/__dev__/permissionOverride/useDevPermissionPanel.ts
@@ -1,0 +1,56 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type Dispatch, type SetStateAction, useCallback, useState } from "react";
+
+import { isDebugStaffEmail } from "./debugStaffEmail";
+import { useNewPasswordPageInvite } from "./useNewPasswordPageInvite";
+
+export type DevPanelTab = "ui-preview" | "real-session";
+
+export interface UseDevPermissionPanelResult {
+  open: boolean;
+  pageInvite: ReturnType<typeof useNewPasswordPageInvite>;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+  setTab: Dispatch<SetStateAction<DevPanelTab>>;
+  tab: DevPanelTab;
+}
+
+export const useDevPermissionPanel = (): UseDevPermissionPanelResult => {
+  const pageInvite = useNewPasswordPageInvite();
+  const shouldAutoOpen = pageInvite !== null && isDebugStaffEmail(pageInvite.email);
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null);
+  const [manualTab, setManualTab] = useState<DevPanelTab | null>(null);
+
+  const defaultTab: DevPanelTab = shouldAutoOpen ? "real-session" : "ui-preview";
+  const open = manualOpen ?? shouldAutoOpen;
+  const tab = manualTab ?? defaultTab;
+
+  const setOpen = useCallback<Dispatch<SetStateAction<boolean>>>(
+    value => {
+      setManualOpen(previous => {
+        const current = previous ?? shouldAutoOpen;
+
+        return typeof value === "function" ? value(current) : value;
+      });
+    },
+    [shouldAutoOpen],
+  );
+
+  const setTab = useCallback<Dispatch<SetStateAction<DevPanelTab>>>(
+    value => {
+      setManualTab(previous => {
+        const current = previous ?? defaultTab;
+
+        return typeof value === "function" ? value(current) : value;
+      });
+    },
+    [defaultTab],
+  );
+
+  return {
+    open,
+    pageInvite,
+    setOpen,
+    setTab,
+    tab,
+  };
+};

--- a/src/__dev__/permissionOverride/useNewPasswordPageInvite.ts
+++ b/src/__dev__/permissionOverride/useNewPasswordPageInvite.ts
@@ -1,0 +1,44 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { useEffect, useMemo } from "react";
+import { useLocation } from "react-router";
+
+import { buildNewPasswordPageUrl } from "./buildNewPasswordPageUrl";
+import { debugStaffInviteTokenStore } from "./debugStaffInviteTokenStore";
+import {
+  type NewPasswordPageInvite,
+  readNewPasswordInviteFromLocation,
+} from "./readNewPasswordInviteFromLocation";
+
+export interface CapturedNewPasswordPageInvite extends NewPasswordPageInvite {
+  url: string;
+}
+
+export const useNewPasswordPageInvite = (): CapturedNewPasswordPageInvite | null => {
+  const location = useLocation();
+
+  const pageInvite = useMemo(() => {
+    const parsed = readNewPasswordInviteFromLocation(location.pathname, location.search);
+
+    if (!parsed) {
+      return null;
+    }
+
+    return {
+      ...parsed,
+      url: buildNewPasswordPageUrl(parsed.email, parsed.token),
+    };
+  }, [location.pathname, location.search]);
+
+  useEffect(
+    function persistInviteToken() {
+      if (!pageInvite) {
+        return;
+      }
+
+      debugStaffInviteTokenStore.set(pageInvite.email, pageInvite.token);
+    },
+    [pageInvite],
+  );
+
+  return pageInvite;
+};

--- a/src/__dev__/permissionOverride/usePermissionOverride.ts
+++ b/src/__dev__/permissionOverride/usePermissionOverride.ts
@@ -1,0 +1,17 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+import { useSyncExternalStore } from "react";
+
+import { permissionOverrideStore } from "./store";
+
+/**
+ * Returns the developer's permission override, or `null` when no override is
+ * active. When non-null, callers should treat the array as the user's
+ * effective `userPermissions.code` set.
+ */
+export const usePermissionOverride = (): PermissionEnum[] | null =>
+  useSyncExternalStore(
+    permissionOverrideStore.subscribe,
+    permissionOverrideStore.getSnapshot,
+    () => null,
+  );

--- a/src/__dev__/permissionOverride/usePermissionPresets.ts
+++ b/src/__dev__/permissionOverride/usePermissionPresets.ts
@@ -1,0 +1,79 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type PermissionEnum } from "@dashboard/graphql";
+import { useCallback, useSyncExternalStore } from "react";
+
+import { type PermissionPreset, permissionPresetStore } from "./permissionPresetStore";
+import { hashPermissions } from "./permissionsHash";
+
+type SavePresetResult =
+  | { status: "saved" }
+  | { status: "duplicate"; name: string }
+  | { status: "error" };
+
+export interface UsePermissionPresetsResult {
+  findPresetByPermissions: (permissions: PermissionEnum[]) => Promise<PermissionPreset | null>;
+  presets: PermissionPreset[];
+  removePreset: (hash: string) => void;
+  savePreset: (name: string, permissions: PermissionEnum[]) => Promise<SavePresetResult>;
+}
+
+export const usePermissionPresets = (): UsePermissionPresetsResult => {
+  const presets = useSyncExternalStore(
+    permissionPresetStore.subscribe,
+    permissionPresetStore.getSnapshot,
+    () => [],
+  );
+
+  const savePreset = useCallback(
+    async (name: string, permissions: PermissionEnum[]): Promise<SavePresetResult> => {
+      const trimmedName = name.trim();
+
+      if (!trimmedName) {
+        return { status: "error" };
+      }
+
+      const hash = await hashPermissions(permissions);
+      const existing = permissionPresetStore.getByHash(hash);
+
+      if (existing) {
+        return { status: "duplicate", name: existing.name };
+      }
+
+      const saved = permissionPresetStore.upsert({
+        hash,
+        name: trimmedName,
+        permissions,
+        savedAt: new Date().toISOString(),
+      });
+
+      if (!saved) {
+        const duplicate = permissionPresetStore.getByHash(hash);
+
+        return duplicate ? { status: "duplicate", name: duplicate.name } : { status: "error" };
+      }
+
+      return { status: "saved" };
+    },
+    [],
+  );
+
+  const removePreset = useCallback((hash: string): void => {
+    permissionPresetStore.remove(hash);
+  }, []);
+
+  const findPresetByPermissions = useCallback(
+    async (permissions: PermissionEnum[]): Promise<PermissionPreset | null> => {
+      const hash = await hashPermissions(permissions);
+
+      return permissionPresetStore.getByHash(hash);
+    },
+    [],
+  );
+
+  return {
+    findPresetByPermissions,
+    presets,
+    removePreset,
+    savePreset,
+  };
+};

--- a/src/__dev__/permissionOverride/useRealUser.ts
+++ b/src/__dev__/permissionOverride/useRealUser.ts
@@ -1,0 +1,7 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: see ./store.ts header for removal instructions.
+import { type UserContext as UserContextValue } from "@dashboard/auth/types";
+import { UserContext } from "@dashboard/auth/useUser";
+import { useContext } from "react";
+
+/** Auth context without the client-side permission override applied. */
+export const useRealUser = (): UserContextValue => useContext(UserContext);

--- a/src/auth/permissionOverrideBinding.dev.ts
+++ b/src/auth/permissionOverrideBinding.dev.ts
@@ -1,0 +1,4 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: loaded via Vite alias when VITE_ENABLE_PERMISSIONS_DEBUGGER=true.
+export { usePermissionOverride } from "../__dev__/permissionOverride/usePermissionOverride";
+
+export const isPermissionsDebuggerEnabled = true;

--- a/src/auth/permissionOverrideBinding.stub.ts
+++ b/src/auth/permissionOverrideBinding.stub.ts
@@ -1,0 +1,5 @@
+import { type PermissionEnum } from "@dashboard/graphql";
+
+export const isPermissionsDebuggerEnabled = false;
+
+export const usePermissionOverride = (): PermissionEnum[] | null => null;

--- a/src/auth/permissionOverrideBinding.ts
+++ b/src/auth/permissionOverrideBinding.ts
@@ -1,0 +1,6 @@
+// DEV-ONLY-PERMISSION-OVERRIDE: Vite may alias this file to permissionOverrideBinding.dev.ts
+// when VITE_ENABLE_PERMISSIONS_DEBUGGER=true. TypeScript always type-checks the stub.
+export {
+  isPermissionsDebuggerEnabled,
+  usePermissionOverride,
+} from "./permissionOverrideBinding.stub";

--- a/src/auth/urls.test.ts
+++ b/src/auth/urls.test.ts
@@ -1,0 +1,22 @@
+import {
+  isAuthOnlyPath,
+  newPasswordPath,
+  passwordResetPath,
+  passwordResetSuccessPath,
+} from "./urls";
+
+describe("isAuthOnlyPath", () => {
+  it("matches new-password and reset-password routes", () => {
+    // Arrange // Act // Assert
+    expect(isAuthOnlyPath(newPasswordPath)).toBe(true);
+    expect(isAuthOnlyPath("/dashboard/new-password/")).toBe(true);
+    expect(isAuthOnlyPath(passwordResetPath)).toBe(true);
+    expect(isAuthOnlyPath(passwordResetSuccessPath)).toBe(true);
+  });
+
+  it("does not match dashboard routes", () => {
+    // Arrange // Act // Assert
+    expect(isAuthOnlyPath("/orders/")).toBe(false);
+    expect(isAuthOnlyPath("/")).toBe(false);
+  });
+});

--- a/src/auth/urls.ts
+++ b/src/auth/urls.ts
@@ -10,6 +10,14 @@ export const newPasswordPath = "/new-password/";
 
 export const loginCallbackPath = "/login/callback/";
 
+const AUTH_ONLY_PATHS = [newPasswordPath, passwordResetPath, passwordResetSuccessPath] as const;
+
+export const isAuthOnlyPath = (pathname: string): boolean => {
+  const normalizedPath = pathname.endsWith("/") ? pathname : `${pathname}/`;
+
+  return AUTH_ONLY_PATHS.some(path => normalizedPath.endsWith(path));
+};
+
 export interface NewPasswordUrlQueryParams {
   email: string;
   token: string;

--- a/src/auth/useUser.ts
+++ b/src/auth/useUser.ts
@@ -1,5 +1,9 @@
-import { createContext, useContext } from "react";
+// DEV-ONLY-PERMISSION-OVERRIDE: remove this import and the override block
+// inside `useUser` below before pushing upstream. See
+// src/__dev__/permissionOverride/store.ts for full removal instructions.
+import { createContext, useContext, useMemo } from "react";
 
+import { usePermissionOverride } from "./permissionOverrideBinding";
 import { type UserContext as Context } from "./types";
 
 export const UserContext = createContext<Context>({
@@ -14,4 +18,30 @@ export const UserContext = createContext<Context>({
   refetchUser: undefined,
 });
 
-export const useUser = () => useContext(UserContext);
+export const useUser = (): Context => {
+  const ctx = useContext(UserContext);
+  // DEV-ONLY-PERMISSION-OVERRIDE: when the developer has set an override via
+  // the floating widget, replace the user's `userPermissions` so every
+  // consumer (`useUserPermissions`, `RequirePermissions`, `SectionRoute`,
+  // `useCanEditCustomers`, ...) sees the impersonated set. When the
+  // override is null this returns the real context unchanged.
+  const override = usePermissionOverride();
+
+  return useMemo(() => {
+    if (override !== null && ctx.user) {
+      return {
+        ...ctx,
+        user: {
+          ...ctx.user,
+          userPermissions: override.map(code => ({
+            __typename: "UserPermission" as const,
+            code,
+            name: code,
+          })),
+        },
+      };
+    }
+
+    return ctx;
+  }, [ctx, override]);
+};

--- a/src/featureFlags/FeatureFlagsProvider.tsx
+++ b/src/featureFlags/FeatureFlagsProvider.tsx
@@ -1,6 +1,7 @@
 import LoginLoading from "@dashboard/auth/components/LoginLoading/LoginLoading";
-import { useUser } from "@dashboard/auth/useUser";
-import { type ReactNode, useEffect, useState } from "react";
+import { UserContext } from "@dashboard/auth/useUser";
+import { type MetadataItemFragment } from "@dashboard/graphql";
+import { type ReactNode, useContext, useEffect, useMemo, useState } from "react";
 
 import { type FlagList } from "./availableFlags";
 import { Provider } from "./context";
@@ -32,18 +33,17 @@ interface FeatureFlagsProviderWithUserProps {
   children: ReactNode;
 }
 
-export const FeatureFlagsProviderWithUser = ({ children }: FeatureFlagsProviderWithUserProps) => {
-  const user = useUser();
+const EMPTY_METADATA: MetadataItemFragment[] = [];
 
-  return (
-    <FeatureFlagsProvider
-      strategies={[
-        new LocalStorageStrategy(),
-        new EnvVarsStrategy(),
-        new MetadataStrategy(user.user?.metadata || []),
-      ]}
-    >
-      {children}
-    </FeatureFlagsProvider>
+export const FeatureFlagsProviderWithUser = ({ children }: FeatureFlagsProviderWithUserProps) => {
+  // Use raw auth context — UI permission override must not re-resolve feature flags.
+  const user = useContext(UserContext);
+  const metadata = user.user?.metadata ?? EMPTY_METADATA;
+  const metadataKey = JSON.stringify(metadata);
+  const strategies = useMemo(
+    () => [new LocalStorageStrategy(), new EnvVarsStrategy(), new MetadataStrategy(metadata)],
+    [metadataKey],
   );
+
+  return <FeatureFlagsProvider strategies={strategies}>{children}</FeatureFlagsProvider>;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "react-error-boundary";
 import TagManager from "react-gtm-module";
 import { useIntl } from "react-intl";
+import { useLocation } from "react-router";
 import { Redirect, Switch } from "react-router-dom";
 
 import { attributeSection } from "./attributes/urls";
@@ -26,6 +27,10 @@ import AuthProvider from "./auth/AuthProvider";
 import LoginLoading from "./auth/components/LoginLoading/LoginLoading";
 import SectionRoute from "./auth/components/SectionRoute";
 import { useAuthRedirection } from "./auth/hooks/useAuthRedirection";
+// DEV-ONLY-PERMISSION-OVERRIDE: remove DevPermissionOverride mount below
+// before pushing upstream. Run `git grep DEV-ONLY-PERMISSION-OVERRIDE` to
+// find every reference to delete.
+import { isAuthOnlyPath } from "./auth/urls";
 import { channelsSection } from "./channels/urls";
 import AppLayout from "./components/AppLayout";
 import useAppChannel, { AppChannelProvider } from "./components/AppLayout/AppChannelContext";
@@ -58,6 +63,17 @@ import { OnboardingProvider } from "./welcomePage/WelcomePageOnboarding/onboardi
 // Lazy-loaded page sections for code splitting
 const AttributeSection = lazy(() => import("./attributes"));
 const Auth = lazy(() => import("./auth"));
+
+const permissionsDebuggerEnabled =
+  import.meta.env.DEV && import.meta.env.VITE_ENABLE_PERMISSIONS_DEBUGGER === "true";
+
+const DevPermissionOverrideLazy = permissionsDebuggerEnabled
+  ? lazy(async () => {
+      const module = await import("./__dev__/permissionOverride/DevPermissionOverride");
+
+      return { default: module.DevPermissionOverride };
+    })
+  : null;
 const CategorySection = lazy(() => import("./categories"));
 const ChannelsSection = lazy(() => import("./channels"));
 const CollectionSection = lazy(() => import("./collections"));
@@ -136,6 +152,12 @@ const App = (): JSX.Element => (
                                     <FeatureFlagsProviderWithUser>
                                       <OnboardingProvider>
                                         <Routes />
+                                        {/* DEV-ONLY-PERMISSION-OVERRIDE */}
+                                        {DevPermissionOverrideLazy && (
+                                          <Suspense fallback={null}>
+                                            <DevPermissionOverrideLazy />
+                                          </Suspense>
+                                        )}
                                       </OnboardingProvider>
                                     </FeatureFlagsProviderWithUser>
                                   </SavebarRefProvider>
@@ -158,6 +180,7 @@ const App = (): JSX.Element => (
 );
 const Routes = () => {
   const intl = useIntl();
+  const location = useLocation();
   const [, dispatchAppState] = useAppState();
   const { authenticated, authenticating } = useAuthRedirection();
   const { channel } = useAppChannel(false);
@@ -165,11 +188,16 @@ const Routes = () => {
   const homePageLoaded = channelLoaded && authenticated;
   const homePageLoading = (authenticated && !channelLoaded) || authenticating;
   const { isAppPath } = useLocationState();
+  const isAuthOnlyRoute = isAuthOnlyPath(location.pathname);
 
   return (
     <>
       <WindowTitle title={intl.formatMessage(commonMessages.dashboard)} />
-      {homePageLoaded ? (
+      {isAuthOnlyRoute ? (
+        <Suspense fallback={<LoginLoading />}>
+          <Auth />
+        </Suspense>
+      ) : homePageLoaded ? (
         <AppExtensionPopupProvider>
           <AppLayout fullSize={isAppPath}>
             <ErrorBoundary

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly DEV: boolean;
   readonly PROD: boolean;
   readonly VITE_DISABLE_STRICT_MODE?: string;
+  readonly VITE_ENABLE_PERMISSIONS_DEBUGGER?: string;
 }
 
 interface ImportMeta {

--- a/vite.config.js
+++ b/vite.config.js
@@ -59,11 +59,46 @@ export default defineConfig(({ command, mode }) => {
     ONBOARDING_USER_JOINED_DATE_THRESHOLD,
     DEPRECATED_SALEOR_VERSION,
     DEPRECATED_SALEOR_VERSION_TIMESTAMP,
+    VITE_ENABLE_PERMISSIONS_DEBUGGER,
     // Multi-schema support
     FF_USE_STAGING_SCHEMA,
 
     npm_package_version,
   } = env;
+
+  const enablePermissionsDebugger = isDev && VITE_ENABLE_PERMISSIONS_DEBUGGER === "true";
+
+  const permissionOverrideBindingPath = path.resolve(
+    __dirname,
+    enablePermissionsDebugger
+      ? "./src/auth/permissionOverrideBinding.dev.ts"
+      : "./src/auth/permissionOverrideBinding.stub.ts",
+  );
+
+  const permissionOverrideBindingPlugin = () => ({
+    name: "permission-override-binding",
+    enforce: "pre",
+    resolveId(source) {
+      const isPermissionOverrideBinding =
+        source === "./permissionOverrideBinding" ||
+        source === "./auth/permissionOverrideBinding" ||
+        source.endsWith("/auth/permissionOverrideBinding") ||
+        source.endsWith("/auth/permissionOverrideBinding.ts") ||
+        source.endsWith("/permissionOverrideBinding.ts");
+
+      if (isPermissionOverrideBinding) {
+        return permissionOverrideBindingPath;
+      }
+
+      return null;
+    },
+  });
+
+  if (enablePermissionsDebugger) {
+    console.log(
+      "[saleor-dashboard] Permission debugger enabled (VITE_ENABLE_PERMISSIONS_DEBUGGER=true)",
+    );
+  }
 
   const base = STATIC_URL ?? "/";
   const featureFlagsEnvs = Object.fromEntries(
@@ -73,6 +108,7 @@ export default defineConfig(({ command, mode }) => {
   const sourcemap = !SKIP_SOURCEMAPS;
 
   const plugins = [
+    permissionOverrideBindingPlugin(),
     react(),
     CodeInspectorPlugin({
       bundler: "vite",
@@ -203,14 +239,8 @@ export default defineConfig(({ command, mode }) => {
         "@locale": path.resolve(__dirname, "./locale"),
         "@dashboard": path.resolve(__dirname, "./src"),
         src: path.resolve(__dirname, "./src"),
-        // Force locally linked packages to use dashboard's React
         react: path.resolve(__dirname, "./node_modules/react"),
         "react-dom": path.resolve(__dirname, "./node_modules/react-dom"),
-        /*
-          Moment.js/react-moment does not fully suport ES modules.
-          Vite resolves it by using jsnext:main https://github.com/moment/moment/blob/develop/package.json#L26.
-          We enforce to use a different path, ignoring jsnext:main field.
-        */
         moment: path.resolve(__dirname, "./node_modules/moment/min/moment-with-locales.js"),
       },
     },


### PR DESCRIPTION
Enables local permission testing via a gated floating panel.

### Two modes

* **UI preview** - Mock permissions on your current user in the dashboard only. JWTs are unchanged, so this does not affect apps. Use this to manually test dashboard UI, routes, and guards.

* **Real session** - Quickly create and switch between debug staff users for session-based permission testing. JWTs match the selected permissions. Use this to manually test apps and API behavior.

### Gating

Behind `VITE_ENABLE_PERMISSIONS_DEBUGGER=true` (dev server only). Production builds use a no-op stub and do not bundle the debugger code.