### PR TITLE
Update Model view for consistency with other views

### DIFF
--- a/.changeset/model-detail-page-consistency.md
+++ b/.changeset/model-detail-page-consistency.md
@@ -1,0 +1,9 @@
+---
+"saleor-dashboard": patch
+---
+
+Model detail pages now align with other detail views:
+
+- **Metadata** — edit public and private metadata from a header button instead of an inline section on saved models.
+- **Model type** — the model type appears in the header beside the title, with a link to browse other models of that type.
+- **Slug validation** — duplicate slug errors show once in the SEO section with a clearer message instead of also triggering a toast.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -806,6 +806,10 @@
     "context": "button",
     "string": "Set maximal quantities"
   },
+  "2WV5Q8": {
+    "context": "model type a11y label prefix",
+    "string": "Model type"
+  },
   "2Xt+sw": {
     "context": "dialog header",
     "string": "Add postal codes"
@@ -7341,6 +7345,10 @@
     "context": "amount filter label",
     "string": "Amount"
   },
+  "bWGTLR": {
+    "context": "model detail page, top-bar metadata button tooltip",
+    "string": "Edit model metadata"
+  },
   "bZenNC": {
     "string": "Description (optional)"
   },
@@ -7789,6 +7797,10 @@
   "e/61NZ": {
     "context": "current balance filter label",
     "string": "Current balance"
+  },
+  "e/f4WI": {
+    "context": "error message when model slug is not unique",
+    "string": "Model with this slug already exists. Please provide another."
   },
   "e0RKe+": {
     "context": "generate invoice button",
@@ -8527,6 +8539,10 @@
   "iLNRJL": {
     "context": "product type a11y label prefix",
     "string": "Product type"
+  },
+  "iMZEfi": {
+    "context": "model detail page menu, opens model type configuration",
+    "string": "Model type settings"
   },
   "iPg/Z+": {
     "context": "Pagination info showing current range",
@@ -9867,6 +9883,10 @@
   "pepgIN": {
     "string": "Choose the Model Type whose extended Models will serve as refund reasons."
   },
+  "pg1ODC": {
+    "context": "model type scope link in model header, opens filtered model list",
+    "string": "View models of {modelTypeName}"
+  },
   "pgTwKM": {
     "context": "section header",
     "string": "Model attributes"
@@ -10741,6 +10761,10 @@
   },
   "u9WrRb": {
     "string": "Add Custom Extensions"
+  },
+  "uCJ+gT": {
+    "context": "model metadata dialog header",
+    "string": "Model Metadata"
   },
   "uCn/rd": {
     "context": "dialog header",

--- a/src/components/MetadataDialog/useHandleMetadataSubmit.ts
+++ b/src/components/MetadataDialog/useHandleMetadataSubmit.ts
@@ -1,8 +1,9 @@
-import { type DocumentNode, useApolloClient } from "@apollo/client";
+import { type ApolloQueryResult, type DocumentNode, useApolloClient } from "@apollo/client";
 import { type MetadataFormData } from "@dashboard/components/Metadata";
 import { useUpdateMetadataMutation, useUpdatePrivateMetadataMutation } from "@dashboard/graphql";
 import { useNotifier } from "@dashboard/hooks/useNotifier";
 import createMetadataUpdateHandler from "@dashboard/utils/handlers/metadataUpdateHandler";
+import { mapMetadataItemToInput } from "@dashboard/utils/maps";
 import { useMemo, useRef } from "react";
 import { useIntl } from "react-intl";
 
@@ -12,10 +13,12 @@ export const useHandleMetadataSubmit = <
   initialData,
   onClose,
   refetchDocument,
+  refetch,
 }: {
   initialData: T | undefined;
   onClose: () => void;
   refetchDocument: DocumentNode;
+  refetch?: () => Promise<ApolloQueryResult<unknown>>;
 }): {
   onSubmit: (data: MetadataFormData) => Promise<void>;
   lastSubmittedData: MetadataFormData | undefined;
@@ -33,19 +36,31 @@ export const useHandleMetadataSubmit = <
   const submitInProgress = metadataLoading || privateMetadataLoading;
   const submittedData = useRef<MetadataFormData>();
 
-  const fulfillmentSubmitHandler = useMemo(() => {
+  const normalizedInitialData = useMemo(() => {
     if (!initialData) {
+      return undefined;
+    }
+
+    return {
+      ...initialData,
+      metadata: (initialData.metadata ?? []).map(mapMetadataItemToInput),
+      privateMetadata: (initialData.privateMetadata ?? []).map(mapMetadataItemToInput),
+    };
+  }, [initialData]);
+
+  const fulfillmentSubmitHandler = useMemo(() => {
+    if (!normalizedInitialData) {
       return (): Promise<any[]> => Promise.resolve([]);
     }
 
     return createMetadataUpdateHandler(
-      initialData,
+      normalizedInitialData,
       // Placeholder to keep backward compatibility - we now use react-hook-form for form state management
       (): Promise<any[]> => Promise.resolve([]),
       variables => updateMetadata({ variables }),
       variables => updatePrivateMetadata({ variables }),
     );
-  }, [initialData, updateMetadata, updatePrivateMetadata]);
+  }, [normalizedInitialData, updateMetadata, updatePrivateMetadata]);
 
   const onSubmit = async (data: MetadataFormData): Promise<void> => {
     submittedData.current = data;
@@ -56,9 +71,19 @@ export const useHandleMetadataSubmit = <
       return;
     }
 
-    const result = client.refetchQueries({ include: [refetchDocument] });
+    if (refetch) {
+      await refetch();
+    } else {
+      const result = client.refetchQueries({ include: [refetchDocument] });
 
-    await Promise.all(result.queries.map(q => q.refetch()));
+      await Promise.all(
+        result.queries.map(query =>
+          query.refetch({
+            fetchPolicy: "network-only",
+          }),
+        ),
+      );
+    }
 
     notify({
       status: "success",

--- a/src/components/MetadataDialog/useMetadataForm.ts
+++ b/src/components/MetadataDialog/useMetadataForm.ts
@@ -33,6 +33,7 @@ interface MetadataFormReturn {
   formIsDirty: boolean;
   handleChange: (event: ChangeEvent, isPrivate: boolean) => void;
   formData: MetadataFormData;
+  getFormData: () => MetadataFormData;
 }
 
 export const useMetadataForm = ({
@@ -137,5 +138,6 @@ export const useMetadataForm = ({
     formIsDirty: formState.isDirty,
     handleChange,
     formData: getValues(),
+    getFormData: () => getValues(),
   };
 };

--- a/src/components/ModelType/ModelType.module.css
+++ b/src/components/ModelType/ModelType.module.css
@@ -1,0 +1,41 @@
+.icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: inherit;
+}
+
+.icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.icon svg path {
+  stroke: currentColor;
+}
+
+.link {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  min-width: 0;
+  border-radius: 4px;
+}
+
+.link:focus-visible {
+  outline: 2px solid var(--mu-colors-border-info1);
+  outline-offset: 2px;
+}
+
+.link:hover {
+  color: var(--mu-colors-text-default1);
+}
+
+.name {
+  display: inline-block;
+  max-width: 24rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}

--- a/src/components/ModelType/ModelType.tsx
+++ b/src/components/ModelType/ModelType.tsx
@@ -1,0 +1,140 @@
+import { useUserPermissions } from "@dashboard/auth/hooks/useUserPermissions";
+import { hasPermissions } from "@dashboard/components/RequirePermissions";
+import { PermissionEnum } from "@dashboard/graphql";
+import ModelingIcon from "@dashboard/icons/Modeling";
+import { pageListUrlWithPageType } from "@dashboard/modeling/urls";
+import { Box, Skeleton, Text, type TextProps } from "@saleor/macaw-ui-next";
+import { useIntl } from "react-intl";
+import { Link as RouterLink } from "react-router-dom";
+
+import { messages } from "./messages";
+import styles from "./ModelType.module.css";
+
+type ModelTypeTextSize = NonNullable<TextProps["size"]>;
+
+interface ModelTypeLike {
+  id?: string;
+  name: string;
+}
+
+interface ModelTypeProps {
+  /**
+   * The model type to display. Pass `undefined` to render a skeleton placeholder while loading.
+   */
+  modelType: ModelTypeLike | undefined;
+  /**
+   * Hide the leading model type icon.
+   * @default false
+   */
+  hideIcon?: boolean;
+  /**
+   * Macaw text size token used for the label.
+   * @default 2
+   */
+  size?: ModelTypeTextSize;
+  /**
+   * Macaw text color token used for the label.
+   * @default "default2"
+   */
+  color?: TextProps["color"];
+  /**
+   * Optional override for the `data-test-id` attribute.
+   * @default "model-type-display"
+   */
+  "data-test-id"?: string;
+  /**
+   * Native hover tooltip for the model type name.
+   * @default modelType.name
+   */
+  title?: string;
+}
+
+const ICON_SIZE_BY_TEXT_SIZE: Record<ModelTypeTextSize, number> = {
+  1: 12,
+  2: 14,
+  3: 14,
+  4: 16,
+  5: 18,
+  6: 20,
+  7: 24,
+  8: 28,
+  9: 32,
+  10: 36,
+  11: 40,
+};
+
+export const ModelTypeDisplay = ({
+  modelType,
+  hideIcon = false,
+  size = 2,
+  color = "default2",
+  "data-test-id": dataTestId = "model-type-display",
+  title,
+}: ModelTypeProps): JSX.Element => {
+  const intl = useIntl();
+
+  if (!modelType) {
+    return (
+      <Box display="flex" alignItems="center" gap={1} data-test-id={dataTestId}>
+        <Skeleton __width="6rem" __height="1rem" />
+      </Box>
+    );
+  }
+
+  const iconSize = ICON_SIZE_BY_TEXT_SIZE[size];
+  const ariaLabel = `${intl.formatMessage(messages.modelTypeLabel)}: ${modelType.name}`;
+  const nameTitle = title ?? modelType.name;
+
+  return (
+    <Text
+      size={size}
+      color={color}
+      fontWeight="medium"
+      display="flex"
+      alignItems="center"
+      gap={1}
+      data-test-id={dataTestId}
+      aria-label={ariaLabel}
+    >
+      {!hideIcon && (
+        <Box
+          className={styles.icon}
+          __width={`${iconSize}px`}
+          __height={`${iconSize}px`}
+          aria-hidden="true"
+        >
+          <ModelingIcon />
+        </Box>
+      )}
+      <span className={styles.name} title={nameTitle}>
+        {modelType.name}
+      </span>
+    </Text>
+  );
+};
+
+export const ClickableModelType = (props: ModelTypeProps): JSX.Element => {
+  const { modelType } = props;
+  const intl = useIntl();
+  const userPermissions = useUserPermissions();
+  const canViewModels = hasPermissions(userPermissions ?? [], [PermissionEnum.MANAGE_PAGES]);
+
+  if (!modelType?.id || !canViewModels) {
+    return <ModelTypeDisplay {...props} />;
+  }
+
+  const linkLabel = intl.formatMessage(messages.viewModelsOfModelType, {
+    modelTypeName: modelType.name,
+  });
+
+  return (
+    <RouterLink
+      to={pageListUrlWithPageType({ id: modelType.id })}
+      className={styles.link}
+      title={linkLabel}
+      aria-label={linkLabel}
+    >
+      <ModelTypeDisplay {...props} title={linkLabel} />
+    </RouterLink>
+  );
+};

--- a/src/components/ModelType/messages.ts
+++ b/src/components/ModelType/messages.ts
@@ -1,0 +1,14 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  modelTypeLabel: {
+    id: "2WV5Q8",
+    defaultMessage: "Model type",
+    description: "model type a11y label prefix",
+  },
+  viewModelsOfModelType: {
+    id: "pg1ODC",
+    defaultMessage: "View models of {modelTypeName}",
+    description: "model type scope link in model header, opens filtered model list",
+  },
+});

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.topNav.test.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.topNav.test.tsx
@@ -1,11 +1,54 @@
-import { type PageDetailsFragment } from "@dashboard/graphql";
+import { UserContext } from "@dashboard/auth/useUser";
+import { type PageDetailsFragment, PermissionEnum, type UserFragment } from "@dashboard/graphql";
 import { page } from "@dashboard/modeling/fixtures";
-import Wrapper from "@test/wrapper";
+import { ThemeProvider } from "@saleor/macaw-ui-next";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import PageDetailsPage from "./PageDetailsPage";
+
+const staffUser: UserFragment = {
+  __typename: "User",
+  id: "user-1",
+  email: "admin@example.com",
+  firstName: "Admin",
+  lastName: "User",
+  isStaff: true,
+  dateJoined: "2024-01-01T00:00:00Z",
+  metadata: [],
+  userPermissions: [
+    {
+      __typename: "UserPermission",
+      code: PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+      name: "Manage page types",
+    },
+  ],
+  avatar: null,
+  accessibleChannels: [],
+  restrictedAccessToChannels: false,
+};
+
+const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <MemoryRouter>
+    <UserContext.Provider
+      value={{
+        login: undefined,
+        loginByExternalPlugin: undefined,
+        logout: undefined,
+        requestLoginByExternalPlugin: undefined,
+        authenticating: false,
+        isCredentialsLogin: false,
+        authenticated: true,
+        errors: [],
+        refetchUser: undefined,
+        user: staffUser,
+      }}
+    >
+      <ThemeProvider>{children}</ThemeProvider>
+    </UserContext.Provider>
+  </MemoryRouter>
+);
 
 global.IntersectionObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
@@ -92,16 +135,12 @@ const renderPage = ({
   pageProp,
   onShowMetadata = jest.fn(),
 }: {
-  pageProp: PageDetailsFragment | null;
+  pageProp: PageDetailsFragment | null | undefined;
   onShowMetadata?: () => void;
-}) =>
-  render(
-    <Wrapper>
-      <MemoryRouter>
-        <PageDetailsPage {...defaultProps} page={pageProp} onShowMetadata={onShowMetadata} />
-      </MemoryRouter>
-    </Wrapper>,
-  );
+}): ReturnType<typeof render> =>
+  render(<PageDetailsPage {...defaultProps} page={pageProp} onShowMetadata={onShowMetadata} />, {
+    wrapper: Wrapper,
+  });
 
 describe("PageDetailsPage top nav", () => {
   it("renders the metadata button on edit view", () => {
@@ -140,5 +179,23 @@ describe("PageDetailsPage top nav", () => {
     // Assert
     expect(screen.queryByTestId("show-page-metadata")).not.toBeInTheDocument();
     expect(screen.getByTestId("metadata-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("page-organize-content-mock")).toBeInTheDocument();
+  });
+
+  it("renders model type in the header on edit view", () => {
+    // Arrange & Act
+    renderPage({ pageProp: mockPage });
+
+    // Assert
+    expect(screen.getByTestId("model-type-display")).toBeInTheDocument();
+    expect(screen.queryByTestId("page-organize-content-mock")).not.toBeInTheDocument();
+  });
+
+  it("shows the actions menu when model type settings are available", () => {
+    // Arrange & Act
+    renderPage({ pageProp: mockPage });
+
+    // Assert
+    expect(screen.getByTestId("show-more-button")).toBeInTheDocument();
   });
 });

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.topNav.test.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.topNav.test.tsx
@@ -1,0 +1,144 @@
+import { type PageDetailsFragment } from "@dashboard/graphql";
+import { page } from "@dashboard/modeling/fixtures";
+import Wrapper from "@test/wrapper";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import PageDetailsPage from "./PageDetailsPage";
+
+global.IntersectionObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
+jest.mock("@dashboard/components/Savebar");
+jest.mock("@dashboard/extensions/hooks/useExtensions", () => ({
+  useExtensions: () => ({
+    PAGE_DETAILS_MORE_ACTIONS: [],
+  }),
+}));
+jest.mock("@dashboard/extensions/getExtensionsItems", () => ({
+  getExtensionsItemForPageDetails: () => [],
+}));
+jest.mock("./form", () => ({
+  __esModule: true,
+  default: ({ children }: { children: (props: unknown) => ReactNode }) =>
+    children({
+      change: jest.fn(),
+      data: {
+        attributes: [],
+        title: "Test model",
+        seoTitle: "",
+        seoDescription: "",
+        slug: "",
+        isPublished: true,
+        publishedAt: "",
+        pageType: null,
+        metadata: [],
+        privateMetadata: [],
+      },
+      validationErrors: [],
+      handlers: {
+        changeMetadata: jest.fn(),
+        selectPageType: jest.fn(),
+        selectAttribute: jest.fn(),
+        selectAttributeMulti: jest.fn(),
+        selectAttributeFile: jest.fn(),
+        selectAttributeReference: jest.fn(),
+        reorderAttributeValue: jest.fn(),
+        fetchReferences: jest.fn(),
+        fetchMoreReferences: jest.fn(),
+      },
+      submit: jest.fn(),
+      attributeRichTextGetters: {},
+    }),
+}));
+jest.mock("../PageInfo", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="page-info-mock" />,
+}));
+jest.mock("@dashboard/components/SeoForm", () => ({
+  SeoForm: () => <div data-test-id="seo-form-mock" />,
+}));
+jest.mock("@dashboard/components/Metadata", () => ({
+  Metadata: () => <div data-test-id="metadata-mock" />,
+}));
+jest.mock("../PageOrganizeContent/PageOrganizeContent", () => ({
+  PageOrganizeContent: () => <div data-test-id="page-organize-content-mock" />,
+}));
+jest.mock("@dashboard/components/VisibilityCard", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="visibility-card-mock" />,
+}));
+
+const mockPage: PageDetailsFragment = page;
+
+const defaultProps = {
+  loading: false,
+  errors: [],
+  attributeValues: [],
+  saveButtonBarState: "default" as const,
+  onRemove: jest.fn(),
+  onSubmit: jest.fn(),
+  onAssignReferencesClick: jest.fn(),
+  onCloseDialog: jest.fn(),
+  onAttributeSelectBlur: jest.fn(),
+  fetchAttributeValues: jest.fn(),
+};
+
+const renderPage = ({
+  pageProp,
+  onShowMetadata = jest.fn(),
+}: {
+  pageProp: PageDetailsFragment | null;
+  onShowMetadata?: () => void;
+}) =>
+  render(
+    <Wrapper>
+      <MemoryRouter>
+        <PageDetailsPage {...defaultProps} page={pageProp} onShowMetadata={onShowMetadata} />
+      </MemoryRouter>
+    </Wrapper>,
+  );
+
+describe("PageDetailsPage top nav", () => {
+  it("renders the metadata button on edit view", () => {
+    // Arrange & Act
+    renderPage({ pageProp: mockPage });
+
+    // Assert
+    expect(screen.getByTestId("show-page-metadata")).toBeInTheDocument();
+  });
+
+  it("calls onShowMetadata when the metadata button is clicked", () => {
+    // Arrange
+    const onShowMetadata = jest.fn();
+
+    renderPage({ pageProp: mockPage, onShowMetadata });
+
+    // Act
+    screen.getByTestId("show-page-metadata").click();
+
+    // Assert
+    expect(onShowMetadata).toHaveBeenCalled();
+  });
+
+  it("disables the metadata button while page data is loading", () => {
+    // Arrange & Act
+    renderPage({ pageProp: undefined as unknown as PageDetailsFragment });
+
+    // Assert
+    expect(screen.getByTestId("show-page-metadata")).toBeDisabled();
+  });
+
+  it("does not render the metadata button on create view", () => {
+    // Arrange & Act
+    renderPage({ pageProp: null, onShowMetadata: jest.fn() });
+
+    // Assert
+    expect(screen.queryByTestId("show-page-metadata")).not.toBeInTheDocument();
+    expect(screen.getByTestId("metadata-mock")).toBeInTheDocument();
+  });
+});

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
@@ -36,22 +36,25 @@ import useDateLocalize from "@dashboard/hooks/useDateLocalize";
 import { type SubmitPromise } from "@dashboard/hooks/useForm";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { modelingSection } from "@dashboard/modeling/urls";
+import { pageTypeUrl } from "@dashboard/modelTypes/urls";
 import { TranslationsButton } from "@dashboard/translations/components/TranslationsButton/TranslationsButton";
 import { languageEntityUrl, TranslatableEntities } from "@dashboard/translations/urls";
 import { useCachedLocales } from "@dashboard/translations/useCachedLocales";
 import { type Container, type FetchMoreProps, type RelayToFlat } from "@dashboard/types";
 import { mapNodeToChoice } from "@dashboard/utils/maps";
+import { useMemo } from "react";
 import { useIntl } from "react-intl";
 
 import PageInfo from "../PageInfo";
 import { PageOrganizeContent } from "../PageOrganizeContent/PageOrganizeContent";
 import PageForm, { type PageData, type PageUpdateHandlers } from "./form";
 import { messages } from "./messages";
+import { PageDetailsTitle } from "./Title";
 
 interface PageDetailsPageProps {
   loading: boolean;
   errors: PageErrorWithAttributesFragment[];
-  page: PageDetailsFragment;
+  page: PageDetailsFragment | null | undefined;
   pageTypes?: RelayToFlat<SearchPageTypesQuery["search"]>;
   referencePages?: RelayToFlat<SearchPagesQuery["search"]>;
   referenceProducts?: RelayToFlat<SearchProductsQuery["search"]>;
@@ -122,6 +125,8 @@ const PageDetailsPage = ({
   const { lastUsedLocaleOrFallback } = useCachedLocales();
   const { user } = useUser();
   const canTranslate = user && hasPermission(PermissionEnum.MANAGE_TRANSLATIONS, user);
+  const canManageModelTypes =
+    user && hasPermission(PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES, user);
   const localizeDate = useDateLocalize();
   const navigate = useNavigator();
   const pageExists = page !== null;
@@ -149,6 +154,20 @@ const PageDetailsPage = ({
 
   const { PAGE_DETAILS_MORE_ACTIONS } = useExtensions(extensionMountPoints.PAGE_DETAILS);
   const extensionMenuItems = getExtensionsItemForPageDetails(PAGE_DETAILS_MORE_ACTIONS, page?.id);
+  const builtInMenuItems = useMemo(() => {
+    const items = [];
+
+    if (canManageModelTypes && page?.pageType?.id) {
+      items.push({
+        label: intl.formatMessage(messages.openModelTypeSettings),
+        onSelect: () => navigate(pageTypeUrl(page.pageType.id)),
+        testId: "open-model-type-settings",
+      });
+    }
+
+    return items;
+  }, [canManageModelTypes, intl, navigate, page?.pageType?.id]);
+  const menuItems = [...extensionMenuItems, ...builtInMenuItems];
 
   return (
     <PageForm
@@ -179,7 +198,13 @@ const PageDetailsPage = ({
           <DetailPageLayout>
             <TopNav
               href={pageListBackLink}
-              title={!pageExists ? intl.formatMessage(messages.title) : page?.title}
+              title={
+                !pageExists ? (
+                  intl.formatMessage(messages.title)
+                ) : (
+                  <PageDetailsTitle page={page} loading={loading} />
+                )
+              }
               actionsGap={3}
             >
               {pageExists && onShowMetadata && (
@@ -204,9 +229,7 @@ const PageDetailsPage = ({
                 />
               )}
 
-              {extensionMenuItems.length > 0 && (
-                <TopNav.Menu items={[...extensionMenuItems]} dataTestId="menu" />
-              )}
+              {menuItems.length > 0 && <TopNav.Menu items={menuItems} dataTestId="menu" />}
             </TopNav>
             <DetailPageLayout.Content>
               <PageInfo data={data} disabled={loading} errors={errors} onChange={change} />
@@ -266,19 +289,23 @@ const PageDetailsPage = ({
                 }}
                 onChange={change}
               />
-              <CardSpacer />
-              <PageOrganizeContent
-                data={data}
-                errors={errors}
-                disabled={loading}
-                pageTypes={pageTypes}
-                pageType={data.pageType}
-                pageTypeInputDisplayValue={data.pageType?.name || ""}
-                onPageTypeChange={handlers.selectPageType}
-                fetchPageTypes={fetchPageTypes}
-                fetchMorePageTypes={fetchMorePageTypes}
-                canChangeType={!page?.pageType}
-              />
+              {!pageExists && (
+                <>
+                  <CardSpacer />
+                  <PageOrganizeContent
+                    data={data}
+                    errors={errors}
+                    disabled={loading}
+                    pageTypes={pageTypes}
+                    pageType={data.pageType}
+                    pageTypeInputDisplayValue={data.pageType?.name || ""}
+                    onPageTypeChange={handlers.selectPageType}
+                    fetchPageTypes={fetchPageTypes}
+                    fetchMorePageTypes={fetchMorePageTypes}
+                    canChangeType={!page?.pageType}
+                  />
+                </>
+              )}
             </DetailPageLayout.RightSidebar>
             <Savebar>
               {page !== null && <Savebar.DeleteButton onClick={onRemove} />}

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
@@ -48,7 +48,7 @@ import { useIntl } from "react-intl";
 
 import PageInfo from "../PageInfo";
 import { PageOrganizeContent } from "../PageOrganizeContent/PageOrganizeContent";
-import PageForm, { type PageData, type PageUpdateHandlers } from "./form";
+import PageForm, { type PageData, type PageSubmitData, type PageUpdateHandlers } from "./form";
 import { messages } from "./messages";
 import { PageDetailsTitle } from "./Title";
 
@@ -67,7 +67,7 @@ interface PageDetailsPageProps {
   attributeValues: RelayToFlat<SearchAttributeValuesQuery["attribute"]["choices"]>;
   onRemove: () => void;
   onShowMetadata?: () => void;
-  onSubmit: (data: PageData) => SubmitPromise;
+  onSubmit: (data: PageSubmitData) => SubmitPromise;
   fetchPageTypes?: (data: string) => void;
   fetchMorePageTypes?: FetchMoreProps;
   assignReferencesAttributeId?: string;

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
@@ -62,6 +62,7 @@ interface PageDetailsPageProps {
   selectedPageType?: PageDetailsFragment["pageType"];
   attributeValues: RelayToFlat<SearchAttributeValuesQuery["attribute"]["choices"]>;
   onRemove: () => void;
+  onShowMetadata?: () => void;
   onSubmit: (data: PageData) => SubmitPromise;
   fetchPageTypes?: (data: string) => void;
   fetchMorePageTypes?: FetchMoreProps;
@@ -96,6 +97,7 @@ const PageDetailsPage = ({
   selectedPageType,
   attributeValues,
   onRemove,
+  onShowMetadata,
   onSubmit,
   fetchPageTypes,
   fetchMorePageTypes,
@@ -178,7 +180,16 @@ const PageDetailsPage = ({
             <TopNav
               href={pageListBackLink}
               title={!pageExists ? intl.formatMessage(messages.title) : page?.title}
+              actionsGap={3}
             >
+              {pageExists && onShowMetadata && (
+                <TopNav.MetadataButton
+                  onClick={onShowMetadata}
+                  disabled={!page}
+                  data-test-id="show-page-metadata"
+                  title={intl.formatMessage(messages.editPageMetadata)}
+                />
+              )}
               {canTranslate && (
                 <TranslationsButton
                   onClick={() =>
@@ -233,8 +244,12 @@ const PageDetailsPage = ({
                   richTextGetters={attributeRichTextGetters}
                 />
               )}
-              <CardSpacer />
-              <Metadata data={data} onChange={handlers.changeMetadata} />
+              {!pageExists && (
+                <>
+                  <CardSpacer />
+                  <Metadata data={data} onChange={handlers.changeMetadata} />
+                </>
+              )}
             </DetailPageLayout.Content>
             <DetailPageLayout.RightSidebar>
               <VisibilityCard

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
@@ -35,6 +35,7 @@ import { useBackLinkWithState } from "@dashboard/hooks/useBackLinkWithState";
 import useDateLocalize from "@dashboard/hooks/useDateLocalize";
 import { type SubmitPromise } from "@dashboard/hooks/useForm";
 import useNavigator from "@dashboard/hooks/useNavigator";
+import { rippleModelMetadata } from "@dashboard/modeling/ripples/modelMetadata";
 import { modelingSection } from "@dashboard/modeling/urls";
 import { pageTypeUrl } from "@dashboard/modelTypes/urls";
 import { TranslationsButton } from "@dashboard/translations/components/TranslationsButton/TranslationsButton";
@@ -213,6 +214,7 @@ const PageDetailsPage = ({
                   disabled={!page}
                   data-test-id="show-page-metadata"
                   title={intl.formatMessage(messages.editPageMetadata)}
+                  ripple={rippleModelMetadata}
                 />
               )}
               {canTranslate && (

--- a/src/modeling/components/PageDetailsPage/Title.test.tsx
+++ b/src/modeling/components/PageDetailsPage/Title.test.tsx
@@ -1,0 +1,96 @@
+import { UserContext } from "@dashboard/auth/useUser";
+import { PermissionEnum, type UserFragment } from "@dashboard/graphql";
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import { type ReactElement, type ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import { PageDetailsTitle } from "./Title";
+
+const page = {
+  id: "page-id",
+  title: "Summer lookbook",
+  pageType: {
+    id: "type-id",
+    name: "Blog",
+  },
+};
+
+const mockUser: UserFragment = {
+  __typename: "User",
+  id: "user-1",
+  email: "admin@example.com",
+  firstName: "Admin",
+  lastName: "User",
+  isStaff: true,
+  dateJoined: "2024-01-01T00:00:00Z",
+  metadata: [],
+  userPermissions: [
+    {
+      __typename: "UserPermission",
+      code: PermissionEnum.MANAGE_PAGES,
+      name: "Manage pages",
+    },
+  ],
+  avatar: null,
+  accessibleChannels: [],
+  restrictedAccessToChannels: false,
+};
+
+const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <MemoryRouter>
+    <UserContext.Provider
+      value={{
+        login: undefined,
+        loginByExternalPlugin: undefined,
+        logout: undefined,
+        requestLoginByExternalPlugin: undefined,
+        authenticating: false,
+        isCredentialsLogin: false,
+        authenticated: true,
+        errors: [],
+        refetchUser: undefined,
+        user: mockUser,
+      }}
+    >
+      <ThemeProvider>{children}</ThemeProvider>
+    </UserContext.Provider>
+  </MemoryRouter>
+);
+
+const renderTitle = (ui: ReactElement) => render(ui, { wrapper: Wrapper });
+
+describe("PageDetailsTitle", () => {
+  it("renders skeletons on initial load", () => {
+    // Arrange & Act
+    renderTitle(<PageDetailsTitle loading />);
+
+    // Assert
+    expect(screen.getByTestId("page-details-title-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("page-details-model-type-skeleton")).toBeInTheDocument();
+  });
+
+  it("keeps header content during background refetch", () => {
+    // Arrange & Act
+    renderTitle(<PageDetailsTitle page={page} loading />);
+
+    // Assert
+    expect(screen.getByText("Summer lookbook")).toBeInTheDocument();
+    expect(screen.queryByTestId("page-details-title-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("renders model title and linked model type when loaded", () => {
+    // Arrange & Act
+    renderTitle(<PageDetailsTitle page={page} />);
+
+    // Assert
+    expect(screen.getByText("Summer lookbook")).toBeInTheDocument();
+
+    const typeLink = screen.getByText("Blog").closest("a");
+
+    expect(typeLink).toBeInTheDocument();
+    expect(typeLink?.getAttribute("href")).toContain("/models/");
+    expect(typeLink?.getAttribute("href")).toContain("pageTypes");
+    expect(typeLink?.getAttribute("href")).toContain("type-id");
+  });
+});

--- a/src/modeling/components/PageDetailsPage/Title.tsx
+++ b/src/modeling/components/PageDetailsPage/Title.tsx
@@ -1,0 +1,69 @@
+import { ClickableModelType } from "@dashboard/components/ModelType/ModelType";
+import { makeStyles } from "@saleor/macaw-ui";
+import { Box, Skeleton } from "@saleor/macaw-ui-next";
+
+interface PageDetailsHeaderPage {
+  title: string;
+  pageType?: {
+    id?: string;
+    name?: string;
+  } | null;
+}
+
+interface PageDetailsTitleProps {
+  page?: PageDetailsHeaderPage | null;
+  loading?: boolean;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    container: {
+      alignItems: "center",
+      display: "flex",
+      gap: theme.spacing(2),
+    },
+    name: {
+      minWidth: 0,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+    },
+  }),
+  { name: "PageDetailsTitle" },
+);
+
+export const PageDetailsTitle = ({ page, loading }: PageDetailsTitleProps) => {
+  const classes = useStyles();
+
+  const isHeaderLoading = loading && !page;
+
+  if (isHeaderLoading) {
+    return (
+      <div className={classes.container}>
+        <Skeleton __width="12em" data-test-id="page-details-title-skeleton" />
+        <Skeleton __width="6rem" data-test-id="page-details-model-type-skeleton" />
+      </div>
+    );
+  }
+
+  if (!page) {
+    return null;
+  }
+
+  return (
+    <div className={classes.container}>
+      <Box className={classes.name} title={page.title}>
+        {page.title}
+      </Box>
+      {page.pageType?.name && (
+        <ClickableModelType
+          modelType={{
+            id: page.pageType.id,
+            name: page.pageType.name,
+          }}
+          size={3}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/modeling/components/PageDetailsPage/form.tsx
+++ b/src/modeling/components/PageDetailsPage/form.tsx
@@ -237,7 +237,7 @@ function usePageForm(
   };
   const getSubmitData = async (): Promise<PageSubmitData> => ({
     ...data,
-    ...getMetadata(formData, isMetadataModified, isPrivateMetadataModified),
+    ...(pageExists ? {} : getMetadata(formData, isMetadataModified, isPrivateMetadataModified)),
     ...getPublicationData(formData),
     content: await richText.getValue(),
     attributes: mergeAttributes(

--- a/src/modeling/components/PageDetailsPage/form.tsx
+++ b/src/modeling/components/PageDetailsPage/form.tsx
@@ -122,7 +122,7 @@ interface UsePageFormOpts {
 interface PageFormProps extends UsePageFormOpts {
   children: (props: UsePageUpdateFormRenderProps) => React.ReactNode;
   page: PageDetailsFragment;
-  onSubmit: (data: PageData) => SubmitPromise;
+  onSubmit: (data: PageSubmitData) => SubmitPromise;
   disabled: boolean;
 }
 
@@ -140,7 +140,7 @@ const getInitialFormData = (pageExists: boolean, page?: PageDetailsFragment): Pa
 
 function usePageForm(
   page: PageDetailsFragment,
-  onSubmit: (data: PageData) => SubmitPromise,
+  onSubmit: (data: PageSubmitData) => SubmitPromise,
   disabled: boolean,
   opts: UsePageFormOpts,
 ): UsePageUpdateFormOutput {
@@ -246,7 +246,7 @@ function usePageForm(
     ),
     attributesWithNewFileValue: attributesWithNewFileValue.data,
   });
-  const handleSubmit = async (data: PageData) => {
+  const handleSubmit = async (data: PageSubmitData) => {
     let errors = validatePageCreateData(data);
 
     setValidationErrors(errors);

--- a/src/modeling/components/PageDetailsPage/messages.ts
+++ b/src/modeling/components/PageDetailsPage/messages.ts
@@ -31,4 +31,9 @@ export const messages = defineMessages({
     defaultMessage: "Set availability date",
     description: "model availability date label",
   },
+  editPageMetadata: {
+    id: "bWGTLR",
+    defaultMessage: "Edit model metadata",
+    description: "model detail page, top-bar metadata button tooltip",
+  },
 });

--- a/src/modeling/components/PageDetailsPage/messages.ts
+++ b/src/modeling/components/PageDetailsPage/messages.ts
@@ -36,4 +36,9 @@ export const messages = defineMessages({
     defaultMessage: "Edit model metadata",
     description: "model detail page, top-bar metadata button tooltip",
   },
+  openModelTypeSettings: {
+    id: "iMZEfi",
+    defaultMessage: "Model type settings",
+    description: "model detail page menu, opens model type configuration",
+  },
 });

--- a/src/modeling/components/PageMetadataDialog/PageMetadataDialog.test.tsx
+++ b/src/modeling/components/PageMetadataDialog/PageMetadataDialog.test.tsx
@@ -1,0 +1,73 @@
+import { type PageDetailsFragment } from "@dashboard/graphql";
+import { page } from "@dashboard/modeling/fixtures";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { PageMetadataDialog } from "./PageMetadataDialog";
+
+const mockOnSubmit = jest.fn();
+
+jest.mock("@dashboard/components/MetadataDialog/useHandleMetadataSubmit", () => ({
+  useHandleMetadataSubmit: jest.fn(() => ({
+    onSubmit: mockOnSubmit,
+    lastSubmittedData: undefined,
+    submitInProgress: false,
+  })),
+}));
+
+const mockPage: PageDetailsFragment = {
+  ...page,
+  metadata: [{ key: "test-key", value: "test-value", __typename: "MetadataItem" }],
+  privateMetadata: [{ key: "private-key", value: "private-value", __typename: "MetadataItem" }],
+};
+
+describe("PageMetadataDialog", () => {
+  const onCloseMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders dialog with correct title when open", () => {
+    // Arrange & Act
+    render(<PageMetadataDialog open={true} onClose={onCloseMock} page={mockPage} />);
+
+    // Assert
+    expect(screen.getByText("Model Metadata")).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    // Arrange & Act
+    render(<PageMetadataDialog open={false} onClose={onCloseMock} page={mockPage} />);
+
+    // Assert
+    expect(screen.queryByText("Model Metadata")).not.toBeInTheDocument();
+  });
+
+  it("closes when user clicks close button", () => {
+    // Arrange
+    render(<PageMetadataDialog open={true} onClose={onCloseMock} page={mockPage} />);
+
+    // Act
+    fireEvent.click(screen.getByTestId("back"));
+
+    // Assert
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it("displays metadata when section is expanded", () => {
+    // Arrange
+    render(<PageMetadataDialog open={true} onClose={onCloseMock} page={mockPage} />);
+
+    const metadataEditors = screen.getAllByTestId("metadata-editor");
+    const publicMetadataEditor = metadataEditors.find(
+      editor => editor.getAttribute("data-test-is-private") === "false",
+    )!;
+
+    // Act
+    fireEvent.click(within(publicMetadataEditor).getByTestId("expand"));
+
+    // Assert
+    expect(within(publicMetadataEditor).getByDisplayValue("test-key")).toBeInTheDocument();
+    expect(within(publicMetadataEditor).getByDisplayValue("test-value")).toBeInTheDocument();
+  });
+});

--- a/src/modeling/components/PageMetadataDialog/PageMetadataDialog.tsx
+++ b/src/modeling/components/PageMetadataDialog/PageMetadataDialog.tsx
@@ -1,26 +1,47 @@
+import { type ApolloQueryResult } from "@apollo/client";
 import { MetadataDialog } from "@dashboard/components/MetadataDialog/MetadataDialog";
 import { useHandleMetadataSubmit } from "@dashboard/components/MetadataDialog/useHandleMetadataSubmit";
 import { useMetadataForm } from "@dashboard/components/MetadataDialog/useMetadataForm";
 import { mapFieldArrayToMetadataInput } from "@dashboard/components/MetadataDialog/validation";
-import { PageDetailsDocument, type PageDetailsFragment } from "@dashboard/graphql";
-import { useEffect } from "react";
+import {
+  PageDetailsDocument,
+  type PageDetailsFragment,
+  type PageDetailsQuery,
+} from "@dashboard/graphql";
+import { mapMetadataItemToInput } from "@dashboard/utils/maps";
+import { useEffect, useMemo, useRef } from "react";
 import { useIntl } from "react-intl";
 
 interface PageMetadataDialogProps {
   open: boolean;
   onClose: () => void;
   page: PageDetailsFragment | undefined | null;
+  refetchPage?: () => Promise<ApolloQueryResult<PageDetailsQuery>>;
 }
 
-export const PageMetadataDialog = ({ onClose, open, page }: PageMetadataDialogProps) => {
+export const PageMetadataDialog = ({
+  onClose,
+  open,
+  page,
+  refetchPage,
+}: PageMetadataDialogProps) => {
   const intl = useIntl();
-  const normalizedPage = page
-    ? { ...page, privateMetadata: page.privateMetadata ?? [] }
-    : undefined;
+  const normalizedPage = useMemo(
+    () =>
+      page
+        ? {
+            ...page,
+            metadata: page.metadata ?? [],
+            privateMetadata: page.privateMetadata ?? [],
+          }
+        : undefined,
+    [page],
+  );
   const { onSubmit, lastSubmittedData, submitInProgress } = useHandleMetadataSubmit({
     initialData: normalizedPage,
     onClose,
     refetchDocument: PageDetailsDocument,
+    refetch: refetchPage,
   });
 
   const {
@@ -31,25 +52,40 @@ export const PageMetadataDialog = ({ onClose, open, page }: PageMetadataDialogPr
     reset,
     formIsDirty,
     handleChange,
-    formData,
+    getFormData,
   } = useMetadataForm({
     graphqlData: normalizedPage,
     submitInProgress,
     lastSubmittedData,
   });
 
+  const wasOpenRef = useRef(false);
+
   useEffect(() => {
     if (!open) {
+      wasOpenRef.current = false;
       reset();
+
+      return;
     }
-  }, [open, reset]);
+
+    if (!normalizedPage || wasOpenRef.current) {
+      return;
+    }
+
+    reset({
+      metadata: normalizedPage.metadata.map(mapMetadataItemToInput),
+      privateMetadata: normalizedPage.privateMetadata.map(mapMetadataItemToInput),
+    });
+    wasOpenRef.current = true;
+  }, [open, normalizedPage, reset]);
 
   return (
     <MetadataDialog
       open={open}
       onClose={onClose}
       onSave={async () => {
-        await onSubmit(formData);
+        await onSubmit(getFormData());
       }}
       title={intl.formatMessage({
         defaultMessage: "Model Metadata",

--- a/src/modeling/components/PageMetadataDialog/PageMetadataDialog.tsx
+++ b/src/modeling/components/PageMetadataDialog/PageMetadataDialog.tsx
@@ -1,0 +1,74 @@
+import { MetadataDialog } from "@dashboard/components/MetadataDialog/MetadataDialog";
+import { useHandleMetadataSubmit } from "@dashboard/components/MetadataDialog/useHandleMetadataSubmit";
+import { useMetadataForm } from "@dashboard/components/MetadataDialog/useMetadataForm";
+import { mapFieldArrayToMetadataInput } from "@dashboard/components/MetadataDialog/validation";
+import { PageDetailsDocument, type PageDetailsFragment } from "@dashboard/graphql";
+import { useEffect } from "react";
+import { useIntl } from "react-intl";
+
+interface PageMetadataDialogProps {
+  open: boolean;
+  onClose: () => void;
+  page: PageDetailsFragment | undefined | null;
+}
+
+export const PageMetadataDialog = ({ onClose, open, page }: PageMetadataDialogProps) => {
+  const intl = useIntl();
+  const normalizedPage = page
+    ? { ...page, privateMetadata: page.privateMetadata ?? [] }
+    : undefined;
+  const { onSubmit, lastSubmittedData, submitInProgress } = useHandleMetadataSubmit({
+    initialData: normalizedPage,
+    onClose,
+    refetchDocument: PageDetailsDocument,
+  });
+
+  const {
+    metadataFields,
+    privateMetadataFields,
+    metadataErrors,
+    privateMetadataErrors,
+    reset,
+    formIsDirty,
+    handleChange,
+    formData,
+  } = useMetadataForm({
+    graphqlData: normalizedPage,
+    submitInProgress,
+    lastSubmittedData,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      reset();
+    }
+  }, [open, reset]);
+
+  return (
+    <MetadataDialog
+      open={open}
+      onClose={onClose}
+      onSave={async () => {
+        await onSubmit(formData);
+      }}
+      title={intl.formatMessage({
+        defaultMessage: "Model Metadata",
+        description: "model metadata dialog header",
+        id: "uCJ+gT",
+      })}
+      data={{
+        metadata: mapFieldArrayToMetadataInput(metadataFields),
+        privateMetadata: mapFieldArrayToMetadataInput(privateMetadataFields),
+      }}
+      onChange={handleChange}
+      loading={submitInProgress}
+      errors={{
+        metadata: metadataErrors.length ? metadataErrors.join(", ") : undefined,
+        privateMetadata: privateMetadataErrors.length
+          ? privateMetadataErrors.join(", ")
+          : undefined,
+      }}
+      formIsDirty={formIsDirty}
+    />
+  );
+};

--- a/src/modeling/ripples/modelMetadata.ts
+++ b/src/modeling/ripples/modelMetadata.ts
@@ -1,0 +1,14 @@
+import { type Ripple } from "@dashboard/ripples/types";
+
+export const rippleModelMetadata: Ripple = {
+  type: "improvement",
+  ID: "model-metadata-header",
+  TTL_seconds: 60 * 60 * 24 * 7,
+  dateAdded: new Date(2026, 5, 12),
+  content: {
+    oneLiner: "Model metadata in header",
+    contextual: "Model metadata is now edited from this button, which opens a dedicated dialog.",
+    global:
+      "Model metadata has moved from the bottom of the model page into a header button that opens a dedicated dialog. Public and private metadata are easier to find and edit without scrolling past other sections.",
+  },
+};

--- a/src/modeling/urls.test.ts
+++ b/src/modeling/urls.test.ts
@@ -1,0 +1,32 @@
+import { pageListPath, pageListUrlWithPageType } from "./urls";
+
+describe("pageListUrlWithPageType", () => {
+  it("returns pageListPath when model type is undefined", () => {
+    // Arrange & Act
+    const result = pageListUrlWithPageType(undefined);
+
+    // Assert
+    expect(result).toBe(pageListPath);
+  });
+
+  it("returns pageListPath when model type id is missing", () => {
+    // Arrange & Act
+    const result = pageListUrlWithPageType({ id: "" });
+
+    // Assert
+    expect(result).toBe(pageListPath);
+  });
+
+  it("builds URL filtered by model type id", () => {
+    // Arrange
+    const pageType = { id: "UGFnZVR5cGU6MQ==" };
+
+    // Act
+    const result = pageListUrlWithPageType(pageType);
+
+    // Assert
+    expect(result).toContain("/models/");
+    expect(result).toContain("pageTypes");
+    expect(decodeURIComponent(result)).toContain(pageType.id);
+  });
+});

--- a/src/modeling/urls.ts
+++ b/src/modeling/urls.ts
@@ -41,6 +41,17 @@ export type PageListUrlQueryParams = BulkAction &
 export const pageListUrl = (params?: PageListUrlQueryParams) =>
   pageListPath + "?" + stringifyQs(params);
 
+/**
+ * Builds the model list URL pre-filtered by a single model type.
+ */
+export const pageListUrlWithPageType = (pageType?: { id: string }) => {
+  if (!pageType?.id) {
+    return pageListPath;
+  }
+
+  return pageListUrl({ pageTypes: [pageType.id] });
+};
+
 export const pagePath = (id: string) => urlJoin(modelingSection, id);
 type PageUrlDialog = "remove" | "assign-attribute-value" | "view-metadata";
 interface PageCreateUrlPageType {

--- a/src/modeling/urls.ts
+++ b/src/modeling/urls.ts
@@ -42,7 +42,7 @@ export const pageListUrl = (params?: PageListUrlQueryParams) =>
   pageListPath + "?" + stringifyQs(params);
 
 export const pagePath = (id: string) => urlJoin(modelingSection, id);
-type PageUrlDialog = "remove" | "assign-attribute-value";
+type PageUrlDialog = "remove" | "assign-attribute-value" | "view-metadata";
 interface PageCreateUrlPageType {
   "page-type-id"?: string;
 }

--- a/src/modeling/views/PageCreate.tsx
+++ b/src/modeling/views/PageCreate.tsx
@@ -117,6 +117,7 @@ const PageCreate = ({ params }: PageCreateProps) => {
   const attributeValues = mapEdgesToItems(searchAttributeValuesOpts?.data?.attribute.choices) || [];
   const [uploadFile, uploadFileOpts] = useFileUploadMutation({});
   const [pageCreate, pageCreateOpts] = usePageCreateMutation({
+    disableErrorHandling: true,
     onCompleted: data => {
       if (data.pageCreate.errors.length === 0) {
         notify({

--- a/src/modeling/views/PageDetails.tsx
+++ b/src/modeling/views/PageDetails.tsx
@@ -226,8 +226,8 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
         saveButtonBarState={pageUpdateOpts.status}
         page={pageDetails.data?.page}
         attributeValues={attributeValues}
-        onRemove={() => openModal("remove")}
-        onShowMetadata={() => openModal("view-metadata")}
+        onRemove={() => openModal("remove", { id: undefined })}
+        onShowMetadata={() => openModal("view-metadata", { id: undefined })}
         onSubmit={handleUpdate}
         assignReferencesAttributeId={params.action === "assign-attribute-value" && params.id}
         onAssignReferencesClick={handleAssignAttributeReferenceClick}
@@ -253,6 +253,7 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
         open={params.action === "view-metadata" && !!pageDetails.data?.page}
         onClose={closeModal}
         page={pageDetails.data?.page}
+        refetchPage={pageDetails.refetch}
       />
       <ActionDialog
         open={params.action === "remove"}

--- a/src/modeling/views/PageDetails.tsx
+++ b/src/modeling/views/PageDetails.tsx
@@ -90,7 +90,9 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
     },
   });
   const [uploadFile, uploadFileOpts] = useFileUploadMutation({});
-  const [pageUpdate, pageUpdateOpts] = usePageUpdateMutation({});
+  const [pageUpdate, pageUpdateOpts] = usePageUpdateMutation({
+    disableErrorHandling: true,
+  });
   const [deleteAttributeValue, deleteAttributeValueOpts] = useAttributeValueDeleteMutation({});
   const [pageRemove, pageRemoveOpts] = usePageRemoveMutation({
     onCompleted: data => {

--- a/src/modeling/views/PageDetails.tsx
+++ b/src/modeling/views/PageDetails.tsx
@@ -25,8 +25,6 @@ import {
   usePageDetailsQuery,
   usePageRemoveMutation,
   usePageUpdateMutation,
-  useUpdateMetadataMutation,
-  useUpdatePrivateMetadataMutation,
 } from "@dashboard/graphql";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { useNotifier } from "@dashboard/hooks/useNotifier";
@@ -37,7 +35,7 @@ import {
   useReferenceProductSearch,
 } from "@dashboard/searches/useReferenceSearch";
 import useAttributeValueSearchHandler from "@dashboard/utils/handlers/attributeValueSearchHandler";
-import createMetadataUpdateHandler from "@dashboard/utils/handlers/metadataUpdateHandler";
+import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
 import { getParsedDataForJsonStringField } from "@dashboard/utils/richText/misc";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -46,6 +44,7 @@ import { useAssignAttributeValueDialogFilterChangeHandlers } from "../../compone
 import { getStringOrPlaceholder, maybe } from "../../misc";
 import PageDetailsPage from "../components/PageDetailsPage";
 import { type PageData, type PageSubmitData } from "../components/PageDetailsPage/form";
+import { PageMetadataDialog } from "../components/PageMetadataDialog/PageMetadataDialog";
 import { pageListUrl, pageUrl, type PageUrlQueryParams } from "../urls";
 import { getAttributeInputFromPage } from "../utils/data";
 
@@ -79,8 +78,11 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
   const navigate = useNavigator();
   const notify = useNotifier();
   const intl = useIntl();
-  const [updateMetadata] = useUpdateMetadataMutation({});
-  const [updatePrivateMetadata] = useUpdatePrivateMetadataMutation({});
+  const [openModal, closeModal] = createDialogActionHandlers(
+    navigate,
+    dialogParams => pageUrl(id, dialogParams),
+    params,
+  );
   const pageDetails = usePageDetailsQuery({
     variables: {
       id,
@@ -102,13 +104,7 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
     },
   });
   const handleAssignAttributeReferenceClick = (attribute: AttributeInput) =>
-    navigate(
-      pageUrl(id, {
-        ...params,
-        action: "assign-attribute-value",
-        id: attribute.id,
-      }),
-    );
+    openModal("assign-attribute-value", { id: attribute.id });
   const handleUpdate = async (data: PageSubmitData) => {
     let errors: Array<AttributeErrorFragment | UploadErrorFragment | PageErrorFragment> = [];
 
@@ -142,12 +138,6 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
 
     return errors;
   };
-  const handleSubmit = createMetadataUpdateHandler(
-    pageDetails.data?.page,
-    handleUpdate,
-    variables => updateMetadata({ variables }),
-    variables => updatePrivateMetadata({ variables }),
-  );
   const refAttr =
     params.action === "assign-attribute-value" && params.id
       ? pageDetails?.data?.page?.attributes?.find(a => a.attribute.id === params.id)?.attribute
@@ -234,14 +224,9 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
         saveButtonBarState={pageUpdateOpts.status}
         page={pageDetails.data?.page}
         attributeValues={attributeValues}
-        onRemove={() =>
-          navigate(
-            pageUrl(id, {
-              action: "remove",
-            }),
-          )
-        }
-        onSubmit={handleSubmit}
+        onRemove={() => openModal("remove")}
+        onShowMetadata={() => openModal("view-metadata")}
+        onSubmit={handleUpdate}
         assignReferencesAttributeId={params.action === "assign-attribute-value" && params.id}
         onAssignReferencesClick={handleAssignAttributeReferenceClick}
         referencePages={mapEdgesToItems(searchPagesOpts?.data?.search) || []}
@@ -258,9 +243,14 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
         fetchMoreReferenceCollections={fetchMoreReferenceCollections}
         fetchAttributeValues={searchAttributeValues}
         fetchMoreAttributeValues={fetchMoreAttributeValues}
-        onCloseDialog={() => navigate(pageUrl(id))}
+        onCloseDialog={closeModal}
         onAttributeSelectBlur={searchAttributeReset}
         onFilterChange={onFilterChange}
+      />
+      <PageMetadataDialog
+        open={params.action === "view-metadata" && !!pageDetails.data?.page}
+        onClose={closeModal}
+        page={pageDetails.data?.page}
       />
       <ActionDialog
         open={params.action === "remove"}
@@ -270,7 +260,7 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
           defaultMessage: "Delete model",
           description: "dialog header",
         })}
-        onClose={() => navigate(pageUrl(id))}
+        onClose={closeModal}
         onConfirm={() => pageRemove({ variables: { id } })}
         variant="delete"
       >

--- a/src/ripples/allRipples.ts
+++ b/src/ripples/allRipples.ts
@@ -5,6 +5,7 @@ import { rippleCustomerOverview } from "@dashboard/customers/ripples/customerOve
 import { rippleNewCustomersView } from "@dashboard/customers/ripples/newCustomersView";
 import { rippleAppProblems } from "@dashboard/extensions/ripples/appProblems";
 import { rippleHomeWidgets } from "@dashboard/home/ripples/homeWidgets";
+import { rippleModelMetadata } from "@dashboard/modeling/ripples/modelMetadata";
 import { rippleModelTypeTabs } from "@dashboard/modeling/ripples/modelTypeTabs";
 import { ripplePagesAreModels } from "@dashboard/modeling/ripples/pagesAreModels";
 import { rippleDraftOrderMetadata } from "@dashboard/orders/ripples/draftOrderMetadata";
@@ -31,6 +32,7 @@ export const allRipples: Ripple[] = [
   // Modelling / pages
   ripplePagesAreModels,
   rippleModelTypeTabs,
+  rippleModelMetadata,
 
   // Orders
   rippleNewRefundReasons,

--- a/src/utils/errors/page.ts
+++ b/src/utils/errors/page.ts
@@ -19,6 +19,11 @@ const messages = defineMessages({
     defaultMessage: "This name is already taken. Please provide another.",
     description: "error message",
   },
+  slugAlreadyTaken: {
+    id: "e/f4WI",
+    defaultMessage: "Model with this slug already exists. Please provide another.",
+    description: "error message when model slug is not unique",
+  },
   notFound: {
     id: "PCoO4D",
     defaultMessage: "Page not found.",
@@ -33,6 +38,10 @@ function getPageErrorMessage(
   if (err) {
     switch (err.code) {
       case PageErrorCode.UNIQUE:
+        if (err.field === "slug") {
+          return intl.formatMessage(messages.slugAlreadyTaken);
+        }
+
         return intl.formatMessage(messages.nameAlreadyTaken);
       case PageErrorCode.ATTRIBUTE_ALREADY_ASSIGNED:
         return intl.formatMessage(messages.attributeAlreadyAssigned);

--- a/src/utils/handlers/metadataUpdateHandler.ts
+++ b/src/utils/handlers/metadataUpdateHandler.ts
@@ -38,9 +38,11 @@ function createMetadataUpdateHandler<TData extends MetadataFormData, TError>(
 ) {
   return async (data: TData): Promise<Array<MetadataErrorFragment | TError>> => {
     const errors = await update(data);
-    const hasMetadataChanged = !areMetadataArraysEqual(initial.metadata, data.metadata);
+    const initialMetadata = initial.metadata ?? [];
+    const initialPrivateMetadata = initial.privateMetadata ?? [];
+    const hasMetadataChanged = !areMetadataArraysEqual(initialMetadata, data.metadata);
     const hasPrivateMetadataChanged = !areMetadataArraysEqual(
-      initial.privateMetadata,
+      initialPrivateMetadata,
       data.privateMetadata,
     );
 
@@ -48,9 +50,9 @@ function createMetadataUpdateHandler<TData extends MetadataFormData, TError>(
       return errors;
     }
 
-    if (errors?.length === 0) {
+    if (!errors?.length) {
       if (data.metadata && hasMetadataChanged) {
-        const initialKeys = initial.metadata.map(m => m.key);
+        const initialKeys = initialMetadata.map(m => m.key);
         const modifiedKeys = data.metadata.map(m => m.key);
         const keyDiff = arrayDiff(initialKeys, modifiedKeys);
         const metadataInput = filterMetadataArray(data.metadata);
@@ -73,7 +75,7 @@ function createMetadataUpdateHandler<TData extends MetadataFormData, TError>(
       }
 
       if (data.privateMetadata && hasPrivateMetadataChanged) {
-        const initialKeys = initial.privateMetadata.map(m => m.key);
+        const initialKeys = initialPrivateMetadata.map(m => m.key);
         const modifiedKeys = data.privateMetadata.map(m => m.key);
         const keyDiff = arrayDiff(initialKeys, modifiedKeys);
         const privateMetadataInput = filterMetadataArray(data.privateMetadata);


### PR DESCRIPTION
Aligns model detail pages with products/orders: metadata moves to a header modal, model type shows in the header, duplicate slug errors are inline only, plus a what's-new ripple on the metadata button.

### New
<img width="1795" height="961" alt="image" src="https://github.com/user-attachments/assets/243f75eb-defd-47c4-9277-c5b9fe96b13f" />


### Old
<img width="1795" height="961" alt="image" src="https://github.com/user-attachments/assets/4d0148d2-d551-4115-98c3-e5430e87b710" />
