### PR TITLE
fix: simplify incomplete translations copy

### DIFF
--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -7844,7 +7844,7 @@
     "string": "Not set"
   },
   "e822us": {
-    "string": "Please note, while all currency and date adjustments are complete, language translations are at varying degrees of completion."
+    "string": "Note: some languages might have incomplete translations that will be displayed in English."
   },
   "e8O72h": {
     "context": "password login mode option",

--- a/src/staff/components/StaffPreferences/StaffPreferences.tsx
+++ b/src/staff/components/StaffPreferences/StaffPreferences.tsx
@@ -64,7 +64,7 @@ export const StaffPreferences = ({ locale, onLocaleChange }: StaffPreferencesPro
         <Text>
           <FormattedMessage
             id="e822us"
-            defaultMessage="Please note, while all currency and date adjustments are complete, language translations are at varying degrees of completion."
+            defaultMessage="Note: some languages might have incomplete translations that will be displayed in English."
           />
         </Text>
       </DashboardCard.Content>


### PR DESCRIPTION
## Summary
- simplify the language translation notice on staff preferences
- keep the generated default messages catalog in sync

Fixes #4409