### PR TITLE
fix(nginx): add referrer-policy header

### DIFF
--- a/.changeset/fancy-canyons-jump.md
+++ b/.changeset/fancy-canyons-jump.md
@@ -1,0 +1,6 @@
+---
+"saleor-dashboard": patch
+---
+
+Added `Referrer-Policy: origin-when-cross-origin` header to the
+NGINX config bundled inside the container image.

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -3,6 +3,8 @@ server {
     server_name  localhost;
     root   /app/dashboard/;
 
+    add_header Referrer-Policy origin-when-cross-origin;
+
     location / {
         alias /app/dashboard/;
         index  index.html;


### PR DESCRIPTION
_Backport of 64211cc38d4cd1ec8dc6979b86c68bfc6dcfad05 (#6637)_

This adds `Referrer-Policy: origin-when-cross-origin` to the Dashboard's HTTP headers in order to tell browsers that they should always pass the `Referer` header when performing cross-origin requests.

Without that header, browsers with a stricter default referrer policy (`Referrer-Policy: same-origin`) would cause apps to not work (for example, authenticated GraphQL queries would fail due to the AppBridge handshake never being performed)

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
