### PR TITLE
Fix exit prompt when assigning reference attribute values

### DIFF
--- a/.changeset/reference-attribute-exit-prompt.md
+++ b/.changeset/reference-attribute-exit-prompt.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+**Fix spurious "Leave without saving changes?" prompt when assigning reference attribute values**
+
+Assigning a value to a reference attribute (e.g. choosing a Collection, Category, Product or Model) on a detail page with unsaved changes no longer triggers the "Leave without saving changes?" exit prompt. Opening and closing URL-driven dialogs (such as the "Assign Collection" modal) is now correctly treated as part of editing the form rather than navigating away from it, so the modal closes cleanly and your changes stay ready to save. This also fixes the same prompt appearing for other URL-driven modals (metadata, remove confirmations, etc.) across Models, Products, Orders and similar detail pages.

--- a/src/components/Form/useExitFormDialog.test.tsx
+++ b/src/components/Form/useExitFormDialog.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 
 import { ExitFormDialogContext } from "./ExitFormDialogProvider";
 import { useExitFormDialog } from "./useExitFormDialog";
-import { useExitFormDialogProvider } from "./useExitFormDialogProvider";
+import { isDialogOnlyQueryChange, useExitFormDialogProvider } from "./useExitFormDialogProvider";
 
 jest.mock("../../hooks/useNotifier", () => ({
   useNotifier: () => jest.fn(),
@@ -107,6 +107,61 @@ describe("useExitFormDialog", () => {
 
     // Then
     expect(result.current.exit.shouldBlockNavigation()).toBe(true);
+    expect(result.current.history.location.search).toBe("");
+  });
+  it("allows opening a dialog (action query param) on same pathname when form is dirty", async () => {
+    // Given
+    const submitFn = jest.fn(() => Promise.resolve([]));
+    const { result } = setup(submitFn);
+
+    // When
+    act(() => {
+      result.current.form.change({
+        target: { name: "field", value: "something" },
+      });
+    });
+    act(() => {
+      result.current.history.push("/?action=assign-attribute-value&id=123");
+    });
+
+    // Then - modal opens, no exit prompt, form stays dirty
+    expect(result.current.exit.shouldBlockNavigation()).toBe(false);
+    expect(result.current.history.location.search).toBe("?action=assign-attribute-value&id=123");
+  });
+  it("allows closing a dialog (clearing action query params) on same pathname when form is dirty", async () => {
+    // Given - start with an open dialog
+    const submitFn = jest.fn(() => Promise.resolve([]));
+    const { result } = renderHook(
+      () => {
+        const form = useForm({ field: "" }, submitFn, { confirmLeave: true });
+        const exit = useExitFormDialog();
+        const history = useHistory();
+
+        return { form, exit, history };
+      },
+      {
+        wrapper: ({ children }) => (
+          <MemoryRouter
+            initialEntries={[{ pathname: "/", search: "?action=assign-attribute-value&id=123" }]}
+          >
+            <MockExitFormDialogProvider>{children}</MockExitFormDialogProvider>
+          </MemoryRouter>
+        ),
+      },
+    );
+
+    // When - assigning marks the form dirty and then closes the dialog
+    act(() => {
+      result.current.form.change({
+        target: { name: "field", value: "something" },
+      });
+    });
+    act(() => {
+      result.current.history.replace("/");
+    });
+
+    // Then - dialog closes without an exit prompt
+    expect(result.current.exit.shouldBlockNavigation()).toBe(false);
     expect(result.current.history.location.search).toBe("");
   });
   it("allows query navigation on same pathname when form is clean", async () => {
@@ -316,5 +371,39 @@ describe("useExitFormDialog", () => {
     // Assert - must stay on single-field edit, not revert to bulk query
     expect(provider?.showDialog).toBe(true);
     expect(result.current.history.location.search).toBe("?activeField=name");
+  });
+});
+
+describe("isDialogOnlyQueryChange", () => {
+  it("treats opening a dialog as a dialog-only change", () => {
+    expect(isDialogOnlyQueryChange("", "?action=assign-attribute-value&id=123")).toBe(true);
+  });
+  it("treats closing a dialog as a dialog-only change", () => {
+    expect(isDialogOnlyQueryChange("?action=assign-attribute-value&id=123", "")).toBe(true);
+  });
+  it("ignores ordering of preserved params", () => {
+    expect(
+      isDialogOnlyQueryChange(
+        "?activeField=name&action=remove&id=1",
+        "?action=assign-attribute-value&activeField=name",
+      ),
+    ).toBe(true);
+  });
+  it("does not treat a bulk mode change as a dialog-only change", () => {
+    expect(isDialogOnlyQueryChange("", "?bulk=1")).toBe(false);
+  });
+  it("does not treat an inline-edit (activeField) change as a dialog-only change", () => {
+    expect(isDialogOnlyQueryChange("", "?activeField=name")).toBe(false);
+  });
+  it("does not treat a change in a non-dialog param as a dialog-only change", () => {
+    expect(isDialogOnlyQueryChange("?activeField=name", "?activeField=price")).toBe(false);
+  });
+  it("does not treat a simultaneous dialog and non-dialog param change as a dialog-only change", () => {
+    expect(isDialogOnlyQueryChange("?activeField=name", "?activeField=price&action=remove")).toBe(
+      false,
+    );
+  });
+  it("does not treat an identical query string as a dialog-only change", () => {
+    expect(isDialogOnlyQueryChange("?action=remove&id=1", "?action=remove&id=1")).toBe(false);
   });
 });

--- a/src/components/Form/useExitFormDialogProvider.tsx
+++ b/src/components/Form/useExitFormDialogProvider.tsx
@@ -1,11 +1,59 @@
 // @ts-strict-ignore
 import { type SubmitPromise } from "@dashboard/hooks/useForm";
+import { parseQs } from "@dashboard/url-utils";
+import { stringifyQs } from "@dashboard/utils/urls";
 import { type Action, type Location } from "history";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useHistory } from "react-router";
 import useRouter from "use-react-router";
 
 import { type ExitFormDialogData, type FormData, type FormsData } from "./types";
+
+// Query params used solely to drive URL-based dialogs/modals (see
+// `createDialogActionHandlers`). Toggling these opens/closes a modal on the
+// same page and must never trigger the "leave without saving" prompt.
+const DIALOG_QUERY_PARAMS = ["action", "id", "ids"];
+
+// Stringifies with keys sorted so two equivalent query objects with different
+// key ordering produce the same string and compare equal.
+const sortedStringify = (params: Record<string, unknown>): string => {
+  const sorted: Record<string, unknown> = {};
+
+  Object.keys(params)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach(key => {
+      sorted[key] = params[key];
+    });
+
+  return stringifyQs(sorted);
+};
+
+const splitDialogParams = (search: string) => {
+  const parsed = parseQs(search.startsWith("?") ? search.slice(1) : search);
+  const dialog: Record<string, unknown> = {};
+  const rest: Record<string, unknown> = {};
+
+  Object.keys(parsed).forEach(key => {
+    if (DIALOG_QUERY_PARAMS.includes(key)) {
+      dialog[key] = parsed[key];
+    } else {
+      rest[key] = parsed[key];
+    }
+  });
+
+  return { dialog: sortedStringify(dialog), rest: sortedStringify(rest) };
+};
+
+// Returns true when a transition only opens or closes a URL-driven modal:
+// the dialog params change while every other query param stays the same.
+// Navigating to an identical or differently-scoped location is not treated
+// as a dialog toggle, so the regular exit-prompt logic still applies there.
+export const isDialogOnlyQueryChange = (currentSearch: string, nextSearch: string): boolean => {
+  const current = splitDialogParams(currentSearch);
+  const next = splitDialogParams(nextSearch);
+
+  return current.rest === next.rest && current.dialog !== next.dialog;
+};
 
 const defaultValues = {
   isDirty: false,
@@ -165,6 +213,14 @@ export function useExitFormDialogProvider() {
       // needs to be done before the shouldBlockNav condition
       // so it doesn't trigger setting default values
       if (isOnlyQuerying(transition)) {
+        // Opening/closing a URL-driven modal (dialog params only) is part of
+        // editing the form, not leaving it, so it must never be blocked.
+        if (isDialogOnlyQueryChange(currentLocation.current.search, transition.search)) {
+          setCurrentLocation(transition);
+
+          return null;
+        }
+
         if (shouldBlockNavRef.current()) {
           navAction.current = transition;
           lastBlockedAction.current = action;


### PR DESCRIPTION
URL-driven modals (e.g. "Assign Collection") open/close by changing query params on the same path. The exit-form provider blocked any same-path query change on a dirty form, so opening or saving from these modals wrongly triggered the "Leave without saving changes?" prompt.

Exempt transitions that only toggle dialog params (action/id/ids) while all other params stay identical. Genuine navigations and bulk/inline-edit query changes still prompt as before. Fixes the issue across all URL-driven modals (reference attributes, metadata, remove, etc.).