### PR TITLE
ci: diff-based dependency audit + nightly main audit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-lock:
+  # Runs `pnpm audit` on both the PR and `main`, then fails ONLY on advisories
+  # the PR introduces. Pre-existing vulnerabilities on `main` no longer turn
+  # every PR red - those are tracked by the nightly `nightly-audit.yml` instead.
+  audit-lock:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write # for the sticky PR comment (same-repo PRs only)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -25,8 +31,56 @@ jobs:
           node-version-file: "package.json"
           # Don't cache in this job as we don't install dependencies
 
-      - name: Audit dependencies
-        run: pnpm audit --audit-level moderate
+      # `pnpm audit` exits non-zero whenever it finds anything, so swallow the
+      # exit code here (`|| true`) and let the diff script own the pass/fail.
+      - name: Audit PR dependencies
+        run: pnpm audit --json > pr-audit.json || true
+
+      - name: Check out main's lockfile as the baseline
+        run: |
+          git fetch --depth=1 origin main
+          # Restore the consistent trio so the lockfile is not out of sync.
+          git checkout FETCH_HEAD -- pnpm-lock.yaml package.json pnpm-workspace.yaml
+
+      - name: Audit main (baseline) dependencies
+        run: pnpm audit --json > main-audit.json || true
+
+      - name: Diff audits
+        id: diff
+        # `--fail-open` keeps registry/network hiccups from blocking PRs; the
+        # nightly audit (fail-closed) is the backstop. Don't fail the step here -
+        # the explicit "Fail" step below gates on the `introduced` output.
+        continue-on-error: true
+        run: >-
+          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/audit-diff.ts diff
+          --base main-audit.json --head pr-audit.json --level moderate --fail-open
+          --comment-file audit-comment.md
+
+      - name: Comment on PR with introduced vulnerabilities
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.diff.outputs.introduced == 'true'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: audit-lock
+          path: audit-comment.md
+
+      - name: Remove stale audit comment when resolved
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          steps.diff.outputs.introduced != 'true'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: audit-lock
+          delete: true
+
+      - name: Fail if the PR introduces new vulnerabilities
+        if: steps.diff.outputs.introduced == 'true'
+        run: |
+          echo "::error::This PR introduces new moderate+ vulnerabilities. See the job summary."
+          exit 1
 
   tsc-and-linters:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-audit.yml
+++ b/.github/workflows/nightly-audit.yml
@@ -1,0 +1,40 @@
+name: Nightly dependency audit
+
+# Audits `main` for known vulnerabilities and fails (red) when any moderate+
+# advisory is present, so the recurring failure surfaces them. The full report
+# is written to the job summary. PRs are gated separately by `audit-lock` in
+# `main.yml`, which only fails on vulnerabilities a PR *introduces*; this job is
+# the dedicated place where pre-existing `main` vulnerabilities stay visible.
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # 04:30 UTC daily - off the top of the hour to dodge scheduler congestion.
+    - cron: "30 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  audit-main:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: "package.json"
+          # Don't cache in this job as we don't install dependencies
+
+      # `pnpm audit` exits non-zero whenever it finds anything; the report
+      # script owns the pass/fail decision instead.
+      - name: Audit dependencies
+        run: pnpm audit --json > main-audit.json || true
+
+      # No --fail-open: this job is the backstop, so an unreadable audit should
+      # fail loudly rather than hide a problem.
+      - name: Report vulnerabilities
+        run: >-
+          node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/audit-diff.ts report
+          --input main-audit.json --level moderate

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test-storybook:coverage": "vitest --project=storybook --coverage",
     "test:ci": "CI=true jest --coverage --silent && pnpm run test:lint-rules",
     "test:debug": "DEBUG_PRINT_LIMIT=20000 jest",
-    "test:lint-rules": "node lint/rules/named-styles.test.mjs && node lint/rules/named-effects.test.mjs && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-changesets.test.ts",
+    "test:lint-rules": "node lint/rules/named-styles.test.mjs && node lint/rules/named-effects.test.mjs && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-changesets.test.ts && node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/audit-diff.test.ts",
     "test:quiet": "jest --silent",
     "test:watch": "jest --watch",
     "update-payment-assets": "node scripts/update-payment-assets.cjs"

--- a/scripts/audit-diff.test.ts
+++ b/scripts/audit-diff.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert";
+
+import {
+  type Advisory,
+  diffIntroduced,
+  filterBySeverity,
+  meetsThreshold,
+  parseAudit,
+  renderTable,
+  severityRank,
+  sortBySeverity,
+} from "./audit-diff.ts";
+
+// Arrange / Act / Assert
+
+// Builds a minimal `pnpm audit --json` payload for the given advisories.
+function auditJson(advisories: Array<Partial<Record<string, unknown>> & { id: number }>): string {
+  const map: Record<string, unknown> = {};
+
+  for (const advisory of advisories) {
+    map[String(advisory.id)] = advisory;
+  }
+
+  return JSON.stringify({ advisories: map });
+}
+
+// parseAudit keys advisories on the GHSA id when present
+{
+  const advisories = parseAudit(
+    auditJson([
+      {
+        id: 1115393,
+        github_advisory_id: "GHSA-v3rj-xjv7-4jmq",
+        severity: "moderate",
+        module_name: "smol-toml",
+        title: "DoS via TOML",
+        url: "https://github.com/advisories/GHSA-v3rj-xjv7-4jmq",
+        vulnerable_versions: "<1.6.1",
+        patched_versions: ">=1.6.1",
+      },
+    ]),
+  );
+
+  assert.strictEqual(advisories.length, 1);
+  assert.strictEqual(advisories[0].key, "GHSA-v3rj-xjv7-4jmq");
+  assert.strictEqual(advisories[0].severity, "moderate");
+  assert.strictEqual(advisories[0].module, "smol-toml");
+}
+
+// parseAudit falls back to the numeric id when GHSA is missing
+{
+  const advisories = parseAudit(auditJson([{ id: 42, severity: "high", module_name: "foo" }]));
+
+  assert.strictEqual(advisories[0].key, "42");
+  assert.strictEqual(advisories[0].ghsa, null);
+}
+
+// parseAudit treats an empty advisories object (no vulns) as an empty list
+{
+  assert.deepStrictEqual(parseAudit(JSON.stringify({ advisories: {} })), []);
+}
+
+// parseAudit throws on JSON missing the advisories object (so callers can fail open/closed)
+{
+  assert.throws(() => parseAudit(JSON.stringify({ metadata: {} })));
+  assert.throws(() => parseAudit("not json"));
+}
+
+// severityRank orders info < low < moderate < high < critical, unknown highest
+{
+  assert.ok(severityRank("low") < severityRank("moderate"));
+  assert.ok(severityRank("moderate") < severityRank("high"));
+  assert.ok(severityRank("high") < severityRank("critical"));
+  assert.ok(severityRank("unknown") > severityRank("critical"));
+}
+
+// meetsThreshold is inclusive of the threshold and excludes lower severities
+{
+  assert.strictEqual(meetsThreshold("moderate", "moderate"), true);
+  assert.strictEqual(meetsThreshold("high", "moderate"), true);
+  assert.strictEqual(meetsThreshold("low", "moderate"), false);
+  assert.strictEqual(meetsThreshold("info", "moderate"), false);
+}
+
+// diffIntroduced returns only advisories present in head but not in base
+{
+  const base = parseAudit(auditJson([{ id: 1, github_advisory_id: "GHSA-aaa", severity: "high" }]));
+  const head = parseAudit(
+    auditJson([
+      { id: 1, github_advisory_id: "GHSA-aaa", severity: "high" }, // pre-existing on main
+      { id: 2, github_advisory_id: "GHSA-bbb", severity: "critical" }, // introduced by PR
+    ]),
+  );
+
+  const introduced = diffIntroduced(head, base);
+
+  assert.strictEqual(introduced.length, 1);
+  assert.strictEqual(introduced[0].key, "GHSA-bbb");
+}
+
+// diffIntroduced ignores advisories removed by the PR and pre-existing ones
+{
+  const base = parseAudit(
+    auditJson([
+      { id: 1, github_advisory_id: "GHSA-aaa", severity: "high" },
+      { id: 2, github_advisory_id: "GHSA-bbb", severity: "moderate" },
+    ]),
+  );
+  const head = parseAudit(auditJson([{ id: 1, github_advisory_id: "GHSA-aaa", severity: "high" }]));
+
+  // Act / Assert: nothing introduced even though head differs from base
+  assert.deepStrictEqual(diffIntroduced(head, base), []);
+}
+
+// filterBySeverity drops advisories below the threshold
+{
+  const advisories = parseAudit(
+    auditJson([
+      { id: 1, github_advisory_id: "GHSA-low", severity: "low" },
+      { id: 2, github_advisory_id: "GHSA-mod", severity: "moderate" },
+      { id: 3, github_advisory_id: "GHSA-crit", severity: "critical" },
+    ]),
+  );
+
+  const filtered = filterBySeverity(advisories, "moderate");
+
+  assert.deepStrictEqual(filtered.map(a => a.key).sort(), ["GHSA-crit", "GHSA-mod"]);
+}
+
+// sortBySeverity puts critical first, then breaks ties by module name
+{
+  const advisories: Advisory[] = parseAudit(
+    auditJson([
+      { id: 1, github_advisory_id: "GHSA-1", severity: "moderate", module_name: "b-mod" },
+      { id: 2, github_advisory_id: "GHSA-2", severity: "critical", module_name: "z-crit" },
+      { id: 3, github_advisory_id: "GHSA-3", severity: "moderate", module_name: "a-mod" },
+    ]),
+  );
+
+  assert.deepStrictEqual(
+    sortBySeverity(advisories).map(a => a.module),
+    ["z-crit", "a-mod", "b-mod"],
+  );
+}
+
+// renderTable returns empty string for no advisories and a markdown table otherwise
+{
+  assert.strictEqual(renderTable([]), "");
+
+  const table = renderTable(
+    parseAudit(
+      auditJson([
+        {
+          id: 1,
+          github_advisory_id: "GHSA-xyz",
+          severity: "high",
+          module_name: "ws",
+          title: "Vuln | with pipe",
+          url: "https://example.com/GHSA-xyz",
+        },
+      ]),
+    ),
+  );
+
+  assert.ok(table.includes("| Severity | Package |"));
+  assert.ok(table.includes("[GHSA-xyz](https://example.com/GHSA-xyz)"));
+  // Pipe characters in titles must be escaped so they don't break the table
+  assert.ok(table.includes("Vuln \\| with pipe"));
+}
+
+console.log("✔ audit-diff.test.ts: all assertions passed");

--- a/scripts/audit-diff.ts
+++ b/scripts/audit-diff.ts
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+
+/**
+ * Compares `pnpm audit --json` results to decide whether a change introduces
+ * NEW vulnerabilities, and renders a human-readable report.
+ *
+ * Why this exists: a plain `pnpm audit` on a PR is red whenever `main` already
+ * has a vulnerable (usually transitive) dependency, so every PR looked broken
+ * even when it changed nothing security-relevant. This script diffs the PR's
+ * advisories against `main`'s and only fails on advisories the PR INTRODUCED.
+ *
+ * Two modes (both read `pnpm audit --json` output saved to files):
+ *
+ *   # PR gate - fail only on advisories present in head but not in base
+ *   node scripts/audit-diff.ts diff --base main.json --head pr.json
+ *
+ *   # Nightly report - fail on any advisory at/above the threshold
+ *   node scripts/audit-diff.ts report --input main.json
+ *
+ * Flags:
+ *   --level <severity>   minimum severity that fails the run (default: moderate)
+ *   --fail-open          on unreadable/invalid input, warn and exit 0 instead
+ *                        of failing (used by the PR gate so registry/network
+ *                        hiccups don't block unrelated PRs)
+ *
+ * Executed directly by Node's TypeScript type stripping (Node >= 24).
+ */
+
+import fs from "node:fs";
+
+export type Severity = "info" | "low" | "moderate" | "high" | "critical" | "unknown";
+
+/** Ordered from least to most severe; index doubles as the comparable rank. */
+const SEVERITY_ORDER: Severity[] = ["info", "low", "moderate", "high", "critical"];
+
+export interface Advisory {
+  /** Stable identity used for the set difference (GHSA, falling back to id). */
+  key: string;
+  ghsa: string | null;
+  severity: Severity;
+  module: string;
+  title: string;
+  url: string;
+  vulnerableVersions: string;
+  patchedVersions: string;
+}
+
+interface RawAdvisory {
+  id?: number;
+  github_advisory_id?: string;
+  severity?: string;
+  module_name?: string;
+  title?: string;
+  url?: string;
+  vulnerable_versions?: string;
+  patched_versions?: string;
+}
+
+interface AuditJson {
+  advisories?: Record<string, RawAdvisory>;
+}
+
+function normalizeSeverity(value: string | undefined): Severity {
+  const lower = (value ?? "").toLowerCase();
+
+  return (SEVERITY_ORDER as string[]).includes(lower) ? (lower as Severity) : "unknown";
+}
+
+export function severityRank(severity: Severity): number {
+  const index = SEVERITY_ORDER.indexOf(severity);
+
+  // "unknown" sorts above everything so it is never silently ignored by a gate.
+  return index === -1 ? SEVERITY_ORDER.length : index;
+}
+
+export function meetsThreshold(severity: Severity, minimum: Severity): boolean {
+  return severityRank(severity) >= severityRank(minimum);
+}
+
+/**
+ * Parses `pnpm audit --json` output into a flat list of advisories.
+ *
+ * Throws on invalid JSON or a missing `advisories` object so callers can decide
+ * whether to fail open or closed. An empty `advisories` object (no vulns) is
+ * valid and yields an empty list.
+ */
+export function parseAudit(content: string): Advisory[] {
+  const data: AuditJson = JSON.parse(content);
+
+  if (typeof data !== "object" || data === null || typeof data.advisories !== "object") {
+    throw new Error("audit JSON is missing the `advisories` object");
+  }
+
+  return Object.entries(data.advisories ?? {}).map(([id, raw]) => {
+    const ghsa = raw.github_advisory_id ?? null;
+
+    return {
+      key: ghsa ?? String(raw.id ?? id),
+      ghsa,
+      severity: normalizeSeverity(raw.severity),
+      module: raw.module_name ?? "unknown",
+      title: raw.title ?? "",
+      url: raw.url ?? "",
+      vulnerableVersions: raw.vulnerable_versions ?? "",
+      patchedVersions: raw.patched_versions ?? "",
+    };
+  });
+}
+
+/** Advisories present in `head` whose key is absent from `base`. */
+export function diffIntroduced(head: Advisory[], base: Advisory[]): Advisory[] {
+  const baseKeys = new Set(base.map(advisory => advisory.key));
+
+  return head.filter(advisory => !baseKeys.has(advisory.key));
+}
+
+export function filterBySeverity(advisories: Advisory[], minimum: Severity): Advisory[] {
+  return advisories.filter(advisory => meetsThreshold(advisory.severity, minimum));
+}
+
+/** Sorts critical-first so the most urgent rows are read first. */
+export function sortBySeverity(advisories: Advisory[]): Advisory[] {
+  return [...advisories].sort((a, b) => {
+    const bySeverity = severityRank(b.severity) - severityRank(a.severity);
+
+    return bySeverity !== 0 ? bySeverity : a.module.localeCompare(b.module);
+  });
+}
+
+function countsBySeverity(advisories: Advisory[]): string {
+  const counts = new Map<Severity, number>();
+
+  for (const advisory of advisories) {
+    counts.set(advisory.severity, (counts.get(advisory.severity) ?? 0) + 1);
+  }
+
+  return [...SEVERITY_ORDER]
+    .reverse()
+    .concat("unknown")
+    .filter(severity => (counts.get(severity) ?? 0) > 0)
+    .map(severity => `${counts.get(severity)} ${severity}`)
+    .join(", ");
+}
+
+function advisoryLink(advisory: Advisory): string {
+  if (advisory.ghsa && advisory.url) {
+    return `[${advisory.ghsa}](${advisory.url})`;
+  }
+
+  return advisory.ghsa ?? advisory.url ?? "—";
+}
+
+/** Renders advisories as a GitHub-flavored markdown table, critical-first. */
+export function renderTable(advisories: Advisory[]): string {
+  if (advisories.length === 0) {
+    return "";
+  }
+
+  const header = "| Severity | Package | Advisory | Title | Vulnerable | Fixed in |";
+  const divider = "| --- | --- | --- | --- | --- | --- |";
+  const rows = sortBySeverity(advisories).map(advisory =>
+    [
+      advisory.severity,
+      `\`${advisory.module}\``,
+      advisoryLink(advisory),
+      advisory.title.replace(/\|/g, "\\|"),
+      `\`${advisory.vulnerableVersions || "—"}\``,
+      `\`${advisory.patchedVersions || "—"}\``,
+    ].join(" | "),
+  );
+
+  return [header, divider, ...rows.map(row => `| ${row} |`)].join("\n");
+}
+
+/** Appends markdown to the GitHub step summary, falling back to stdout. */
+function writeSummary(markdown: string): void {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${markdown}\n`);
+  }
+
+  console.log(markdown);
+}
+
+/** Appends a `name=value` pair to the GitHub Actions step output, if running in CI. */
+function writeOutput(name: string, value: string): void {
+  const outputPath = process.env.GITHUB_OUTPUT;
+
+  if (outputPath) {
+    fs.appendFileSync(outputPath, `${name}=${value}\n`);
+  }
+}
+
+function readArg(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+
+  return index !== -1 ? args[index + 1] : undefined;
+}
+
+function runDiff(args: string[], minimum: Severity, failOpen: boolean): number {
+  const basePath = readArg(args, "--base");
+  const headPath = readArg(args, "--head");
+
+  if (!basePath || !headPath) {
+    throw new Error("`diff` requires --base <file> and --head <file>");
+  }
+
+  const commentFile = readArg(args, "--comment-file");
+
+  let base: Advisory[];
+  let head: Advisory[];
+
+  try {
+    base = parseAudit(fs.readFileSync(basePath, "utf8"));
+    head = parseAudit(fs.readFileSync(headPath, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (failOpen) {
+      writeSummary(
+        `### ⚠️ Dependency audit skipped\n\nCould not run the audit diff (${message}). ` +
+          `Not blocking this PR; the nightly audit will re-check \`main\`.`,
+      );
+      writeOutput("introduced", "false");
+
+      return 0;
+    }
+
+    throw error;
+  }
+
+  const introduced = filterBySeverity(diffIntroduced(head, base), minimum);
+
+  writeOutput("introduced", introduced.length > 0 ? "true" : "false");
+
+  if (introduced.length === 0) {
+    writeSummary(
+      `### ✅ Dependency audit\n\nThis PR introduces no new ${minimum}+ vulnerabilities.`,
+    );
+
+    return 0;
+  }
+
+  const report =
+    `### ❌ Dependency audit: new vulnerabilities introduced\n\n` +
+    `This PR adds **${introduced.length}** ${minimum}+ advisory(ies) not present on \`main\` ` +
+    `(${countsBySeverity(introduced)}).\n\n${renderTable(introduced)}`;
+
+  writeSummary(report);
+
+  if (commentFile) {
+    fs.writeFileSync(commentFile, `${report}\n`);
+  }
+
+  return 1;
+}
+
+function runReport(args: string[], minimum: Severity, failOpen: boolean): number {
+  const inputPath = readArg(args, "--input");
+
+  if (!inputPath) {
+    throw new Error("`report` requires --input <file>");
+  }
+
+  let advisories: Advisory[];
+
+  try {
+    advisories = parseAudit(fs.readFileSync(inputPath, "utf8"));
+  } catch (error) {
+    if (failOpen) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      writeSummary(`### ⚠️ Dependency audit skipped\n\nCould not run the audit (${message}).`);
+
+      return 0;
+    }
+
+    throw error;
+  }
+
+  const relevant = filterBySeverity(advisories, minimum);
+
+  if (relevant.length === 0) {
+    writeSummary(`### ✅ Dependency audit\n\nNo ${minimum}+ vulnerabilities on \`main\`. 🎉`);
+
+    return 0;
+  }
+
+  writeSummary(
+    `### ❌ Dependency audit: \`main\` has known vulnerabilities\n\n` +
+      `**${relevant.length}** ${minimum}+ advisory(ies) (${countsBySeverity(relevant)}).\n\n` +
+      `${renderTable(relevant)}`,
+  );
+
+  return 1;
+}
+
+function main(): void {
+  const [command, ...args] = process.argv.slice(2);
+  const minimum = normalizeSeverity(readArg(args, "--level") ?? "moderate");
+  const failOpen = args.includes("--fail-open");
+
+  let exitCode: number;
+
+  switch (command) {
+    case "diff":
+      exitCode = runDiff(args, minimum, failOpen);
+      break;
+    case "report":
+      exitCode = runReport(args, minimum, failOpen);
+      break;
+    default:
+      console.error("Usage: audit-diff.ts <diff|report> [options]");
+      exitCode = 2;
+  }
+
+  process.exit(exitCode);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
`pnpm audit` on a PR was red whenever `main` already had a vulnerable (usually transitive) dependency, so every PR looked broken even when it changed nothing security-relevant.

- Replace the `check-lock` job with `audit-lock`, which audits both the PR and `main` and fails ONLY on advisories the PR introduces. Renders the result to the job summary and posts a sticky PR comment (same-repo PRs) when new vulnerabilities are added. Fails open on audit infra errors.
- Add `nightly-audit.yml` (04:30 UTC + workflow_dispatch) that audits `main` and fails red on any moderate+ advisory, so pre-existing vulnerabilities stay visible. Fails closed as the backstop.
- Add `scripts/audit-diff.ts` (pure functions + CLI, run via Node TS type stripping) and `node:assert` tests wired into `test:lint-rules`.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
