### PR TITLE
Fix product numeric filter zero values

### DIFF
--- a/.changeset/product-filter-zero-values.md
+++ b/.changeset/product-filter-zero-values.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Preserve zero values in product numeric attribute filters, so ranges starting or ending at 0 remain applied.

--- a/src/products/views/ProductList/filters.test.ts
+++ b/src/products/views/ProductList/filters.test.ts
@@ -109,6 +109,37 @@ describe("Parsing filter value", () => {
     expect(parsedValue1).toEqual(expectedValue1);
     expect(parsedValue2).toEqual(expectedValue2);
   });
+  it("should preserve zero when numeric attributes values passed", () => {
+    // Arrange
+    const params: ProductListUrlFilters = {
+      "numeric-attributes": {
+        "test-1": ["0"],
+        "test-2": ["0", "10"],
+      },
+    };
+    const type = ProductListUrlFiltersAsDictWithMultipleValues.numericAttributes;
+    // Act
+    const parsedValue1 = parseFilterValue(params, "test-1", type);
+    const parsedValue2 = parseFilterValue(params, "test-2", type);
+    // Assert
+    const expectedValue1: FilterParam = {
+      slug: "test-1",
+      valuesRange: {
+        gte: 0,
+        lte: 0,
+      },
+    };
+    const expectedValue2: FilterParam = {
+      slug: "test-2",
+      valuesRange: {
+        gte: 0,
+        lte: 10,
+      },
+    };
+
+    expect(parsedValue1).toEqual(expectedValue1);
+    expect(parsedValue2).toEqual(expectedValue2);
+  });
   it("should return string values when string attributes values passed", () => {
     // Arrange
     const params: ProductListUrlFilters = {

--- a/src/products/views/ProductList/filters.ts
+++ b/src/products/views/ProductList/filters.ts
@@ -80,6 +80,12 @@ export type FilterParam =
   | DefaultFilterParam
   | NumericFilterParam;
 
+const parseNumericFilterValue = (value: string | undefined) => {
+  const parsedValue = parseFloat(value ?? "");
+
+  return Number.isNaN(parsedValue) ? undefined : parsedValue;
+};
+
 export const parseFilterValue = (
   params: ProductListUrlFilters,
   key: string,
@@ -109,13 +115,14 @@ export const parseFilterValue = (
         }),
       };
     case ProductListUrlFiltersAsDictWithMultipleValues.numericAttributes: {
-      const [gte, lte] = value.map(v => parseFloat(v));
+      const gte = parseNumericFilterValue(value[0]);
+      const lte = isMulti ? parseNumericFilterValue(value[1]) : gte;
 
       return {
         ...name,
         valuesRange: {
-          gte: gte || undefined,
-          lte: isMulti ? lte || undefined : gte || undefined,
+          gte,
+          lte,
         },
       };
     }


### PR DESCRIPTION
## Scope of the change

Fixes product numeric attribute filter parsing so zero values are preserved instead of being treated as empty.

Before this change, a numeric filter value of `0` could be converted to `undefined`. Now ranges starting or ending at 0 remain applied.

Added focused unit coverage for zero-only and zero-to-positive numeric ranges.

## Reproduction steps

1. Open the products list with a numeric attribute filter in the URL.
2. Use a range where one side is `0`, for example `numeric-attributes[<attribute-slug>]=0` or `numeric-attributes[<attribute-slug>]=0&numeric-attributes[<attribute-slug>]=10`.
3. Before this change, parsing the URL filter dropped the zero because `0 || undefined` resolved to `undefined`, so the generated `valuesRange` missed the `0` bound.
4. With this change, the same URL filter is parsed as `valuesRange: { gte: 0, lte: 0 }` for a zero-only filter, or `valuesRange: { gte: 0, lte: 10 }` for a zero-to-positive range.

## Testing

- `./node_modules/.bin/jest --silent src/products/views/ProductList/filters.test.ts`

- [x] I confirm I added ripples for changes or my feature doesn't contain any user-facing changes
- [x] I used analytics "trackEvent" for important events
