### PR TITLE
Fix numeric variant attributes in variants datagrid

### DIFF
--- a/.changeset/tame-plants-add.md
+++ b/.changeset/tame-plants-add.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed numeric variant attributes not being editable in the variants datagrid.

--- a/src/products/components/ProductVariants/ProductVariants.tsx
+++ b/src/products/components/ProductVariants/ProductVariants.tsx
@@ -9,7 +9,6 @@ import {
 } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import {
-  AttributeInputTypeEnum,
   type ProductDetailsVariantFragment,
   type ProductFragment,
   type ProductVariantBulkCreateInput,
@@ -35,6 +34,7 @@ import {
 } from "../ProductVariantGenerator/types";
 import { ProductVariantsHeader } from "./components/ProductVariantsHeader";
 import {
+  isVariantDatagridSupportedAttribute,
   useAttributesAdapter,
   useChannelAdapter,
   useChannelAvailabilityAdapter,
@@ -183,11 +183,7 @@ export const ProductVariants = ({
             ]),
             ...warehouses.map(warehouse => `warehouse:${warehouse.id}`),
             ...(variantAttributes
-              ?.filter(
-                attribute =>
-                  attribute.inputType === AttributeInputTypeEnum.DROPDOWN ||
-                  attribute.inputType === AttributeInputTypeEnum.PLAIN_TEXT,
-              )
+              ?.filter(attribute => isVariantDatagridSupportedAttribute(attribute.inputType))
               .map(attribute => `attribute:${attribute.id}`) ?? []),
           ]
         : undefined,
@@ -256,10 +252,11 @@ export const ProductVariants = ({
         row,
         channels,
         variants,
+        variantAttributes,
         searchAttributeValues: onAttributeValuesSearch,
         ...opts,
       }),
-    [channels, visibleColumns, onAttributeValuesSearch, variants],
+    [channels, visibleColumns, onAttributeValuesSearch, variantAttributes, variants],
   );
   const getCellError = useCallback(
     ([column, row]: Item, opts: GetCellContentOpts) =>

--- a/src/products/components/ProductVariants/datagrid.test.ts
+++ b/src/products/components/ProductVariants/datagrid.test.ts
@@ -1,0 +1,36 @@
+import { AttributeInputTypeEnum } from "@dashboard/graphql";
+
+import { isVariantDatagridSupportedAttribute } from "./datagrid";
+
+describe("isVariantDatagridSupportedAttribute", () => {
+  it("should return true for attributes supported by variants datagrid", () => {
+    // Arrange
+    const supportedInputTypes = [
+      AttributeInputTypeEnum.DROPDOWN,
+      AttributeInputTypeEnum.PLAIN_TEXT,
+      AttributeInputTypeEnum.NUMERIC,
+    ];
+
+    // Act
+    const result = supportedInputTypes.map(isVariantDatagridSupportedAttribute);
+
+    // Assert
+    expect(result).toEqual([true, true, true]);
+  });
+
+  it("should return false for attributes unsupported by variants datagrid", () => {
+    // Arrange
+    const unsupportedInputTypes = [
+      AttributeInputTypeEnum.SWATCH,
+      AttributeInputTypeEnum.BOOLEAN,
+      null,
+      undefined,
+    ];
+
+    // Act
+    const result = unsupportedInputTypes.map(isVariantDatagridSupportedAttribute);
+
+    // Assert
+    expect(result).toEqual([false, false, false, false]);
+  });
+});

--- a/src/products/components/ProductVariants/datagrid.ts
+++ b/src/products/components/ProductVariants/datagrid.ts
@@ -12,6 +12,13 @@ import { type IntlShape } from "react-intl";
 
 import messages from "./messages";
 
+export const isVariantDatagridSupportedAttribute = (
+  inputType: AttributeInputTypeEnum | null | undefined,
+) =>
+  inputType === AttributeInputTypeEnum.DROPDOWN ||
+  inputType === AttributeInputTypeEnum.PLAIN_TEXT ||
+  inputType === AttributeInputTypeEnum.NUMERIC;
+
 export const variantsStaticColumnsAdapter = (intl: IntlShape) => [
   {
     id: "name",
@@ -126,15 +133,9 @@ export const useAttributesAdapter = ({
   selectedColumns: string[] | undefined;
   attributes: ProductFragment["productType"]["variantAttributes"];
 }) => {
-  const supportedAttributes = attributes?.filter(attribute => {
-    if (!attribute.inputType) {
-      return false;
-    }
-
-    return [AttributeInputTypeEnum.DROPDOWN, AttributeInputTypeEnum.PLAIN_TEXT].includes(
-      attribute.inputType,
-    );
-  });
+  const supportedAttributes = attributes?.filter(attribute =>
+    isVariantDatagridSupportedAttribute(attribute.inputType),
+  );
   const [attributeQuery, setAttributeQuery] = useState("");
   const { paginate, currentPage, changeCurrentPage } = useClientPagination();
   const paginatedAttributes = paginate(

--- a/src/products/components/ProductVariants/utils.tsx
+++ b/src/products/components/ProductVariants/utils.tsx
@@ -11,7 +11,11 @@ import { emptyDropdownCellValue } from "@dashboard/components/Datagrid/customCel
 import { numberCellEmptyValue } from "@dashboard/components/Datagrid/customCells/NumberCell";
 import { type DatagridChange } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
 import { type AvailableColumn } from "@dashboard/components/Datagrid/types";
-import { type ProductDetailsVariantFragment } from "@dashboard/graphql";
+import {
+  AttributeInputTypeEnum,
+  type ProductDetailsVariantFragment,
+  type VariantAttributeFragment,
+} from "@dashboard/graphql";
 import { type ProductVariantListError } from "@dashboard/products/views/ProductUpdate/handlers/errors";
 import { mapNodeToChoice } from "@dashboard/utils/maps";
 import { type GridCell } from "@glideapps/glide-data-grid";
@@ -73,6 +77,7 @@ interface GetDataOrError {
   column: number;
   row: number;
   variants: ProductDetailsVariantFragment[];
+  variantAttributes?: VariantAttributeFragment[] | null;
   changes: MutableRefObject<DatagridChange[]>;
   channels: ChannelData[];
   added: number[];
@@ -91,6 +96,7 @@ export function getData({
   row,
   channels,
   variants,
+  variantAttributes,
   searchAttributeValues,
 }: GetDataOrError): GridCell {
   // For some reason it happens when user deselects channel
@@ -151,19 +157,35 @@ export function getData({
   }
 
   if (getColumnAttribute(columnId)) {
-    const value =
-      change?.value ??
-      mapNodeToChoice(
-        dataRow?.attributes.find(
-          attribute => attribute.attribute.id === getColumnAttribute(columnId),
-        )?.values,
-      )[0] ??
-      emptyDropdownCellValue;
+    const attributeId = getColumnAttribute(columnId);
+
+    if (!attributeId) {
+      return textCell("");
+    }
+
+    const attribute = dataRow?.attributes.find(attribute => attribute.attribute.id === attributeId);
+    const inputType = variantAttributes?.find(attribute => attribute.id === attributeId)?.inputType;
+
+    if (inputType === AttributeInputTypeEnum.NUMERIC) {
+      const value = change?.value ?? getNumericAttributeValue(attribute?.values[0]?.name);
+
+      return numberCell(value, { hasFloatingPoint: true });
+    }
+
+    const value = change?.value ?? mapNodeToChoice(attribute?.values)[0] ?? emptyDropdownCellValue;
 
     return dropdownCell(value, {
       allowCustomValues: true,
       emptyOption: true,
-      update: text => searchAttributeValues(getColumnAttribute(columnId), text),
+      update: text => searchAttributeValues(attributeId, text),
     });
   }
+}
+
+function getNumericAttributeValue(value: string | null | undefined) {
+  if (!value) {
+    return numberCellEmptyValue;
+  }
+
+  return Number(value);
 }

--- a/src/products/components/ProductVariants/utils.tsx
+++ b/src/products/components/ProductVariants/utils.tsx
@@ -187,5 +187,7 @@ function getNumericAttributeValue(value: string | null | undefined) {
     return numberCellEmptyValue;
   }
 
-  return Number(value);
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? parsed : numberCellEmptyValue;
 }

--- a/src/products/views/ProductUpdate/handlers/data/attributes.test.ts
+++ b/src/products/views/ProductUpdate/handlers/data/attributes.test.ts
@@ -1,7 +1,21 @@
+import { numberCellEmptyValue } from "@dashboard/components/Datagrid/customCells/NumberCell";
 import { type DatagridChange } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
+import { AttributeInputTypeEnum, type VariantAttributeFragment } from "@dashboard/graphql";
 import { variantAttributes } from "@dashboard/products/fixtures";
 
 import { getAttributeData } from "./attributes";
+
+const numericAttributeId = "numeric-attribute-id";
+const numericVariantAttributes: VariantAttributeFragment[] = [
+  ...variantAttributes,
+  {
+    ...variantAttributes[0],
+    id: numericAttributeId,
+    name: "Weight",
+    slug: "weight",
+    inputType: AttributeInputTypeEnum.NUMERIC,
+  },
+];
 
 describe("getAttributeData", () => {
   test("should filter and map data to attribute format", () => {
@@ -55,5 +69,53 @@ describe("getAttributeData", () => {
 
     // Assert
     expect(attributes).toEqual([]);
+  });
+  test("should return numeric input for numeric attribute change", () => {
+    // Arrange
+    const changeData: DatagridChange[] = [
+      {
+        column: `attribute:${numericAttributeId}`,
+        row: 1,
+        data: {
+          kind: "number-cell",
+          value: 150,
+        },
+      },
+    ];
+
+    // Act
+    const attributes = getAttributeData(changeData, 1, numericVariantAttributes);
+
+    // Assert
+    expect(attributes).toEqual([
+      {
+        id: numericAttributeId,
+        numeric: "150",
+      },
+    ]);
+  });
+  test("should return null numeric input when numeric attribute is cleared", () => {
+    // Arrange
+    const changeData: DatagridChange[] = [
+      {
+        column: `attribute:${numericAttributeId}`,
+        row: 1,
+        data: {
+          kind: "number-cell",
+          value: numberCellEmptyValue,
+        },
+      },
+    ];
+
+    // Act
+    const attributes = getAttributeData(changeData, 1, numericVariantAttributes);
+
+    // Assert
+    expect(attributes).toEqual([
+      {
+        id: numericAttributeId,
+        numeric: null,
+      },
+    ]);
   });
 });

--- a/src/products/views/ProductUpdate/handlers/data/attributes.ts
+++ b/src/products/views/ProductUpdate/handlers/data/attributes.ts
@@ -1,3 +1,4 @@
+import { numberCellEmptyValue } from "@dashboard/components/Datagrid/customCells/NumberCell";
 import { type DatagridChange } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
 import {
   AttributeInputTypeEnum,
@@ -9,6 +10,8 @@ import {
 import { getColumnAttribute, isCurrentRow } from "@dashboard/products/utils/datagrid";
 
 import { byAttributeName } from "../utils";
+
+type DatagridAttributeValue = string | number | typeof numberCellEmptyValue | null | undefined;
 
 export function getAttributeData(
   data: DatagridChange[],
@@ -36,7 +39,10 @@ function toAttributeData(variantAttributes: VariantAttributeFragment[]) {
 
     return {
       id: attributeId,
-      ...getDatagridAttributeInput(attributeType, change.data.value.value),
+      ...getDatagridAttributeInput(
+        attributeType,
+        getDatagridAttributeValue(attributeType, change.data),
+      ),
     };
   };
 }
@@ -50,27 +56,47 @@ export function getAttributeType(
   return attributeVariant?.inputType;
 }
 
-// Datagrid only support PLAIN_TEXT and DROPDOWN attribute types
+function getDatagridAttributeValue(
+  inputType: AttributeInputTypeEnum,
+  data: DatagridChange["data"],
+): DatagridAttributeValue {
+  if (inputType === AttributeInputTypeEnum.NUMERIC) {
+    return data.value;
+  }
+
+  return data.value?.value;
+}
+
+// Datagrid only support PLAIN_TEXT, DROPDOWN and NUMERIC attribute types
 function getDatagridAttributeInput(
   inputType: AttributeInputTypeEnum,
-  value = "",
+  value: DatagridAttributeValue = "",
 ): BulkAttributeValueInput {
+  if (inputType === AttributeInputTypeEnum.NUMERIC) {
+    return {
+      numeric:
+        value === numberCellEmptyValue || value === "" || value == null ? null : String(value),
+    };
+  }
+
+  const textValue = typeof value === "string" ? value : "";
+
   if (inputType === AttributeInputTypeEnum.DROPDOWN) {
     return {
       dropdown: {
-        value,
+        value: textValue,
       },
     };
   }
 
   if (inputType === AttributeInputTypeEnum.PLAIN_TEXT) {
     return {
-      plainText: value,
+      plainText: textValue,
     };
   }
 
   return {
-    values: [value],
+    values: [textValue],
   };
 }
 


### PR DESCRIPTION
## What

Fixes numeric variant attributes in the variants datagrid.

Numeric variant attributes are now:

- available as supported datagrid attribute columns
- rendered with the existing number cell
- submitted as the expected `numeric` attribute input

## Why

The variants datagrid previously only supported dropdown and plain text variant attributes. As a result, numeric variant attributes could not be edited from the grid, which prevented users from filling required numeric variant attributes in that flow.

## Testing

- `corepack pnpm run lint`
- `corepack pnpm run test:quiet products/components/ProductVariants/datagrid.test.ts`
- `corepack pnpm run test:quiet products/views/ProductUpdate/handlers/data/attributes.test.ts`
- `corepack pnpm run check-types`
- `corepack pnpm run knip`
