### PR TITLE
Add swatch variant attributes to variants datagrid

### DIFF
--- a/.changeset/swatch-variant-columns.md
+++ b/.changeset/swatch-variant-columns.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Swatch variant attributes now appear in the product variants grid, so merchants can edit color-style variant values alongside other variant columns.

--- a/src/products/components/ProductVariants/ProductVariants.tsx
+++ b/src/products/components/ProductVariants/ProductVariants.tsx
@@ -9,7 +9,6 @@ import {
 } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import {
-  AttributeInputTypeEnum,
   type ProductDetailsVariantFragment,
   type ProductFragment,
   type ProductVariantBulkCreateInput,
@@ -35,6 +34,7 @@ import {
 } from "../ProductVariantGenerator/types";
 import { ProductVariantsHeader } from "./components/ProductVariantsHeader";
 import {
+  isVariantDatagridSupportedAttribute,
   useAttributesAdapter,
   useChannelAdapter,
   useChannelAvailabilityAdapter,
@@ -183,11 +183,7 @@ export const ProductVariants = ({
             ]),
             ...warehouses.map(warehouse => `warehouse:${warehouse.id}`),
             ...(variantAttributes
-              ?.filter(
-                attribute =>
-                  attribute.inputType === AttributeInputTypeEnum.DROPDOWN ||
-                  attribute.inputType === AttributeInputTypeEnum.PLAIN_TEXT,
-              )
+              ?.filter(attribute => isVariantDatagridSupportedAttribute(attribute.inputType))
               .map(attribute => `attribute:${attribute.id}`) ?? []),
           ]
         : undefined,

--- a/src/products/components/ProductVariants/datagrid.test.ts
+++ b/src/products/components/ProductVariants/datagrid.test.ts
@@ -1,0 +1,31 @@
+import { AttributeInputTypeEnum } from "@dashboard/graphql";
+
+import { isVariantDatagridSupportedAttribute } from "./datagrid";
+
+describe("isVariantDatagridSupportedAttribute", () => {
+  it("should return true for attributes supported by variants datagrid", () => {
+    // Arrange
+    const supportedInputTypes = [
+      AttributeInputTypeEnum.DROPDOWN,
+      AttributeInputTypeEnum.PLAIN_TEXT,
+      AttributeInputTypeEnum.SWATCH,
+    ];
+
+    // Act
+    const result = supportedInputTypes.map(isVariantDatagridSupportedAttribute);
+
+    // Assert
+    expect(result).toEqual([true, true, true]);
+  });
+
+  it("should return false for attributes unsupported by variants datagrid", () => {
+    // Arrange
+    const unsupportedInputTypes = [AttributeInputTypeEnum.BOOLEAN, null, undefined];
+
+    // Act
+    const result = unsupportedInputTypes.map(isVariantDatagridSupportedAttribute);
+
+    // Assert
+    expect(result).toEqual([false, false, false]);
+  });
+});

--- a/src/products/components/ProductVariants/datagrid.ts
+++ b/src/products/components/ProductVariants/datagrid.ts
@@ -12,6 +12,13 @@ import { type IntlShape } from "react-intl";
 
 import messages from "./messages";
 
+export const isVariantDatagridSupportedAttribute = (
+  inputType: AttributeInputTypeEnum | null | undefined,
+) =>
+  inputType === AttributeInputTypeEnum.DROPDOWN ||
+  inputType === AttributeInputTypeEnum.PLAIN_TEXT ||
+  inputType === AttributeInputTypeEnum.SWATCH;
+
 export const variantsStaticColumnsAdapter = (intl: IntlShape) => [
   {
     id: "name",
@@ -126,15 +133,9 @@ export const useAttributesAdapter = ({
   selectedColumns: string[] | undefined;
   attributes: ProductFragment["productType"]["variantAttributes"];
 }) => {
-  const supportedAttributes = attributes?.filter(attribute => {
-    if (!attribute.inputType) {
-      return false;
-    }
-
-    return [AttributeInputTypeEnum.DROPDOWN, AttributeInputTypeEnum.PLAIN_TEXT].includes(
-      attribute.inputType,
-    );
-  });
+  const supportedAttributes = attributes?.filter(attribute =>
+    isVariantDatagridSupportedAttribute(attribute.inputType),
+  );
   const [attributeQuery, setAttributeQuery] = useState("");
   const { paginate, currentPage, changeCurrentPage } = useClientPagination();
   const paginatedAttributes = paginate(

--- a/src/products/views/ProductUpdate/handlers/data/attributes.test.ts
+++ b/src/products/views/ProductUpdate/handlers/data/attributes.test.ts
@@ -1,7 +1,20 @@
 import { type DatagridChange } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
+import { AttributeInputTypeEnum, type VariantAttributeFragment } from "@dashboard/graphql";
 import { variantAttributes } from "@dashboard/products/fixtures";
 
 import { getAttributeData } from "./attributes";
+
+const swatchAttributeId = "swatch-attribute-id";
+const swatchVariantAttributes: VariantAttributeFragment[] = [
+  ...variantAttributes,
+  {
+    ...variantAttributes[0],
+    id: swatchAttributeId,
+    name: "Color",
+    slug: "color",
+    inputType: AttributeInputTypeEnum.SWATCH,
+  },
+];
 
 describe("getAttributeData", () => {
   test("should filter and map data to attribute format", () => {
@@ -55,5 +68,33 @@ describe("getAttributeData", () => {
 
     // Assert
     expect(attributes).toEqual([]);
+  });
+  test("should return swatch input for swatch attribute change", () => {
+    // Arrange
+    const changeData: DatagridChange[] = [
+      {
+        column: `attribute:${swatchAttributeId}`,
+        row: 1,
+        data: {
+          value: {
+            label: "Red",
+            value: "red",
+          },
+        },
+      },
+    ];
+
+    // Act
+    const attributes = getAttributeData(changeData, 1, swatchVariantAttributes);
+
+    // Assert
+    expect(attributes).toEqual([
+      {
+        id: swatchAttributeId,
+        swatch: {
+          value: "red",
+        },
+      },
+    ]);
   });
 });

--- a/src/products/views/ProductUpdate/handlers/data/attributes.ts
+++ b/src/products/views/ProductUpdate/handlers/data/attributes.ts
@@ -50,7 +50,7 @@ export function getAttributeType(
   return attributeVariant?.inputType;
 }
 
-// Datagrid only support PLAIN_TEXT and DROPDOWN attribute types
+// Datagrid only supports PLAIN_TEXT, DROPDOWN and SWATCH attribute types
 function getDatagridAttributeInput(
   inputType: AttributeInputTypeEnum,
   value = "",
@@ -66,6 +66,14 @@ function getDatagridAttributeInput(
   if (inputType === AttributeInputTypeEnum.PLAIN_TEXT) {
     return {
       plainText: value,
+    };
+  }
+
+  if (inputType === AttributeInputTypeEnum.SWATCH) {
+    return {
+      swatch: {
+        value,
+      },
     };
   }
 


### PR DESCRIPTION
## Summary
- Add swatch variant attributes to the variants datagrid column picker and default visible columns
- Save swatch datagrid edits using the swatch attribute input
- Add tests for supported datagrid attributes and swatch attribute mapping

Fixes #3801

## Tests
- pnpm run lint
- pnpm run test:quiet products/components/ProductVariants/datagrid.test.ts
- pnpm run test:quiet products/views/ProductUpdate/handlers/data/attributes.test.ts
- pnpm run check-types
- pnpm run knip