### PR TITLE
Add attribute input type filter

### DIFF
--- a/.changeset/silver-attributes-filter.md
+++ b/.changeset/silver-attributes-filter.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Added filtering attributes by input type, so users can quickly find attributes such as swatches from the attributes list.

--- a/.changeset/tame-plants-add.md
+++ b/.changeset/tame-plants-add.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed numeric variant attributes not being editable in the variants datagrid.

--- a/src/attributes/queries.ts
+++ b/src/attributes/queries.ts
@@ -24,9 +24,11 @@ export const attributeList = gql`
     $first: Int
     $last: Int
     $sort: AttributeSortingInput
+    $where: AttributeWhereInput
   ) {
     attributes(
       filter: $filter
+      where: $where
       before: $before
       after: $after
       first: $first

--- a/src/attributes/views/AttributeList/AttributeList.tsx
+++ b/src/attributes/views/AttributeList/AttributeList.tsx
@@ -5,7 +5,10 @@ import {
   storageUtils,
 } from "@dashboard/attributes/views/AttributeList/filters";
 import { useConditionalFilterContext } from "@dashboard/components/ConditionalFilter";
-import { createAttributesQueryVariables } from "@dashboard/components/ConditionalFilter/queryVariables";
+import {
+  createAttributesQueryVariables,
+  createAttributesWhereVariables,
+} from "@dashboard/components/ConditionalFilter/queryVariables";
 import DeleteFilterTabDialog from "@dashboard/components/DeleteFilterTabDialog";
 import SaveFilterTabDialog from "@dashboard/components/SaveFilterTabDialog";
 import {
@@ -53,7 +56,14 @@ const AttributeList = ({ params }: AttributeListProps) => {
   const intl = useIntl();
   const { updateListSettings, settings } = useListSettings(ListViews.ATTRIBUTE_LIST);
   const { valueProvider } = useConditionalFilterContext();
-  const filters = createAttributesQueryVariables(valueProvider.value);
+  const filters = useMemo(
+    () => createAttributesQueryVariables(valueProvider.value),
+    [valueProvider.value],
+  );
+  const where = useMemo(
+    () => createAttributesWhereVariables(valueProvider.value),
+    [valueProvider.value],
+  );
 
   usePaginationReset(attributeListUrl, params, settings.rowNumber);
 
@@ -66,9 +76,10 @@ const AttributeList = ({ params }: AttributeListProps) => {
         ...filters,
         search: params.query,
       },
+      where,
       sort: getSortQueryVariables(params),
     }),
-    [filters, paginationState, params],
+    [filters, paginationState, params, where],
   );
   const { data, loading, refetch } = useAttributeListQuery({
     variables: newQueryVariables,

--- a/src/components/ConditionalFilter/API/intl.ts
+++ b/src/components/ConditionalFilter/API/intl.ts
@@ -1,5 +1,7 @@
+import { getAttributeInputTypeLabel } from "@dashboard/attributes/utils/getAttributeInputTypeLabel";
 import { type LeftOperand } from "@dashboard/components/ConditionalFilter/LeftOperandsProvider";
 import {
+  type AttributeInputTypeEnum,
   AttributeTypeEnum,
   CollectionPublished,
   DiscountStatusEnum,
@@ -182,6 +184,8 @@ export const getLocalizedLabel = (rowType: LeftOperand["type"], value: string, i
       return getStaffMemberStatusLabel(value as StaffMemberStatus, intl);
     case "attributeType":
       return getAttributeTypeLabel(value as AttributeTypeEnum, intl);
+    case "inputType":
+      return getAttributeInputTypeLabel(intl, value as AttributeInputTypeEnum);
     case "transactionsPaymentType":
       return getPaymentMethodTypeLabel(value as PaymentMethodTypeEnum, intl);
     case "fulfillmentStatus":

--- a/src/components/ConditionalFilter/API/providers/AttributesFilterAPIProvider.tsx
+++ b/src/components/ConditionalFilter/API/providers/AttributesFilterAPIProvider.tsx
@@ -1,5 +1,5 @@
 import { type ApolloClient, useApolloClient } from "@apollo/client";
-import { AttributeTypeEnum } from "@dashboard/graphql";
+import { AttributeInputTypeEnum, AttributeTypeEnum } from "@dashboard/graphql";
 import { type IntlShape, useIntl } from "react-intl";
 
 import { type FilterContainer, type FilterElement } from "../../FilterElement";
@@ -37,6 +37,10 @@ const createAPIHandler = (
 
   if (rowType === "attributeType") {
     return new EnumValuesHandler(AttributeTypeEnum, "attributeType", intl);
+  }
+
+  if (rowType === "inputType") {
+    return new EnumValuesHandler(AttributeInputTypeEnum, "inputType", intl);
   }
 
   if (rowType && booleanTypes.includes(rowType) && rowType !== "attribute") {

--- a/src/components/ConditionalFilter/constants.ts
+++ b/src/components/ConditionalFilter/constants.ts
@@ -47,6 +47,7 @@ export const STATIC_CONDITIONS = {
   visibleInStorefront: [{ type: "select", label: "is", value: "input-1" }],
   filterableInStorefront: [{ type: "select", label: "is", value: "input-1" }],
   attributeType: [{ type: "select", label: "is", value: "input-1" }],
+  inputType: [{ type: "select", label: "is", value: "input-1" }],
   hasCategory: [{ type: "select", label: "is", value: "input-1" }],
   giftCard: [{ type: "select", label: "is", value: "input-1" }],
   startDate: [
@@ -812,6 +813,13 @@ export const STATIC_ATTRIBUTES_OPTIONS: LeftOperand[] = [
     label: "Type",
     type: "attributeType",
     slug: "attributeType",
+    maxOccurrences: 1,
+  },
+  {
+    value: "inputType",
+    label: "Input type",
+    type: "inputType",
+    slug: "inputType",
     maxOccurrences: 1,
   },
   {

--- a/src/components/ConditionalFilter/queryVariables.test.ts
+++ b/src/components/ConditionalFilter/queryVariables.test.ts
@@ -11,6 +11,7 @@ import { ConditionSelected } from "./FilterElement/ConditionSelected";
 import { ExpressionValue } from "./FilterElement/FilterElement";
 import {
   createAttributesQueryVariables,
+  createAttributesWhereVariables,
   createCategoryQueryVariables,
   createCustomerQueryVariables,
   createDraftOrderQueryVariables,
@@ -947,5 +948,60 @@ describe("ConditionalFilter / queryVariables / createAttributesQueryVariables", 
 
     // Assert
     expect(result).toEqual(expectedOutput);
+  });
+
+  it("should create where variables with selected input type filter", () => {
+    // Arrange
+    const inputTypeFilterElement = new FilterElement(
+      new ExpressionValue("inputType", "Input type", "inputType"),
+      new Condition(
+        ConditionOptions.fromStaticElementName("inputType"),
+        new ConditionSelected(
+          AttributeInputTypeEnum.SWATCH,
+          { type: "select", label: "is", value: "input-1" },
+          [],
+          false,
+        ),
+        false,
+      ),
+      false,
+    );
+    const filters: FilterContainer = [inputTypeFilterElement];
+    const expectedOutput = {
+      inputType: {
+        eq: AttributeInputTypeEnum.SWATCH,
+      },
+    };
+
+    // Act
+    const result = createAttributesWhereVariables(filters);
+
+    // Assert
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it("should omit input type from legacy filter variables", () => {
+    // Arrange
+    const inputTypeFilterElement = new FilterElement(
+      new ExpressionValue("inputType", "Input type", "inputType"),
+      new Condition(
+        ConditionOptions.fromStaticElementName("inputType"),
+        new ConditionSelected(
+          AttributeInputTypeEnum.SWATCH,
+          { type: "select", label: "is", value: "input-1" },
+          [],
+          false,
+        ),
+        false,
+      ),
+      false,
+    );
+    const filters: FilterContainer = [inputTypeFilterElement];
+
+    // Act
+    const result = createAttributesQueryVariables(filters);
+
+    // Assert
+    expect(result).toEqual({});
   });
 });

--- a/src/components/ConditionalFilter/queryVariables.ts
+++ b/src/components/ConditionalFilter/queryVariables.ts
@@ -1,5 +1,7 @@
 import {
   type AttributeFilterInput,
+  AttributeInputTypeEnum,
+  type AttributeWhereInput,
   type CategoryFilterInput,
   type CollectionFilterInput,
   type CustomerFilterInput,
@@ -15,7 +17,8 @@ import {
   type VoucherFilterInput,
 } from "@dashboard/graphql";
 
-import { type FilterContainer } from "./FilterElement";
+import { type FilterContainer, FilterElement } from "./FilterElement";
+import { isItemOption } from "./FilterElement/ConditionValue";
 import { FiltersQueryBuilder, QueryApiType } from "./FiltersQueryBuilder";
 import { FilterQueryVarsBuilderResolver } from "./FiltersQueryBuilder/FilterQueryVarsBuilderResolver";
 import { AddressFieldQueryVarsBuilder } from "./FiltersQueryBuilder/queryVarsBuilders/AddressFieldQueryVarsBuilder";
@@ -245,13 +248,39 @@ export const createStaffMembersQueryVariables = (value: FilterContainer): StaffU
 };
 
 export const createAttributesQueryVariables = (value: FilterContainer): AttributeFilterInput => {
+  const filterContainer = value.filter(
+    item => !FilterElement.isFilterElement(item) || item.value.value !== "inputType",
+  );
   const builder = new FiltersQueryBuilder<AttributeFilterInput>({
     apiType: QUERY_API_TYPES.ATTRIBUTE,
-    filterContainer: value,
+    filterContainer,
   });
   const { filters } = builder.build();
 
   return filters;
+};
+
+export const createAttributesWhereVariables = (value: FilterContainer): AttributeWhereInput => {
+  const inputTypeFilter = value.find(
+    item => FilterElement.isFilterElement(item) && item.value.value === "inputType",
+  );
+
+  if (!FilterElement.isFilterElement(inputTypeFilter)) {
+    return {};
+  }
+
+  const { value: selectedValue } = inputTypeFilter.condition.selected;
+  const inputType = isItemOption(selectedValue) ? selectedValue.value : selectedValue;
+
+  if (!Object.values(AttributeInputTypeEnum).includes(inputType as AttributeInputTypeEnum)) {
+    return {};
+  }
+
+  return {
+    inputType: {
+      eq: inputType as AttributeInputTypeEnum,
+    },
+  };
 };
 
 const categoryFilterDefinitionResolver = new FilterQueryVarsBuilderResolver([

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -4299,9 +4299,10 @@ export type AttributeDetailsQueryHookResult = ReturnType<typeof useAttributeDeta
 export type AttributeDetailsLazyQueryHookResult = ReturnType<typeof useAttributeDetailsLazyQuery>;
 export type AttributeDetailsQueryResult = Apollo.QueryResult<Types.AttributeDetailsQuery, Types.AttributeDetailsQueryVariables>;
 export const AttributeListDocument = gql`
-    query AttributeList($filter: AttributeFilterInput, $before: String, $after: String, $first: Int, $last: Int, $sort: AttributeSortingInput) {
+    query AttributeList($filter: AttributeFilterInput, $before: String, $after: String, $first: Int, $last: Int, $sort: AttributeSortingInput, $where: AttributeWhereInput) {
   attributes(
     filter: $filter
+    where: $where
     before: $before
     after: $after
     first: $first
@@ -4339,6 +4340,7 @@ ${PageInfoFragmentDoc}`;
  *      first: // value for 'first'
  *      last: // value for 'last'
  *      sort: // value for 'sort'
+ *      where: // value for 'where'
  *   },
  * });
  */

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -10296,6 +10296,7 @@ export type AttributeListQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   sort?: InputMaybe<AttributeSortingInput>;
+  where?: InputMaybe<AttributeWhereInput>;
 }>;
 
 

--- a/src/products/components/ProductVariants/ProductVariants.tsx
+++ b/src/products/components/ProductVariants/ProductVariants.tsx
@@ -9,7 +9,6 @@ import {
 } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import {
-  AttributeInputTypeEnum,
   type ProductDetailsVariantFragment,
   type ProductFragment,
   type ProductVariantBulkCreateInput,
@@ -35,6 +34,7 @@ import {
 } from "../ProductVariantGenerator/types";
 import { ProductVariantsHeader } from "./components/ProductVariantsHeader";
 import {
+  isVariantDatagridSupportedAttribute,
   useAttributesAdapter,
   useChannelAdapter,
   useChannelAvailabilityAdapter,
@@ -183,11 +183,7 @@ export const ProductVariants = ({
             ]),
             ...warehouses.map(warehouse => `warehouse:${warehouse.id}`),
             ...(variantAttributes
-              ?.filter(
-                attribute =>
-                  attribute.inputType === AttributeInputTypeEnum.DROPDOWN ||
-                  attribute.inputType === AttributeInputTypeEnum.PLAIN_TEXT,
-              )
+              ?.filter(attribute => isVariantDatagridSupportedAttribute(attribute.inputType))
               .map(attribute => `attribute:${attribute.id}`) ?? []),
           ]
         : undefined,
@@ -256,10 +252,11 @@ export const ProductVariants = ({
         row,
         channels,
         variants,
+        variantAttributes,
         searchAttributeValues: onAttributeValuesSearch,
         ...opts,
       }),
-    [channels, visibleColumns, onAttributeValuesSearch, variants],
+    [channels, visibleColumns, onAttributeValuesSearch, variantAttributes, variants],
   );
   const getCellError = useCallback(
     ([column, row]: Item, opts: GetCellContentOpts) =>

--- a/src/products/components/ProductVariants/datagrid.test.ts
+++ b/src/products/components/ProductVariants/datagrid.test.ts
@@ -1,0 +1,36 @@
+import { AttributeInputTypeEnum } from "@dashboard/graphql";
+
+import { isVariantDatagridSupportedAttribute } from "./datagrid";
+
+describe("isVariantDatagridSupportedAttribute", () => {
+  it("should return true for attributes supported by variants datagrid", () => {
+    // Arrange
+    const supportedInputTypes = [
+      AttributeInputTypeEnum.DROPDOWN,
+      AttributeInputTypeEnum.PLAIN_TEXT,
+      AttributeInputTypeEnum.NUMERIC,
+    ];
+
+    // Act
+    const result = supportedInputTypes.map(isVariantDatagridSupportedAttribute);
+
+    // Assert
+    expect(result).toEqual([true, true, true]);
+  });
+
+  it("should return false for attributes unsupported by variants datagrid", () => {
+    // Arrange
+    const unsupportedInputTypes = [
+      AttributeInputTypeEnum.SWATCH,
+      AttributeInputTypeEnum.BOOLEAN,
+      null,
+      undefined,
+    ];
+
+    // Act
+    const result = unsupportedInputTypes.map(isVariantDatagridSupportedAttribute);
+
+    // Assert
+    expect(result).toEqual([false, false, false, false]);
+  });
+});

--- a/src/products/components/ProductVariants/datagrid.ts
+++ b/src/products/components/ProductVariants/datagrid.ts
@@ -12,6 +12,13 @@ import { type IntlShape } from "react-intl";
 
 import messages from "./messages";
 
+export const isVariantDatagridSupportedAttribute = (
+  inputType: AttributeInputTypeEnum | null | undefined,
+) =>
+  inputType === AttributeInputTypeEnum.DROPDOWN ||
+  inputType === AttributeInputTypeEnum.PLAIN_TEXT ||
+  inputType === AttributeInputTypeEnum.NUMERIC;
+
 export const variantsStaticColumnsAdapter = (intl: IntlShape) => [
   {
     id: "name",
@@ -126,15 +133,9 @@ export const useAttributesAdapter = ({
   selectedColumns: string[] | undefined;
   attributes: ProductFragment["productType"]["variantAttributes"];
 }) => {
-  const supportedAttributes = attributes?.filter(attribute => {
-    if (!attribute.inputType) {
-      return false;
-    }
-
-    return [AttributeInputTypeEnum.DROPDOWN, AttributeInputTypeEnum.PLAIN_TEXT].includes(
-      attribute.inputType,
-    );
-  });
+  const supportedAttributes = attributes?.filter(attribute =>
+    isVariantDatagridSupportedAttribute(attribute.inputType),
+  );
   const [attributeQuery, setAttributeQuery] = useState("");
   const { paginate, currentPage, changeCurrentPage } = useClientPagination();
   const paginatedAttributes = paginate(

--- a/src/products/components/ProductVariants/utils.tsx
+++ b/src/products/components/ProductVariants/utils.tsx
@@ -11,7 +11,11 @@ import { emptyDropdownCellValue } from "@dashboard/components/Datagrid/customCel
 import { numberCellEmptyValue } from "@dashboard/components/Datagrid/customCells/NumberCell";
 import { type DatagridChange } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
 import { type AvailableColumn } from "@dashboard/components/Datagrid/types";
-import { type ProductDetailsVariantFragment } from "@dashboard/graphql";
+import {
+  AttributeInputTypeEnum,
+  type ProductDetailsVariantFragment,
+  type VariantAttributeFragment,
+} from "@dashboard/graphql";
 import { type ProductVariantListError } from "@dashboard/products/views/ProductUpdate/handlers/errors";
 import { mapNodeToChoice } from "@dashboard/utils/maps";
 import { type GridCell } from "@glideapps/glide-data-grid";
@@ -73,6 +77,7 @@ interface GetDataOrError {
   column: number;
   row: number;
   variants: ProductDetailsVariantFragment[];
+  variantAttributes?: VariantAttributeFragment[] | null;
   changes: MutableRefObject<DatagridChange[]>;
   channels: ChannelData[];
   added: number[];
@@ -91,6 +96,7 @@ export function getData({
   row,
   channels,
   variants,
+  variantAttributes,
   searchAttributeValues,
 }: GetDataOrError): GridCell {
   // For some reason it happens when user deselects channel
@@ -151,19 +157,35 @@ export function getData({
   }
 
   if (getColumnAttribute(columnId)) {
-    const value =
-      change?.value ??
-      mapNodeToChoice(
-        dataRow?.attributes.find(
-          attribute => attribute.attribute.id === getColumnAttribute(columnId),
-        )?.values,
-      )[0] ??
-      emptyDropdownCellValue;
+    const attributeId = getColumnAttribute(columnId);
+
+    if (!attributeId) {
+      return textCell("");
+    }
+
+    const attribute = dataRow?.attributes.find(attribute => attribute.attribute.id === attributeId);
+    const inputType = variantAttributes?.find(attribute => attribute.id === attributeId)?.inputType;
+
+    if (inputType === AttributeInputTypeEnum.NUMERIC) {
+      const value = change?.value ?? getNumericAttributeValue(attribute?.values[0]?.name);
+
+      return numberCell(value, { hasFloatingPoint: true });
+    }
+
+    const value = change?.value ?? mapNodeToChoice(attribute?.values)[0] ?? emptyDropdownCellValue;
 
     return dropdownCell(value, {
       allowCustomValues: true,
       emptyOption: true,
-      update: text => searchAttributeValues(getColumnAttribute(columnId), text),
+      update: text => searchAttributeValues(attributeId, text),
     });
   }
+}
+
+function getNumericAttributeValue(value: string | null | undefined) {
+  if (!value) {
+    return numberCellEmptyValue;
+  }
+
+  return Number(value);
 }

--- a/src/products/views/ProductUpdate/handlers/data/attributes.test.ts
+++ b/src/products/views/ProductUpdate/handlers/data/attributes.test.ts
@@ -1,7 +1,21 @@
+import { numberCellEmptyValue } from "@dashboard/components/Datagrid/customCells/NumberCell";
 import { type DatagridChange } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
+import { AttributeInputTypeEnum, type VariantAttributeFragment } from "@dashboard/graphql";
 import { variantAttributes } from "@dashboard/products/fixtures";
 
 import { getAttributeData } from "./attributes";
+
+const numericAttributeId = "numeric-attribute-id";
+const numericVariantAttributes: VariantAttributeFragment[] = [
+  ...variantAttributes,
+  {
+    ...variantAttributes[0],
+    id: numericAttributeId,
+    name: "Weight",
+    slug: "weight",
+    inputType: AttributeInputTypeEnum.NUMERIC,
+  },
+];
 
 describe("getAttributeData", () => {
   test("should filter and map data to attribute format", () => {
@@ -55,5 +69,53 @@ describe("getAttributeData", () => {
 
     // Assert
     expect(attributes).toEqual([]);
+  });
+  test("should return numeric input for numeric attribute change", () => {
+    // Arrange
+    const changeData: DatagridChange[] = [
+      {
+        column: `attribute:${numericAttributeId}`,
+        row: 1,
+        data: {
+          kind: "number-cell",
+          value: 150,
+        },
+      },
+    ];
+
+    // Act
+    const attributes = getAttributeData(changeData, 1, numericVariantAttributes);
+
+    // Assert
+    expect(attributes).toEqual([
+      {
+        id: numericAttributeId,
+        numeric: "150",
+      },
+    ]);
+  });
+  test("should return null numeric input when numeric attribute is cleared", () => {
+    // Arrange
+    const changeData: DatagridChange[] = [
+      {
+        column: `attribute:${numericAttributeId}`,
+        row: 1,
+        data: {
+          kind: "number-cell",
+          value: numberCellEmptyValue,
+        },
+      },
+    ];
+
+    // Act
+    const attributes = getAttributeData(changeData, 1, numericVariantAttributes);
+
+    // Assert
+    expect(attributes).toEqual([
+      {
+        id: numericAttributeId,
+        numeric: null,
+      },
+    ]);
   });
 });

--- a/src/products/views/ProductUpdate/handlers/data/attributes.ts
+++ b/src/products/views/ProductUpdate/handlers/data/attributes.ts
@@ -1,3 +1,4 @@
+import { numberCellEmptyValue } from "@dashboard/components/Datagrid/customCells/NumberCell";
 import { type DatagridChange } from "@dashboard/components/Datagrid/hooks/useDatagridChange";
 import {
   AttributeInputTypeEnum,
@@ -9,6 +10,8 @@ import {
 import { getColumnAttribute, isCurrentRow } from "@dashboard/products/utils/datagrid";
 
 import { byAttributeName } from "../utils";
+
+type DatagridAttributeValue = string | number | typeof numberCellEmptyValue | null | undefined;
 
 export function getAttributeData(
   data: DatagridChange[],
@@ -36,7 +39,10 @@ function toAttributeData(variantAttributes: VariantAttributeFragment[]) {
 
     return {
       id: attributeId,
-      ...getDatagridAttributeInput(attributeType, change.data.value.value),
+      ...getDatagridAttributeInput(
+        attributeType,
+        getDatagridAttributeValue(attributeType, change.data),
+      ),
     };
   };
 }
@@ -50,27 +56,47 @@ export function getAttributeType(
   return attributeVariant?.inputType;
 }
 
-// Datagrid only support PLAIN_TEXT and DROPDOWN attribute types
+function getDatagridAttributeValue(
+  inputType: AttributeInputTypeEnum,
+  data: DatagridChange["data"],
+): DatagridAttributeValue {
+  if (inputType === AttributeInputTypeEnum.NUMERIC) {
+    return data.value;
+  }
+
+  return data.value?.value;
+}
+
+// Datagrid only support PLAIN_TEXT, DROPDOWN and NUMERIC attribute types
 function getDatagridAttributeInput(
   inputType: AttributeInputTypeEnum,
-  value = "",
+  value: DatagridAttributeValue = "",
 ): BulkAttributeValueInput {
+  if (inputType === AttributeInputTypeEnum.NUMERIC) {
+    return {
+      numeric:
+        value === numberCellEmptyValue || value === "" || value == null ? null : String(value),
+    };
+  }
+
+  const textValue = typeof value === "string" ? value : "";
+
   if (inputType === AttributeInputTypeEnum.DROPDOWN) {
     return {
       dropdown: {
-        value,
+        value: textValue,
       },
     };
   }
 
   if (inputType === AttributeInputTypeEnum.PLAIN_TEXT) {
     return {
-      plainText: value,
+      plainText: textValue,
     };
   }
 
   return {
-    values: [value],
+    values: [textValue],
   };
 }
 


### PR DESCRIPTION
## What changed

Adds an `Input type` filter to the attributes list so users can filter attributes by input type, including swatch attributes.

The filter uses the existing conditional filter enum handler for `AttributeInputTypeEnum` and sends the selected value through `AttributeWhereInput.inputType.eq`.

## Why

`AttributeFilterInput` does not support filtering by input type, but the current schema exposes it through the newer `where` argument. This keeps existing attribute filters on the legacy `filter` input and sends only input type through `where`.

Closes #4155

## Validation

- `graphql-codegen --config codegen-main.ts`
- `graphql-codegen --config codegen-staging.ts`
- `node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/check-changesets.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 eslint "{src,playwright}/**/*.@(tsx|ts|jsx|js)" --fix`
- `prettier --ignore-unknown --write .`
- `jest --silent components/ConditionalFilter/queryVariables.test.ts`
- `knip --reporter markdown`

`pnpm run check-types` could not complete locally because pnpm's supply-chain policy rejected existing lockfile entries for `ua-parser-js@1.0.41` and `undici-types@6.21.0`. Running `tsc --noEmit` directly showed existing test matcher/type dependency issues, with no errors reported for the changed files.
