### PR TITLE
Fix scheduling future CMS page publication (ENG-1681)

### DIFF
--- a/.changeset/cms-page-scheduled-publication.md
+++ b/.changeset/cms-page-scheduled-publication.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed scheduling future publication of CMS pages (models). Previously, setting an availability date on a page sent `isPublished: false` to the API, so the page stayed hidden from storefront visitors even after the scheduled date passed. Now setting a publication date sends `isPublished: true` together with the date, so the page automatically becomes visible once the scheduled time is reached. Pages waiting for a future publication date are now also correctly shown as "Hidden" with the scheduled date in the visibility card.

--- a/src/components/VisibilityCard/VisibilityCard.stories.tsx
+++ b/src/components/VisibilityCard/VisibilityCard.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import VisibilityCard from "./VisibilityCard";
+
+const messages = {
+  visibleLabel: "Visible",
+  hiddenLabel: "Hidden",
+  hiddenSecondLabel: "will be visible from a scheduled date",
+  visibleSecondLabel: "since",
+  availableLabel: "Available for purchase",
+  unavailableLabel: "Unavailable for purchase",
+  availableSecondLabel: "will become available on a scheduled date",
+  setAvailabilityDateLabel: "Set availability date",
+};
+
+const meta: Meta<typeof VisibilityCard> = {
+  title: "Components / VisibilityCard",
+  component: VisibilityCard,
+  args: {
+    errors: [],
+    messages,
+    onChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VisibilityCard>;
+
+export const Visible: Story = {
+  args: {
+    data: {
+      isPublished: true,
+      publishedAt: null,
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    data: {
+      isPublished: false,
+      publishedAt: null,
+    },
+  },
+};
+
+// A page stored with `isPublished: true` and a future `publishedAt` is not yet
+// visible to storefront visitors, so the card presents it under "Hidden" with
+// the scheduled date controls revealed.
+export const ScheduledForFuturePublication: Story = {
+  args: {
+    data: {
+      isPublished: true,
+      publishedAt: "2099-01-01T00:00:00Z",
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    data: {
+      isPublished: true,
+      publishedAt: null,
+    },
+  },
+};
+
+// Product-style usage: the availability-for-purchase section appears when both
+// `isAvailableForPurchase` and `availableForPurchaseAt` are provided.
+export const WithAvailableForPurchase: Story = {
+  args: {
+    data: {
+      isPublished: true,
+      publishedAt: null,
+      isAvailableForPurchase: false,
+      availableForPurchaseAt: null,
+    },
+  },
+};
+
+// Product-style usage with the listings visibility checkbox.
+export const WithVisibleInListings: Story = {
+  args: {
+    data: {
+      isPublished: true,
+      publishedAt: null,
+      isAvailableForPurchase: true,
+      availableForPurchaseAt: null,
+      visibleInListings: true,
+    },
+  },
+};

--- a/src/components/VisibilityCard/VisibilityCard.test.tsx
+++ b/src/components/VisibilityCard/VisibilityCard.test.tsx
@@ -1,0 +1,72 @@
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import type * as React from "react";
+import { IntlProvider } from "react-intl";
+
+import VisibilityCard from "./VisibilityCard";
+
+// Freeze "now" so future/past publication dates are deterministic.
+const NOW = Date.parse("2020-01-01T00:00:00Z");
+
+jest.mock("@dashboard/hooks/useCurrentDate", () => ({
+  useCurrentDate: () => NOW,
+}));
+
+const Wrapper = ({ children }: React.PropsWithChildren<{}>) => (
+  <ThemeProvider>
+    <IntlProvider locale="en">{children}</IntlProvider>
+  </ThemeProvider>
+);
+
+const messages = {
+  visibleLabel: "Visible",
+  hiddenLabel: "Hidden",
+  hiddenSecondLabel: "will be visible from date",
+  setAvailabilityDateLabel: "Set availability date",
+};
+
+const renderCard = (data: { isPublished: boolean; publishedAt: string }, onChange = jest.fn()) => {
+  const utils = render(
+    <Wrapper>
+      <VisibilityCard data={data} errors={[]} messages={messages} onChange={onChange} />
+    </Wrapper>,
+  );
+
+  return { ...utils, onChange };
+};
+
+describe("VisibilityCard", () => {
+  it("presents a page scheduled for future publication as hidden with the date field shown", () => {
+    // Arrange & Act
+    const { getByTestId, getByRole } = renderCard({
+      isPublished: true,
+      publishedAt: "2099-01-01T00:00:00Z",
+    });
+
+    // Assert - despite isPublished=true, a future date means the page is not yet
+    // visible, so it is shown under "Hidden" with the editable schedule date.
+    expect(getByRole("radio", { name: /Hidden/ })).toBeChecked();
+    expect(getByRole("radio", { name: /Visible/ })).not.toBeChecked();
+    expect(getByTestId("date-time-field")).toBeInTheDocument();
+  });
+
+  it("sets isPublished=true when a publication date is entered", async () => {
+    // Arrange - a hidden page that already has the schedule checkbox revealed
+    const { getByTestId, onChange } = renderCard({
+      isPublished: false,
+      publishedAt: "2099-01-01T00:00:00Z",
+    });
+
+    // Act
+    fireEvent.change(getByTestId("date-time-field"), {
+      target: { value: "2099-06-15T10:00" },
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        target: { name: "isPublished", value: true },
+      });
+    });
+  });
+});

--- a/src/components/VisibilityCard/VisibilityCard.tsx
+++ b/src/components/VisibilityCard/VisibilityCard.tsx
@@ -113,6 +113,14 @@ const VisibilityCard = (props: VisibilityCardProps) => {
 
   const [isPublishedAt, setPublishedAt] = useState(!!publishedAt);
 
+  // A page scheduled for future publication is stored in Saleor Core as
+  // `isPublished: true` together with a future `publishedAt`. Core only exposes
+  // it to storefront visitors once that date passes. Such a page is therefore
+  // "published" but not yet visible, so we present it under the "Hidden" option
+  // with a "will be visible from {date}" hint rather than as "Visible".
+  const isPublishedInFuture = !!publishedAt && Date.parse(publishedAt) > dateNow;
+  const isVisibleNow = isPublished && !isPublishedInFuture;
+
   const hasAvailableProps =
     isAvailableForPurchase !== undefined && availableForPurchaseAt !== undefined;
   const visibleMessage = (date: string) =>
@@ -145,12 +153,15 @@ const VisibilityCard = (props: VisibilityCardProps) => {
         <RadioGroup
           disabled={disabled}
           name="isPublished"
-          value={String(isPublished)}
+          value={String(isVisibleNow)}
           onValueChange={value => {
+            // Selecting "Visible" publishes immediately, "Hidden" clears any
+            // scheduled date. Future-date scheduling is handled by the
+            // "Set availability date" controls below.
             onChange({
               target: {
                 name: "publishedAt",
-                value: value === "false" ? null : availableForPurchaseAt,
+                value: null,
               },
             });
             onChange({
@@ -181,7 +192,7 @@ const VisibilityCard = (props: VisibilityCardProps) => {
           <RadioGroup.Item id={`isPublished-false`} value="false">
             <Box display="flex" __alignItems="baseline" gap={2}>
               <Text>{messages.hiddenLabel}</Text>
-              {publishedAt && !isPublished && (
+              {publishedAt && !isVisibleNow && (
                 <Text size={2} color="default2">
                   {messages.hiddenSecondLabel}
                 </Text>
@@ -190,10 +201,19 @@ const VisibilityCard = (props: VisibilityCardProps) => {
           </RadioGroup.Item>
         </RadioGroup>
 
-        {!isPublished && (
+        {!isVisibleNow && (
           <Box display="flex" gap={1} flexDirection="column" alignItems="start" marginTop={2}>
             <Checkbox
-              onCheckedChange={(checked: boolean) => setPublishedAt(checked)}
+              onCheckedChange={(checked: boolean) => {
+                setPublishedAt(checked);
+
+                // Clearing the schedule returns the page to a plainly hidden
+                // state (isPublished=false, no publication date).
+                if (!checked) {
+                  onChange({ target: { name: "publishedAt", value: null } });
+                  onChange({ target: { name: "isPublished", value: false } });
+                }
+              }}
               checked={isPublishedAt}
             >
               {messages.setAvailabilityDateLabel}
@@ -205,14 +225,23 @@ const VisibilityCard = (props: VisibilityCardProps) => {
                 disabled={disabled}
                 name="publishedAt"
                 value={publishedAt || ""}
-                onChange={value =>
+                onChange={value => {
                   onChange({
                     target: {
                       name: "publishedAt",
                       value: value,
                     },
-                  })
-                }
+                  });
+                  // A scheduled publication date requires isPublished=true so
+                  // Saleor Core makes the page visible once the date passes.
+                  // Clearing the date reverts to a plainly hidden page.
+                  onChange({
+                    target: {
+                      name: "isPublished",
+                      value: Boolean(value),
+                    },
+                  });
+                }}
                 //eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore todo
                 error={getFieldError(errors, "isPublishedAt")}

--- a/src/utils/data/getPublicationData.test.ts
+++ b/src/utils/data/getPublicationData.test.ts
@@ -1,0 +1,50 @@
+import getPublicationData from "./getPublicationData";
+
+describe("getPublicationData", () => {
+  it("keeps a visible page published", () => {
+    // Arrange
+    const data = { isPublished: true, publishedAt: null };
+
+    // Act
+    const result = getPublicationData(data);
+
+    // Assert
+    expect(result).toEqual({ isPublished: true, publishedAt: null });
+  });
+
+  it("keeps a hidden page without a date unpublished", () => {
+    // Arrange
+    const data = { isPublished: false, publishedAt: null };
+
+    // Act
+    const result = getPublicationData(data);
+
+    // Assert
+    expect(result).toEqual({ isPublished: false, publishedAt: null });
+  });
+
+  it("forces isPublished=true when a publication date is set so the page becomes visible once it passes", () => {
+    // Arrange
+    const data = { isPublished: false, publishedAt: "2099-01-01T00:00:00Z" };
+
+    // Act
+    const result = getPublicationData(data);
+
+    // Assert
+    expect(result).toEqual({
+      isPublished: true,
+      publishedAt: "2099-01-01T00:00:00Z",
+    });
+  });
+
+  it("normalizes an empty publication date to null", () => {
+    // Arrange
+    const data = { isPublished: false, publishedAt: "" };
+
+    // Act
+    const result = getPublicationData(data);
+
+    // Assert
+    expect(result).toEqual({ isPublished: false, publishedAt: null });
+  });
+});

--- a/src/utils/data/getPublicationData.ts
+++ b/src/utils/data/getPublicationData.ts
@@ -5,7 +5,10 @@ interface PublicationData {
 
 function getPublishedAt({ publishedAt, isPublished }: PublicationData): PublicationData {
   return {
-    isPublished,
+    // A stored publication date implies the page should be published: Saleor
+    // Core only reveals it to storefront visitors once the date passes, and an
+    // isPublished=false + publishedAt combination would keep it hidden forever.
+    isPublished: isPublished || Boolean(publishedAt),
     publishedAt: publishedAt || null,
   };
 }


### PR DESCRIPTION
Setting an availability date on a page sent isPublished=false +
publishedAt, which Saleor Core treats as hidden forever since
PublishedQuerySet.published() requires both is_published=True and
published_at <= now(). Now a publication date forces isPublished=true,
and the visibility card presents future-dated pages as Hidden with the
scheduled date so the state survives a reload.

https://linear.app/saleor/issue/ENG-1681

