### PR TITLE
fix(build): delete unnecessary code in prepare-sandbox-release

### DIFF
--- a/.github/workflows/prepare-sanbox-release-PR.yaml
+++ b/.github/workflows/prepare-sanbox-release-PR.yaml
@@ -16,16 +16,6 @@ jobs:
     env:
       VERSION: ${{ github.event.inputs.git_ref || github.ref_name }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: "package.json"
-          cache: pnpm
-
       - name: Prepare Sandbox release pull request
         run: |
           export GITHUB_TOKEN=$( \


### PR DESCRIPTION
This deletes unneeded checkout, setup-pnpm, and setup-node which should resolve the post-setup-node step failing with:

```
Error: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

This was likely failing because PNPM was never used thus there was nothing to cache for setup-node.

Example problematic run: https://github.com/saleor/saleor-dashboard/actions/runs/28504988933/job/84491141482

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [x] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [x] I used analytics "trackEvent" for important events
