### PR TITLE
Cache extensions

### DIFF
--- a/.changeset/homepage-widgets-blink.md
+++ b/.changeset/homepage-widgets-blink.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed a flash on the homepage where an empty "Welcome" screen briefly appeared before the app extension tabs and widgets loaded on every page refresh. The homepage now caches the last-known extensions locally and renders their tabs immediately on load while refreshing in the background. On the very first load (before anything is cached) the page stays blank until extensions resolve, instead of flashing the "Welcome" message.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -386,9 +386,6 @@
     "context": "Suffix for show-more button when hidden problems include active ones",
     "string": ", including {active} active"
   },
-  "0+zatS": {
-    "string": "Hello {userName}, welcome to your Store Dashboard"
-  },
   "0/Y0nG": {
     "context": "date group header",
     "string": "Last 7 days"

--- a/src/components/Sidebar/menu/hooks/useMenuStructure.tsx
+++ b/src/components/Sidebar/menu/hooks/useMenuStructure.tsx
@@ -19,6 +19,7 @@ import {
 } from "@dashboard/extensions/urls";
 import { giftCardListUrl } from "@dashboard/giftCards/urls";
 import { PermissionEnum } from "@dashboard/graphql";
+import { rippleHomeWidgets } from "@dashboard/home/ripples/homeWidgets";
 import { ConfigurationIcon } from "@dashboard/icons/Configuration";
 import { CustomersIcon } from "@dashboard/icons/Customers";
 import { DiscountsIcon } from "@dashboard/icons/Discounts";
@@ -105,6 +106,7 @@ export function useMenuStructure() {
       id: "home",
       url: "/home",
       type: "item",
+      endAdornment: <Ripple model={rippleHomeWidgets} />,
     },
     {
       icon: renderIcon(<Search {...navigationLucideIconProps} />),

--- a/src/components/Sidebar/menu/utils.test.ts
+++ b/src/components/Sidebar/menu/utils.test.ts
@@ -42,6 +42,7 @@ describe("mapToExtensionsItems", () => {
     targetName: "APP_PAGE",
     settings: {},
     isSaleorOfficial: false,
+    fromCache: false,
   };
 
   const mockHeader: SidebarMenuItem = {
@@ -291,6 +292,7 @@ describe("getMenuItemExtension", () => {
     settings: {},
     targetName: "POPUP",
     isSaleorOfficial: false,
+    fromCache: false,
   };
 
   const mockExtension: Extension = {

--- a/src/extensions/components/AppWidgets/AppWidgetExtensionItem.test.tsx
+++ b/src/extensions/components/AppWidgets/AppWidgetExtensionItem.test.tsx
@@ -1,0 +1,64 @@
+import { type ExtensionWithParams } from "@dashboard/extensions/types";
+import { render, screen } from "@testing-library/react";
+
+import { AppWidgetExtensionItem } from "./AppWidgetExtensionItem";
+
+jest.mock("@dashboard/extensions/components/IframePost/IframePost", () => ({
+  IframePost: () => <div data-test-id="iframe-post" />,
+}));
+
+jest.mock("@dashboard/extensions/views/ViewManifestExtension/components/AppFrame/AppFrame", () => ({
+  AppFrame: () => <div data-test-id="app-frame" />,
+}));
+
+jest.mock("@dashboard/extensions/components/AppWidgetCard/AppWidgetCard", () => ({
+  AppWidgetCard: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const buildExtension = (overrides: Partial<ExtensionWithParams> = {}): ExtensionWithParams =>
+  ({
+    id: "ext1",
+    app: { id: "app1", name: "App 1", appUrl: "https://example.com", brand: null },
+    accessToken: "token1",
+    permissions: [],
+    label: "Extension 1",
+    mountName: "ORDER_DETAILS_WIDGETS",
+    url: "https://example.com/ext1",
+    open: jest.fn(),
+    targetName: "WIDGET",
+    settings: {},
+    isSaleorOfficial: false,
+    fromCache: false,
+    ...overrides,
+  }) as ExtensionWithParams;
+
+describe("AppWidgetExtensionItem", () => {
+  it("does not mount the widget iframe while fromCache is true", () => {
+    // Arrange & Act
+    render(
+      <AppWidgetExtensionItem
+        extension={buildExtension({ fromCache: true })}
+        params={{}}
+        theme="light"
+      />,
+    );
+
+    // Assert
+    expect(screen.queryByTestId("iframe-post")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("app-frame")).not.toBeInTheDocument();
+  });
+
+  it("mounts the widget iframe once real data is loaded (fromCache=false)", () => {
+    // Arrange & Act
+    render(
+      <AppWidgetExtensionItem
+        extension={buildExtension({ fromCache: false })}
+        params={{}}
+        theme="light"
+      />,
+    );
+
+    // Assert
+    expect(screen.getByTestId("app-frame")).toBeInTheDocument();
+  });
+});

--- a/src/extensions/components/AppWidgets/AppWidgetExtensionItem.tsx
+++ b/src/extensions/components/AppWidgets/AppWidgetExtensionItem.tsx
@@ -9,7 +9,7 @@ import { type ExtensionWithParams } from "@dashboard/extensions/types";
 import { type AppDetailsUrlMountQueryParams, ExtensionsUrls } from "@dashboard/extensions/urls";
 import { AppFrame } from "@dashboard/extensions/views/ViewManifestExtension/components/AppFrame/AppFrame";
 import { type ThemeType } from "@saleor/app-sdk/app-bridge";
-import { Box, Text } from "@saleor/macaw-ui-next";
+import { Box, Skeleton, Text } from "@saleor/macaw-ui-next";
 import { ExternalLink } from "lucide-react";
 import { useIntl } from "react-intl";
 
@@ -61,6 +61,17 @@ export const AppWidgetExtensionItem = ({
           </Link>
         );
     }
+  }
+
+  if (extension.fromCache) {
+    // Snapshot extension has no real access token yet — show a loader and wait
+    // for the background revalidation. Mounting the iframe now would POST/handshake
+    // an empty token and crash the app with "Invalid JWT".
+    return (
+      <AppWidgetCard extension={extension}>
+        <Skeleton />
+      </AppWidgetCard>
+    );
   }
 
   const isIframePost = settings?.widgetTarget?.method === "POST";

--- a/src/extensions/getExtensionsItems.test.ts
+++ b/src/extensions/getExtensionsItems.test.ts
@@ -53,6 +53,7 @@ const mockedExtension: ExtensionWithParams = {
   targetName: "POPUP",
   settings: {},
   isSaleorOfficial: false,
+  fromCache: false,
 };
 
 describe("getExtensionsItems", () => {

--- a/src/extensions/hooks/extensionsSnapshotStorage.test.ts
+++ b/src/extensions/hooks/extensionsSnapshotStorage.test.ts
@@ -1,0 +1,105 @@
+import { type ExtensionListQuery } from "@dashboard/graphql";
+import { type RelayToFlat } from "@dashboard/types";
+
+import {
+  type ExtensionSnapshotNode,
+  getExtensionsSnapshotKey,
+  readExtensionsSnapshot,
+  writeExtensionsSnapshot,
+} from "./extensionsSnapshotStorage";
+
+type Node = RelayToFlat<NonNullable<ExtensionListQuery["appExtensions"]>>[number];
+
+const buildNode = (overrides: Partial<Node> = {}): ExtensionSnapshotNode =>
+  ({
+    __typename: "AppExtension",
+    id: "ext1",
+    accessToken: "secret-token",
+    permissions: [],
+    url: "https://example.com/ext1",
+    label: "Extension 1",
+    mountName: "HOMEPAGE_WIDGETS",
+    targetName: "WIDGET",
+    settings: {},
+    app: {
+      __typename: "App",
+      id: "app1",
+      name: "App 1",
+      appUrl: "https://example.com",
+      brand: null,
+    },
+    ...overrides,
+  }) as ExtensionSnapshotNode;
+
+describe("extensionsSnapshotStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("derives a stable, order-independent key from the mount list", () => {
+    // Arrange & Act
+    const keyA = getExtensionsSnapshotKey(["HOMEPAGE_WIDGETS", "PRODUCT_DETAILS_WIDGETS"]);
+    const keyB = getExtensionsSnapshotKey(["PRODUCT_DETAILS_WIDGETS", "HOMEPAGE_WIDGETS"]);
+
+    // Assert
+    expect(keyA).toBe(keyB);
+  });
+
+  it("round-trips nodes for a given key", () => {
+    // Arrange
+    const key = getExtensionsSnapshotKey(["HOMEPAGE_WIDGETS"]);
+    const nodes = [buildNode({ id: "a" }), buildNode({ id: "b" })];
+
+    // Act
+    writeExtensionsSnapshot(key, nodes);
+
+    const read = readExtensionsSnapshot(key);
+
+    // Assert
+    expect(read?.map(n => n.id)).toEqual(["a", "b"]);
+  });
+
+  it("never persists accessToken", () => {
+    // Arrange
+    const key = getExtensionsSnapshotKey(["HOMEPAGE_WIDGETS"]);
+
+    // Act
+    writeExtensionsSnapshot(key, [buildNode({ accessToken: "secret-token" })]);
+
+    const read = readExtensionsSnapshot(key);
+
+    // Assert
+    expect(read?.[0].accessToken).toBe("");
+    expect(JSON.stringify(read)).not.toContain("secret-token");
+  });
+
+  it("returns null for a missing key", () => {
+    // Arrange & Act & Assert
+    expect(readExtensionsSnapshot(getExtensionsSnapshotKey(["HOMEPAGE_WIDGETS"]))).toBeNull();
+  });
+
+  it("returns null and does not throw on corrupt JSON", () => {
+    // Arrange
+    const key = getExtensionsSnapshotKey(["HOMEPAGE_WIDGETS"]);
+
+    localStorage.setItem(key, "{not-json");
+
+    // Act & Assert
+    expect(() => readExtensionsSnapshot(key)).not.toThrow();
+    expect(readExtensionsSnapshot(key)).toBeNull();
+  });
+
+  it("isolates snapshots per key", () => {
+    // Arrange
+    const homeKey = getExtensionsSnapshotKey(["HOMEPAGE_WIDGETS"]);
+    const productKey = getExtensionsSnapshotKey(["PRODUCT_DETAILS_WIDGETS"]);
+
+    // Act
+    writeExtensionsSnapshot(homeKey, [buildNode({ id: "home" })]);
+    writeExtensionsSnapshot(productKey, [buildNode({ id: "product" })]);
+
+    // Assert
+    expect(readExtensionsSnapshot(homeKey)?.[0].id).toBe("home");
+    expect(readExtensionsSnapshot(productKey)?.[0].id).toBe("product");
+  });
+});

--- a/src/extensions/hooks/extensionsSnapshotStorage.ts
+++ b/src/extensions/hooks/extensionsSnapshotStorage.ts
@@ -1,0 +1,42 @@
+import { type ExtensionListQuery } from "@dashboard/graphql";
+import { type RelayToFlat } from "@dashboard/types";
+
+export type ExtensionSnapshotNode = RelayToFlat<
+  NonNullable<ExtensionListQuery["appExtensions"]>
+>[number];
+
+const KEY_PREFIX = "dashboard-extensions-snapshot";
+
+export const getExtensionsSnapshotKey = (mountList: readonly string[]): string =>
+  `${KEY_PREFIX}:${[...mountList].sort().join(",")}`;
+
+export const readExtensionsSnapshot = (key: string): ExtensionSnapshotNode[] | null => {
+  try {
+    const raw = localStorage.getItem(key);
+
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+export const writeExtensionsSnapshot = (key: string, nodes: ExtensionSnapshotNode[]): void => {
+  try {
+    // Never persist the access token — it is the only secret and can go stale.
+    const sanitized = nodes.map(node => ({ ...node, accessToken: "" }));
+
+    localStorage.setItem(key, JSON.stringify(sanitized));
+  } catch {
+    // Storage may be unavailable (quota, privacy mode); degrade silently.
+  }
+};

--- a/src/extensions/hooks/useExtensions.test.ts
+++ b/src/extensions/hooks/useExtensions.test.ts
@@ -3,7 +3,8 @@ import { type ExtensionWithParams } from "@dashboard/extensions/types";
 import { type ExtensionListQuery, PermissionEnum, useExtensionListQuery } from "@dashboard/graphql";
 import { renderHook } from "@testing-library/react";
 
-import { useExtensions } from "./useExtensions";
+import { getExtensionsSnapshotKey } from "./extensionsSnapshotStorage";
+import { useExtensions, useExtensionsWithLoadingState } from "./useExtensions";
 
 const mockOpenApp = jest.fn();
 
@@ -222,7 +223,7 @@ describe("Extensions / hooks / useExtensions", () => {
 
     // Assert
     expect(useExtensionListQueryMock).toHaveBeenCalledWith({
-      fetchPolicy: "cache-first",
+      fetchPolicy: "cache-and-network",
       variables: {
         filter: {
           mountName: mountList,
@@ -450,7 +451,7 @@ describe("Extensions / hooks / useExtensions", () => {
     });
   });
 
-  it("should use cache-first fetch policy", () => {
+  it("should use cache-and-network fetch policy", () => {
     // Arrange
     useUserPermissionsMock.mockReturnValue([{ code: PermissionEnum.MANAGE_APPS }]);
     useExtensionListQueryMock.mockReturnValue({ data: mockExtensionsData });
@@ -463,7 +464,7 @@ describe("Extensions / hooks / useExtensions", () => {
     // Assert
     expect(useExtensionListQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        fetchPolicy: "cache-first",
+        fetchPolicy: "cache-and-network",
       }),
     );
   });
@@ -661,6 +662,103 @@ describe("Extensions / hooks / useExtensions", () => {
       accessToken: "token7",
       appId: "app7",
       extensionUrl: "https://app7.example.com/ext7",
+    });
+  });
+
+  describe("snapshot + loading", () => {
+    beforeEach(() => {
+      localStorage.clear();
+      useUserPermissionsMock.mockReturnValue([{ code: PermissionEnum.MANAGE_APPS }]);
+    });
+
+    it("reports loading=true when there is no data and no snapshot", () => {
+      // Arrange
+      useExtensionListQueryMock.mockReturnValue({ data: undefined, error: undefined });
+
+      // Act
+      const { result } = renderHook(() =>
+        useExtensionsWithLoadingState(["PRODUCT_OVERVIEW_CREATE"] as const),
+      );
+
+      // Assert
+      expect(result.current.loading).toBe(true);
+      expect(result.current.extensions.PRODUCT_OVERVIEW_CREATE).toEqual([]);
+    });
+
+    it("renders snapshot extensions synchronously with loading=false and fromCache=true", () => {
+      // Arrange - persist a snapshot, then simulate a cold query (no data yet)
+      const key = getExtensionsSnapshotKey(["PRODUCT_OVERVIEW_CREATE"]);
+
+      localStorage.setItem(
+        key,
+        JSON.stringify([
+          {
+            __typename: "AppExtension",
+            id: "cached1",
+            accessToken: "",
+            permissions: [{ code: PermissionEnum.MANAGE_APPS, __typename: "Permission" }],
+            url: "https://example.com/cached1",
+            label: "Cached Extension",
+            mountName: "PRODUCT_OVERVIEW_CREATE",
+            targetName: "POPUP",
+            settings: {},
+            app: {
+              __typename: "App",
+              id: "app-cached",
+              name: "Cached App",
+              appUrl: "https://example.com",
+              brand: null,
+            },
+          },
+        ]),
+      );
+      useExtensionListQueryMock.mockReturnValue({ data: undefined, error: undefined });
+
+      // Act
+      const { result } = renderHook(() =>
+        useExtensionsWithLoadingState(["PRODUCT_OVERVIEW_CREATE"] as const),
+      );
+
+      // Assert
+      expect(result.current.loading).toBe(false);
+      expect(result.current.extensions.PRODUCT_OVERVIEW_CREATE).toEqual([
+        expect.objectContaining({ id: "cached1", fromCache: true, accessToken: "" }),
+      ]);
+    });
+
+    it("prefers live data (fromCache=false) and writes a token-free snapshot", () => {
+      // Arrange
+      useExtensionListQueryMock.mockReturnValue({ data: mockExtensionsData, error: undefined });
+
+      // Act
+      const { result } = renderHook(() =>
+        useExtensionsWithLoadingState(["PRODUCT_OVERVIEW_CREATE"] as const),
+      );
+
+      // Assert - live data wins
+      expect(result.current.loading).toBe(false);
+      expect(result.current.extensions.PRODUCT_OVERVIEW_CREATE[0]).toEqual(
+        expect.objectContaining({ id: "ext1", fromCache: false }),
+      );
+
+      // Assert - snapshot written without the access token
+      const stored = localStorage.getItem(getExtensionsSnapshotKey(["PRODUCT_OVERVIEW_CREATE"]));
+
+      expect(stored).not.toBeNull();
+      expect(stored).not.toContain("token1");
+    });
+
+    it("keeps useExtensions returning the plain record", () => {
+      // Arrange
+      useExtensionListQueryMock.mockReturnValue({ data: mockExtensionsData, error: undefined });
+
+      // Act
+      const { result } = renderHook(() => useExtensions(["PRODUCT_OVERVIEW_CREATE"] as const));
+
+      // Assert
+      expect(result.current.PRODUCT_OVERVIEW_CREATE[0]).toEqual(
+        expect.objectContaining({ id: "ext1" }),
+      );
     });
   });
 });

--- a/src/extensions/hooks/useExtensions.ts
+++ b/src/extensions/hooks/useExtensions.ts
@@ -12,16 +12,24 @@ import { newTabActions } from "@dashboard/extensions/new-tab-actions";
 import { type ExtensionListQuery, useExtensionListQuery } from "@dashboard/graphql";
 import { type RelayToFlat } from "@dashboard/types";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
+import { useEffect, useRef, useState } from "react";
 
 import { type Extension, type ExtensionWithParams } from "../types";
 import { type AppDetailsUrlMountQueryParams } from "../urls";
+import {
+  getExtensionsSnapshotKey,
+  readExtensionsSnapshot,
+  writeExtensionsSnapshot,
+} from "./extensionsSnapshotStorage";
 
 const prepareExtensionsWithActions = ({
   extensions,
   openAppInContext,
+  fromCache,
 }: {
   extensions: RelayToFlat<NonNullable<ExtensionListQuery["appExtensions"]>>;
   openAppInContext: (appData: AppExtensionActiveParams) => void;
+  fromCache: boolean;
 }): ExtensionWithParams[] =>
   extensions
     .filter(({ id, url, label, mountName, app }) => {
@@ -61,11 +69,17 @@ const prepareExtensionsWithActions = ({
         targetName: AppExtensionManifestTarget.parse(targetName),
         settings,
         isSaleorOfficial: isSaleorOfficialAppUrl(resolvedUrl),
+        fromCache,
         /**
          * Only available for NEW_TAB, POPUP, APP_PAGE
          * TODO: Change interface to *not* contain this method if type is WIDGET
          */
         open: (params: AppDetailsUrlMountQueryParams) => {
+          if (fromCache) {
+            // No real access token yet — do not POST/redirect with an empty token.
+            return;
+          }
+
           if (!settingsValidation.success) {
             console.error("Invalid extension configuration", settingsValidation.error);
 
@@ -119,12 +133,41 @@ const prepareExtensionsWithActions = ({
       };
     });
 
-export const useExtensions = <T extends AllAppExtensionMounts>(
+const buildExtensionsMap = <T extends AllAppExtensionMounts>(
+  extensions: ExtensionWithParams[],
   mountList: readonly T[],
 ): Record<T, Extension[]> => {
+  const extensionsMap: Record<AllAppExtensionMounts, Extension[]> = mountList.reduce(
+    (acc, mount) => ({ ...acc, [mount]: [] }),
+    {} as Record<AllAppExtensionMounts, Extension[]>,
+  );
+
+  return extensions.reduce(
+    (acc, extension) => ({
+      ...acc,
+      [extension.mountName]: [...(acc[extension.mountName] || []), extension],
+    }),
+    extensionsMap,
+  );
+};
+
+const useExtensionsCore = <T extends AllAppExtensionMounts>(
+  mountList: readonly T[],
+): { extensions: Record<T, Extension[]>; loading: boolean } => {
   const { activate } = useActiveAppExtension();
-  const { data } = useExtensionListQuery({
-    fetchPolicy: "cache-first",
+
+  const snapshotKey = getExtensionsSnapshotKey(mountList);
+  // Read once, synchronously, so cached structure paints on the first frame.
+  const snapshotRef = useRef<ReturnType<typeof readExtensionsSnapshot>>(null);
+
+  const [snapshot] = useState(() => {
+    snapshotRef.current = readExtensionsSnapshot(snapshotKey);
+
+    return snapshotRef.current;
+  });
+
+  const { data, error } = useExtensionListQuery({
+    fetchPolicy: "cache-and-network",
     variables: {
       filter: {
         // @ts-expect-error - type is fine, but generated type is mutable instead of readonly. We must fix codegen
@@ -132,20 +175,34 @@ export const useExtensions = <T extends AllAppExtensionMounts>(
       },
     },
   });
-  const extensions = prepareExtensionsWithActions({
-    extensions: mapEdgesToItems(data?.appExtensions ?? undefined) || [],
-    openAppInContext: activate,
-  });
-  const extensionsMap: Record<AllAppExtensionMounts, Extension[]> = mountList.reduce(
-    (extensionsMap, mount) => ({ ...extensionsMap, [mount]: [] }),
-    {} as Record<AllAppExtensionMounts, Extension[]>,
-  );
 
-  return extensions.reduce(
-    (prevExtensionsMap, extension) => ({
-      ...prevExtensionsMap,
-      [extension.mountName]: [...(prevExtensionsMap[extension.mountName] || []), extension],
-    }),
-    extensionsMap,
-  );
+  const hasLiveData = Boolean(data);
+  const liveNodes = mapEdgesToItems(data?.appExtensions ?? undefined) || [];
+  const fromCache = !hasLiveData && Boolean(snapshot);
+  const sourceNodes = hasLiveData ? liveNodes : (snapshot ?? []);
+  const loading = !hasLiveData && !snapshot && !error;
+
+  // Persist a fresh, token-free snapshot whenever live data arrives.
+  useEffect(() => {
+    if (hasLiveData) {
+      writeExtensionsSnapshot(snapshotKey, liveNodes);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  const extensions = prepareExtensionsWithActions({
+    extensions: sourceNodes,
+    openAppInContext: activate,
+    fromCache,
+  });
+
+  return { extensions: buildExtensionsMap(extensions, mountList), loading };
 };
+
+export const useExtensions = <T extends AllAppExtensionMounts>(
+  mountList: readonly T[],
+): Record<T, Extension[]> => useExtensionsCore(mountList).extensions;
+
+export const useExtensionsWithLoadingState = <T extends AllAppExtensionMounts>(
+  mountList: readonly T[],
+): { extensions: Record<T, Extension[]>; loading: boolean } => useExtensionsCore(mountList);

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -89,6 +89,13 @@ export interface Extension {
    * extension is mapped from the GraphQL response.
    */
   isSaleorOfficial: boolean;
+  /**
+   * True when this extension was reconstructed from the localStorage snapshot
+   * (background revalidation still in flight). Snapshot extensions have no real
+   * accessToken yet, so token-dependent actions (iframe POST/handshake, new-tab
+   * POST) must wait until this is false.
+   */
+  fromCache: boolean;
 }
 
 export interface ExtensionWithParams extends Omit<Extension, "open"> {

--- a/src/home/ExtensionIframe.test.tsx
+++ b/src/home/ExtensionIframe.test.tsx
@@ -1,0 +1,48 @@
+import { type Extension } from "@dashboard/extensions/types";
+import { render, screen } from "@testing-library/react";
+
+import { ExtensionIframe } from "./ExtensionIframe";
+
+jest.mock("@dashboard/extensions/components/IframePost/IframePost", () => ({
+  IframePost: () => <div data-test-id="iframe-post" />,
+}));
+
+jest.mock("@dashboard/extensions/views/ViewManifestExtension/components/AppFrame/AppFrame", () => ({
+  AppFrame: () => <div data-test-id="app-frame" />,
+}));
+
+const buildExtension = (overrides: Partial<Extension> = {}): Extension =>
+  ({
+    id: "ext1",
+    app: { id: "app1", name: "App 1", appUrl: "https://example.com", brand: null },
+    accessToken: "token1",
+    permissions: [],
+    label: "Extension 1",
+    mountName: "HOMEPAGE_WIDGETS",
+    url: "https://example.com/ext1",
+    open: jest.fn(),
+    targetName: "WIDGET",
+    settings: {},
+    isSaleorOfficial: false,
+    fromCache: false,
+    ...overrides,
+  }) as Extension;
+
+describe("ExtensionIframe", () => {
+  it("does not mount the POST iframe while fromCache is true", () => {
+    // Arrange & Act
+    render(<ExtensionIframe extension={buildExtension({ fromCache: true })} height="100%" />);
+
+    // Assert
+    expect(screen.queryByTestId("iframe-post")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("app-frame")).not.toBeInTheDocument();
+  });
+
+  it("mounts the POST iframe once real data is loaded (fromCache=false)", () => {
+    // Arrange & Act
+    render(<ExtensionIframe extension={buildExtension({ fromCache: false })} height="100%" />);
+
+    // Assert
+    expect(screen.getByTestId("iframe-post")).toBeInTheDocument();
+  });
+});

--- a/src/home/ExtensionIframe.tsx
+++ b/src/home/ExtensionIframe.tsx
@@ -1,10 +1,11 @@
+import { SaleorThrobber } from "@dashboard/components/Throbber";
 import { APP_VERSION } from "@dashboard/config";
 import { IframePost } from "@dashboard/extensions/components/IframePost/IframePost";
 import { appExtensionManifestOptionsSchema } from "@dashboard/extensions/domain/app-extension-manifest-options";
 import { isUrlAbsolute } from "@dashboard/extensions/isUrlAbsolute";
 import { type Extension } from "@dashboard/extensions/types";
 import { AppFrame } from "@dashboard/extensions/views/ViewManifestExtension/components/AppFrame/AppFrame";
-import { Box } from "@saleor/macaw-ui-next";
+import { Box, Skeleton } from "@saleor/macaw-ui-next";
 
 interface ExtensionIframeProps {
   extension: Extension;
@@ -17,6 +18,23 @@ export const ExtensionIframe = ({
   height,
   loaderType = "skeleton",
 }: ExtensionIframeProps) => {
+  if (extension.fromCache) {
+    // Snapshot extension has no real access token yet — show a loader and wait
+    // for the background revalidation before handing anything to appBridge.
+    return (
+      <Box
+        position="relative"
+        width="100%"
+        height="100%"
+        display={loaderType === "throbber" ? "flex" : "block"}
+        alignItems={loaderType === "throbber" ? "center" : undefined}
+        justifyContent={loaderType === "throbber" ? "center" : undefined}
+      >
+        {loaderType === "throbber" ? <SaleorThrobber /> : <Skeleton __height={height} />}
+      </Box>
+    );
+  }
+
   const settings = appExtensionManifestOptionsSchema.safeParse(extension.settings);
   const method = settings.success ? (settings.data.homeWidgetTarget?.method ?? "POST") : "POST";
   const extensionUrl = isUrlAbsolute(extension.url)

--- a/src/home/HomePage.test.tsx
+++ b/src/home/HomePage.test.tsx
@@ -1,9 +1,32 @@
-import { renderHook } from "@testing-library/react";
+import { render, renderHook, screen } from "@testing-library/react";
 import type React from "react";
 import { MemoryRouter, Route } from "react-router-dom";
 
-import { useHomeRouteParams } from "./HomePage";
+import { HomePage, useHomeRouteParams } from "./HomePage";
 import { homeWidgetsUrl, homeWidgetUrl } from "./urls";
+
+jest.mock("@dashboard/extensions/hooks/useExtensions", () => ({
+  useExtensionsWithLoadingState: jest.fn(),
+}));
+
+jest.mock("@dashboard/auth/useUser", () => ({
+  useUser: () => ({
+    user: { firstName: "Ada", email: "ada@example.com", userPermissions: [] },
+  }),
+}));
+
+import { useExtensionsWithLoadingState } from "@dashboard/extensions/hooks/useExtensions";
+
+const useExtensionsWithLoadingStateMock = useExtensionsWithLoadingState as jest.Mock;
+
+const renderHomePage = (path = "/home/widgets") =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Route path={["/home/widget/:extensionId", "/home/widgets", "/home"]}>
+        <HomePage />
+      </Route>
+    </MemoryRouter>,
+  );
 
 const renderRouteHook = (initialPath: string) =>
   renderHook(() => useHomeRouteParams(), {
@@ -83,5 +106,36 @@ describe("useHomeRouteParams", () => {
     expect(result.current.extensionId).toBe(id);
     expect(result.current.extensionId).not.toContain("%3D");
     expect(result.current.extensionId).not.toContain("%2B");
+  });
+});
+
+describe("HomePage states", () => {
+  it("renders neither Welcome nor tabs while loading", () => {
+    // Arrange
+    useExtensionsWithLoadingStateMock.mockReturnValue({
+      extensions: { HOMEPAGE_WIDGETS: [] },
+      loading: true,
+    });
+
+    // Act
+    renderHomePage();
+
+    // Assert
+    expect(screen.queryByText("Welcome")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("home-widgets-grid")).not.toBeInTheDocument();
+  });
+
+  it("renders the Welcome empty state when loaded with no extensions", () => {
+    // Arrange
+    useExtensionsWithLoadingStateMock.mockReturnValue({
+      extensions: { HOMEPAGE_WIDGETS: [] },
+      loading: false,
+    });
+
+    // Act
+    renderHomePage();
+
+    // Assert
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
   });
 });

--- a/src/home/HomePage.tsx
+++ b/src/home/HomePage.tsx
@@ -1,7 +1,5 @@
 import { useUser } from "@dashboard/auth/useUser";
 import { useExtensionsWithLoadingState } from "@dashboard/extensions/hooks/useExtensions";
-import { getUserName } from "@dashboard/misc";
-import { Ripple } from "@dashboard/ripples/components/Ripple";
 import { Box, Text } from "@saleor/macaw-ui-next";
 import { FormattedMessage } from "react-intl";
 import { useParams, useRouteMatch } from "react-router";
@@ -11,7 +9,6 @@ import { filterHomeExtensions } from "./filterHomeExtensions";
 import { HomeWidgetsGrid } from "./HomeWidgetsGrid";
 import { type HomeActiveTab, HomeWidgetTabs } from "./HomeWidgetTabs";
 import { HomeWidgetView } from "./HomeWidgetView";
-import { rippleHomeWidgets } from "./ripples/homeWidgets";
 import { homeWidgetsUrl, homeWidgetUrl } from "./urls";
 
 const HOMEPAGE_MOUNT = ["HOMEPAGE_WIDGETS"] as const;
@@ -108,22 +105,11 @@ export const HomePage = () => {
     activeTab = { kind: "extension", id: activeExtension.id };
   }
 
-  const userName = getUserName(user, true);
   const showWidgetsTab = widgets.length > 0;
 
   return (
     <Box display="flex" flexDirection="column" height="100%">
-      <Box paddingX={6} paddingTop={6} display="flex" alignItems="center" gap={4}>
-        <Text size={6} fontWeight="bold" as="h1" data-test-id="welcome-header">
-          <FormattedMessage
-            id="0+zatS"
-            defaultMessage="Hello {userName}, welcome to your Store Dashboard"
-            values={{ userName }}
-          />
-        </Text>
-        <Ripple model={rippleHomeWidgets} />
-      </Box>
-      <Box paddingX={6} paddingTop={4}>
+      <Box paddingX={6} paddingTop={6}>
         <HomeWidgetTabs
           fullscreenExtensions={fullscreen}
           showWidgetsTab={showWidgetsTab}

--- a/src/home/HomePage.tsx
+++ b/src/home/HomePage.tsx
@@ -1,5 +1,5 @@
 import { useUser } from "@dashboard/auth/useUser";
-import { useExtensions } from "@dashboard/extensions/hooks/useExtensions";
+import { useExtensionsWithLoadingState } from "@dashboard/extensions/hooks/useExtensions";
 import { getUserName } from "@dashboard/misc";
 import { Ripple } from "@dashboard/ripples/components/Ripple";
 import { Box, Text } from "@saleor/macaw-ui-next";
@@ -48,8 +48,15 @@ export const HomePage = () => {
   const { user } = useUser();
   const userPermissions = user?.userPermissions ?? [];
 
-  const { HOMEPAGE_WIDGETS: extensions } = useExtensions(HOMEPAGE_MOUNT);
+  const { extensions: extensionsByMount, loading } = useExtensionsWithLoadingState(HOMEPAGE_MOUNT);
+  const extensions = extensionsByMount.HOMEPAGE_WIDGETS;
   const { fullscreen, widgets } = filterHomeExtensions(extensions, userPermissions);
+
+  if (loading) {
+    // First-ever load with no cached snapshot: keep the screen blank to avoid
+    // flashing the "Welcome" empty state before extensions resolve.
+    return <Box height="100%" />;
+  }
 
   if (fullscreen.length === 0 && widgets.length === 0) {
     return (

--- a/src/home/HomeWidgetTabs.stories.tsx
+++ b/src/home/HomeWidgetTabs.stories.tsx
@@ -21,6 +21,7 @@ const buildExtension = (overrides: Partial<Extension>): Extension => ({
   targetName: "WIDGET",
   settings: null,
   isSaleorOfficial: true,
+  fromCache: false,
   ...overrides,
 });
 

--- a/src/home/filterHomeExtensions.test.ts
+++ b/src/home/filterHomeExtensions.test.ts
@@ -26,6 +26,7 @@ const buildExtension = (overrides: Partial<Extension>): Extension => ({
   targetName: "WIDGET",
   settings: null,
   isSaleorOfficial: false,
+  fromCache: false,
   ...overrides,
 });
 


### PR DESCRIPTION
Persist the extensions query to localStorage (minus the secret accessToken) and seed useExtensions synchronously on first render so homepage tabs paint immediately on refresh, revalidating via cache-and-network in the background. Snapshot-derived extensions are flagged fromCache so the widget iframe waits for the real token before handing anything to appBridge. HomePage shows a blank screen during the true first-ever load instead of flashing "Welcome".

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
