### PR TITLE
Add settings shortcuts for product and model types in sidebar sections

### DIFF
--- a/.changeset/modeling-menu-model-types.md
+++ b/.changeset/modeling-menu-model-types.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Moved Model Types and Product Types to the bottom of their sidebar sections, separated by a dashed line from daily-use items. Both open the same settings views as Configuration, with a small settings icon and lighter label styling.

--- a/src/components/Sidebar/menu/ItemGroup.tsx
+++ b/src/components/Sidebar/menu/ItemGroup.tsx
@@ -1,9 +1,12 @@
 // @ts-strict-ignore
 import { Box, List, sprinkles, Text } from "@saleor/macaw-ui-next";
+import { Fragment } from "react";
 import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
 
 import { MenuItem } from "./Item";
+import { showSubmenuSeparator } from "./settingsSubmenuItem";
+import { SubmenuSeparator } from "./SubmenuSeparator";
 import { type SidebarMenuItem } from "./types";
 import { isMenuActive } from "./utils";
 
@@ -68,8 +71,11 @@ export const ItemGroup = ({ menuItem }: Props) => {
           marginTop={1}
           gap="px"
         >
-          {menuItem.children?.map(child => (
-            <MenuItem menuItem={child} key={child.id} />
+          {menuItem.children?.map((child, index) => (
+            <Fragment key={child.id}>
+              {showSubmenuSeparator(child, index) && <SubmenuSeparator />}
+              <MenuItem menuItem={child} />
+            </Fragment>
           ))}
         </Box>
       </List.ItemGroup.Content>

--- a/src/components/Sidebar/menu/MenuItemLabel.tsx
+++ b/src/components/Sidebar/menu/MenuItemLabel.tsx
@@ -1,0 +1,28 @@
+import { Text } from "@saleor/macaw-ui-next";
+
+import { type SidebarMenuItem } from "./types";
+
+interface MenuItemLabelProps {
+  menuItem: SidebarMenuItem;
+}
+
+// Custom ReactNode labels must set their own typography (see Search / Extensions items).
+export const MenuItemLabel = ({ menuItem }: MenuItemLabelProps) => {
+  if (typeof menuItem.label !== "string") {
+    return <>{menuItem.label}</>;
+  }
+
+  if (menuItem.labelStyle === "settings") {
+    return (
+      <Text size={2} fontWeight="regular" color="default2">
+        {menuItem.label}
+      </Text>
+    );
+  }
+
+  return (
+    <Text size={3} fontWeight="medium">
+      {menuItem.label}
+    </Text>
+  );
+};

--- a/src/components/Sidebar/menu/SingleItem.tsx
+++ b/src/components/Sidebar/menu/SingleItem.tsx
@@ -1,7 +1,8 @@
-import { Box, List, sprinkles, Text } from "@saleor/macaw-ui-next";
+import { Box, List, sprinkles } from "@saleor/macaw-ui-next";
 import { Link } from "react-router-dom";
 
 import { useIsMenuActive } from "./hooks/useIsMenuActive";
+import { MenuItemLabel } from "./MenuItemLabel";
 import { type SidebarMenuItem } from "./types";
 
 interface Props {
@@ -34,17 +35,13 @@ export const SingleItem = ({ menuItem }: Props) => {
         })}
       >
         <Box
-          className={sprinkles({
-            paddingY: 1.5,
-            gap: 3,
-            display: "flex",
-            alignItems: "center",
-          })}
+          paddingY={1.5}
+          gap={menuItem.labelStyle === "settings" ? 1.5 : 3}
+          display="flex"
+          alignItems="center"
         >
           {menuItem.icon}
-          <Text size={3} fontWeight="medium">
-            {menuItem.label}
-          </Text>
+          <MenuItemLabel menuItem={menuItem} />
         </Box>
       </Link>
       {menuItem.endAdornment && (

--- a/src/components/Sidebar/menu/SubmenuSeparator.module.css
+++ b/src/components/Sidebar/menu/SubmenuSeparator.module.css
@@ -1,0 +1,5 @@
+.separator {
+  border-top: 1px dashed var(--mu-colors-border-default1);
+  margin: 6px 0;
+  opacity: 0.7;
+}

--- a/src/components/Sidebar/menu/SubmenuSeparator.tsx
+++ b/src/components/Sidebar/menu/SubmenuSeparator.tsx
@@ -1,0 +1,3 @@
+import styles from "./SubmenuSeparator.module.css";
+
+export const SubmenuSeparator = () => <div aria-hidden className={styles.separator} />;

--- a/src/components/Sidebar/menu/hooks/useMenuStructure.tsx
+++ b/src/components/Sidebar/menu/hooks/useMenuStructure.tsx
@@ -34,16 +34,18 @@ import { pageListPath } from "@dashboard/modeling/urls";
 import { pageTypeListUrl } from "@dashboard/modelTypes/urls";
 import { orderDraftListUrl, orderListUrl } from "@dashboard/orders/urls";
 import { productListUrl } from "@dashboard/products/urls";
+import { productTypeListUrl } from "@dashboard/productTypes/urls";
 import { Ripple } from "@dashboard/ripples/components/Ripple";
 import { SearchShortcut } from "@dashboard/search/SearchShortcut";
 import { menuListUrl } from "@dashboard/structures/urls";
 import { languageListUrl } from "@dashboard/translations/urls";
-import { Box } from "@saleor/macaw-ui-next";
+import { Box, Text } from "@saleor/macaw-ui-next";
 import isEmpty from "lodash/isEmpty";
 import { Search } from "lucide-react";
 import { useIntl } from "react-intl";
 
 import { SidebarIconSlot } from "../../SidebarIconSlot";
+import { createSettingsSubmenuItem } from "../settingsSubmenuItem";
 import { type SidebarMenuItem } from "../types";
 import { mapToExtensionsItems } from "../utils";
 
@@ -74,7 +76,9 @@ export function useMenuStructure() {
       {
         label: (
           <Box display="flex" alignItems="center" gap={3}>
-            {intl.formatMessage(sectionNames.installedExtensions)}
+            <Text size={3} fontWeight="medium">
+              {intl.formatMessage(sectionNames.installedExtensions)}
+            </Text>
             <SidebarAppAlert hasNewFailedAttempts={hasProblems} small />
           </Box>
         ),
@@ -112,7 +116,9 @@ export function useMenuStructure() {
       icon: renderIcon(<Search {...navigationLucideIconProps} />),
       label: (
         <Box display="flex" alignItems="center" gap={2}>
-          {intl.formatMessage(sectionNames.search)}
+          <Text size={3} fontWeight="medium">
+            {intl.formatMessage(sectionNames.search)}
+          </Text>
           <SearchShortcut />
         </Box>
       ),
@@ -157,11 +163,21 @@ export function useMenuStructure() {
           type: "item",
         },
         ...mapToExtensionsItems(extensions.NAVIGATION_CATALOG, appExtensionsHeaderItem),
+        createSettingsSubmenuItem({
+          id: "product-types",
+          label: intl.formatMessage(sectionNames.productTypes),
+          url: productTypeListUrl(),
+          permissions: [PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES],
+        }),
       ],
       icon: renderIcon(<ProductsIcon />),
       url: productListUrl(),
       label: intl.formatMessage(sectionNames.catalog),
-      permissions: [PermissionEnum.MANAGE_GIFT_CARD, PermissionEnum.MANAGE_PRODUCTS],
+      permissions: [
+        PermissionEnum.MANAGE_GIFT_CARD,
+        PermissionEnum.MANAGE_PRODUCTS,
+        PermissionEnum.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+      ],
       id: "products",
       type: "itemGroup",
     },
@@ -255,16 +271,6 @@ export function useMenuStructure() {
           type: "item",
         },
         {
-          label: intl.formatMessage(sectionNames.modelTypes),
-          id: "model-types",
-          url: pageTypeListUrl(),
-          permissions: [
-            PermissionEnum.MANAGE_PAGES,
-            PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
-          ],
-          type: "item",
-        },
-        {
           label: intl.formatMessage(sectionNames.structures),
           id: "structures",
           url: menuListUrl(),
@@ -272,10 +278,20 @@ export function useMenuStructure() {
           type: "item",
         },
         ...mapToExtensionsItems(extensions.NAVIGATION_PAGES, appExtensionsHeaderItem),
+        createSettingsSubmenuItem({
+          id: "model-types",
+          label: intl.formatMessage(sectionNames.modelTypes),
+          url: pageTypeListUrl(),
+          permissions: [PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES],
+        }),
       ],
       icon: renderIcon(<ModelingIcon />),
       label: intl.formatMessage(sectionNames.modeling),
-      permissions: [PermissionEnum.MANAGE_PAGES, PermissionEnum.MANAGE_MENUS],
+      permissions: [
+        PermissionEnum.MANAGE_PAGES,
+        PermissionEnum.MANAGE_MENUS,
+        PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+      ],
       id: "modeling",
       url: pageListPath,
       type: "itemGroup",

--- a/src/components/Sidebar/menu/settingsSubmenuItem.test.ts
+++ b/src/components/Sidebar/menu/settingsSubmenuItem.test.ts
@@ -1,0 +1,59 @@
+import { PermissionEnum } from "@dashboard/graphql";
+
+import { createSettingsSubmenuItem, showSubmenuSeparator } from "./settingsSubmenuItem";
+import { type SidebarMenuItem } from "./types";
+
+describe("showSubmenuSeparator", () => {
+  const settingsItem: SidebarMenuItem = {
+    id: "product-types",
+    label: "Product types",
+    type: "item",
+    separatorBefore: true,
+  };
+
+  it("shows separator when item is not first in submenu", () => {
+    // Arrange & Act & Assert
+    expect(showSubmenuSeparator(settingsItem, 1)).toBe(true);
+  });
+
+  it("hides separator when settings item is first visible submenu entry", () => {
+    // Arrange & Act & Assert
+    expect(showSubmenuSeparator(settingsItem, 0)).toBe(false);
+  });
+
+  it("hides separator when flag is not set", () => {
+    // Arrange
+    const item: SidebarMenuItem = {
+      id: "products",
+      label: "Products",
+      type: "item",
+    };
+
+    // Act & Assert
+    expect(showSubmenuSeparator(item, 2)).toBe(false);
+  });
+});
+
+describe("createSettingsSubmenuItem", () => {
+  it("creates a settings-styled submenu item", () => {
+    // Arrange & Act
+    const item = createSettingsSubmenuItem({
+      id: "model-types",
+      label: "Model types",
+      url: "/model-types/",
+      permissions: [PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES],
+    });
+
+    // Assert
+    expect(item).toMatchObject({
+      id: "model-types",
+      label: "Model types",
+      labelStyle: "settings",
+      url: "/model-types/",
+      type: "item",
+      separatorBefore: true,
+      permissions: [PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES],
+    });
+    expect(item.icon).toBeTruthy();
+  });
+});

--- a/src/components/Sidebar/menu/settingsSubmenuItem.tsx
+++ b/src/components/Sidebar/menu/settingsSubmenuItem.tsx
@@ -1,0 +1,48 @@
+import { type PermissionEnum } from "@dashboard/graphql";
+import { Box } from "@saleor/macaw-ui-next";
+import { Settings } from "lucide-react";
+
+import { type SidebarMenuItem } from "./types";
+
+export function showSubmenuSeparator(child: SidebarMenuItem, index: number): boolean {
+  return Boolean(child.separatorBefore) && index > 0;
+}
+
+export function createSettingsSubmenuItem({
+  id,
+  label,
+  url,
+  permissions,
+}: {
+  id: string;
+  label: string;
+  url: string;
+  permissions: PermissionEnum[];
+}): SidebarMenuItem {
+  return {
+    icon: renderSubmenuSettingsIcon(),
+    label,
+    labelStyle: "settings",
+    id,
+    url,
+    permissions,
+    type: "item",
+    separatorBefore: true,
+  };
+}
+
+function renderSubmenuSettingsIcon() {
+  return (
+    <Box
+      color="default2"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      __flexShrink={0}
+      __width={14}
+      __height={14}
+    >
+      <Settings size={12} strokeWidth={2} />
+    </Box>
+  );
+}

--- a/src/components/Sidebar/menu/types.ts
+++ b/src/components/Sidebar/menu/types.ts
@@ -14,4 +14,6 @@ export interface SidebarMenuItem {
   children?: SidebarMenuItem[];
   paddingY?: Sprinkles["paddingY"];
   endAdornment?: ReactNode;
+  separatorBefore?: boolean;
+  labelStyle?: "default" | "settings";
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -241,13 +241,9 @@ const Routes = () => {
                     component={PageSection}
                   />
                   <SectionRoute
-                    permissions={[
-                      PermissionEnum.MANAGE_PAGES,
-                      PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
-                    ]}
+                    permissions={[PermissionEnum.MANAGE_PAGE_TYPES_AND_ATTRIBUTES]}
                     path={modelTypesPath}
                     component={PageTypesSection}
-                    matchPermission="any"
                   />
                   <SectionRoute
                     permissions={[PermissionEnum.MANAGE_ORDERS]}

--- a/src/modelTypes/components/PageTypeListPage/PageTypeListPage.tsx
+++ b/src/modelTypes/components/PageTypeListPage/PageTypeListPage.tsx
@@ -2,6 +2,7 @@ import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import { ButtonGroupWithDropdown } from "@dashboard/components/ButtonGroupWithDropdown";
 import { FilterPresetsSelect } from "@dashboard/components/FilterPresetsSelect";
 import { ListPageLayout } from "@dashboard/components/Layouts";
+import { configurationMenuUrl } from "@dashboard/configuration/urls";
 import { extensionMountPoints } from "@dashboard/extensions/extensionMountPoints";
 import {
   getExtensionItemsForOverviewCreate,
@@ -70,6 +71,7 @@ const PageTypeListPage = ({
       <TopNav
         isAlignToRight={false}
         withoutBorder
+        href={configurationMenuUrl}
         title={intl.formatMessage(sectionNames.modelTypes)}
       >
         <Box __flex={1} display="flex" justifyContent="space-between" alignItems="center">


### PR DESCRIPTION
I want to test a new settings access pattern.

<img width="572" height="341" alt="image" src="https://github.com/user-attachments/assets/ab2d9288-ec76-4023-bbd0-8a352ae520be" />
