### PR TITLE
Pre-set reference type filter in model reference picker

### DIFF
--- a/.changeset/model-reference-attribute-filter.md
+++ b/.changeset/model-reference-attribute-filter.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed the reference value picker on models (pages) not respecting the attribute's configured type restriction. When a reference attribute limits references to specific product types or model types, editing a model and assigning a value now pre-sets that filter in the picker dialog and only shows matching items, instead of listing all items. This already worked for products and now behaves the same for models.

--- a/src/components/AssignModelDialog/AssignModelDialog.initialConstraints.test.tsx
+++ b/src/components/AssignModelDialog/AssignModelDialog.initialConstraints.test.tsx
@@ -1,0 +1,54 @@
+import { MockedProvider } from "@apollo/client/testing";
+import { render, waitFor } from "@testing-library/react";
+import type React from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import AssignModelDialog from "./AssignModelDialog";
+
+jest.mock("react-intl", () => ({
+  FormattedMessage: ({ defaultMessage }: { defaultMessage: string }) => <>{defaultMessage}</>,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage }: { defaultMessage: string }) => defaultMessage,
+  }),
+  defineMessages: (messages: Record<string, unknown>) => messages,
+}));
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MockedProvider mocks={[]} addTypename={false}>
+    <MemoryRouter initialEntries={["/?action=assign-attribute-value"]}>{children}</MemoryRouter>
+  </MockedProvider>
+);
+
+const mockPages = [{ __typename: "Page" as const, id: "page-1", title: "Test Page 1" }];
+
+describe("AssignModelDialog initialConstraints", () => {
+  it("applies pageType constraint to the filter when initialConstraints has pageTypes", async () => {
+    // Arrange
+    const onFilterChange = jest.fn();
+
+    // Act
+    render(
+      <AssignModelDialog
+        confirmButtonState="default"
+        pages={mockPages}
+        loading={false}
+        hasMore={false}
+        onFetchMore={jest.fn()}
+        onSubmit={jest.fn()}
+        onClose={jest.fn()}
+        open
+        onFilterChange={onFilterChange}
+        initialConstraints={{ pageTypes: [{ id: "type-1", name: "Blog" }] }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    // Assert
+    await waitFor(() => {
+      expect(onFilterChange).toHaveBeenCalledWith(
+        { pageType: { oneOf: ["type-1"] } },
+        expect.any(String),
+      );
+    });
+  });
+});

--- a/src/components/ModalFilters/getReferenceTypeConstraints.test.ts
+++ b/src/components/ModalFilters/getReferenceTypeConstraints.test.ts
@@ -1,0 +1,64 @@
+import { getReferenceTypeConstraints } from "./getReferenceTypeConstraints";
+
+describe("getReferenceTypeConstraints", () => {
+  it("returns undefined when referenceTypes is null/undefined/empty", () => {
+    // Arrange / Act / Assert
+    expect(getReferenceTypeConstraints(null)).toBeUndefined();
+    expect(getReferenceTypeConstraints(undefined)).toBeUndefined();
+    expect(getReferenceTypeConstraints([])).toBeUndefined();
+  });
+
+  it("builds pageTypes constraint from PageType references (model reference)", () => {
+    // Arrange
+    const referenceTypes = [{ __typename: "PageType" as const, id: "pt-1", name: "Blog" }];
+
+    // Act
+    const result = getReferenceTypeConstraints(referenceTypes);
+
+    // Assert
+    expect(result).toEqual({ pageTypes: [{ id: "pt-1", name: "Blog" }] });
+  });
+
+  it("builds productTypes constraint from ProductType references", () => {
+    // Arrange
+    const referenceTypes = [{ __typename: "ProductType" as const, id: "prt-1", name: "Shirt" }];
+
+    // Act
+    const result = getReferenceTypeConstraints(referenceTypes);
+
+    // Assert
+    expect(result).toEqual({ productTypes: [{ id: "prt-1", name: "Shirt" }] });
+  });
+
+  it("builds both constraints when mixed reference types are present", () => {
+    // Arrange
+    const referenceTypes = [
+      { __typename: "ProductType" as const, id: "prt-1", name: "Shirt" },
+      { __typename: "PageType" as const, id: "pt-1", name: "Blog" },
+    ];
+
+    // Act
+    const result = getReferenceTypeConstraints(referenceTypes);
+
+    // Assert
+    expect(result).toEqual({
+      productTypes: [{ id: "prt-1", name: "Shirt" }],
+      pageTypes: [{ id: "pt-1", name: "Blog" }],
+    });
+  });
+
+  it("ignores entries without id and null entries", () => {
+    // Arrange
+    const referenceTypes = [
+      null,
+      { __typename: "PageType" as const, id: "", name: "Empty" },
+      { __typename: "PageType" as const, id: "pt-2", name: "Landing" },
+    ];
+
+    // Act
+    const result = getReferenceTypeConstraints(referenceTypes);
+
+    // Assert
+    expect(result).toEqual({ pageTypes: [{ id: "pt-2", name: "Landing" }] });
+  });
+});

--- a/src/components/ModalFilters/getReferenceTypeConstraints.ts
+++ b/src/components/ModalFilters/getReferenceTypeConstraints.ts
@@ -1,0 +1,46 @@
+import { type InitialPageConstraints } from "./entityConfigs/ModalPageFilterProvider";
+import { type InitialConstraints } from "./entityConfigs/ModalProductFilterProvider";
+
+type ReferenceTypeOption =
+  | { __typename?: "ProductType"; id: string; name: string }
+  | { __typename?: "PageType"; id: string; name: string };
+
+/**
+ * Builds modal filter constraints from a reference attribute's `referenceTypes`.
+ *
+ * Reference attributes can restrict the referenceable objects to specific product
+ * types and/or model (page) types. This maps that restriction into the constraint
+ * shape consumed by the assign-reference modals so the type filter is pre-set.
+ *
+ * Returns `undefined` when there is no restriction to apply.
+ */
+export const getReferenceTypeConstraints = (
+  referenceTypes: ReadonlyArray<ReferenceTypeOption | null> | null | undefined,
+): (InitialConstraints & InitialPageConstraints) | undefined => {
+  if (!referenceTypes?.length) {
+    return undefined;
+  }
+
+  const productTypeRefs = referenceTypes.filter(
+    (t): t is { __typename?: "ProductType"; id: string; name: string } =>
+      t?.__typename === "ProductType" && Boolean(t?.id),
+  );
+
+  const pageTypeRefs = referenceTypes.filter(
+    (t): t is { __typename?: "PageType"; id: string; name: string } =>
+      t?.__typename === "PageType" && Boolean(t?.id),
+  );
+
+  if (productTypeRefs.length === 0 && pageTypeRefs.length === 0) {
+    return undefined;
+  }
+
+  return {
+    ...(productTypeRefs.length > 0 && {
+      productTypes: productTypeRefs.map(t => ({ id: t.id, name: t.name })),
+    }),
+    ...(pageTypeRefs.length > 0 && {
+      pageTypes: pageTypeRefs.map(t => ({ id: t.id, name: t.name })),
+    }),
+  };
+};

--- a/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
+++ b/src/modeling/components/PageDetailsPage/PageDetailsPage.tsx
@@ -15,6 +15,8 @@ import { type ConfirmButtonTransitionState } from "@dashboard/components/Confirm
 import { useDevModeContext } from "@dashboard/components/DevModePanel/hooks";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
 import { Metadata } from "@dashboard/components/Metadata";
+import { type InitialPageConstraints } from "@dashboard/components/ModalFilters/entityConfigs/ModalPageFilterProvider";
+import { type InitialConstraints } from "@dashboard/components/ModalFilters/entityConfigs/ModalProductFilterProvider";
 import { Savebar } from "@dashboard/components/Savebar";
 import { SeoForm } from "@dashboard/components/SeoForm";
 import VisibilityCard from "@dashboard/components/VisibilityCard";
@@ -88,6 +90,7 @@ interface PageDetailsPageProps {
   onSelectPageType?: (pageTypeId: string) => void;
   onAttributeSelectBlur: () => void;
   onFilterChange?: AssignAttributeValueDialogFilterChangeMap;
+  initialConstraints?: InitialConstraints & InitialPageConstraints;
 }
 
 const PageDetailsPage = ({
@@ -123,6 +126,7 @@ const PageDetailsPage = ({
   onSelectPageType,
   onAttributeSelectBlur,
   onFilterChange,
+  initialConstraints,
 }: PageDetailsPageProps) => {
   const intl = useIntl();
   const { lastUsedLocaleOrFallback } = useCachedLocales();
@@ -353,6 +357,7 @@ const PageDetailsPage = ({
                 loading={handlers.fetchMoreReferences?.loading}
                 onClose={onCloseDialog}
                 onFilterChange={onFilterChange}
+                initialConstraints={initialConstraints}
                 onSubmit={attributeValues =>
                   handleAssignReferenceAttribute(attributeValues, data, handlers)
                 }

--- a/src/modeling/views/PageDetails.tsx
+++ b/src/modeling/views/PageDetails.tsx
@@ -11,6 +11,8 @@ import {
 } from "@dashboard/attributes/utils/handlers";
 import ActionDialog from "@dashboard/components/ActionDialog";
 import { type AttributeInput } from "@dashboard/components/Attributes";
+import { type InitialPageConstraints } from "@dashboard/components/ModalFilters/entityConfigs/ModalPageFilterProvider";
+import { type InitialConstraints } from "@dashboard/components/ModalFilters/entityConfigs/ModalProductFilterProvider";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA, VALUES_PAGINATE_BY } from "@dashboard/config";
 import { useRegisterEntityRefresh } from "@dashboard/extensions/entity-refresh";
@@ -39,6 +41,7 @@ import useAttributeValueSearchHandler from "@dashboard/utils/handlers/attributeV
 import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
 import { getParsedDataForJsonStringField } from "@dashboard/utils/richText/misc";
+import { useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { useAssignAttributeValueDialogFilterChangeHandlers } from "../../components/AssignAttributeValueDialog/useAssignAttributeValueDialogFilterChangeHandlers";
@@ -148,6 +151,39 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
     params.action === "assign-attribute-value" && params.id
       ? pageDetails?.data?.page?.attributes?.find(a => a.attribute.id === params.id)?.attribute
       : undefined;
+
+  // Extract productType and pageType constraints from reference attribute for modal filter
+  const initialConstraints = useMemo(():
+    | (InitialConstraints & InitialPageConstraints)
+    | undefined => {
+    if (!refAttr?.referenceTypes?.length) {
+      return undefined;
+    }
+
+    const productTypeRefs = refAttr.referenceTypes.filter(
+      (t): t is { __typename: "ProductType"; id: string; name: string } =>
+        t?.__typename === "ProductType" && Boolean(t?.id),
+    );
+
+    const pageTypeRefs = refAttr.referenceTypes.filter(
+      (t): t is { __typename: "PageType"; id: string; name: string } =>
+        t?.__typename === "PageType" && Boolean(t?.id),
+    );
+
+    if (productTypeRefs.length === 0 && pageTypeRefs.length === 0) {
+      return undefined;
+    }
+
+    return {
+      ...(productTypeRefs.length > 0 && {
+        productTypes: productTypeRefs.map(t => ({ id: t.id, name: t.name })),
+      }),
+      ...(pageTypeRefs.length > 0 && {
+        pageTypes: pageTypeRefs.map(t => ({ id: t.id, name: t.name })),
+      }),
+    };
+  }, [refAttr?.referenceTypes]);
+
   const {
     loadMore: loadMoreProducts,
     search: searchProducts,
@@ -252,6 +288,7 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
         onCloseDialog={closeModal}
         onAttributeSelectBlur={searchAttributeReset}
         onFilterChange={onFilterChange}
+        initialConstraints={initialConstraints}
       />
       <PageMetadataDialog
         open={params.action === "view-metadata" && !!pageDetails.data?.page}

--- a/src/modeling/views/PageDetails.tsx
+++ b/src/modeling/views/PageDetails.tsx
@@ -11,8 +11,7 @@ import {
 } from "@dashboard/attributes/utils/handlers";
 import ActionDialog from "@dashboard/components/ActionDialog";
 import { type AttributeInput } from "@dashboard/components/Attributes";
-import { type InitialPageConstraints } from "@dashboard/components/ModalFilters/entityConfigs/ModalPageFilterProvider";
-import { type InitialConstraints } from "@dashboard/components/ModalFilters/entityConfigs/ModalProductFilterProvider";
+import { getReferenceTypeConstraints } from "@dashboard/components/ModalFilters/getReferenceTypeConstraints";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
 import { DEFAULT_INITIAL_SEARCH_DATA, VALUES_PAGINATE_BY } from "@dashboard/config";
 import { useRegisterEntityRefresh } from "@dashboard/extensions/entity-refresh";
@@ -41,7 +40,6 @@ import useAttributeValueSearchHandler from "@dashboard/utils/handlers/attributeV
 import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
 import { getParsedDataForJsonStringField } from "@dashboard/utils/richText/misc";
-import { useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { useAssignAttributeValueDialogFilterChangeHandlers } from "../../components/AssignAttributeValueDialog/useAssignAttributeValueDialogFilterChangeHandlers";
@@ -153,36 +151,7 @@ const PageDetails = ({ id, params }: PageDetailsProps) => {
       : undefined;
 
   // Extract productType and pageType constraints from reference attribute for modal filter
-  const initialConstraints = useMemo(():
-    | (InitialConstraints & InitialPageConstraints)
-    | undefined => {
-    if (!refAttr?.referenceTypes?.length) {
-      return undefined;
-    }
-
-    const productTypeRefs = refAttr.referenceTypes.filter(
-      (t): t is { __typename: "ProductType"; id: string; name: string } =>
-        t?.__typename === "ProductType" && Boolean(t?.id),
-    );
-
-    const pageTypeRefs = refAttr.referenceTypes.filter(
-      (t): t is { __typename: "PageType"; id: string; name: string } =>
-        t?.__typename === "PageType" && Boolean(t?.id),
-    );
-
-    if (productTypeRefs.length === 0 && pageTypeRefs.length === 0) {
-      return undefined;
-    }
-
-    return {
-      ...(productTypeRefs.length > 0 && {
-        productTypes: productTypeRefs.map(t => ({ id: t.id, name: t.name })),
-      }),
-      ...(pageTypeRefs.length > 0 && {
-        pageTypes: pageTypeRefs.map(t => ({ id: t.id, name: t.name })),
-      }),
-    };
-  }, [refAttr?.referenceTypes]);
+  const initialConstraints = getReferenceTypeConstraints(refAttr?.referenceTypes);
 
   const {
     loadMore: loadMoreProducts,

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -2,8 +2,7 @@
 import ActionDialog from "@dashboard/components/ActionDialog";
 import useAppChannel from "@dashboard/components/AppLayout/AppChannelContext";
 import { type AttributeInput } from "@dashboard/components/Attributes";
-import { type InitialPageConstraints } from "@dashboard/components/ModalFilters/entityConfigs/ModalPageFilterProvider";
-import { type InitialConstraints } from "@dashboard/components/ModalFilters/entityConfigs/ModalProductFilterProvider";
+import { getReferenceTypeConstraints } from "@dashboard/components/ModalFilters/getReferenceTypeConstraints";
 import NotFoundPage from "@dashboard/components/NotFoundPage";
 import { useShopLimitsQuery } from "@dashboard/components/Shop/queries";
 import { WindowTitle } from "@dashboard/components/WindowTitle";
@@ -38,7 +37,7 @@ import { getProductErrorMessage } from "@dashboard/utils/errors";
 import useAttributeValueSearchHandler from "@dashboard/utils/handlers/attributeValueSearchHandler";
 import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { useAssignAttributeValueDialogFilterChangeHandlers } from "../../../components/AssignAttributeValueDialog/useAssignAttributeValueDialogFilterChangeHandlers";
@@ -420,36 +419,7 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
       : undefined;
 
   // Extract productType and pageType constraints from reference attribute for modal filter
-  const initialConstraints = useMemo(():
-    | (InitialConstraints & InitialPageConstraints)
-    | undefined => {
-    if (!refAttr?.referenceTypes?.length) {
-      return undefined;
-    }
-
-    const productTypeRefs = refAttr.referenceTypes.filter(
-      (t): t is { __typename: "ProductType"; id: string; name: string } =>
-        t?.__typename === "ProductType" && Boolean(t?.id),
-    );
-
-    const pageTypeRefs = refAttr.referenceTypes.filter(
-      (t): t is { __typename: "PageType"; id: string; name: string } =>
-        t?.__typename === "PageType" && Boolean(t?.id),
-    );
-
-    if (productTypeRefs.length === 0 && pageTypeRefs.length === 0) {
-      return undefined;
-    }
-
-    return {
-      ...(productTypeRefs.length > 0 && {
-        productTypes: productTypeRefs.map(t => ({ id: t.id, name: t.name })),
-      }),
-      ...(pageTypeRefs.length > 0 && {
-        pageTypes: pageTypeRefs.map(t => ({ id: t.id, name: t.name })),
-      }),
-    };
-  }, [refAttr?.referenceTypes]);
+  const initialConstraints = getReferenceTypeConstraints(refAttr?.referenceTypes);
 
   const {
     loadMore: loadMoreProducts,


### PR DESCRIPTION
When editing a model (page) and assigning a reference attribute value, the picker dialog now applies the attribute's configured product/model type restriction, matching the existing product behavior. Previously it listed all items despite rendering the filter row.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
