### PR TITLE
Don't render empty datagrid for fulfillments with no lines

### DIFF
--- a/.changeset/hide-empty-fulfillment-grid.md
+++ b/.changeset/hide-empty-fulfillment-grid.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+On the order details page, fulfillments with no lines no longer show an empty table with just column headers. The fulfillment card is now rendered without the empty product grid.

--- a/src/orders/components/OrderFulfillmentCard/OrderFulfillmentCard.tsx
+++ b/src/orders/components/OrderFulfillmentCard/OrderFulfillmentCard.tsx
@@ -65,7 +65,8 @@ export const OrderFulfillmentCard = (props: OrderFulfillmentCardProps) => {
     statusesToMergeLines.includes(fulfillment?.status)
       ? mergeRepeatedOrderLines(fulfillment.lines)
       : (fulfillment?.lines ?? []);
-  const getLines = () => getFulfillmentLines().map(fulfillmentLineToLine);
+  const lines = getFulfillmentLines().map(fulfillmentLineToLine);
+  const hasLines = lines.length > 0;
   const lineReasons = getFulfillmentLines().map(line => ({
     reason: line.reason ?? null,
     reasonType: line.reasonReference?.title ?? null,
@@ -148,26 +149,28 @@ export const OrderFulfillmentCard = (props: OrderFulfillmentCardProps) => {
           />
         </Box>
       )}
-      <DashboardCard.Content paddingX={0}>
-        <OrderDetailsDatagrid
-          lines={getLines()}
-          lineReasons={hasLineReasons ? lineReasons : undefined}
-          loading={false}
-          onOrderLineShowMetadata={onOrderLineShowMetadata}
-          onShowLinePriceBreakdown={onShowLinePriceBreakdown}
-          datagridCustomTheme={{
-            bgHeader: themeValues.colors.background.default2,
-          }}
-        />
-        <Box
-          backgroundColor={"default1"}
-          width="100%"
-          height={6}
-          borderBottomStyle={"solid"}
-          borderBottomWidth={1}
-          borderColor={"default1"}
-        />
-      </DashboardCard.Content>
+      {hasLines && (
+        <DashboardCard.Content paddingX={0}>
+          <OrderDetailsDatagrid
+            lines={lines}
+            lineReasons={hasLineReasons ? lineReasons : undefined}
+            loading={false}
+            onOrderLineShowMetadata={onOrderLineShowMetadata}
+            onShowLinePriceBreakdown={onShowLinePriceBreakdown}
+            datagridCustomTheme={{
+              bgHeader: themeValues.colors.background.default2,
+            }}
+          />
+          <Box
+            backgroundColor={"default1"}
+            width="100%"
+            height={6}
+            borderBottomStyle={"solid"}
+            borderBottomWidth={1}
+            borderColor={"default1"}
+          />
+        </DashboardCard.Content>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
Fulfillments with zero lines rendered a headers-only datagrid on the
order details page. Guard the datagrid so the parent card renders
without it when there are no fulfillment lines.


