### PR TITLE
Product Type and Model Type views update

### DIFF
--- a/.changeset/type-page-metadata-in-header.md
+++ b/.changeset/type-page-metadata-in-header.md
@@ -3,3 +3,5 @@
 ---
 
 - Model type and product type metadata now opens from a header button on the detail page, in a dedicated dialog — matching attribute, product, and model detail pages. Metadata is saved separately from the main type form. Create flows still use the inline metadata card until the type is saved.
+
+- Model type and product type detail pages now expose Delete in the header cogs menu (with icon and destructive styling), alongside GraphiQL and extension actions. Delete remains in the save bar for discoverability.

--- a/.changeset/type-page-metadata-in-header.md
+++ b/.changeset/type-page-metadata-in-header.md
@@ -2,14 +2,4 @@
 "saleor-dashboard": patch
 ---
 
-- Model type and product type metadata now opens from a header button on the detail page, in a dedicated dialog — matching attribute, product, and model detail pages. Metadata is saved separately from the main type form. Create flows still use the inline metadata card until the type is saved.
-
-- Model type and product type detail pages now expose Delete in the header cogs menu (with icon and destructive styling), alongside GraphiQL and extension actions. Delete remains in the save bar for discoverability.
-
-- Product type and model type pages now use a consistent layout: attribute schema in the main column, and type identity plus configuration (name, kind, shipping, taxes) in the sidebar. The variant attributes toggle stays in the main column because it controls the attribute schema below it.
-
-- Product type and model type create/update forms no longer show duplicate error toasts when validation errors are already displayed inline on the affected fields.
-
-- Product type and model type delete dialogs now follow the standard delete modal pattern: description in the header, Back + Delete actions, and consistent destructive button styling.
-
-- Type delete dialogs link "View products" / "View models" to lists filtered by the type being deleted, use model-type terminology consistently, and open immediately without a blocking loading spinner.
+Product type and model type detail pages now match the refreshed layout used elsewhere in the dashboard: metadata is edited from a header button, attributes sit in the main column, and type settings (name, shipping, taxes, etc.) move to the sidebar.

--- a/.changeset/type-page-metadata-in-header.md
+++ b/.changeset/type-page-metadata-in-header.md
@@ -11,3 +11,5 @@
 - Product type and model type create/update forms no longer show duplicate error toasts when validation errors are already displayed inline on the affected fields.
 
 - Product type and model type delete dialogs now follow the standard delete modal pattern: description in the header, Back + Delete actions, and consistent destructive button styling.
+
+- Type delete dialogs link "View products" / "View models" to lists filtered by the type being deleted, use model-type terminology consistently, and open immediately without a blocking loading spinner.

--- a/.changeset/type-page-metadata-in-header.md
+++ b/.changeset/type-page-metadata-in-header.md
@@ -5,3 +5,7 @@
 - Model type and product type metadata now opens from a header button on the detail page, in a dedicated dialog — matching attribute, product, and model detail pages. Metadata is saved separately from the main type form. Create flows still use the inline metadata card until the type is saved.
 
 - Model type and product type detail pages now expose Delete in the header cogs menu (with icon and destructive styling), alongside GraphiQL and extension actions. Delete remains in the save bar for discoverability.
+
+- Product type and model type pages now use a consistent layout: attribute schema in the main column, and type identity plus configuration (name, kind, shipping, taxes) in the sidebar. The variant attributes toggle stays in the main column because it controls the attribute schema below it.
+
+- Product type and model type create/update forms no longer show duplicate error toasts when validation errors are already displayed inline on the affected fields.

--- a/.changeset/type-page-metadata-in-header.md
+++ b/.changeset/type-page-metadata-in-header.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+- Model type and product type metadata now opens from a header button on the detail page, in a dedicated dialog — matching attribute, product, and model detail pages. Metadata is saved separately from the main type form. Create flows still use the inline metadata card until the type is saved.

--- a/.changeset/type-page-metadata-in-header.md
+++ b/.changeset/type-page-metadata-in-header.md
@@ -9,3 +9,5 @@
 - Product type and model type pages now use a consistent layout: attribute schema in the main column, and type identity plus configuration (name, kind, shipping, taxes) in the sidebar. The variant attributes toggle stays in the main column because it controls the attribute schema below it.
 
 - Product type and model type create/update forms no longer show duplicate error toasts when validation errors are already displayed inline on the affected fields.
+
+- Product type and model type delete dialogs now follow the standard delete modal pattern: description in the header, Back + Delete actions, and consistent destructive button styling.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2368,6 +2368,10 @@
     "context": "reference types multiselect search placeholder",
     "string": "Search by name…"
   },
+  "AB4VSm": {
+    "context": "PageTypeDeleteWarningDialog single assigned items button label",
+    "string": "View models"
+  },
   "AD1PlC": {
     "context": "channels availability text",
     "string": "In {selectedChannelsCount} out of {allChannelsCount, plural, one {# channel} other {# channels}}"
@@ -3987,10 +3991,6 @@
     "context": "order refund amount",
     "string": "Max Refund"
   },
-  "I8mqqj": {
-    "context": "PageTypeDeleteWarningDialog single assigned items button label",
-    "string": "View models"
-  },
   "IBw72y": {
     "context": "switch button",
     "string": "Is this product shippable?"
@@ -5032,6 +5032,10 @@
     "context": "attribute values list: slug column header",
     "string": "Swatch"
   },
+  "NUkDAo": {
+    "context": "PageTypeDeleteWarningDialog single assigned items description",
+    "string": "You are about to delete model type <b>{typeName}</b>. It is assigned to {assignedItemsCount} {assignedItemsCount,plural,one{model} other{models}}. Deleting this model type will also delete those models. Are you sure you want to do this?"
+  },
   "NVYVA+": {
     "context": "return items table, add reason button",
     "string": "Add reason"
@@ -5846,10 +5850,6 @@
   "RXbkle": {
     "context": "copy code button label",
     "string": "Copy code"
-  },
-  "RZ32u5": {
-    "context": "PageTypeDeleteWarningDialog single consent label",
-    "string": "Yes, I want to delete this model type and assigned models"
   },
   "RZDxej": {
     "context": "Popover trigger text (button)",
@@ -8919,6 +8919,10 @@
   "hAoqp6": {
     "string": "Failed to save permissions. Refresh the page and try again."
   },
+  "hGI8RO": {
+    "context": "PageTypeDeleteWarningDialog single consent label",
+    "string": "Yes, I want to delete this model type and assigned models"
+  },
   "hHOI7D": {
     "context": "product type name",
     "string": "Type Name"
@@ -9716,6 +9720,10 @@
     "context": "Description for warehouse-not-in-zone warning (only fires in legacy stock availability mode)",
     "string": "Warehouses with stock are not covered by any shipping zone in this channel. In legacy stock availability mode this hides the product from customers; assign the warehouse to a shipping zone or switch to direct stock availability."
   },
+  "kugtAu": {
+    "context": "PageTypeDeleteWarningDialog title",
+    "string": "Delete model {selectedTypesCount,plural,one{type} other{types}}"
+  },
   "kuo4fW": {
     "context": "dialog title",
     "string": "Capture manual transaction"
@@ -10380,10 +10388,6 @@
   "oEFc87": {
     "context": "Warning when no shipping zones configured",
     "string": "No shipping zones"
-  },
-  "oHbgcK": {
-    "context": "PageTypeDeleteWarningDialog title",
-    "string": "Delete model {selectedTypesCount,plural,one{type} other{types}}"
   },
   "oIL8jk": {
     "context": "error message",
@@ -11435,10 +11439,6 @@
   "tQA//+": {
     "context": "customer overview, recent net sales tooltip",
     "string": "Sum of product revenue from this customer's last {windowSize} orders in this channel. Excludes shipping and tax. Discounts are already applied."
-  },
-  "tQxBXs": {
-    "context": "PageTypeDeleteWarningDialog single assigned items description",
-    "string": "You are about to delete model type <b>{typeName}</b>. It is assigned to {assignedItemsCount} {assignedItemsCount,plural,one{model} other{models}}. Deleting this model type will also delete those models. Are you sure you want to do this?"
   },
   "tR+UuE": {
     "string": "User doesn't exist. Please check your email in URL"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -1023,6 +1023,10 @@
     "context": "button to reset cut-off date to saved value",
     "string": "Reset to saved value"
   },
+  "3IiSxs": {
+    "context": "label",
+    "string": "Model type Name"
+  },
   "3PVGWj": {
     "string": "Filter preset"
   },
@@ -3043,9 +3047,6 @@
     "context": "transaction event type, transaction was chargeback by payment provider",
     "string": "Chargeback"
   },
-  "DWWw3M": {
-    "string": "Model type Name"
-  },
   "DYn8fL": {
     "context": "shipping method channel picker dialog description",
     "string": "Select channels in the {zoneName} shipping zone where this method will be offered at checkout. You'll set prices for each channel next."
@@ -3988,7 +3989,7 @@
   },
   "I8mqqj": {
     "context": "PageTypeDeleteWarningDialog single assigned items button label",
-    "string": "View pages"
+    "string": "View models"
   },
   "IBw72y": {
     "context": "switch button",
@@ -4030,6 +4031,10 @@
   },
   "ILrXJV": {
     "string": "Press {key1} {key2} to send"
+  },
+  "IMXS9Z": {
+    "context": "model type metadata dialog header",
+    "string": "Model Type Metadata"
   },
   "IN5iJz": {
     "context": "value input helper text",
@@ -4344,6 +4349,10 @@
   "JkO0jp": {
     "context": "input description",
     "string": "{unitsLeft} units left"
+  },
+  "JkUOSW": {
+    "context": "product type detail page, top-bar metadata button tooltip",
+    "string": "Edit product type metadata"
   },
   "JmdBa3": {
     "context": "product availability publish date",
@@ -4884,6 +4893,10 @@
   "MqF/Kg": {
     "context": "dialog content",
     "string": "Are you sure you want to void this payment?"
+  },
+  "MqFTyz": {
+    "context": "product type detail cogs menu, opens the delete-confirmation dialog",
+    "string": "Delete product type"
   },
   "MwfSVA": {
     "context": "input helper text",
@@ -5836,7 +5849,7 @@
   },
   "RZ32u5": {
     "context": "PageTypeDeleteWarningDialog single consent label",
-    "string": "Yes, I want to delete this page type and assigned pages"
+    "string": "Yes, I want to delete this model type and assigned models"
   },
   "RZDxej": {
     "context": "Popover trigger text (button)",
@@ -6196,6 +6209,10 @@
   },
   "TPW2tP": {
     "string": "You have reached your order limit, you will be billed extra for orders above limit. If you would like to up your limit, contact your administration staff about raising your limits."
+  },
+  "TQWDo7": {
+    "context": "model type detail page, top-bar metadata button tooltip",
+    "string": "Edit model type metadata"
   },
   "TSJRiZ": {
     "context": "channel status title",
@@ -6647,6 +6664,10 @@
     "context": "dialog subtitle explaining what user should do",
     "string": "Select attribute values to create all possible variant combinations"
   },
+  "VxRMgP": {
+    "context": "product type metadata dialog header",
+    "string": "Product Type Metadata"
+  },
   "VxStyU": {
     "context": "order history message",
     "string": "Replacement order was created"
@@ -6786,6 +6807,10 @@
   "WZ2kxO": {
     "context": "Section heading for issues that affect whether a customer can purchase (warehouses, stock, channel listing, pricing)",
     "string": "Purchasability"
+  },
+  "WaZUkL": {
+    "context": "product type configuration section header",
+    "string": "Type configuration"
   },
   "WasHjQ": {
     "context": "voucher discount",
@@ -8191,6 +8216,9 @@
   },
   "cyR7Kh": {
     "string": "Back"
+  },
+  "d+F7sb": {
+    "string": "Open this product type in GraphiQL"
   },
   "d+Wc8t": {
     "context": "description field hint",
@@ -10064,6 +10092,10 @@
   "mmcHeH": {
     "string": "Discount Value"
   },
+  "mn9eY+": {
+    "context": "model type detail cogs menu, opens the delete-confirmation dialog",
+    "string": "Delete model type"
+  },
   "mqwLmD": {
     "string": "Menu updated"
   },
@@ -10351,7 +10383,7 @@
   },
   "oHbgcK": {
     "context": "PageTypeDeleteWarningDialog title",
-    "string": "Delete page {selectedTypesCount,plural,one{type} other{types}}"
+    "string": "Delete model {selectedTypesCount,plural,one{type} other{types}}"
   },
   "oIL8jk": {
     "context": "error message",
@@ -11406,7 +11438,7 @@
   },
   "tQxBXs": {
     "context": "PageTypeDeleteWarningDialog single assigned items description",
-    "string": "You are about to delete page type <b>{typeName}</b>. It is assigned to {assignedItemsCount} {assignedItemsCount,plural,one{page} other{pages}}. Deleting this page type will also delete those pages. Are you sure you want to do this?"
+    "string": "You are about to delete model type <b>{typeName}</b>. It is assigned to {assignedItemsCount} {assignedItemsCount,plural,one{model} other{models}}. Deleting this model type will also delete those models. Are you sure you want to do this?"
   },
   "tR+UuE": {
     "string": "User doesn't exist. Please check your email in URL"

--- a/src/components/AppLayout/TopNav/Menu.test.tsx
+++ b/src/components/AppLayout/TopNav/Menu.test.tsx
@@ -1,0 +1,66 @@
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Trash2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Menu, type TopNavMenuItem } from "./Menu";
+
+const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <ThemeProvider>{children}</ThemeProvider>
+);
+
+const menuItems: TopNavMenuItem[] = [
+  {
+    label: "Open in GraphiQL",
+    onSelect: jest.fn(),
+    testId: "graphiql-redirect",
+    icon: <span data-test-id="graphiql-icon" />,
+  },
+  {
+    label: "Delete",
+    onSelect: jest.fn(),
+    testId: "delete-item",
+    color: "critical1",
+    icon: <Trash2 data-test-id="delete-icon" />,
+  },
+];
+
+describe("TopNav Menu", () => {
+  it("renders menu item icons", async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    render(<Menu items={menuItems} />, { wrapper: Wrapper });
+
+    // Act
+    await user.click(screen.getByTestId("show-more-button"));
+
+    // Assert
+    expect(screen.getByTestId("graphiql-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("delete-icon")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when a menu item is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+    const items: TopNavMenuItem[] = [
+      {
+        label: "Delete",
+        onSelect: onDelete,
+        testId: "delete-item",
+        color: "critical1",
+      },
+    ];
+
+    render(<Menu items={items} />, { wrapper: Wrapper });
+    await user.click(screen.getByTestId("show-more-button"));
+
+    // Act
+    await user.click(screen.getByTestId("delete-item"));
+
+    // Assert
+    expect(onDelete).toHaveBeenCalled();
+  });
+});

--- a/src/components/AppLayout/TopNav/Menu.tsx
+++ b/src/components/AppLayout/TopNav/Menu.tsx
@@ -1,22 +1,34 @@
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { Box, Button, Dropdown, List, Text, type TextProps } from "@saleor/macaw-ui-next";
 import { CheckSquare, Settings, Square } from "lucide-react";
+import type * as React from "react";
 import { useIntl } from "react-intl";
 
 import { topNavMessages } from "./messages";
 
-interface TopNavMenuItem {
+export interface TopNavMenuItem {
   label: string;
   testId?: string;
   onSelect: <T extends object>(params: T) => void;
   color?: TextProps["color"];
   checked?: boolean;
+  icon?: React.ReactNode;
 }
 
 interface TopNavMenuProps {
   items: TopNavMenuItem[];
   dataTestId?: string;
 }
+
+const menuItemIconStyle: React.CSSProperties = {
+  alignItems: "center",
+  display: "inline-flex",
+  flexShrink: 0,
+  height: iconSize.small,
+  justifyContent: "center",
+  lineHeight: 0,
+  width: iconSize.small,
+};
 
 export const Menu = ({ items, dataTestId }: TopNavMenuProps) => {
   const intl = useIntl();
@@ -35,7 +47,7 @@ export const Menu = ({ items, dataTestId }: TopNavMenuProps) => {
         <Box>
           <List padding={2} borderRadius={4} boxShadow="defaultOverlay" backgroundColor="default1">
             {items.map(item => (
-              <Dropdown.Item key={item.label}>
+              <Dropdown.Item key={item.testId ?? item.label}>
                 <List.Item
                   borderRadius={4}
                   paddingX={1.5}
@@ -50,6 +62,11 @@ export const Menu = ({ items, dataTestId }: TopNavMenuProps) => {
                       ) : (
                         <Square size={14} aria-hidden />
                       ))}
+                    {item.icon && (
+                      <Box color={item.color} style={menuItemIconStyle}>
+                        {item.icon}
+                      </Box>
+                    )}
                     <Text color={item.color}>{item.label}</Text>
                   </Box>
                 </List.Item>

--- a/src/components/AppLayout/TopNav/TopNav.stories.tsx
+++ b/src/components/AppLayout/TopNav/TopNav.stories.tsx
@@ -1,8 +1,10 @@
 import type { UserContext as UserContextType } from "@dashboard/auth/types";
 import { UserContext } from "@dashboard/auth/useUser";
 import type { UserFragment } from "@dashboard/graphql";
+import { TerminalIcon } from "@dashboard/icons/TerminalIcon";
 import { Button } from "@saleor/macaw-ui-next";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Trash2 } from "lucide-react";
 import type { ComponentType } from "react";
 import { fn } from "storybook/test";
 
@@ -72,8 +74,8 @@ export const WithMenu: Story = {
     <TopNav title="Product Details" href="/products">
       <TopNav.Menu
         items={[
-          { label: "Edit", onSelect: fn() },
-          { label: "Delete", onSelect: fn(), color: "critical1" },
+          { label: "Edit", onSelect: fn(), icon: <TerminalIcon /> },
+          { label: "Delete", onSelect: fn(), color: "critical1", icon: <Trash2 size={16} /> },
         ]}
       />
     </TopNav>
@@ -86,8 +88,19 @@ export const WithDetailPageActions: Story = {
       <TopNav.MetadataButton title="Edit product metadata" onClick={fn()} />
       <TopNav.Menu
         items={[
-          { label: "Open in GraphiQL", onSelect: fn() },
-          { label: "Delete", onSelect: fn(), color: "critical1" },
+          {
+            label: "Open in GraphiQL",
+            onSelect: fn(),
+            testId: "graphiql-redirect",
+            icon: <TerminalIcon />,
+          },
+          {
+            label: "Delete",
+            onSelect: fn(),
+            testId: "delete-item",
+            color: "critical1",
+            icon: <Trash2 size={16} />,
+          },
         ]}
       />
     </TopNav>

--- a/src/components/AppLayout/TopNav/mapExtensionMenuItems.tsx
+++ b/src/components/AppLayout/TopNav/mapExtensionMenuItems.tsx
@@ -1,0 +1,20 @@
+import { iconSize } from "@dashboard/components/icons";
+import { type ExtensionMenuItem } from "@dashboard/extensions/getExtensionsItems";
+
+import { type TopNavMenuItem } from "./Menu";
+
+export const mapExtensionMenuItemsToTopNavItems = (items: ExtensionMenuItem[]): TopNavMenuItem[] =>
+  items.map(item => ({
+    label: item.label,
+    onSelect: item.onSelect,
+    testId: item.testId,
+    icon: item.avatar ? (
+      <img
+        src={item.avatar}
+        alt=""
+        width={iconSize.small}
+        height={iconSize.small}
+        style={{ borderRadius: 4, display: "block" }}
+      />
+    ) : undefined,
+  }));

--- a/src/components/Form/FormDirtyStateSync.tsx
+++ b/src/components/Form/FormDirtyStateSync.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+interface FormDirtyStateSyncProps {
+  enabled: boolean;
+  isSaveDisabled?: boolean;
+  triggerChange: (value?: boolean) => void;
+}
+
+/**
+ * Keeps the exit-form dialog dirty flag aligned with a pristine comparison.
+ * Run in an effect so navigation in the same handler as a field change is not
+ * blocked before the dirty state is updated.
+ */
+export function FormDirtyStateSync({
+  enabled,
+  isSaveDisabled,
+  triggerChange,
+}: FormDirtyStateSyncProps) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    triggerChange(!isSaveDisabled);
+  }, [enabled, isSaveDisabled, triggerChange]);
+
+  return null;
+}

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,4 +1,5 @@
 export * from "./Form";
 export { default } from "./Form";
+export * from "./FormDirtyStateSync";
 export * from "./types";
 export * from "./useExitFormDialog";

--- a/src/components/TypeDeleteWarningDialog/DeleteWarningDialogConsentContent.tsx
+++ b/src/components/TypeDeleteWarningDialog/DeleteWarningDialogConsentContent.tsx
@@ -1,33 +1,24 @@
 import { Checkbox, Text } from "@saleor/macaw-ui-next";
-import type * as React from "react";
 
 interface DeleteWarningDialogConsentContentProps {
-  description: string | React.ReactNode[] | readonly React.ReactNode[];
   consentLabel: string;
   isConsentChecked: boolean;
   onConsentChange: (value: boolean) => void;
 }
 
 const DeleteWarningDialogConsentContent = ({
-  description,
   consentLabel,
   isConsentChecked,
   onConsentChange,
 }: DeleteWarningDialogConsentContentProps) => (
-  <>
-    <Text>{description}</Text>
-
-    {consentLabel && (
-      <Checkbox
-        name="delete-assigned-items-consent"
-        data-test-id="delete-assigned-items-consent"
-        checked={isConsentChecked}
-        onCheckedChange={value => onConsentChange(!!value)}
-      >
-        <Text>{consentLabel}</Text>
-      </Checkbox>
-    )}
-  </>
+  <Checkbox
+    name="delete-assigned-items-consent"
+    data-test-id="delete-assigned-items-consent"
+    checked={isConsentChecked}
+    onCheckedChange={value => onConsentChange(!!value)}
+  >
+    <Text>{consentLabel}</Text>
+  </Checkbox>
 );
 
 export default DeleteWarningDialogConsentContent;

--- a/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialog.tsx
+++ b/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialog.tsx
@@ -7,7 +7,7 @@ import {
 import { DashboardModal } from "@dashboard/components/Modal";
 import { buttonMessages } from "@dashboard/intl";
 import { getById } from "@dashboard/misc";
-import { Box, Button, Spinner } from "@saleor/macaw-ui-next";
+import { Button } from "@saleor/macaw-ui-next";
 import { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import { Link } from "react-router-dom";
@@ -36,11 +36,9 @@ interface TypeDeleteWarningDialogProps<T extends TypeBaseData> extends TypeDelet
   typesToDelete: string[];
   assignedItemsCount: number | undefined;
   typesData: T[];
-  isLoading?: boolean;
 }
 
 function TypeDeleteWarningDialog<T extends TypeBaseData>({
-  isLoading = false,
   isOpen,
   baseMessages,
   singleWithItemsMessages,
@@ -74,7 +72,14 @@ function TypeDeleteWarningDialog<T extends TypeBaseData>({
   };
 
   const showMultiple = typesToDelete.length > 1;
-  const hasAssignedItems = !!assignedItemsCount;
+  const hasKnownNoAssignedModelItems =
+    !showMultiple &&
+    typesData.length === 1 &&
+    "hasPages" in typesData[0] &&
+    typesData[0].hasPages === false;
+  const isCountPending = assignedItemsCount === undefined && !hasKnownNoAssignedModelItems;
+  const hasAssignedItems =
+    !isCountPending && !hasKnownNoAssignedModelItems && (assignedItemsCount ?? 0) > 0;
   const selectMessages = () => {
     if (showMultiple) {
       const multipleMessages = hasAssignedItems
@@ -95,7 +100,9 @@ function TypeDeleteWarningDialog<T extends TypeBaseData>({
   const { description, consentLabel } = selectMessages();
 
   const singleItemSelectedId = typesToDelete[0];
-  const singleItemSelectedName = typesData.find(getById(singleItemSelectedId))?.name;
+  const singleItemSelectedName =
+    typesData.find(getById(singleItemSelectedId))?.name ??
+    (typesData.length === 1 ? typesData[0]?.name : undefined);
   const shouldShowViewAssignedItemsButton = hasAssignedItems;
   const descriptionContent = intl.formatMessage(description, {
     typeName: singleItemSelectedName,
@@ -113,44 +120,35 @@ function TypeDeleteWarningDialog<T extends TypeBaseData>({
           })}
         </DashboardModal.Header>
 
-        {isLoading ? (
+        {resolvedConsentLabel && (
           <DashboardModal.Body>
-            <Box display="flex" width="100%" justifyContent="center" paddingY={10}>
-              <Spinner />
-            </Box>
+            <DashboardModal.Inset>
+              <DeleteWarningDialogConsentContent
+                consentLabel={resolvedConsentLabel}
+                isConsentChecked={isConsentChecked}
+                onConsentChange={setIsConsentChecked}
+              />
+            </DashboardModal.Inset>
           </DashboardModal.Body>
-        ) : (
-          resolvedConsentLabel && (
-            <DashboardModal.Body>
-              <DashboardModal.Inset>
-                <DeleteWarningDialogConsentContent
-                  consentLabel={resolvedConsentLabel}
-                  isConsentChecked={isConsentChecked}
-                  onConsentChange={setIsConsentChecked}
-                />
-              </DashboardModal.Inset>
-            </DashboardModal.Body>
-          )
         )}
 
         <DashboardModal.Actions>
-          <BackButton disabled={isSubmitting || isLoading} onClick={handleClose} />
+          <BackButton disabled={isSubmitting} onClick={handleClose} />
           {shouldShowViewAssignedItemsButton && (
             <Link
               to={viewAssignedItemsUrl ?? "#"}
               style={{ pointerEvents: viewAssignedItemsUrl ? undefined : "none" }}
             >
-              <Button
-                variant="secondary"
-                disabled={!viewAssignedItemsUrl || isSubmitting || isLoading}
-              >
+              <Button variant="secondary" disabled={!viewAssignedItemsUrl || isSubmitting}>
                 {intl.formatMessage(baseMessages.viewAssignedItemsButtonLabel)}
               </Button>
             </Link>
           )}
           <ConfirmButton
             data-test-id="confirm-delete"
-            disabled={isLoading || (hasAssignedItems ? !isConsentChecked : false) || isSubmitting}
+            disabled={
+              isCountPending || (hasAssignedItems ? !isConsentChecked : false) || isSubmitting
+            }
             onClick={onDelete}
             transitionState={deleteButtonState}
             variant="error"

--- a/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialog.tsx
+++ b/src/components/TypeDeleteWarningDialog/TypeDeleteWarningDialog.tsx
@@ -1,17 +1,17 @@
 // @ts-strict-ignore
+import BackButton from "@dashboard/components/BackButton";
 import {
   ConfirmButton,
   type ConfirmButtonTransitionState,
 } from "@dashboard/components/ConfirmButton";
+import { DashboardModal } from "@dashboard/components/Modal";
 import { buttonMessages } from "@dashboard/intl";
 import { getById } from "@dashboard/misc";
-import { Box, Spinner } from "@saleor/macaw-ui-next";
-import { useState } from "react";
+import { Box, Button, Spinner } from "@saleor/macaw-ui-next";
+import { useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import { Link } from "react-router-dom";
 
-import DeleteButton from "../DeleteButton";
-import { DashboardModal } from "../Modal";
 import DeleteWarningDialogConsentContent from "./DeleteWarningDialogConsentContent";
 import {
   type CommonTypeDeleteWarningMessages,
@@ -47,6 +47,7 @@ function TypeDeleteWarningDialog<T extends TypeBaseData>({
   singleWithoutItemsMessages,
   multipleWithItemsMessages,
   multipleWithoutItemsMessages,
+  deleteButtonState,
   onClose,
   onDelete,
   assignedItemsCount,
@@ -56,6 +57,21 @@ function TypeDeleteWarningDialog<T extends TypeBaseData>({
 }: TypeDeleteWarningDialogProps<T>) {
   const intl = useIntl();
   const [isConsentChecked, setIsConsentChecked] = useState(false);
+  const isSubmitting = deleteButtonState === "loading";
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsConsentChecked(false);
+    }
+  }, [isOpen]);
+
+  const handleClose = () => {
+    if (isSubmitting) {
+      return;
+    }
+
+    onClose();
+  };
 
   const showMultiple = typesToDelete.length > 1;
   const hasAssignedItems = !!assignedItemsCount;
@@ -81,53 +97,67 @@ function TypeDeleteWarningDialog<T extends TypeBaseData>({
   const singleItemSelectedId = typesToDelete[0];
   const singleItemSelectedName = typesData.find(getById(singleItemSelectedId))?.name;
   const shouldShowViewAssignedItemsButton = hasAssignedItems;
+  const descriptionContent = intl.formatMessage(description, {
+    typeName: singleItemSelectedName,
+    assignedItemsCount,
+    b: (...chunks) => <strong>{chunks}</strong>,
+  });
+  const resolvedConsentLabel = consentLabel ? intl.formatMessage(consentLabel) : null;
 
   return (
-    <DashboardModal open={isOpen} onChange={onClose}>
-      <DashboardModal.Content size="sm">
-        <DashboardModal.Header>
+    <DashboardModal open={isOpen} onChange={handleClose}>
+      <DashboardModal.Content size="xs">
+        <DashboardModal.Header subtitle={descriptionContent}>
           {intl.formatMessage(baseMessages.title, {
             selectedTypesCount: typesToDelete.length,
           })}
         </DashboardModal.Header>
 
         {isLoading ? (
-          <Box display="flex" width="100%" justifyContent="center" paddingY={10}>
-            <Spinner />
-          </Box>
+          <DashboardModal.Body>
+            <Box display="flex" width="100%" justifyContent="center" paddingY={10}>
+              <Spinner />
+            </Box>
+          </DashboardModal.Body>
         ) : (
-          <>
-            <DeleteWarningDialogConsentContent
-              description={intl.formatMessage(description, {
-                typeName: singleItemSelectedName,
-                assignedItemsCount,
-                b: (...chunks) => <b>{chunks}</b>,
-              })}
-              consentLabel={consentLabel && intl.formatMessage(consentLabel)}
-              isConsentChecked={isConsentChecked}
-              onConsentChange={setIsConsentChecked}
-            />
-
-            <DashboardModal.Actions>
-              {shouldShowViewAssignedItemsButton && (
-                <Link
-                  to={viewAssignedItemsUrl}
-                  style={{ pointerEvents: viewAssignedItemsUrl ? undefined : "none" }}
-                >
-                  <ConfirmButton transitionState="default" disabled={!viewAssignedItemsUrl}>
-                    {intl.formatMessage(baseMessages.viewAssignedItemsButtonLabel)}
-                  </ConfirmButton>
-                </Link>
-              )}
-              <DeleteButton
-                onClick={onDelete}
-                disabled={hasAssignedItems ? !isConsentChecked : false}
-                testId="confirm-delete"
-                label={intl.formatMessage(buttonMessages.delete)}
-              />
-            </DashboardModal.Actions>
-          </>
+          resolvedConsentLabel && (
+            <DashboardModal.Body>
+              <DashboardModal.Inset>
+                <DeleteWarningDialogConsentContent
+                  consentLabel={resolvedConsentLabel}
+                  isConsentChecked={isConsentChecked}
+                  onConsentChange={setIsConsentChecked}
+                />
+              </DashboardModal.Inset>
+            </DashboardModal.Body>
+          )
         )}
+
+        <DashboardModal.Actions>
+          <BackButton disabled={isSubmitting || isLoading} onClick={handleClose} />
+          {shouldShowViewAssignedItemsButton && (
+            <Link
+              to={viewAssignedItemsUrl ?? "#"}
+              style={{ pointerEvents: viewAssignedItemsUrl ? undefined : "none" }}
+            >
+              <Button
+                variant="secondary"
+                disabled={!viewAssignedItemsUrl || isSubmitting || isLoading}
+              >
+                {intl.formatMessage(baseMessages.viewAssignedItemsButtonLabel)}
+              </Button>
+            </Link>
+          )}
+          <ConfirmButton
+            data-test-id="confirm-delete"
+            disabled={isLoading || (hasAssignedItems ? !isConsentChecked : false) || isSubmitting}
+            onClick={onDelete}
+            transitionState={deleteButtonState}
+            variant="error"
+          >
+            {intl.formatMessage(buttonMessages.delete)}
+          </ConfirmButton>
+        </DashboardModal.Actions>
       </DashboardModal.Content>
     </DashboardModal>
   );

--- a/src/components/TypeDeleteWarningDialog/types.ts
+++ b/src/components/TypeDeleteWarningDialog/types.ts
@@ -12,5 +12,5 @@ export type TypeDeleteWarningMessages = Partial<
 export interface TypeBaseData {
   id: string;
   name: string;
-  slug?: string;
+  slug?: string | null;
 }

--- a/src/components/TypeDeleteWarningDialog/useViewProducts.test.ts
+++ b/src/components/TypeDeleteWarningDialog/useViewProducts.test.ts
@@ -18,7 +18,7 @@ describe("useViewProducts", () => {
     // Assert
     expect(result.current).not.toBeNull();
 
-    const expectedQuery = "0[s0.productType][0]=audiobooks";
+    const expectedQuery = "0[s0.productType]=audiobooks";
     const receivedQuery = decodeURIComponent(result.current!.split("?")[1]);
 
     expect(receivedQuery).toBe(expectedQuery);

--- a/src/components/TypeDeleteWarningDialog/useViewProducts.ts
+++ b/src/components/TypeDeleteWarningDialog/useViewProducts.ts
@@ -1,49 +1,15 @@
-import { productListPath } from "@dashboard/products/urls";
-import { stringify } from "qs";
+import { productListUrlWithProductTypes } from "@dashboard/products/urls";
 import { useMemo } from "react";
-import urljoin from "url-join";
 
-import { FilterElement } from "../ConditionalFilter/FilterElement";
-import { prepareStructure } from "../ConditionalFilter/ValueProvider/utils";
 import { type TypeBaseData } from "./types";
 
 export interface ProductTypeBaseData extends TypeBaseData {
-  slug: string;
+  slug?: string | null;
 }
 
 interface ViewProductsProps {
   productTypeBaseData: ProductTypeBaseData[] | undefined;
 }
 
-const baseDataToCondition = (baseData: ProductTypeBaseData) => ({
-  label: baseData.name,
-  slug: baseData.slug,
-  value: baseData.id,
-});
-
-export const useViewProducts = ({ productTypeBaseData }: ViewProductsProps) => {
-  const viewProductsUrl = useMemo(() => {
-    if (!productTypeBaseData) {
-      return null;
-    }
-
-    const productFilterElement = FilterElement.createStaticBySlug("productType");
-
-    const condition =
-      productTypeBaseData.length > 1
-        ? productFilterElement.condition.options[1]
-        : productFilterElement.condition.options[0]; // "in" or "is"
-
-    productFilterElement.updateCondition(condition);
-
-    productFilterElement.updateRightOperator(productTypeBaseData.map(baseDataToCondition));
-
-    const url = stringify({
-      ...prepareStructure([productFilterElement]),
-    });
-
-    return urljoin(productListPath, `?${url}`);
-  }, [productTypeBaseData]);
-
-  return viewProductsUrl;
-};
+export const useViewProducts = ({ productTypeBaseData }: ViewProductsProps) =>
+  useMemo(() => productListUrlWithProductTypes(productTypeBaseData), [productTypeBaseData]);

--- a/src/modelTypes/components/PageTypeCreatePage/PageTypeCreatePage.tsx
+++ b/src/modelTypes/components/PageTypeCreatePage/PageTypeCreatePage.tsx
@@ -51,11 +51,17 @@ const PageTypeCreatePage = (props: PageTypeCreatePageProps) => {
                 description: "header",
               })}
             />
-            <DetailPageLayout.Content>
+            <DetailPageLayout.Content paddingBottom={10}>
               <Metadata data={data} onChange={changeMetadata} />
             </DetailPageLayout.Content>
             <DetailPageLayout.RightSidebar>
-              <PageTypeDetails data={data} disabled={disabled} errors={errors} onChange={change} />
+              <PageTypeDetails
+                autoFocus
+                data={data}
+                disabled={disabled}
+                errors={errors}
+                onChange={change}
+              />
             </DetailPageLayout.RightSidebar>
             <Savebar>
               <Savebar.Spacer />

--- a/src/modelTypes/components/PageTypeDetails/PageTypeDetails.tsx
+++ b/src/modelTypes/components/PageTypeDetails/PageTypeDetails.tsx
@@ -4,23 +4,41 @@ import { type PageErrorFragment } from "@dashboard/graphql";
 import { commonMessages } from "@dashboard/intl";
 import { getFormErrors } from "@dashboard/utils/errors";
 import getPageErrorMessage from "@dashboard/utils/errors/page";
-import { TextField } from "@material-ui/core";
+import { Input } from "@saleor/macaw-ui-next";
 import type * as React from "react";
+import { useEffect, useRef } from "react";
 import { useIntl } from "react-intl";
+
+import { messages } from "./messages";
 
 interface PageTypeDetailsProps {
   data?: {
     name: string;
   };
+  autoFocus?: boolean;
   disabled: boolean;
-  errors: PageErrorFragment[];
+  errors?: PageErrorFragment[];
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const PageTypeDetails = (props: PageTypeDetailsProps) => {
-  const { data, disabled, errors, onChange } = props;
+const PageTypeDetails = ({
+  autoFocus = false,
+  data,
+  disabled,
+  errors = [],
+  onChange,
+}: PageTypeDetailsProps) => {
   const intl = useIntl();
   const formErrors = getFormErrors(["name"], errors);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!autoFocus || disabled) {
+      return;
+    }
+
+    nameInputRef.current?.focus();
+  }, [autoFocus, disabled]);
 
   return (
     <DashboardCard>
@@ -30,15 +48,13 @@ const PageTypeDetails = (props: PageTypeDetailsProps) => {
         </DashboardCard.Title>
       </DashboardCard.Header>
       <DashboardCard.Content>
-        <TextField
+        <Input
+          ref={nameInputRef}
           disabled={disabled}
-          fullWidth
           error={!!formErrors.name}
+          width="100%"
           helperText={getPageErrorMessage(formErrors.name, intl)}
-          label={intl.formatMessage({
-            id: "DWWw3M",
-            defaultMessage: "Model type Name",
-          })}
+          label={intl.formatMessage(messages.modelTypeName)}
           name="name"
           data-test-id="page-type-name"
           onChange={onChange}
@@ -49,8 +65,5 @@ const PageTypeDetails = (props: PageTypeDetailsProps) => {
   );
 };
 
-PageTypeDetails.defaultProps = {
-  errors: [],
-};
 PageTypeDetails.displayName = "PageTypeDetails";
 export default PageTypeDetails;

--- a/src/modelTypes/components/PageTypeDetails/messages.ts
+++ b/src/modelTypes/components/PageTypeDetails/messages.ts
@@ -1,9 +1,9 @@
 import { defineMessages } from "react-intl";
 
 export const messages = defineMessages({
-  productTypeName: {
-    id: "H5yp8O",
-    defaultMessage: "Product Type Name",
+  modelTypeName: {
+    id: "3IiSxs",
+    defaultMessage: "Model type Name",
     description: "label",
   },
 });

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.dirtyState.test.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.dirtyState.test.tsx
@@ -1,0 +1,121 @@
+import ExitFormDialogProvider from "@dashboard/components/Form/ExitFormDialogProvider";
+import { pageType } from "@dashboard/modelTypes/fixtures";
+import { modelTypesPath } from "@dashboard/modelTypes/urls";
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryHistory, type MemoryHistory } from "history";
+import { Route, Router } from "react-router-dom";
+
+import PageTypeDetailsPage from "./PageTypeDetailsPage";
+
+jest.mock("@dashboard/components/Savebar");
+jest.mock("@dashboard/components/DevModePanel/hooks", () => ({
+  useDevModeContext: () => ({
+    setDevModeContent: jest.fn(),
+    setVariables: jest.fn(),
+    setDevModeVisibility: jest.fn(),
+  }),
+}));
+jest.mock("@dashboard/extensions/hooks/useExtensions", () => ({
+  useExtensions: () => ({
+    PAGE_TYPE_DETAILS_MORE_ACTIONS: [],
+  }),
+}));
+jest.mock("../PageTypeAttributes/PageTypeAttributes", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="page-type-attributes-mock" />,
+}));
+
+const listPath = modelTypesPath;
+const detailPath = `/model-types/${pageType.id}`;
+
+const defaultProps = {
+  disabled: false,
+  errors: [],
+  saveButtonBarState: "default" as const,
+  attributeList: {
+    isChecked: () => false,
+    selected: 0,
+    toggle: jest.fn(),
+    toggleAll: jest.fn(),
+    toolbar: null,
+  },
+  onAttributeAdd: jest.fn(),
+  onAttributeCreate: jest.fn(),
+  onAttributeReorder: jest.fn(),
+  onAttributeUnassign: jest.fn(),
+  onDelete: jest.fn(),
+  onShowMetadata: jest.fn(),
+  onSubmit: jest.fn(),
+};
+
+const renderPage = (history: MemoryHistory): void => {
+  render(
+    <Router history={history}>
+      <ExitFormDialogProvider>
+        <ThemeProvider>
+          <Route path="/model-types/:id">
+            <PageTypeDetailsPage {...defaultProps} pageType={pageType} />
+          </Route>
+          <Route path={listPath}>
+            <div data-test-id="model-type-list-page" />
+          </Route>
+        </ThemeProvider>
+      </ExitFormDialogProvider>
+    </Router>,
+  );
+};
+
+describe("PageTypeDetailsPage dirty state", () => {
+  it("blocks navigation when the name field is edited", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const history = createMemoryHistory({ initialEntries: [detailPath] });
+
+    renderPage(history);
+
+    // Act
+    await user.clear(screen.getByTestId("page-type-name"));
+    await user.type(screen.getByTestId("page-type-name"), "Updated model type");
+    await user.click(screen.getByTestId("app-header-back-button"));
+
+    // Assert
+    expect(screen.getByTestId("ignore-changes")).toBeInTheDocument();
+    expect(history.location.pathname).toBe(detailPath);
+  });
+
+  it("allows navigation when the form is pristine", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const history = createMemoryHistory({ initialEntries: [detailPath] });
+
+    renderPage(history);
+
+    // Act
+    await user.click(screen.getByTestId("app-header-back-button"));
+
+    // Assert
+    expect(screen.queryByTestId("ignore-changes")).not.toBeInTheDocument();
+    expect(history.location.pathname).toBe(listPath);
+  });
+
+  it("clears dirty state when the name is reverted", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const history = createMemoryHistory({ initialEntries: [detailPath] });
+
+    renderPage(history);
+
+    // Act
+    await user.clear(screen.getByTestId("page-type-name"));
+    await user.type(screen.getByTestId("page-type-name"), "Updated model type");
+    await user.clear(screen.getByTestId("page-type-name"));
+    await user.type(screen.getByTestId("page-type-name"), pageType.name);
+    await user.click(screen.getByTestId("app-header-back-button"));
+
+    // Assert
+    expect(screen.queryByTestId("ignore-changes")).not.toBeInTheDocument();
+    expect(history.location.pathname).toBe(listPath);
+  });
+});

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.topNav.test.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.topNav.test.tsx
@@ -37,7 +37,6 @@ const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
 const defaultProps = {
   disabled: false,
   errors: [],
-  pageTitle: "Blog",
   saveButtonBarState: "default" as const,
   attributeList: {
     isChecked: () => false,

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.topNav.test.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.topNav.test.tsx
@@ -1,6 +1,7 @@
 import { pageType } from "@dashboard/modelTypes/fixtures";
 import { ThemeProvider } from "@saleor/macaw-ui-next";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 
@@ -57,15 +58,18 @@ const defaultProps = {
 const renderPage = ({
   pageTypeProp,
   onShowMetadata = jest.fn(),
+  onDelete = jest.fn(),
 }: {
   pageTypeProp: typeof pageType | undefined;
   onShowMetadata?: () => void;
+  onDelete?: () => void;
 }): ReturnType<typeof render> =>
   render(
     <PageTypeDetailsPage
       {...defaultProps}
       pageType={pageTypeProp}
       onShowMetadata={onShowMetadata}
+      onDelete={onDelete}
     />,
     { wrapper: Wrapper },
   );
@@ -98,5 +102,20 @@ describe("PageTypeDetailsPage top nav", () => {
 
     // Assert
     expect(screen.getByTestId("show-model-type-metadata")).toBeDisabled();
+  });
+
+  it("calls onDelete from the cogs menu", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+
+    renderPage({ pageTypeProp: pageType, onDelete });
+
+    // Act
+    await user.click(screen.getByTestId("show-more-button"));
+    await user.click(screen.getByTestId("delete-model-type"));
+
+    // Assert
+    expect(onDelete).toHaveBeenCalled();
   });
 });

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.topNav.test.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.topNav.test.tsx
@@ -1,0 +1,103 @@
+import { pageType } from "@dashboard/modelTypes/fixtures";
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import PageTypeDetailsPage from "./PageTypeDetailsPage";
+
+jest.mock("@dashboard/components/Savebar");
+jest.mock("@dashboard/components/DevModePanel/hooks", () => ({
+  useDevModeContext: () => ({
+    setDevModeContent: jest.fn(),
+    setVariables: jest.fn(),
+    setDevModeVisibility: jest.fn(),
+  }),
+}));
+jest.mock("@dashboard/extensions/hooks/useExtensions", () => ({
+  useExtensions: () => ({
+    PAGE_TYPE_DETAILS_MORE_ACTIONS: [],
+  }),
+}));
+jest.mock("../PageTypeAttributes/PageTypeAttributes", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="page-type-attributes-mock" />,
+}));
+jest.mock("../PageTypeDetails/PageTypeDetails", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="page-type-details-mock" />,
+}));
+
+const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <MemoryRouter>
+    <ThemeProvider>{children}</ThemeProvider>
+  </MemoryRouter>
+);
+
+const defaultProps = {
+  disabled: false,
+  errors: [],
+  pageTitle: "Blog",
+  saveButtonBarState: "default" as const,
+  attributeList: {
+    isChecked: () => false,
+    selected: 0,
+    toggle: jest.fn(),
+    toggleAll: jest.fn(),
+    toolbar: null,
+  },
+  onAttributeAdd: jest.fn(),
+  onAttributeCreate: jest.fn(),
+  onAttributeReorder: jest.fn(),
+  onAttributeUnassign: jest.fn(),
+  onDelete: jest.fn(),
+  onShowMetadata: jest.fn(),
+  onSubmit: jest.fn(),
+};
+
+const renderPage = ({
+  pageTypeProp,
+  onShowMetadata = jest.fn(),
+}: {
+  pageTypeProp: typeof pageType | undefined;
+  onShowMetadata?: () => void;
+}): ReturnType<typeof render> =>
+  render(
+    <PageTypeDetailsPage
+      {...defaultProps}
+      pageType={pageTypeProp}
+      onShowMetadata={onShowMetadata}
+    />,
+    { wrapper: Wrapper },
+  );
+
+describe("PageTypeDetailsPage top nav", () => {
+  it("renders the metadata button", () => {
+    // Arrange & Act
+    renderPage({ pageTypeProp: pageType });
+
+    // Assert
+    expect(screen.getByTestId("show-model-type-metadata")).toBeInTheDocument();
+  });
+
+  it("calls onShowMetadata when the metadata button is clicked", () => {
+    // Arrange
+    const onShowMetadata = jest.fn();
+
+    renderPage({ pageTypeProp: pageType, onShowMetadata });
+
+    // Act
+    screen.getByTestId("show-model-type-metadata").click();
+
+    // Assert
+    expect(onShowMetadata).toHaveBeenCalled();
+  });
+
+  it("disables the metadata button while page type data is loading", () => {
+    // Arrange & Act
+    renderPage({ pageTypeProp: undefined });
+
+    // Assert
+    expect(screen.getByTestId("show-model-type-metadata")).toBeDisabled();
+  });
+});

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -18,7 +18,7 @@ import {
 } from "@dashboard/graphql";
 import { useBackLinkWithState } from "@dashboard/hooks/useBackLinkWithState";
 import useNavigator from "@dashboard/hooks/useNavigator";
-import { TerminalIcon } from "@dashboard/icons/TerminalIcon";
+import { GraphqlIcon } from "@dashboard/icons/GraphqlIcon";
 import { defaultGraphiQLQuery } from "@dashboard/modelTypes/queries";
 import { modelTypesPath } from "@dashboard/modelTypes/urls";
 import { type ListActions, type ReorderEvent } from "@dashboard/types";
@@ -102,7 +102,7 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
         label: intl.formatMessage(messages.openGraphiQL),
         onSelect: openPlaygroundURL,
         testId: "graphiql-redirect",
-        icon: <TerminalIcon />,
+        icon: <GraphqlIcon />,
       },
       {
         label: intl.formatMessage(messages.deleteModelType),

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -3,7 +3,7 @@ import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import { mapExtensionMenuItemsToTopNavItems } from "@dashboard/components/AppLayout/TopNav/mapExtensionMenuItems";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import { useDevModeContext } from "@dashboard/components/DevModePanel/hooks";
-import Form from "@dashboard/components/Form";
+import Form, { FormDirtyStateSync } from "@dashboard/components/Form";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
 import { type MetadataFormData } from "@dashboard/components/Metadata/types";
@@ -21,6 +21,7 @@ import useNavigator from "@dashboard/hooks/useNavigator";
 import { GraphqlIcon } from "@dashboard/icons/GraphqlIcon";
 import { defaultGraphiQLQuery } from "@dashboard/modelTypes/queries";
 import { modelTypesPath } from "@dashboard/modelTypes/urls";
+import { isPageTypeUpdateFormPristine } from "@dashboard/modelTypes/utils/pageTypePageForm";
 import { type ListActions, type ReorderEvent } from "@dashboard/types";
 import { type Option } from "@saleor/macaw-ui-next";
 import { Trash2 } from "lucide-react";
@@ -39,7 +40,7 @@ export interface PageTypeForm extends MetadataFormData {
 
 interface PageTypeDetailsPageProps {
   errors: PageErrorFragment[];
-  pageType: PageTypeDetailsFragment;
+  pageType: PageTypeDetailsFragment | undefined;
   disabled: boolean;
   attributeList: ListActions;
   saveButtonBarState: ConfirmButtonTransitionState;
@@ -75,16 +76,33 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
     context.setVariables(`{ "id": "${pageType?.id}" }`);
     context.setDevModeVisibility(true);
   }, [context, pageType?.id]);
-  const formInitialData: PageTypeForm = {
-    attributes:
-      pageType?.attributes?.map(attribute => ({
-        label: attribute.name,
-        value: attribute.id,
-      })) || [],
-    metadata: [],
-    name: pageType?.name || "",
-    privateMetadata: [],
-  };
+  const formInitialData = useMemo<PageTypeForm>(
+    () => ({
+      attributes:
+        pageType?.attributes?.map(attribute => ({
+          label: attribute.name,
+          value: attribute.id,
+        })) || [],
+      metadata: [],
+      name: pageType?.name || "",
+      privateMetadata: [],
+    }),
+    [pageType],
+  );
+  const checkIfSaveIsDisabled = useCallback(
+    (data: PageTypeForm) => {
+      if (disabled) {
+        return true;
+      }
+
+      if (!pageType) {
+        return true;
+      }
+
+      return isPageTypeUpdateFormPristine(data, formInitialData);
+    },
+    [disabled, formInitialData, pageType],
+  );
 
   const pageTypeListBackLink = useBackLinkWithState({
     path: modelTypesPath,
@@ -116,55 +134,68 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
   );
 
   return (
-    <Form confirmLeave initial={formInitialData} onSubmit={onSubmit} disabled={disabled}>
-      {({ change, data, isSaveDisabled, submit }) => (
-        <DetailPageLayout>
-          <TopNav
-            href={pageTypeListBackLink}
-            title={
-              <PageTypeDetailsTitle
-                pageType={pageType ? { name: pageType.name } : null}
-                loading={disabled}
-              />
-            }
-            actionsGap={3}
-          >
-            <TopNav.MetadataButton
-              onClick={onShowMetadata}
-              disabled={!pageType}
-              data-test-id="show-model-type-metadata"
-              title={intl.formatMessage(messages.editModelTypeMetadata)}
-            />
-            <TopNav.Menu items={menuItems} dataTestId="menu" />
-          </TopNav>
-          <DetailPageLayout.Content paddingBottom={10}>
-            <PageTypeAttributes
-              attributes={pageType?.attributes}
-              disabled={disabled}
-              type={AttributeTypeEnum.PAGE_TYPE}
-              onAttributeAssign={onAttributeAdd}
-              onAttributeCreate={onAttributeCreate}
-              onAttributeReorder={(event: ReorderEvent) =>
-                onAttributeReorder(event, AttributeTypeEnum.PAGE_TYPE)
+    <Form
+      confirmLeave
+      initial={formInitialData}
+      onSubmit={onSubmit}
+      disabled={disabled}
+      checkIfSaveIsDisabled={checkIfSaveIsDisabled}
+    >
+      {({ change, data, isSaveDisabled, submit, triggerChange }) => (
+        <>
+          <FormDirtyStateSync
+            enabled={!!pageType}
+            isSaveDisabled={isSaveDisabled}
+            triggerChange={triggerChange}
+          />
+          <DetailPageLayout>
+            <TopNav
+              href={pageTypeListBackLink}
+              title={
+                <PageTypeDetailsTitle
+                  pageType={pageType ? { name: pageType.name } : null}
+                  loading={disabled}
+                />
               }
-              onAttributeUnassign={onAttributeUnassign}
-              {...attributeList}
-            />
-          </DetailPageLayout.Content>
-          <DetailPageLayout.RightSidebar>
-            <PageTypeDetails data={data} disabled={disabled} errors={errors} onChange={change} />
-          </DetailPageLayout.RightSidebar>
-          <Savebar>
-            <Savebar.DeleteButton onClick={onDelete} />
-            <Savebar.Spacer />
-            <Savebar.CancelButton onClick={() => navigate(pageTypeListBackLink)} />
-            <Savebar.ConfirmButton
-              transitionState={saveButtonBarState}
-              onClick={submit}
-              disabled={isSaveDisabled}
-            />
-          </Savebar>
-        </DetailPageLayout>
+              actionsGap={3}
+            >
+              <TopNav.MetadataButton
+                onClick={onShowMetadata}
+                disabled={!pageType}
+                data-test-id="show-model-type-metadata"
+                title={intl.formatMessage(messages.editModelTypeMetadata)}
+              />
+              <TopNav.Menu items={menuItems} dataTestId="menu" />
+            </TopNav>
+            <DetailPageLayout.Content paddingBottom={10}>
+              <PageTypeAttributes
+                attributes={pageType?.attributes}
+                disabled={disabled}
+                type={AttributeTypeEnum.PAGE_TYPE}
+                onAttributeAssign={onAttributeAdd}
+                onAttributeCreate={onAttributeCreate}
+                onAttributeReorder={(event: ReorderEvent) =>
+                  onAttributeReorder(event, AttributeTypeEnum.PAGE_TYPE)
+                }
+                onAttributeUnassign={onAttributeUnassign}
+                {...attributeList}
+              />
+            </DetailPageLayout.Content>
+            <DetailPageLayout.RightSidebar>
+              <PageTypeDetails data={data} disabled={disabled} errors={errors} onChange={change} />
+            </DetailPageLayout.RightSidebar>
+            <Savebar>
+              <Savebar.DeleteButton onClick={onDelete} />
+              <Savebar.Spacer />
+              <Savebar.CancelButton onClick={() => navigate(pageTypeListBackLink)} />
+              <Savebar.ConfirmButton
+                transitionState={saveButtonBarState}
+                onClick={submit}
+                disabled={isSaveDisabled}
+              />
+            </Savebar>
+          </DetailPageLayout>
+        </>
       )}
     </Form>
   );

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -25,6 +25,7 @@ import { useIntl } from "react-intl";
 import PageTypeAttributes from "../PageTypeAttributes/PageTypeAttributes";
 import PageTypeDetails from "../PageTypeDetails/PageTypeDetails";
 import { messages } from "./messages";
+import { PageTypeDetailsTitle } from "./Title";
 
 export interface PageTypeForm extends MetadataFormData {
   name: string;
@@ -35,7 +36,6 @@ interface PageTypeDetailsPageProps {
   errors: PageErrorFragment[];
   pageType: PageTypeDetailsFragment;
   disabled: boolean;
-  pageTitle: string;
   attributeList: ListActions;
   saveButtonBarState: ConfirmButtonTransitionState;
   onAttributeAdd: (type: AttributeTypeEnum) => void;
@@ -51,7 +51,6 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
   const {
     disabled,
     errors,
-    pageTitle,
     pageType,
     attributeList,
     saveButtonBarState,
@@ -96,7 +95,16 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
     <Form confirmLeave initial={formInitialData} onSubmit={onSubmit} disabled={disabled}>
       {({ change, data, isSaveDisabled, submit }) => (
         <DetailPageLayout>
-          <TopNav href={pageTypeListBackLink} title={pageTitle} actionsGap={3}>
+          <TopNav
+            href={pageTypeListBackLink}
+            title={
+              <PageTypeDetailsTitle
+                pageType={pageType ? { name: pageType.name } : null}
+                loading={disabled}
+              />
+            }
+            actionsGap={3}
+          >
             <TopNav.MetadataButton
               onClick={onShowMetadata}
               disabled={!pageType}

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -1,8 +1,10 @@
 // @ts-strict-ignore
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
+import { mapExtensionMenuItemsToTopNavItems } from "@dashboard/components/AppLayout/TopNav/mapExtensionMenuItems";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import { useDevModeContext } from "@dashboard/components/DevModePanel/hooks";
 import Form from "@dashboard/components/Form";
+import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
 import { type MetadataFormData } from "@dashboard/components/Metadata/types";
 import { Savebar } from "@dashboard/components/Savebar";
@@ -16,10 +18,13 @@ import {
 } from "@dashboard/graphql";
 import { useBackLinkWithState } from "@dashboard/hooks/useBackLinkWithState";
 import useNavigator from "@dashboard/hooks/useNavigator";
+import { TerminalIcon } from "@dashboard/icons/TerminalIcon";
 import { defaultGraphiQLQuery } from "@dashboard/modelTypes/queries";
 import { modelTypesPath } from "@dashboard/modelTypes/urls";
 import { type ListActions, type ReorderEvent } from "@dashboard/types";
 import { type Option } from "@saleor/macaw-ui-next";
+import { Trash2 } from "lucide-react";
+import { useCallback, useMemo } from "react";
 import { useIntl } from "react-intl";
 
 import PageTypeAttributes from "../PageTypeAttributes/PageTypeAttributes";
@@ -65,11 +70,11 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
   const intl = useIntl();
   const navigate = useNavigator();
   const context = useDevModeContext();
-  const openPlaygroundURL = () => {
+  const openPlaygroundURL = useCallback(() => {
     context.setDevModeContent(defaultGraphiQLQuery);
     context.setVariables(`{ "id": "${pageType?.id}" }`);
     context.setDevModeVisibility(true);
-  };
+  }, [context, pageType?.id]);
   const formInitialData: PageTypeForm = {
     attributes:
       pageType?.attributes?.map(attribute => ({
@@ -89,6 +94,25 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
   const extensionMenuItems = getExtensionsItemsForPageTypeDetails(
     PAGE_TYPE_DETAILS_MORE_ACTIONS,
     pageType?.id,
+  );
+  const menuItems = useMemo(
+    () => [
+      ...mapExtensionMenuItemsToTopNavItems(extensionMenuItems),
+      {
+        label: intl.formatMessage(messages.openGraphiQL),
+        onSelect: openPlaygroundURL,
+        testId: "graphiql-redirect",
+        icon: <TerminalIcon />,
+      },
+      {
+        label: intl.formatMessage(messages.deleteModelType),
+        onSelect: onDelete,
+        testId: "delete-model-type",
+        color: "critical1" as const,
+        icon: <Trash2 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />,
+      },
+    ],
+    [extensionMenuItems, intl, onDelete, openPlaygroundURL],
   );
 
   return (
@@ -111,17 +135,7 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
               data-test-id="show-model-type-metadata"
               title={intl.formatMessage(messages.editModelTypeMetadata)}
             />
-            <TopNav.Menu
-              items={[
-                ...extensionMenuItems,
-                {
-                  label: intl.formatMessage(messages.openGraphiQL),
-                  onSelect: openPlaygroundURL,
-                  testId: "graphiql-redirect",
-                },
-              ]}
-              dataTestId="menu"
-            />
+            <TopNav.Menu items={menuItems} dataTestId="menu" />
           </TopNav>
           <DetailPageLayout.Content>
             <PageTypeAttributes

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -4,7 +4,6 @@ import { type ConfirmButtonTransitionState } from "@dashboard/components/Confirm
 import { useDevModeContext } from "@dashboard/components/DevModePanel/hooks";
 import Form from "@dashboard/components/Form";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
-import { Metadata } from "@dashboard/components/Metadata";
 import { type MetadataFormData } from "@dashboard/components/Metadata/types";
 import { Savebar } from "@dashboard/components/Savebar";
 import { extensionMountPoints } from "@dashboard/extensions/extensionMountPoints";
@@ -20,20 +19,12 @@ import useNavigator from "@dashboard/hooks/useNavigator";
 import { defaultGraphiQLQuery } from "@dashboard/modelTypes/queries";
 import { modelTypesPath } from "@dashboard/modelTypes/urls";
 import { type ListActions, type ReorderEvent } from "@dashboard/types";
-import { mapMetadataItemToInput } from "@dashboard/utils/maps";
-import useMetadataChangeTrigger from "@dashboard/utils/metadata/useMetadataChangeTrigger";
 import { type Option } from "@saleor/macaw-ui-next";
-import { defineMessages, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import PageTypeAttributes from "../PageTypeAttributes/PageTypeAttributes";
 import PageTypeDetails from "../PageTypeDetails/PageTypeDetails";
-
-const messages = defineMessages({
-  openGraphiQL: {
-    id: "br+OIS",
-    defaultMessage: "Open this model type in GraphiQL",
-  },
-});
+import { messages } from "./messages";
 
 export interface PageTypeForm extends MetadataFormData {
   name: string;
@@ -52,6 +43,7 @@ interface PageTypeDetailsPageProps {
   onAttributeReorder: (event: ReorderEvent, type: AttributeTypeEnum) => void;
   onAttributeUnassign: (id: string) => void;
   onDelete: () => void;
+  onShowMetadata: () => void;
   onSubmit: (data: PageTypeForm) => void;
 }
 
@@ -68,6 +60,7 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
     onAttributeUnassign,
     onAttributeReorder,
     onDelete,
+    onShowMetadata,
     onSubmit,
   } = props;
   const intl = useIntl();
@@ -78,30 +71,15 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
     context.setVariables(`{ "id": "${pageType?.id}" }`);
     context.setDevModeVisibility(true);
   };
-  const {
-    isMetadataModified,
-    isPrivateMetadataModified,
-    makeChangeHandler: makeMetadataChangeHandler,
-  } = useMetadataChangeTrigger();
   const formInitialData: PageTypeForm = {
     attributes:
       pageType?.attributes?.map(attribute => ({
         label: attribute.name,
         value: attribute.id,
       })) || [],
-    metadata: pageType?.metadata?.map(mapMetadataItemToInput),
+    metadata: [],
     name: pageType?.name || "",
-    privateMetadata: pageType?.privateMetadata?.map(mapMetadataItemToInput),
-  };
-  const handleSubmit = (data: PageTypeForm) => {
-    const metadata = isMetadataModified ? data.metadata : undefined;
-    const privateMetadata = isPrivateMetadataModified ? data.privateMetadata : undefined;
-
-    onSubmit({
-      ...data,
-      metadata,
-      privateMetadata,
-    });
+    privateMetadata: [],
   };
 
   const pageTypeListBackLink = useBackLinkWithState({
@@ -115,56 +93,57 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
   );
 
   return (
-    <Form confirmLeave initial={formInitialData} onSubmit={handleSubmit} disabled={disabled}>
-      {({ change, data, isSaveDisabled, submit }) => {
-        const changeMetadata = makeMetadataChangeHandler(change);
-
-        return (
-          <DetailPageLayout>
-            <TopNav href={pageTypeListBackLink} title={pageTitle}>
-              <TopNav.Menu
-                items={[
-                  ...extensionMenuItems,
-                  {
-                    label: intl.formatMessage(messages.openGraphiQL),
-                    onSelect: openPlaygroundURL,
-                    testId: "graphiql-redirect",
-                  },
-                ]}
-                dataTestId="menu"
-              />
-            </TopNav>
-            <DetailPageLayout.Content>
-              <PageTypeAttributes
-                attributes={pageType?.attributes}
-                disabled={disabled}
-                type={AttributeTypeEnum.PAGE_TYPE}
-                onAttributeAssign={onAttributeAdd}
-                onAttributeCreate={onAttributeCreate}
-                onAttributeReorder={(event: ReorderEvent) =>
-                  onAttributeReorder(event, AttributeTypeEnum.PAGE_TYPE)
-                }
-                onAttributeUnassign={onAttributeUnassign}
-                {...attributeList}
-              />
-              <Metadata data={data} onChange={changeMetadata} />
-            </DetailPageLayout.Content>
-            <DetailPageLayout.RightSidebar>
-              <PageTypeDetails data={data} disabled={disabled} errors={errors} onChange={change} />
-            </DetailPageLayout.RightSidebar>
-            <Savebar>
-              <Savebar.DeleteButton onClick={onDelete} />
-              <Savebar.Spacer />
-              <Savebar.CancelButton onClick={() => navigate(pageTypeListBackLink)} />
-              <Savebar.ConfirmButton
-                transitionState={saveButtonBarState}
-                onClick={submit}
-                disabled={isSaveDisabled}
-              />
-            </Savebar>
-          </DetailPageLayout>
-        );
-      }}
+    <Form confirmLeave initial={formInitialData} onSubmit={onSubmit} disabled={disabled}>
+      {({ change, data, isSaveDisabled, submit }) => (
+        <DetailPageLayout>
+          <TopNav href={pageTypeListBackLink} title={pageTitle} actionsGap={3}>
+            <TopNav.MetadataButton
+              onClick={onShowMetadata}
+              disabled={!pageType}
+              data-test-id="show-model-type-metadata"
+              title={intl.formatMessage(messages.editModelTypeMetadata)}
+            />
+            <TopNav.Menu
+              items={[
+                ...extensionMenuItems,
+                {
+                  label: intl.formatMessage(messages.openGraphiQL),
+                  onSelect: openPlaygroundURL,
+                  testId: "graphiql-redirect",
+                },
+              ]}
+              dataTestId="menu"
+            />
+          </TopNav>
+          <DetailPageLayout.Content>
+            <PageTypeAttributes
+              attributes={pageType?.attributes}
+              disabled={disabled}
+              type={AttributeTypeEnum.PAGE_TYPE}
+              onAttributeAssign={onAttributeAdd}
+              onAttributeCreate={onAttributeCreate}
+              onAttributeReorder={(event: ReorderEvent) =>
+                onAttributeReorder(event, AttributeTypeEnum.PAGE_TYPE)
+              }
+              onAttributeUnassign={onAttributeUnassign}
+              {...attributeList}
+            />
+          </DetailPageLayout.Content>
+          <DetailPageLayout.RightSidebar>
+            <PageTypeDetails data={data} disabled={disabled} errors={errors} onChange={change} />
+          </DetailPageLayout.RightSidebar>
+          <Savebar>
+            <Savebar.DeleteButton onClick={onDelete} />
+            <Savebar.Spacer />
+            <Savebar.CancelButton onClick={() => navigate(pageTypeListBackLink)} />
+            <Savebar.ConfirmButton
+              transitionState={saveButtonBarState}
+              onClick={submit}
+              disabled={isSaveDisabled}
+            />
+          </Savebar>
+        </DetailPageLayout>
+      )}
     </Form>
   );
 };

--- a/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage.tsx
@@ -137,7 +137,7 @@ const PageTypeDetailsPage = (props: PageTypeDetailsPageProps) => {
             />
             <TopNav.Menu items={menuItems} dataTestId="menu" />
           </TopNav>
-          <DetailPageLayout.Content>
+          <DetailPageLayout.Content paddingBottom={10}>
             <PageTypeAttributes
               attributes={pageType?.attributes}
               disabled={disabled}

--- a/src/modelTypes/components/PageTypeDetailsPage/Title.test.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/Title.test.tsx
@@ -1,0 +1,42 @@
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import { type ReactElement, type ReactNode } from "react";
+
+import { PageTypeDetailsTitle } from "./Title";
+
+const pageType = {
+  name: "Blog",
+};
+
+const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <ThemeProvider>{children}</ThemeProvider>
+);
+
+const renderTitle = (ui: ReactElement) => render(ui, { wrapper: Wrapper });
+
+describe("PageTypeDetailsTitle", () => {
+  it("renders skeleton on initial load", () => {
+    // Arrange & Act
+    renderTitle(<PageTypeDetailsTitle loading />);
+
+    // Assert
+    expect(screen.getByTestId("page-type-details-title-skeleton")).toBeInTheDocument();
+  });
+
+  it("keeps header content during background refetch", () => {
+    // Arrange & Act
+    renderTitle(<PageTypeDetailsTitle pageType={pageType} loading />);
+
+    // Assert
+    expect(screen.getByText("Blog")).toBeInTheDocument();
+    expect(screen.queryByTestId("page-type-details-title-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("renders model type name when loaded", () => {
+    // Arrange & Act
+    renderTitle(<PageTypeDetailsTitle pageType={pageType} />);
+
+    // Assert
+    expect(screen.getByText("Blog")).toBeInTheDocument();
+  });
+});

--- a/src/modelTypes/components/PageTypeDetailsPage/Title.tsx
+++ b/src/modelTypes/components/PageTypeDetailsPage/Title.tsx
@@ -1,0 +1,53 @@
+import { makeStyles } from "@saleor/macaw-ui";
+import { Box, Skeleton } from "@saleor/macaw-ui-next";
+
+interface PageTypeDetailsHeaderPageType {
+  name: string;
+}
+
+interface PageTypeDetailsTitleProps {
+  pageType?: PageTypeDetailsHeaderPageType | null;
+  loading?: boolean;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    container: {
+      alignItems: "center",
+      display: "flex",
+      gap: theme.spacing(2),
+    },
+    name: {
+      minWidth: 0,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+    },
+  }),
+  { name: "PageTypeDetailsTitle" },
+);
+
+export const PageTypeDetailsTitle = ({ pageType, loading }: PageTypeDetailsTitleProps) => {
+  const classes = useStyles();
+  const isHeaderLoading = loading && !pageType;
+
+  if (isHeaderLoading) {
+    return (
+      <div className={classes.container}>
+        <Skeleton __width="12em" data-test-id="page-type-details-title-skeleton" />
+      </div>
+    );
+  }
+
+  if (!pageType) {
+    return null;
+  }
+
+  return (
+    <div className={classes.container}>
+      <Box className={classes.name} title={pageType.name}>
+        {pageType.name}
+      </Box>
+    </div>
+  );
+};

--- a/src/modelTypes/components/PageTypeDetailsPage/messages.ts
+++ b/src/modelTypes/components/PageTypeDetailsPage/messages.ts
@@ -10,4 +10,9 @@ export const messages = defineMessages({
     id: "br+OIS",
     defaultMessage: "Open this model type in GraphiQL",
   },
+  deleteModelType: {
+    id: "mn9eY+",
+    defaultMessage: "Delete model type",
+    description: "model type detail cogs menu, opens the delete-confirmation dialog",
+  },
 });

--- a/src/modelTypes/components/PageTypeDetailsPage/messages.ts
+++ b/src/modelTypes/components/PageTypeDetailsPage/messages.ts
@@ -1,0 +1,13 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  editModelTypeMetadata: {
+    id: "TQWDo7",
+    defaultMessage: "Edit model type metadata",
+    description: "model type detail page, top-bar metadata button tooltip",
+  },
+  openGraphiQL: {
+    id: "br+OIS",
+    defaultMessage: "Open this model type in GraphiQL",
+  },
+});

--- a/src/modelTypes/components/PageTypeMetadataDialog/PageTypeMetadataDialog.test.tsx
+++ b/src/modelTypes/components/PageTypeMetadataDialog/PageTypeMetadataDialog.test.tsx
@@ -1,0 +1,102 @@
+import { type PageTypeDetailsFragment } from "@dashboard/graphql";
+import { pageType } from "@dashboard/modelTypes/fixtures";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { PageTypeMetadataDialog } from "./PageTypeMetadataDialog";
+
+const mockOnSubmit = jest.fn();
+
+jest.mock("@dashboard/components/MetadataDialog/useHandleMetadataSubmit", () => ({
+  useHandleMetadataSubmit: jest.fn(() => ({
+    onSubmit: mockOnSubmit,
+    lastSubmittedData: undefined,
+    submitInProgress: false,
+  })),
+}));
+
+const mockPageType: PageTypeDetailsFragment = {
+  ...pageType,
+  metadata: [{ key: "test-key", value: "test-value", __typename: "MetadataItem" }],
+  privateMetadata: [{ key: "private-key", value: "private-value", __typename: "MetadataItem" }],
+};
+
+describe("PageTypeMetadataDialog", () => {
+  const onCloseMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders dialog with correct title when open", () => {
+    // Arrange & Act
+    render(<PageTypeMetadataDialog open={true} onClose={onCloseMock} pageType={mockPageType} />);
+
+    // Assert
+    expect(screen.getByText("Model Type Metadata")).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    // Arrange & Act
+    render(<PageTypeMetadataDialog open={false} onClose={onCloseMock} pageType={mockPageType} />);
+
+    // Assert
+    expect(screen.queryByText("Model Type Metadata")).not.toBeInTheDocument();
+  });
+
+  it("closes when user clicks close button", () => {
+    // Arrange
+    render(<PageTypeMetadataDialog open={true} onClose={onCloseMock} pageType={mockPageType} />);
+
+    // Act
+    fireEvent.click(screen.getByTestId("back"));
+
+    // Assert
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it("renders with undefined page type", () => {
+    // Arrange & Act
+    render(<PageTypeMetadataDialog open={true} onClose={onCloseMock} pageType={undefined} />);
+
+    // Assert
+    expect(screen.getByText("Model Type Metadata")).toBeInTheDocument();
+  });
+
+  it("displays metadata when section is expanded", () => {
+    // Arrange
+    render(<PageTypeMetadataDialog open={true} onClose={onCloseMock} pageType={mockPageType} />);
+
+    const metadataEditors = screen.getAllByTestId("metadata-editor");
+    const publicMetadataEditor = metadataEditors.find(
+      editor => editor.getAttribute("data-test-is-private") === "false",
+    )!;
+
+    // Act
+    const expandButton = within(publicMetadataEditor).getByTestId("expand");
+
+    fireEvent.click(expandButton);
+
+    // Assert
+    expect(within(publicMetadataEditor).getByDisplayValue("test-key")).toBeInTheDocument();
+    expect(within(publicMetadataEditor).getByDisplayValue("test-value")).toBeInTheDocument();
+  });
+
+  it("displays private metadata when section is expanded", () => {
+    // Arrange
+    render(<PageTypeMetadataDialog open={true} onClose={onCloseMock} pageType={mockPageType} />);
+
+    const metadataEditors = screen.getAllByTestId("metadata-editor");
+    const privateMetadataEditor = metadataEditors.find(
+      editor => editor.getAttribute("data-test-is-private") === "true",
+    )!;
+
+    // Act
+    const expandButton = within(privateMetadataEditor).getByTestId("expand");
+
+    fireEvent.click(expandButton);
+
+    // Assert
+    expect(within(privateMetadataEditor).getByDisplayValue("private-key")).toBeInTheDocument();
+    expect(within(privateMetadataEditor).getByDisplayValue("private-value")).toBeInTheDocument();
+  });
+});

--- a/src/modelTypes/components/PageTypeMetadataDialog/PageTypeMetadataDialog.tsx
+++ b/src/modelTypes/components/PageTypeMetadataDialog/PageTypeMetadataDialog.tsx
@@ -1,0 +1,110 @@
+import { type ApolloQueryResult } from "@apollo/client";
+import { MetadataDialog } from "@dashboard/components/MetadataDialog/MetadataDialog";
+import { useHandleMetadataSubmit } from "@dashboard/components/MetadataDialog/useHandleMetadataSubmit";
+import { useMetadataForm } from "@dashboard/components/MetadataDialog/useMetadataForm";
+import { mapFieldArrayToMetadataInput } from "@dashboard/components/MetadataDialog/validation";
+import {
+  PageTypeDetailsDocument,
+  type PageTypeDetailsFragment,
+  type PageTypeDetailsQuery,
+} from "@dashboard/graphql";
+import { mapMetadataItemToInput } from "@dashboard/utils/maps";
+import { useEffect, useMemo, useRef } from "react";
+import { useIntl } from "react-intl";
+
+interface PageTypeMetadataDialogProps {
+  open: boolean;
+  onClose: () => void;
+  pageType: PageTypeDetailsFragment | undefined | null;
+  refetchPageType?: () => Promise<ApolloQueryResult<PageTypeDetailsQuery>>;
+}
+
+export const PageTypeMetadataDialog = ({
+  onClose,
+  open,
+  pageType,
+  refetchPageType,
+}: PageTypeMetadataDialogProps) => {
+  const intl = useIntl();
+  const normalizedPageType = useMemo(
+    () =>
+      pageType
+        ? {
+            ...pageType,
+            metadata: pageType.metadata ?? [],
+            privateMetadata: pageType.privateMetadata ?? [],
+          }
+        : undefined,
+    [pageType],
+  );
+  const { onSubmit, lastSubmittedData, submitInProgress } = useHandleMetadataSubmit({
+    initialData: normalizedPageType,
+    onClose,
+    refetchDocument: PageTypeDetailsDocument,
+    refetch: refetchPageType,
+  });
+
+  const {
+    metadataFields,
+    privateMetadataFields,
+    metadataErrors,
+    privateMetadataErrors,
+    reset,
+    formIsDirty,
+    handleChange,
+    getFormData,
+  } = useMetadataForm({
+    graphqlData: normalizedPageType,
+    submitInProgress,
+    lastSubmittedData,
+  });
+
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      wasOpenRef.current = false;
+      reset();
+
+      return;
+    }
+
+    if (!normalizedPageType || wasOpenRef.current) {
+      return;
+    }
+
+    reset({
+      metadata: normalizedPageType.metadata.map(mapMetadataItemToInput),
+      privateMetadata: normalizedPageType.privateMetadata.map(mapMetadataItemToInput),
+    });
+    wasOpenRef.current = true;
+  }, [open, normalizedPageType, reset]);
+
+  return (
+    <MetadataDialog
+      open={open}
+      onClose={onClose}
+      onSave={async () => {
+        await onSubmit(getFormData());
+      }}
+      title={intl.formatMessage({
+        defaultMessage: "Model Type Metadata",
+        description: "model type metadata dialog header",
+        id: "IMXS9Z",
+      })}
+      data={{
+        metadata: mapFieldArrayToMetadataInput(metadataFields),
+        privateMetadata: mapFieldArrayToMetadataInput(privateMetadataFields),
+      }}
+      onChange={handleChange}
+      loading={submitInProgress}
+      errors={{
+        metadata: metadataErrors.length ? metadataErrors.join(", ") : undefined,
+        privateMetadata: privateMetadataErrors.length
+          ? privateMetadataErrors.join(", ")
+          : undefined,
+      }}
+      formIsDirty={formIsDirty}
+    />
+  );
+};

--- a/src/modelTypes/hooks/usePageTypeDelete/messages.ts
+++ b/src/modelTypes/hooks/usePageTypeDelete/messages.ts
@@ -2,27 +2,27 @@ import { defineMessages } from "react-intl";
 
 export const baseMessages = defineMessages({
   title: {
-    id: "oHbgcK",
-    defaultMessage: "Delete page {selectedTypesCount,plural,one{type} other{types}}",
+    id: "kugtAu",
+    defaultMessage: "Delete model {selectedTypesCount,plural,one{type} other{types}}",
     description: "PageTypeDeleteWarningDialog title",
   },
   viewAssignedItemsButtonLabel: {
-    id: "I8mqqj",
-    defaultMessage: "View pages",
+    id: "AB4VSm",
+    defaultMessage: "View models",
     description: "PageTypeDeleteWarningDialog single assigned items button label",
   },
 });
 
 export const singleWithItemsMessages = defineMessages({
   description: {
-    id: "tQxBXs",
+    id: "NUkDAo",
     defaultMessage:
-      "You are about to delete page type <b>{typeName}</b>. It is assigned to {assignedItemsCount} {assignedItemsCount,plural,one{page} other{pages}}. Deleting this page type will also delete those pages. Are you sure you want to do this?",
+      "You are about to delete model type <b>{typeName}</b>. It is assigned to {assignedItemsCount} {assignedItemsCount,plural,one{model} other{models}}. Deleting this model type will also delete those models. Are you sure you want to do this?",
     description: "PageTypeDeleteWarningDialog single assigned items description",
   },
   consentLabel: {
-    id: "RZ32u5",
-    defaultMessage: "Yes, I want to delete this page type and assigned pages",
+    id: "hGI8RO",
+    defaultMessage: "Yes, I want to delete this model type and assigned models",
     description: "PageTypeDeleteWarningDialog single consent label",
   },
 });

--- a/src/modelTypes/hooks/usePageTypeDelete/types.ts
+++ b/src/modelTypes/hooks/usePageTypeDelete/types.ts
@@ -5,7 +5,6 @@ export interface UseTypeDeleteData extends TypeDeleteMessages {
   isOpen: boolean;
   assignedItemsCount: number | undefined;
   viewAssignedItemsUrl: string | null;
-  isLoading: boolean | undefined;
   typesToDelete: Ids;
 }
 

--- a/src/modelTypes/hooks/usePageTypeDelete/usePageTypeDelete.tsx
+++ b/src/modelTypes/hooks/usePageTypeDelete/usePageTypeDelete.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import { type PageCountQueryVariables, usePageCountQuery } from "@dashboard/graphql";
-import { pageListUrl } from "@dashboard/modeling/urls";
+import { pageListUrlWithPageTypes } from "@dashboard/modeling/urls";
 import {
   type PageTypeListUrlQueryParams,
   type PageTypeUrlQueryParams,
@@ -18,7 +18,13 @@ function usePageTypeDelete({
   params,
   selectedTypes,
 }: UsePageTypeDeleteProps): UseTypeDeleteData {
-  const pageTypes = selectedTypes || [singleId];
+  const pageTypes = useMemo(() => {
+    if (selectedTypes?.length) {
+      return selectedTypes.filter(Boolean);
+    }
+
+    return singleId ? [singleId] : [];
+  }, [selectedTypes, singleId]);
   const isDeleteDialogOpen = params.action === "remove";
   const pagesAssignedToSelectedTypesQueryVars = useMemo<PageCountQueryVariables>(
     () => ({
@@ -29,22 +35,18 @@ function usePageTypeDelete({
     [pageTypes],
   );
   const shouldSkipPageListQuery = !pageTypes.length || !isDeleteDialogOpen;
-  const { data: pagesAssignedToSelectedTypesData, loading: loadingPagesAssignedToSelectedTypes } =
-    usePageCountQuery({
-      variables: pagesAssignedToSelectedTypesQueryVars,
-      skip: shouldSkipPageListQuery,
-    });
-  const selectedPagesAssignedToDeleteUrl = pageListUrl({
-    pageTypes,
+  const { data: pagesAssignedToSelectedTypesData } = usePageCountQuery({
+    variables: pagesAssignedToSelectedTypesQueryVars,
+    skip: shouldSkipPageListQuery,
   });
+  const viewAssignedItemsUrl = pageListUrlWithPageTypes(pageTypes);
   const assignedItemsCount = pagesAssignedToSelectedTypesData?.pages?.totalCount;
 
   return {
     ...messages,
     isOpen: isDeleteDialogOpen,
-    assignedItemsCount,
-    viewAssignedItemsUrl: selectedPagesAssignedToDeleteUrl,
-    isLoading: loadingPagesAssignedToSelectedTypes,
+    assignedItemsCount: assignedItemsCount ?? undefined,
+    viewAssignedItemsUrl,
     typesToDelete: pageTypes,
   };
 }

--- a/src/modelTypes/urls.ts
+++ b/src/modelTypes/urls.ts
@@ -38,12 +38,13 @@ export const pageTypeAddPath = urlJoin(modelTypesSection, "add");
 export const pageTypeAddUrl = pageTypeAddPath;
 
 export const pageTypePath = (id: string) => urlJoin(modelTypesSection, id);
-type PageTypeUrlDialog =
+export type PageTypeUrlDialog =
   | "assign-attribute"
   | "create-attribute"
   | "unassign-attribute"
   | "unassign-attributes"
-  | "remove";
+  | "remove"
+  | "view-metadata";
 export type PageTypeUrlQueryParams = BulkAction &
   Dialog<PageTypeUrlDialog> &
   SingleAction & {

--- a/src/modelTypes/utils/pageTypePageForm.test.ts
+++ b/src/modelTypes/utils/pageTypePageForm.test.ts
@@ -1,0 +1,54 @@
+import { type PageTypeForm } from "@dashboard/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage";
+
+import { isPageTypeUpdateFormPristine } from "./pageTypePageForm";
+
+const initialData: PageTypeForm = {
+  attributes: [{ label: "Title", value: "attr-1" }],
+  metadata: [],
+  name: "Blog",
+  privateMetadata: [],
+};
+
+describe("isPageTypeUpdateFormPristine", () => {
+  it("returns true when only non-form fields differ", () => {
+    // Arrange
+    const current: PageTypeForm = {
+      ...initialData,
+      attributes: [{ label: "Title", value: "attr-2" }],
+    };
+
+    // Act
+    const pristine = isPageTypeUpdateFormPristine(current, initialData);
+
+    // Assert
+    expect(pristine).toBe(true);
+  });
+
+  it("returns false when name changes", () => {
+    // Arrange
+    const current: PageTypeForm = {
+      ...initialData,
+      name: "Landing Page",
+    };
+
+    // Act
+    const pristine = isPageTypeUpdateFormPristine(current, initialData);
+
+    // Assert
+    expect(pristine).toBe(false);
+  });
+
+  it("returns true when name is reverted to initial value", () => {
+    // Arrange
+    const current: PageTypeForm = {
+      ...initialData,
+      name: "Blog",
+    };
+
+    // Act
+    const pristine = isPageTypeUpdateFormPristine(current, initialData);
+
+    // Assert
+    expect(pristine).toBe(true);
+  });
+});

--- a/src/modelTypes/utils/pageTypePageForm.ts
+++ b/src/modelTypes/utils/pageTypePageForm.ts
@@ -1,0 +1,8 @@
+import { type PageTypeForm } from "@dashboard/modelTypes/components/PageTypeDetailsPage/PageTypeDetailsPage";
+
+export function isPageTypeUpdateFormPristine(
+  data: PageTypeForm,
+  initialData: PageTypeForm,
+): boolean {
+  return data.name === initialData.name;
+}

--- a/src/modelTypes/views/PageTypeCreate.tsx
+++ b/src/modelTypes/views/PageTypeCreate.tsx
@@ -21,6 +21,8 @@ const PageTypeCreate = () => {
   const [updateMetadata] = useUpdateMetadataMutation({});
   const [updatePrivateMetadata] = useUpdatePrivateMetadataMutation({});
   const [createPageType, createPageTypeOpts] = usePageTypeCreateMutation({
+    // Name and other field errors are rendered inline on the create form.
+    disableErrorHandling: true,
     onCompleted: updateData => {
       if (updateData.pageTypeCreate.errors.length === 0) {
         notify({

--- a/src/modelTypes/views/PageTypeDetails.tsx
+++ b/src/modelTypes/views/PageTypeDetails.tsx
@@ -247,7 +247,6 @@ const PageTypeDetails = ({ id, params }: PageTypeDetailsProps) => {
       <PageTypeDetailsPage
         disabled={loading}
         errors={updatePageTypeOpts.data?.pageTypeUpdate.errors}
-        pageTitle={data?.pageType.name}
         pageType={data?.pageType}
         saveButtonBarState={updatePageTypeOpts.status}
         onAttributeAdd={type =>

--- a/src/modelTypes/views/PageTypeDetails.tsx
+++ b/src/modelTypes/views/PageTypeDetails.tsx
@@ -32,6 +32,7 @@ import { useListSelectedItems } from "@dashboard/hooks/useListSelectedItems";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { useNotifier } from "@dashboard/hooks/useNotifier";
 import { getStringOrPlaceholder } from "@dashboard/misc";
+import usePageTypeDelete from "@dashboard/modelTypes/hooks/usePageTypeDelete";
 import { type ReorderEvent } from "@dashboard/types";
 import getPageErrorMessage from "@dashboard/utils/errors/page";
 import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
@@ -43,7 +44,6 @@ import useAvailablePageAttributeSearch from "../../searches/useAvailablePageAttr
 import PageTypeDetailsPage, { type PageTypeForm } from "../components/PageTypeDetailsPage";
 import { PageTypeMetadataDialog } from "../components/PageTypeMetadataDialog/PageTypeMetadataDialog";
 import { executePageTypeAttributeCreate } from "../handlers/pageTypeAttributeCreateHandler";
-import usePageTypeDelete from "../hooks/usePageTypeDelete";
 import {
   pageTypeListUrl,
   pageTypeUrl,

--- a/src/modelTypes/views/PageTypeDetails.tsx
+++ b/src/modelTypes/views/PageTypeDetails.tsx
@@ -72,6 +72,8 @@ const PageTypeDetails = ({ id, params }: PageTypeDetailsProps) => {
       text: intl.formatMessage({ id: "GVGaij", defaultMessage: "Model type updated" }),
     });
   const [updatePageType, updatePageTypeOpts] = usePageTypeUpdateMutation({
+    // Name and other field errors are rendered inline on the model type form.
+    disableErrorHandling: true,
     onCompleted: updateData => {
       if (!updateData.pageTypeUpdate.errors || updateData.pageTypeUpdate.errors.length === 0) {
         notifySaved();

--- a/src/modelTypes/views/PageTypeDetails.tsx
+++ b/src/modelTypes/views/PageTypeDetails.tsx
@@ -34,16 +34,22 @@ import { useNotifier } from "@dashboard/hooks/useNotifier";
 import { getStringOrPlaceholder } from "@dashboard/misc";
 import { type ReorderEvent } from "@dashboard/types";
 import getPageErrorMessage from "@dashboard/utils/errors/page";
+import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
 import createMetadataCreateHandler from "@dashboard/utils/handlers/metadataCreateHandler";
-import createMetadataUpdateHandler from "@dashboard/utils/handlers/metadataUpdateHandler";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import useAvailablePageAttributeSearch from "../../searches/useAvailablePageAttributesSearch";
 import PageTypeDetailsPage, { type PageTypeForm } from "../components/PageTypeDetailsPage";
+import { PageTypeMetadataDialog } from "../components/PageTypeMetadataDialog/PageTypeMetadataDialog";
 import { executePageTypeAttributeCreate } from "../handlers/pageTypeAttributeCreateHandler";
 import usePageTypeDelete from "../hooks/usePageTypeDelete";
-import { pageTypeListUrl, pageTypeUrl, type PageTypeUrlQueryParams } from "../urls";
+import {
+  pageTypeListUrl,
+  pageTypeUrl,
+  type PageTypeUrlDialog,
+  type PageTypeUrlQueryParams,
+} from "../urls";
 
 interface PageTypeDetailsProps {
   id: string;
@@ -56,6 +62,10 @@ const PageTypeDetails = ({ id, params }: PageTypeDetailsProps) => {
   const attributeListActions = useBulkActions();
   const assignAttributesActions = useListSelectedItems<string>();
   const intl = useIntl();
+  const [openModal, closeModal] = createDialogActionHandlers<
+    PageTypeUrlDialog,
+    PageTypeUrlQueryParams
+  >(navigate, dialogParams => pageTypeUrl(id, dialogParams), params);
   const notifySaved = () =>
     notify({
       status: "success",
@@ -229,13 +239,6 @@ const PageTypeDetails = ({ id, params }: PageTypeDetailsProps) => {
     return <NotFoundPage backHref={pageTypeListUrl()} />;
   }
 
-  const closeModal = () => navigate(pageTypeUrl(id), { replace: true });
-  const handleSubmit = createMetadataUpdateHandler(
-    data?.pageType,
-    handlePageTypeUpdate,
-    variables => updateMetadata({ variables }),
-    variables => updatePrivateMetadata({ variables }),
-  );
   const loading = updatePageTypeOpts.loading || dataLoading;
 
   return (
@@ -248,52 +251,27 @@ const PageTypeDetails = ({ id, params }: PageTypeDetailsProps) => {
         pageType={data?.pageType}
         saveButtonBarState={updatePageTypeOpts.status}
         onAttributeAdd={type =>
-          navigate(
-            pageTypeUrl(id, {
-              action: "assign-attribute",
-              type,
-            }),
-          )
+          openModal("assign-attribute", {
+            type,
+          })
         }
-        onAttributeCreate={() =>
-          navigate(
-            pageTypeUrl(id, {
-              action: "create-attribute",
-            }),
-          )
-        }
+        onAttributeCreate={() => openModal("create-attribute")}
         onAttributeReorder={handleAttributeReorder}
         onAttributeUnassign={attributeId =>
-          navigate(
-            pageTypeUrl(id, {
-              action: "unassign-attribute",
-              id: attributeId,
-            }),
-          )
+          openModal("unassign-attribute", {
+            id: attributeId,
+          })
         }
-        onDelete={() =>
-          navigate(
-            pageTypeUrl(id, {
-              action: "remove",
-            }),
-          )
-        }
-        onSubmit={handleSubmit}
+        onDelete={() => openModal("remove")}
+        onShowMetadata={() => openModal("view-metadata", { id: undefined })}
+        onSubmit={handlePageTypeUpdate}
         attributeList={{
           isChecked: attributeListActions.isSelected,
           selected: attributeListActions.listElements.length,
           toggle: attributeListActions.toggle,
           toggleAll: attributeListActions.toggleAll,
           toolbar: (
-            <Button
-              onClick={() =>
-                navigate(
-                  pageTypeUrl(id, {
-                    action: "unassign-attributes",
-                  }),
-                )
-              }
-            >
+            <Button onClick={() => openModal("unassign-attributes")}>
               <FormattedMessage
                 id="Y3ELdI"
                 defaultMessage="Unassign"
@@ -306,6 +284,12 @@ const PageTypeDetails = ({ id, params }: PageTypeDetailsProps) => {
 
       {pageType && (
         <>
+          <PageTypeMetadataDialog
+            open={params.action === "view-metadata" && !!pageType}
+            onClose={closeModal}
+            pageType={pageType}
+            refetchPageType={refetch}
+          />
           <TypeDeleteWarningDialog
             {...pageTypeDeleteData}
             typesData={[pageType]}

--- a/src/modelTypes/views/PageTypeList/PageTypeList.tsx
+++ b/src/modelTypes/views/PageTypeList/PageTypeList.tsx
@@ -132,12 +132,13 @@ const PageTypeList = ({ params }: PageTypeListProps) => {
       },
     });
 
+  const pageTypesData = mapEdgesToItems(data?.pageTypes);
+  const typesToDeleteForDialog = params.ids?.length ? params.ids : selectedPageTypes;
+
   const pageTypeDeleteData = usePageTypeDelete({
-    selectedTypes: selectedPageTypes,
+    selectedTypes: typesToDeleteForDialog,
     params,
   });
-
-  const pageTypesData = mapEdgesToItems(data?.pageTypes);
 
   return (
     <PaginatorContext.Provider value={paginationValues}>
@@ -183,7 +184,7 @@ const PageTypeList = ({ params }: PageTypeListProps) => {
         <TypeDeleteWarningDialog
           {...pageTypeDeleteData}
           typesData={pageTypesData}
-          typesToDelete={selectedPageTypes}
+          typesToDelete={typesToDeleteForDialog}
           onClose={closeModal}
           onDelete={hanldePageTypeBulkDelete}
           deleteButtonState={pageTypeBulkDeleteOpts.status}

--- a/src/modeling/index.tsx
+++ b/src/modeling/index.tsx
@@ -2,6 +2,7 @@ import { Route } from "@dashboard/components/Router";
 import { sectionNames } from "@dashboard/intl";
 import { parseQs } from "@dashboard/url-utils";
 import { asSortParams } from "@dashboard/utils/sort";
+import { getArrayQueryParam } from "@dashboard/utils/urls";
 import { useIntl } from "react-intl";
 import { type RouteComponentProps, Switch } from "react-router-dom";
 
@@ -19,10 +20,16 @@ import PageCreateComponent from "./views/PageCreate";
 import PageDetailsComponent from "./views/PageDetails";
 import PageListComponent from "./views/PageList";
 
-const PageList = () => {
-  const qs = parseQs(location.search.substr(1)) as any;
+const PageList = ({ location }: RouteComponentProps) => {
+  const qs = parseQs(location.search.substr(1)) as Record<string, unknown>;
   const params: PageListUrlQueryParams = asSortParams(
-    qs,
+    {
+      ...qs,
+      ids: getArrayQueryParam(qs.ids as string | string[] | Record<string, string> | undefined),
+      pageTypes: getArrayQueryParam(
+        qs.pageTypes as string | string[] | Record<string, string> | undefined,
+      ),
+    },
     PageListUrlSortField,
     PageListUrlSortField.title,
   );

--- a/src/modeling/index.tsx
+++ b/src/modeling/index.tsx
@@ -21,14 +21,12 @@ import PageDetailsComponent from "./views/PageDetails";
 import PageListComponent from "./views/PageList";
 
 const PageList = ({ location }: RouteComponentProps) => {
-  const qs = parseQs(location.search.substr(1)) as Record<string, unknown>;
+  const qs = parseQs(location.search.substr(1)) as any;
   const params: PageListUrlQueryParams = asSortParams(
     {
       ...qs,
-      ids: getArrayQueryParam(qs.ids as string | string[] | Record<string, string> | undefined),
-      pageTypes: getArrayQueryParam(
-        qs.pageTypes as string | string[] | Record<string, string> | undefined,
-      ),
+      ids: getArrayQueryParam(qs.ids),
+      pageTypes: getArrayQueryParam(qs.pageTypes),
     },
     PageListUrlSortField,
     PageListUrlSortField.title,

--- a/src/modeling/urls.test.ts
+++ b/src/modeling/urls.test.ts
@@ -1,4 +1,4 @@
-import { pageListPath, pageListUrlWithPageType } from "./urls";
+import { pageListPath, pageListUrlWithPageType, pageListUrlWithPageTypes } from "./urls";
 
 describe("pageListUrlWithPageType", () => {
   it("returns pageListPath when model type is undefined", () => {
@@ -28,5 +28,41 @@ describe("pageListUrlWithPageType", () => {
     expect(result).toContain("/models/");
     expect(result).toContain("pageTypes");
     expect(decodeURIComponent(result)).toContain(pageType.id);
+  });
+});
+
+describe("pageListUrlWithPageTypes", () => {
+  it("returns null when no model type ids are provided", () => {
+    // Arrange & Act
+    const result = pageListUrlWithPageTypes([]);
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it("builds URL filtered by a single model type id", () => {
+    // Arrange
+    const pageTypeId = "UGFnZVR5cGU6MQ==";
+
+    // Act
+    const result = pageListUrlWithPageTypes([pageTypeId]);
+
+    // Assert
+    expect(result).toContain("/models/");
+    expect(result).toContain("pageTypes");
+    expect(decodeURIComponent(result!)).toContain(pageTypeId);
+  });
+
+  it("builds URL filtered by multiple model type ids", () => {
+    // Arrange
+    const pageTypeIds = ["UGFnZVR5cGU6MQ==", "UGFnZVR5cGU6Mg=="];
+
+    // Act
+    const result = pageListUrlWithPageTypes(pageTypeIds);
+
+    // Assert
+    expect(result).toContain("/models/");
+    expect(decodeURIComponent(result!)).toContain(pageTypeIds[0]);
+    expect(decodeURIComponent(result!)).toContain(pageTypeIds[1]);
   });
 });

--- a/src/modeling/urls.ts
+++ b/src/modeling/urls.ts
@@ -52,6 +52,23 @@ export const pageListUrlWithPageType = (pageType?: { id: string }) => {
   return pageListUrl({ pageTypes: [pageType.id] });
 };
 
+/**
+ * Builds the model list URL pre-filtered by one or more model types.
+ */
+export const pageListUrlWithPageTypes = (pageTypeIds?: string[]): string | null => {
+  const ids = pageTypeIds?.filter(Boolean) ?? [];
+
+  if (!ids.length) {
+    return null;
+  }
+
+  if (ids.length === 1) {
+    return pageListUrlWithPageType({ id: ids[0] });
+  }
+
+  return pageListUrl({ pageTypes: ids });
+};
+
 export const pagePath = (id: string) => urlJoin(modelingSection, id);
 type PageUrlDialog = "remove" | "assign-attribute-value" | "view-metadata";
 interface PageCreateUrlPageType {

--- a/src/modeling/views/PageList/PageList.tsx
+++ b/src/modeling/views/PageList/PageList.tsx
@@ -53,14 +53,22 @@ interface PageListProps {
   params: PageListUrlQueryParams;
 }
 
-const normalizePageTypes = (value: string | string[] | undefined): string[] => {
+const normalizePageTypes = (
+  value: string | string[] | Record<string, string> | undefined,
+): string[] => {
   if (!value) {
     return [];
   }
 
-  const ids = Array.isArray(value) ? value.filter(Boolean) : [value];
+  if (Array.isArray(value)) {
+    return [...new Set(value.filter(Boolean))];
+  }
 
-  return [...new Set(ids)];
+  if (typeof value === "object") {
+    return [...new Set(Object.values(value).filter(Boolean))];
+  }
+
+  return [value];
 };
 
 const PageList = ({ params }: PageListProps) => {
@@ -159,21 +167,23 @@ const PageList = ({ params }: PageListProps) => {
     [pageTypesData],
   );
 
-  // Fall back to "All" if URL references unknown page types.
+  // Drop page type ids that are absent from the tab list only when some ids are still recognized.
+  // Keep the URL filter when none are in the tab list (e.g. outside the first fetched page),
+  // so deep-linked and delete-dialog links still filter the list server-side.
   useEffect(() => {
-    if (!pageTypes || pageTypesLoading) {
+    if (!pageTypes || pageTypesLoading || selectedPageTypes.length === 0) {
       return;
     }
 
     const validIds = selectedPageTypes.filter(id => pageTypes.some(pt => pt.id === id));
 
-    if (validIds.length === selectedPageTypes.length) {
+    if (validIds.length === selectedPageTypes.length || validIds.length === 0) {
       return;
     }
 
     navigate(
       pageListUrl({
-        pageTypes: validIds.length ? validIds : undefined,
+        pageTypes: validIds,
         asc: params.asc,
         sort: params.sort,
       }),

--- a/src/productTypes/components/ProductTypeConfiguration/ProductTypeConfiguration.tsx
+++ b/src/productTypes/components/ProductTypeConfiguration/ProductTypeConfiguration.tsx
@@ -1,8 +1,8 @@
 import { DashboardCard } from "@dashboard/components/Card";
 import { NewRadioGroupField as RadioGroupField } from "@dashboard/components/RadioGroupField";
 import { ProductTypeKindEnum } from "@dashboard/graphql";
+import { type FormChange } from "@dashboard/hooks/useForm";
 import { Text } from "@saleor/macaw-ui-next";
-import type * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import { messages } from "./messages";
@@ -24,7 +24,7 @@ interface ProductTypeConfigurationProps {
     kind: ProductTypeKindEnum;
   };
   disabled: boolean;
-  onKindChange: (event: React.ChangeEvent<any>) => void;
+  onKindChange: FormChange;
 }
 
 export const ProductTypeConfiguration = ({

--- a/src/productTypes/components/ProductTypeConfiguration/ProductTypeConfiguration.tsx
+++ b/src/productTypes/components/ProductTypeConfiguration/ProductTypeConfiguration.tsx
@@ -1,0 +1,65 @@
+import { DashboardCard } from "@dashboard/components/Card";
+import { NewRadioGroupField as RadioGroupField } from "@dashboard/components/RadioGroupField";
+import { ProductTypeKindEnum } from "@dashboard/graphql";
+import { Text } from "@saleor/macaw-ui-next";
+import type * as React from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import { messages } from "./messages";
+
+const kindOptions = [
+  {
+    title: messages.optionNormalTitle,
+    type: ProductTypeKindEnum.NORMAL,
+  },
+  {
+    title: messages.optionGiftCardTitle,
+    subtitle: messages.optionGiftCardDescription,
+    type: ProductTypeKindEnum.GIFT_CARD,
+  },
+];
+
+interface ProductTypeConfigurationProps {
+  data: {
+    kind: ProductTypeKindEnum;
+  };
+  disabled: boolean;
+  onKindChange: (event: React.ChangeEvent<any>) => void;
+}
+
+export const ProductTypeConfiguration = ({
+  data,
+  disabled,
+  onKindChange,
+}: ProductTypeConfigurationProps) => {
+  const intl = useIntl();
+
+  return (
+    <DashboardCard>
+      <DashboardCard.Header>
+        <DashboardCard.Title>{intl.formatMessage(messages.typeConfiguration)}</DashboardCard.Title>
+      </DashboardCard.Header>
+      <DashboardCard.Content>
+        <RadioGroupField
+          disabled={disabled}
+          choices={kindOptions.map(option => ({
+            label: (
+              <>
+                <FormattedMessage {...option.title} />
+                {option.subtitle && (
+                  <Text color="default2" size={2} fontWeight="light" display="block">
+                    <FormattedMessage {...option.subtitle} />
+                  </Text>
+                )}
+              </>
+            ),
+            value: option.type,
+          }))}
+          name="kind"
+          onChange={onKindChange}
+          value={data.kind}
+        />
+      </DashboardCard.Content>
+    </DashboardCard>
+  );
+};

--- a/src/productTypes/components/ProductTypeConfiguration/messages.ts
+++ b/src/productTypes/components/ProductTypeConfiguration/messages.ts
@@ -1,0 +1,24 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  typeConfiguration: {
+    id: "WaZUkL",
+    defaultMessage: "Type configuration",
+    description: "product type configuration section header",
+  },
+  optionNormalTitle: {
+    id: "xRbqcg",
+    defaultMessage: "Regular product type",
+    description: "option",
+  },
+  optionGiftCardTitle: {
+    id: "kp2IYP",
+    defaultMessage: "Gift card product type",
+    description: "option",
+  },
+  optionGiftCardDescription: {
+    id: "7nKXni",
+    defaultMessage: "This product will act as a payment method",
+    description: "option description",
+  },
+});

--- a/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
+++ b/src/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
@@ -22,6 +22,7 @@ import { productTypeListUrl } from "@dashboard/productTypes/urls";
 import { type FetchMoreProps, type UserError } from "@dashboard/types";
 import useMetadataChangeTrigger from "@dashboard/utils/metadata/useMetadataChangeTrigger";
 
+import { ProductTypeConfiguration } from "../ProductTypeConfiguration/ProductTypeConfiguration";
 import ProductTypeDetails from "../ProductTypeDetails/ProductTypeDetails";
 import ProductTypeShipping from "../ProductTypeShipping/ProductTypeShipping";
 import { ProductTypeTaxes } from "../ProductTypeTaxes/ProductTypeTaxes";
@@ -85,13 +86,25 @@ const ProductTypeCreatePage = ({
         return (
           <DetailPageLayout>
             <TopNav href={productTypeListUrl()} title={pageTitle} />
-            <DetailPageLayout.Content>
+            <DetailPageLayout.Content paddingBottom={10}>
+              <Metadata data={data} onChange={changeMetadata} />
+            </DetailPageLayout.Content>
+            <DetailPageLayout.RightSidebar>
               <ProductTypeDetails
+                autoFocus
                 data={data}
                 disabled={disabled}
                 errors={errors}
                 onChange={change}
-                onKindChange={changeKind}
+              />
+              <CardSpacer />
+              <ProductTypeConfiguration data={data} disabled={disabled} onKindChange={changeKind} />
+              <CardSpacer />
+              <ProductTypeShipping
+                disabled={disabled}
+                data={data}
+                weightUnit={defaultWeightUnit}
+                onChange={change}
               />
               <CardSpacer />
               <ProductTypeTaxes
@@ -103,16 +116,6 @@ const ProductTypeCreatePage = ({
                   handleTaxClassChange(event, taxClasses, change, setTaxClassDisplayName)
                 }
                 onFetchMore={onFetchMoreTaxClasses}
-              />
-              <CardSpacer />
-              <Metadata data={data} onChange={changeMetadata} />
-            </DetailPageLayout.Content>
-            <DetailPageLayout.RightSidebar>
-              <ProductTypeShipping
-                disabled={disabled}
-                data={data}
-                weightUnit={defaultWeightUnit}
-                onChange={change}
               />
             </DetailPageLayout.RightSidebar>
             <Savebar>

--- a/src/productTypes/components/ProductTypeDetails/ProductTypeDetails.tsx
+++ b/src/productTypes/components/ProductTypeDetails/ProductTypeDetails.tsx
@@ -1,41 +1,37 @@
 // @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
-import { NewRadioGroupField as RadioGroupField } from "@dashboard/components/RadioGroupField";
-import { ProductTypeKindEnum } from "@dashboard/graphql";
 import { commonMessages } from "@dashboard/intl";
 import { type UserError } from "@dashboard/types";
 import { getFieldError } from "@dashboard/utils/errors";
-import { Divider, Input, Text } from "@saleor/macaw-ui-next";
+import { Input } from "@saleor/macaw-ui-next";
 import type * as React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useEffect, useRef } from "react";
+import { useIntl } from "react-intl";
 
 import { messages } from "./messages";
 
 interface ProductTypeDetailsProps {
   data?: {
     name: string;
-    kind: ProductTypeKindEnum;
   };
+  autoFocus?: boolean;
   disabled: boolean;
   errors: UserError[];
   onChange: (event: React.ChangeEvent<any>) => void;
-  onKindChange: (event: React.ChangeEvent<any>) => void;
 }
 
-const kindOptions = [
-  {
-    title: messages.optionNormalTitle,
-    type: ProductTypeKindEnum.NORMAL,
-  },
-  {
-    title: messages.optionGiftCardTitle,
-    subtitle: messages.optionGiftCardDescription,
-    type: ProductTypeKindEnum.GIFT_CARD,
-  },
-];
 const ProductTypeDetails = (props: ProductTypeDetailsProps) => {
-  const { data, disabled, errors, onChange, onKindChange } = props;
+  const { autoFocus = false, data, disabled, errors, onChange } = props;
   const intl = useIntl();
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!autoFocus || disabled) {
+      return;
+    }
+
+    nameInputRef.current?.focus();
+  }, [autoFocus, disabled]);
 
   return (
     <DashboardCard>
@@ -46,6 +42,7 @@ const ProductTypeDetails = (props: ProductTypeDetailsProps) => {
       </DashboardCard.Header>
       <DashboardCard.Content>
         <Input
+          ref={nameInputRef}
           disabled={disabled}
           error={!!getFieldError(errors, "name")}
           width="100%"
@@ -54,28 +51,6 @@ const ProductTypeDetails = (props: ProductTypeDetailsProps) => {
           name="name"
           onChange={onChange}
           value={data.name}
-        />
-      </DashboardCard.Content>
-      <Divider />
-      <DashboardCard.Content>
-        <RadioGroupField
-          disabled={disabled}
-          choices={kindOptions.map(option => ({
-            label: (
-              <>
-                <FormattedMessage {...option.title} />
-                {option.subtitle && (
-                  <Text color="default2" size={2} fontWeight="light" display="block">
-                    <FormattedMessage {...option.subtitle} />
-                  </Text>
-                )}
-              </>
-            ),
-            value: option.type,
-          }))}
-          name="kind"
-          onChange={onKindChange}
-          value={data.kind}
         />
       </DashboardCard.Content>
     </DashboardCard>

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.dirtyState.test.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.dirtyState.test.tsx
@@ -1,0 +1,203 @@
+import ExitFormDialogProvider from "@dashboard/components/Form/ExitFormDialogProvider";
+import { type ProductTypeDetailsQuery, WeightUnitsEnum } from "@dashboard/graphql";
+import { type SubmitPromise } from "@dashboard/hooks/useForm";
+import { productType } from "@dashboard/productTypes/fixtures";
+import { productTypeListPath } from "@dashboard/productTypes/urls";
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryHistory, type MemoryHistory } from "history";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Route, Router } from "react-router-dom";
+
+import ProductTypeDetailsPage from "./ProductTypeDetailsPage";
+
+jest.mock("@dashboard/components/Savebar");
+jest.mock("@dashboard/components/DevModePanel/hooks", () => ({
+  useDevModeContext: () => ({
+    setDevModeContent: jest.fn(),
+    setVariables: jest.fn(),
+    setDevModeVisibility: jest.fn(),
+  }),
+}));
+jest.mock("../ProductTypeAttributes/ProductTypeAttributes", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="product-type-attributes-mock" />,
+}));
+jest.mock("../ProductTypeConfiguration/ProductTypeConfiguration", () => ({
+  ProductTypeConfiguration: () => <div data-test-id="product-type-configuration-mock" />,
+}));
+jest.mock("../ProductTypeShipping/ProductTypeShipping", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="product-type-shipping-mock" />,
+}));
+jest.mock("../ProductTypeTaxes/ProductTypeTaxes", () => ({
+  ProductTypeTaxes: () => <div data-test-id="product-type-taxes-mock" />,
+}));
+jest.mock("../ProductTypeVariantMode/ProductTypeVariantMode", () => ({
+  ProductTypeVariantMode: () => <div data-test-id="product-type-variant-mode-mock" />,
+}));
+jest.mock("../ProductTypeVariantAttributes/ProductTypeVariantAttributes", () => ({
+  __esModule: true,
+  default: ({
+    setSelectedVariantAttributes,
+    selectedVariantAttributes,
+  }: {
+    setSelectedVariantAttributes: (ids: string[]) => void;
+    selectedVariantAttributes: string[];
+  }) => (
+    <button
+      type="button"
+      data-test-id="toggle-variant-selection"
+      onClick={() =>
+        setSelectedVariantAttributes(
+          selectedVariantAttributes.length > 0 ? [] : ["UHJvZHVjdEF0dHJpYnV0ATo5"],
+        )
+      }
+    />
+  ),
+}));
+
+const listPath = productTypeListPath;
+
+type ProductType = NonNullable<ProductTypeDetailsQuery["productType"]>;
+
+const productTypeFixture: ProductType = productType!;
+const detailPath = `/product-types/${productTypeFixture.id}`;
+const productTypeWithVariants: ProductType = {
+  ...productTypeFixture,
+  hasVariants: true,
+};
+
+const defaultProps = {
+  defaultWeightUnit: WeightUnitsEnum.KG,
+  disabled: false,
+  errors: [],
+  saveButtonBarState: "default" as const,
+  taxClasses: [],
+  selectedVariantAttributes: ["UHJvZHVjdEF0dHJpYnV0ATo5"],
+  setSelectedVariantAttributes: jest.fn(),
+  onFetchMoreTaxClasses: {
+    hasMore: false,
+    loading: false,
+    onFetchMore: jest.fn(),
+  },
+  productAttributeList: {
+    isChecked: () => false,
+    selected: 0,
+    toggle: jest.fn(),
+    toggleAll: jest.fn(),
+    toolbar: null,
+  },
+  variantAttributeList: {
+    isChecked: () => false,
+    selected: 0,
+    toggle: jest.fn(),
+    toggleAll: jest.fn(),
+    toolbar: null,
+  },
+  onAttributeAdd: jest.fn(),
+  onAttributeCreate: jest.fn(),
+  onAttributeReorder: jest.fn(),
+  onAttributeUnassign: jest.fn(),
+  onDelete: jest.fn(),
+  onShowMetadata: jest.fn(),
+  onHasVariantsToggle: jest.fn(),
+  onSubmit: jest.fn((): SubmitPromise => Promise.resolve([])),
+};
+
+const StatefulProductTypePage = ({
+  productTypeProp = productTypeWithVariants,
+}: {
+  productTypeProp?: ProductType;
+}) => {
+  const [selectedVariantAttributes, setSelectedVariantAttributes] = useState([
+    "UHJvZHVjdEF0dHJpYnV0ATo5",
+  ]);
+
+  return (
+    <ProductTypeDetailsPage
+      {...defaultProps}
+      productType={productTypeProp}
+      selectedVariantAttributes={selectedVariantAttributes}
+      setSelectedVariantAttributes={setSelectedVariantAttributes}
+    />
+  );
+};
+
+const renderPage = (
+  history: MemoryHistory,
+  page: ReactNode = <StatefulProductTypePage />,
+): void => {
+  render(
+    <Router history={history}>
+      <ExitFormDialogProvider>
+        <ThemeProvider>
+          <Route path="/product-types/:id">{page}</Route>
+          <Route path={listPath}>
+            <div data-test-id="product-type-list-page" />
+          </Route>
+        </ThemeProvider>
+      </ExitFormDialogProvider>
+    </Router>,
+  );
+};
+
+describe("ProductTypeDetailsPage dirty state", () => {
+  it("blocks navigation when the name field is edited", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const history = createMemoryHistory({ initialEntries: [detailPath] });
+
+    renderPage(
+      history,
+      <ProductTypeDetailsPage {...defaultProps} productType={productTypeFixture} />,
+    );
+
+    // Act
+    const nameInput = screen.getByLabelText("Product Type Name");
+
+    await user.clear(nameInput);
+    await user.type(nameInput, "Updated product type");
+    await user.click(screen.getByTestId("app-header-back-button"));
+
+    // Assert
+    expect(screen.getByTestId("ignore-changes")).toBeInTheDocument();
+    expect(history.location.pathname).toBe(detailPath);
+  });
+
+  it("blocks navigation when variant selection changes", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const history = createMemoryHistory({ initialEntries: [detailPath] });
+
+    renderPage(history);
+
+    // Act
+    await user.click(screen.getByTestId("toggle-variant-selection"));
+    await user.click(screen.getByTestId("app-header-back-button"));
+
+    // Assert
+    expect(screen.getByTestId("ignore-changes")).toBeInTheDocument();
+    expect(history.location.pathname).toBe(detailPath);
+  });
+
+  it("allows navigation when the form is pristine", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const history = createMemoryHistory({ initialEntries: [detailPath] });
+
+    renderPage(
+      history,
+      <ProductTypeDetailsPage {...defaultProps} productType={productTypeFixture} />,
+    );
+
+    // Act
+    await user.click(screen.getByTestId("app-header-back-button"));
+
+    // Assert
+    expect(screen.queryByTestId("ignore-changes")).not.toBeInTheDocument();
+    expect(history.location.pathname).toBe(listPath);
+  });
+});

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
@@ -1,12 +1,20 @@
 import { productType } from "@dashboard/productTypes/fixtures";
 import { ThemeProvider } from "@saleor/macaw-ui-next";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import ProductTypeDetailsPage from "./ProductTypeDetailsPage";
 
 jest.mock("@dashboard/components/Savebar");
+jest.mock("@dashboard/components/DevModePanel/hooks", () => ({
+  useDevModeContext: () => ({
+    setDevModeContent: jest.fn(),
+    setVariables: jest.fn(),
+    setDevModeVisibility: jest.fn(),
+  }),
+}));
 jest.mock("../ProductTypeAttributes/ProductTypeAttributes", () => ({
   __esModule: true,
   default: () => <div data-test-id="product-type-attributes-mock" />,
@@ -73,15 +81,18 @@ const defaultProps = {
 const renderPage = ({
   productTypeProp,
   onShowMetadata = jest.fn(),
+  onDelete = jest.fn(),
 }: {
   productTypeProp: typeof productType | undefined;
   onShowMetadata?: () => void;
+  onDelete?: () => void;
 }): ReturnType<typeof render> =>
   render(
     <ProductTypeDetailsPage
       {...defaultProps}
       productType={productTypeProp}
       onShowMetadata={onShowMetadata}
+      onDelete={onDelete}
     />,
     { wrapper: Wrapper },
   );
@@ -114,5 +125,20 @@ describe("ProductTypeDetailsPage top nav", () => {
 
     // Assert
     expect(screen.getByTestId("show-product-type-metadata")).toBeDisabled();
+  });
+
+  it("calls onDelete from the cogs menu", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+
+    renderPage({ productTypeProp: productType, onDelete });
+
+    // Act
+    await user.click(screen.getByTestId("show-more-button"));
+    await user.click(screen.getByTestId("delete-product-type"));
+
+    // Assert
+    expect(onDelete).toHaveBeenCalled();
   });
 });

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
@@ -23,12 +23,18 @@ jest.mock("../ProductTypeDetails/ProductTypeDetails", () => ({
   __esModule: true,
   default: () => <div data-test-id="product-type-details-mock" />,
 }));
+jest.mock("../ProductTypeConfiguration/ProductTypeConfiguration", () => ({
+  ProductTypeConfiguration: () => <div data-test-id="product-type-configuration-mock" />,
+}));
 jest.mock("../ProductTypeShipping/ProductTypeShipping", () => ({
   __esModule: true,
   default: () => <div data-test-id="product-type-shipping-mock" />,
 }));
 jest.mock("../ProductTypeTaxes/ProductTypeTaxes", () => ({
   ProductTypeTaxes: () => <div data-test-id="product-type-taxes-mock" />,
+}));
+jest.mock("../ProductTypeVariantMode/ProductTypeVariantMode", () => ({
+  ProductTypeVariantMode: () => <div data-test-id="product-type-variant-mode-mock" />,
 }));
 jest.mock("../ProductTypeVariantAttributes/ProductTypeVariantAttributes", () => ({
   __esModule: true,

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
@@ -1,3 +1,5 @@
+import { type ProductTypeDetailsQuery, WeightUnitsEnum } from "@dashboard/graphql";
+import { type SubmitPromise } from "@dashboard/hooks/useForm";
 import { productType } from "@dashboard/productTypes/fixtures";
 import { ThemeProvider } from "@saleor/macaw-ui-next";
 import { render, screen } from "@testing-library/react";
@@ -47,8 +49,10 @@ const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
   </MemoryRouter>
 );
 
+const productTypeFixture: NonNullable<ProductTypeDetailsQuery["productType"]> = productType!;
+
 const defaultProps = {
-  defaultWeightUnit: "KG" as const,
+  defaultWeightUnit: WeightUnitsEnum.KG,
   disabled: false,
   errors: [],
   saveButtonBarState: "default" as const,
@@ -81,7 +85,7 @@ const defaultProps = {
   onDelete: jest.fn(),
   onShowMetadata: jest.fn(),
   onHasVariantsToggle: jest.fn(),
-  onSubmit: jest.fn(),
+  onSubmit: jest.fn((): SubmitPromise => Promise.resolve([])),
 };
 
 const renderPage = ({
@@ -89,14 +93,14 @@ const renderPage = ({
   onShowMetadata = jest.fn(),
   onDelete = jest.fn(),
 }: {
-  productTypeProp: typeof productType | undefined;
+  productTypeProp: NonNullable<ProductTypeDetailsQuery["productType"]> | null | undefined;
   onShowMetadata?: () => void;
   onDelete?: () => void;
 }): ReturnType<typeof render> =>
   render(
     <ProductTypeDetailsPage
       {...defaultProps}
-      productType={productTypeProp}
+      productType={productTypeProp ?? null}
       onShowMetadata={onShowMetadata}
       onDelete={onDelete}
     />,
@@ -106,7 +110,7 @@ const renderPage = ({
 describe("ProductTypeDetailsPage top nav", () => {
   it("renders the metadata button", () => {
     // Arrange & Act
-    renderPage({ productTypeProp: productType });
+    renderPage({ productTypeProp: productTypeFixture });
 
     // Assert
     expect(screen.getByTestId("show-product-type-metadata")).toBeInTheDocument();
@@ -116,7 +120,7 @@ describe("ProductTypeDetailsPage top nav", () => {
     // Arrange
     const onShowMetadata = jest.fn();
 
-    renderPage({ productTypeProp: productType, onShowMetadata });
+    renderPage({ productTypeProp: productTypeFixture, onShowMetadata });
 
     // Act
     screen.getByTestId("show-product-type-metadata").click();
@@ -138,7 +142,7 @@ describe("ProductTypeDetailsPage top nav", () => {
     const user = userEvent.setup();
     const onDelete = jest.fn();
 
-    renderPage({ productTypeProp: productType, onDelete });
+    renderPage({ productTypeProp: productTypeFixture, onDelete });
 
     // Act
     await user.click(screen.getByTestId("show-more-button"));

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.topNav.test.tsx
@@ -1,0 +1,118 @@
+import { productType } from "@dashboard/productTypes/fixtures";
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import ProductTypeDetailsPage from "./ProductTypeDetailsPage";
+
+jest.mock("@dashboard/components/Savebar");
+jest.mock("../ProductTypeAttributes/ProductTypeAttributes", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="product-type-attributes-mock" />,
+}));
+jest.mock("../ProductTypeDetails/ProductTypeDetails", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="product-type-details-mock" />,
+}));
+jest.mock("../ProductTypeShipping/ProductTypeShipping", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="product-type-shipping-mock" />,
+}));
+jest.mock("../ProductTypeTaxes/ProductTypeTaxes", () => ({
+  ProductTypeTaxes: () => <div data-test-id="product-type-taxes-mock" />,
+}));
+jest.mock("../ProductTypeVariantAttributes/ProductTypeVariantAttributes", () => ({
+  __esModule: true,
+  default: () => <div data-test-id="product-type-variant-attributes-mock" />,
+}));
+
+const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <MemoryRouter>
+    <ThemeProvider>{children}</ThemeProvider>
+  </MemoryRouter>
+);
+
+const defaultProps = {
+  defaultWeightUnit: "KG" as const,
+  disabled: false,
+  errors: [],
+  saveButtonBarState: "default" as const,
+  taxClasses: [],
+  selectedVariantAttributes: [],
+  setSelectedVariantAttributes: jest.fn(),
+  onFetchMoreTaxClasses: {
+    hasMore: false,
+    loading: false,
+    onFetchMore: jest.fn(),
+  },
+  productAttributeList: {
+    isChecked: () => false,
+    selected: 0,
+    toggle: jest.fn(),
+    toggleAll: jest.fn(),
+    toolbar: null,
+  },
+  variantAttributeList: {
+    isChecked: () => false,
+    selected: 0,
+    toggle: jest.fn(),
+    toggleAll: jest.fn(),
+    toolbar: null,
+  },
+  onAttributeAdd: jest.fn(),
+  onAttributeCreate: jest.fn(),
+  onAttributeReorder: jest.fn(),
+  onAttributeUnassign: jest.fn(),
+  onDelete: jest.fn(),
+  onShowMetadata: jest.fn(),
+  onHasVariantsToggle: jest.fn(),
+  onSubmit: jest.fn(),
+};
+
+const renderPage = ({
+  productTypeProp,
+  onShowMetadata = jest.fn(),
+}: {
+  productTypeProp: typeof productType | undefined;
+  onShowMetadata?: () => void;
+}): ReturnType<typeof render> =>
+  render(
+    <ProductTypeDetailsPage
+      {...defaultProps}
+      productType={productTypeProp}
+      onShowMetadata={onShowMetadata}
+    />,
+    { wrapper: Wrapper },
+  );
+
+describe("ProductTypeDetailsPage top nav", () => {
+  it("renders the metadata button", () => {
+    // Arrange & Act
+    renderPage({ productTypeProp: productType });
+
+    // Assert
+    expect(screen.getByTestId("show-product-type-metadata")).toBeInTheDocument();
+  });
+
+  it("calls onShowMetadata when the metadata button is clicked", () => {
+    // Arrange
+    const onShowMetadata = jest.fn();
+
+    renderPage({ productTypeProp: productType, onShowMetadata });
+
+    // Act
+    screen.getByTestId("show-product-type-metadata").click();
+
+    // Assert
+    expect(onShowMetadata).toHaveBeenCalled();
+  });
+
+  it("disables the metadata button while product type data is loading", () => {
+    // Arrange & Act
+    renderPage({ productTypeProp: undefined });
+
+    // Assert
+    expect(screen.getByTestId("show-product-type-metadata")).toBeDisabled();
+  });
+});

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -19,7 +19,7 @@ import { useBackLinkWithState } from "@dashboard/hooks/useBackLinkWithState";
 import { type SubmitPromise } from "@dashboard/hooks/useForm";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import useStateFromProps from "@dashboard/hooks/useStateFromProps";
-import { TerminalIcon } from "@dashboard/icons/TerminalIcon";
+import { GraphqlIcon } from "@dashboard/icons/GraphqlIcon";
 import { maybe } from "@dashboard/misc";
 import { handleTaxClassChange } from "@dashboard/productTypes/handlers";
 import { defaultGraphiQLQuery } from "@dashboard/productTypes/queries";
@@ -150,7 +150,7 @@ const ProductTypeDetailsPage = ({
         label: intl.formatMessage(messages.openGraphiQL),
         onSelect: openPlaygroundURL,
         testId: "graphiql-redirect",
-        icon: <TerminalIcon />,
+        icon: <GraphqlIcon />,
       },
       {
         label: intl.formatMessage(messages.deleteProductType),
@@ -185,7 +185,7 @@ const ProductTypeDetailsPage = ({
             />
             <TopNav.Menu items={menuItems} dataTestId="menu" />
           </TopNav>
-          <DetailPageLayout.Content>
+          <DetailPageLayout.Content paddingBottom={10}>
             <ProductTypeDetails
               data={data}
               disabled={disabled}

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -4,7 +4,6 @@ import CardSpacer from "@dashboard/components/CardSpacer";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import Form from "@dashboard/components/Form";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
-import { Metadata } from "@dashboard/components/Metadata/Metadata";
 import { type MetadataFormData } from "@dashboard/components/Metadata/types";
 import { Savebar } from "@dashboard/components/Savebar";
 import {
@@ -27,16 +26,16 @@ import {
   type ReorderEvent,
   type UserError,
 } from "@dashboard/types";
-import { mapMetadataItemToInput } from "@dashboard/utils/maps";
-import useMetadataChangeTrigger from "@dashboard/utils/metadata/useMetadataChangeTrigger";
 import { Box, Text, Toggle } from "@saleor/macaw-ui-next";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 
 import ProductTypeAttributes from "../ProductTypeAttributes/ProductTypeAttributes";
 import ProductTypeDetails from "../ProductTypeDetails/ProductTypeDetails";
 import ProductTypeShipping from "../ProductTypeShipping/ProductTypeShipping";
 import { ProductTypeTaxes } from "../ProductTypeTaxes/ProductTypeTaxes";
 import ProductTypeVariantAttributes from "../ProductTypeVariantAttributes/ProductTypeVariantAttributes";
+import { messages } from "./messages";
+import { ProductTypeDetailsTitle } from "./Title";
 
 interface ChoiceType {
   label: string;
@@ -59,7 +58,6 @@ interface ProductTypeDetailsPageProps {
   productType: ProductTypeDetailsQuery["productType"];
   defaultWeightUnit: WeightUnitsEnum;
   disabled: boolean;
-  pageTitle: string;
   productAttributeList: ListActions;
   saveButtonBarState: ConfirmButtonTransitionState;
   taxClasses: TaxClassBaseFragment[];
@@ -69,6 +67,7 @@ interface ProductTypeDetailsPageProps {
   onAttributeReorder: (event: ReorderEvent, type: ProductAttributeType) => void;
   onAttributeUnassign: (id: string) => void;
   onDelete: () => void;
+  onShowMetadata: () => void;
   onHasVariantsToggle: (hasVariants: boolean) => void;
   onSubmit: (data: ProductTypeForm) => SubmitPromise;
   setSelectedVariantAttributes: (data: string[]) => void;
@@ -80,7 +79,6 @@ const ProductTypeDetailsPage = ({
   defaultWeightUnit,
   disabled,
   errors,
-  pageTitle,
   productType,
   productAttributeList,
   saveButtonBarState,
@@ -91,21 +89,18 @@ const ProductTypeDetailsPage = ({
   onAttributeUnassign,
   onAttributeReorder,
   onDelete,
+  onShowMetadata,
   onHasVariantsToggle,
   onSubmit,
   setSelectedVariantAttributes,
   selectedVariantAttributes,
   onFetchMoreTaxClasses,
 }: ProductTypeDetailsPageProps) => {
+  const intl = useIntl();
   const navigate = useNavigator();
   const productTypeListBackLink = useBackLinkWithState({
     path: productTypeListPath,
   });
-  const {
-    isMetadataModified,
-    isPrivateMetadataModified,
-    makeChangeHandler: makeMetadataChangeHandler,
-  } = useMetadataChangeTrigger();
   const [taxClassDisplayName, setTaxClassDisplayName] = useStateFromProps(
     productType?.taxClass?.name ?? "",
   );
@@ -116,10 +111,10 @@ const ProductTypeDetailsPage = ({
       maybe(() => productType.isShippingRequired) !== undefined
         ? productType.isShippingRequired
         : false,
-    metadata: productType?.metadata?.map(mapMetadataItemToInput),
+    metadata: [],
     name: maybe(() => productType.name) !== undefined ? productType.name : "",
     kind: productType?.kind || ProductTypeKindEnum.NORMAL,
-    privateMetadata: productType?.privateMetadata?.map(mapMetadataItemToInput),
+    privateMetadata: [],
     productAttributes:
       maybe(() => productType.productAttributes) !== undefined
         ? productType.productAttributes.map(attribute => ({
@@ -137,120 +132,120 @@ const ProductTypeDetailsPage = ({
         : [],
     weight: maybe(() => productType.weight.value),
   };
-  const handleSubmit = (data: ProductTypeForm) => {
-    const metadata = isMetadataModified ? data.metadata : undefined;
-    const privateMetadata = isPrivateMetadataModified ? data.privateMetadata : undefined;
-
-    return onSubmit({
-      ...data,
-      metadata,
-      privateMetadata,
-    });
-  };
 
   return (
-    <Form initial={formInitialData} onSubmit={handleSubmit} confirmLeave disabled={disabled}>
-      {({ change, data, isSaveDisabled, submit }) => {
-        const changeMetadata = makeMetadataChangeHandler(change);
+    <Form initial={formInitialData} onSubmit={onSubmit} confirmLeave disabled={disabled}>
+      {({ change, data, isSaveDisabled, submit }) => (
+        <DetailPageLayout>
+          <TopNav
+            href={productTypeListBackLink}
+            title={
+              <ProductTypeDetailsTitle
+                productType={productType ? { name: productType.name } : null}
+                loading={disabled}
+              />
+            }
+            actionsGap={3}
+          >
+            <TopNav.MetadataButton
+              onClick={onShowMetadata}
+              disabled={!productType}
+              data-test-id="show-product-type-metadata"
+              title={intl.formatMessage(messages.editProductTypeMetadata)}
+            />
+          </TopNav>
+          <DetailPageLayout.Content>
+            <ProductTypeDetails
+              data={data}
+              disabled={disabled}
+              errors={errors}
+              onChange={change}
+              onKindChange={change}
+            />
+            <CardSpacer />
+            <ProductTypeTaxes
+              disabled={disabled}
+              data={data}
+              taxClasses={taxClasses}
+              taxClassDisplayName={taxClassDisplayName}
+              onChange={event =>
+                handleTaxClassChange(event, taxClasses, change, setTaxClassDisplayName)
+              }
+              onFetchMore={onFetchMoreTaxClasses}
+            />
+            <CardSpacer />
+            <ProductTypeAttributes
+              testId="assign-products-attributes"
+              attributes={maybe(() => productType.productAttributes)}
+              disabled={disabled}
+              type={ProductAttributeType.PRODUCT}
+              onAttributeAssign={onAttributeAdd}
+              onAttributeCreate={onAttributeCreate}
+              onAttributeReorder={(event: ReorderEvent) =>
+                onAttributeReorder(event, ProductAttributeType.PRODUCT)
+              }
+              onAttributeUnassign={onAttributeUnassign}
+              {...productAttributeList}
+            />
+            <CardSpacer />
 
-        return (
-          <DetailPageLayout>
-            <TopNav href={productTypeListBackLink} title={pageTitle} />
-            <DetailPageLayout.Content>
-              <ProductTypeDetails
-                data={data}
+            <Box marginLeft={6}>
+              <Toggle
+                pressed={data.hasVariants}
                 disabled={disabled}
-                errors={errors}
-                onChange={change}
-                onKindChange={change}
-              />
-              <CardSpacer />
-              <ProductTypeTaxes
-                disabled={disabled}
-                data={data}
-                taxClasses={taxClasses}
-                taxClassDisplayName={taxClassDisplayName}
-                onChange={event =>
-                  handleTaxClassChange(event, taxClasses, change, setTaxClassDisplayName)
-                }
-                onFetchMore={onFetchMoreTaxClasses}
-              />
-              <CardSpacer />
-              <ProductTypeAttributes
-                testId="assign-products-attributes"
-                attributes={maybe(() => productType.productAttributes)}
-                disabled={disabled}
-                type={ProductAttributeType.PRODUCT}
-                onAttributeAssign={onAttributeAdd}
-                onAttributeCreate={onAttributeCreate}
-                onAttributeReorder={(event: ReorderEvent) =>
-                  onAttributeReorder(event, ProductAttributeType.PRODUCT)
-                }
-                onAttributeUnassign={onAttributeUnassign}
-                {...productAttributeList}
-              />
-              <CardSpacer />
-
-              <Box marginLeft={6}>
-                <Toggle
-                  pressed={data.hasVariants}
-                  disabled={disabled}
-                  name="hasVariants"
-                  onPressedChange={pressed => onHasVariantsToggle(pressed)}
-                >
-                  <Text>
-                    <FormattedMessage
-                      id="5pHBSU"
-                      defaultMessage="Product type uses Variant Attributes"
-                      description="switch button"
-                    />
-                  </Text>
-                </Toggle>
-              </Box>
-              {data.hasVariants && (
-                <>
-                  <CardSpacer />
-                  <ProductTypeVariantAttributes
-                    testId="assign-variants-attributes"
-                    assignedVariantAttributes={productType?.assignedVariantAttributes}
-                    disabled={disabled}
-                    type={ProductAttributeType.VARIANT}
-                    onAttributeAssign={onAttributeAdd}
-                    onAttributeCreate={onAttributeCreate}
-                    onAttributeReorder={(event: ReorderEvent) =>
-                      onAttributeReorder(event, ProductAttributeType.VARIANT)
-                    }
-                    onAttributeUnassign={onAttributeUnassign}
-                    setSelectedVariantAttributes={setSelectedVariantAttributes}
-                    selectedVariantAttributes={selectedVariantAttributes}
-                    {...variantAttributeList}
+                name="hasVariants"
+                onPressedChange={pressed => onHasVariantsToggle(pressed)}
+              >
+                <Text>
+                  <FormattedMessage
+                    id="5pHBSU"
+                    defaultMessage="Product type uses Variant Attributes"
+                    description="switch button"
                   />
-                </>
-              )}
-              <CardSpacer />
-              <Metadata data={data} onChange={changeMetadata} />
-            </DetailPageLayout.Content>
-            <DetailPageLayout.RightSidebar>
-              <ProductTypeShipping
-                disabled={disabled}
-                data={data}
-                weightUnit={productType?.weight?.unit || defaultWeightUnit}
-                onChange={change}
-              />
-            </DetailPageLayout.RightSidebar>
-            <Savebar>
-              <Savebar.DeleteButton onClick={onDelete} />
-              <Savebar.Spacer />
-              <Savebar.CancelButton onClick={() => navigate(productTypeListBackLink)} />
-              <Savebar.ConfirmButton
-                transitionState={saveButtonBarState}
-                onClick={submit}
-                disabled={isSaveDisabled}
-              />
-            </Savebar>
-          </DetailPageLayout>
-        );
-      }}
+                </Text>
+              </Toggle>
+            </Box>
+            {data.hasVariants && (
+              <>
+                <CardSpacer />
+                <ProductTypeVariantAttributes
+                  testId="assign-variants-attributes"
+                  assignedVariantAttributes={productType?.assignedVariantAttributes}
+                  disabled={disabled}
+                  type={ProductAttributeType.VARIANT}
+                  onAttributeAssign={onAttributeAdd}
+                  onAttributeCreate={onAttributeCreate}
+                  onAttributeReorder={(event: ReorderEvent) =>
+                    onAttributeReorder(event, ProductAttributeType.VARIANT)
+                  }
+                  onAttributeUnassign={onAttributeUnassign}
+                  setSelectedVariantAttributes={setSelectedVariantAttributes}
+                  selectedVariantAttributes={selectedVariantAttributes}
+                  {...variantAttributeList}
+                />
+              </>
+            )}
+          </DetailPageLayout.Content>
+          <DetailPageLayout.RightSidebar>
+            <ProductTypeShipping
+              disabled={disabled}
+              data={data}
+              weightUnit={productType?.weight?.unit || defaultWeightUnit}
+              onChange={change}
+            />
+          </DetailPageLayout.RightSidebar>
+          <Savebar>
+            <Savebar.DeleteButton onClick={onDelete} />
+            <Savebar.Spacer />
+            <Savebar.CancelButton onClick={() => navigate(productTypeListBackLink)} />
+            <Savebar.ConfirmButton
+              transitionState={saveButtonBarState}
+              onClick={submit}
+              disabled={isSaveDisabled}
+            />
+          </Savebar>
+        </DetailPageLayout>
+      )}
     </Form>
   );
 };

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -2,7 +2,9 @@
 import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
+import { useDevModeContext } from "@dashboard/components/DevModePanel/hooks";
 import Form from "@dashboard/components/Form";
+import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
 import { type MetadataFormData } from "@dashboard/components/Metadata/types";
 import { Savebar } from "@dashboard/components/Savebar";
@@ -17,8 +19,10 @@ import { useBackLinkWithState } from "@dashboard/hooks/useBackLinkWithState";
 import { type SubmitPromise } from "@dashboard/hooks/useForm";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import useStateFromProps from "@dashboard/hooks/useStateFromProps";
+import { TerminalIcon } from "@dashboard/icons/TerminalIcon";
 import { maybe } from "@dashboard/misc";
 import { handleTaxClassChange } from "@dashboard/productTypes/handlers";
+import { defaultGraphiQLQuery } from "@dashboard/productTypes/queries";
 import { productTypeListPath } from "@dashboard/productTypes/urls";
 import {
   type FetchMoreProps,
@@ -27,6 +31,8 @@ import {
   type UserError,
 } from "@dashboard/types";
 import { Box, Text, Toggle } from "@saleor/macaw-ui-next";
+import { Trash2 } from "lucide-react";
+import { useCallback, useMemo } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import ProductTypeAttributes from "../ProductTypeAttributes/ProductTypeAttributes";
@@ -98,6 +104,12 @@ const ProductTypeDetailsPage = ({
 }: ProductTypeDetailsPageProps) => {
   const intl = useIntl();
   const navigate = useNavigator();
+  const context = useDevModeContext();
+  const openPlaygroundURL = useCallback(() => {
+    context.setDevModeContent(defaultGraphiQLQuery);
+    context.setVariables(`{ "id": "${productType?.id}" }`);
+    context.setDevModeVisibility(true);
+  }, [context, productType?.id]);
   const productTypeListBackLink = useBackLinkWithState({
     path: productTypeListPath,
   });
@@ -132,6 +144,24 @@ const ProductTypeDetailsPage = ({
         : [],
     weight: maybe(() => productType.weight.value),
   };
+  const menuItems = useMemo(
+    () => [
+      {
+        label: intl.formatMessage(messages.openGraphiQL),
+        onSelect: openPlaygroundURL,
+        testId: "graphiql-redirect",
+        icon: <TerminalIcon />,
+      },
+      {
+        label: intl.formatMessage(messages.deleteProductType),
+        onSelect: onDelete,
+        testId: "delete-product-type",
+        color: "critical1" as const,
+        icon: <Trash2 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />,
+      },
+    ],
+    [intl, onDelete, openPlaygroundURL],
+  );
 
   return (
     <Form initial={formInitialData} onSubmit={onSubmit} confirmLeave disabled={disabled}>
@@ -153,6 +183,7 @@ const ProductTypeDetailsPage = ({
               data-test-id="show-product-type-metadata"
               title={intl.formatMessage(messages.editProductTypeMetadata)}
             />
+            <TopNav.Menu items={menuItems} dataTestId="menu" />
           </TopNav>
           <DetailPageLayout.Content>
             <ProductTypeDetails

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -3,7 +3,7 @@ import { TopNav } from "@dashboard/components/AppLayout/TopNav";
 import CardSpacer from "@dashboard/components/CardSpacer";
 import { type ConfirmButtonTransitionState } from "@dashboard/components/ConfirmButton";
 import { useDevModeContext } from "@dashboard/components/DevModePanel/hooks";
-import Form from "@dashboard/components/Form";
+import Form, { FormDirtyStateSync } from "@dashboard/components/Form";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { DetailPageLayout } from "@dashboard/components/Layouts";
 import { type MetadataFormData } from "@dashboard/components/Metadata/types";
@@ -24,6 +24,10 @@ import { maybe } from "@dashboard/misc";
 import { handleTaxClassChange } from "@dashboard/productTypes/handlers";
 import { defaultGraphiQLQuery } from "@dashboard/productTypes/queries";
 import { productTypeListPath } from "@dashboard/productTypes/urls";
+import {
+  getVariantSelectionFromAssigned,
+  isProductTypeUpdateFormPristine,
+} from "@dashboard/productTypes/utils/productTypePageForm";
 import {
   type FetchMoreProps,
   type ListActions,
@@ -117,34 +121,60 @@ const ProductTypeDetailsPage = ({
   const [taxClassDisplayName, setTaxClassDisplayName] = useStateFromProps(
     productType?.taxClass?.name ?? "",
   );
-  const formInitialData: ProductTypeForm = {
-    hasVariants:
-      maybe(() => productType.hasVariants) !== undefined ? productType.hasVariants : false,
-    isShippingRequired:
-      maybe(() => productType.isShippingRequired) !== undefined
-        ? productType.isShippingRequired
-        : false,
-    metadata: [],
-    name: maybe(() => productType.name) !== undefined ? productType.name : "",
-    kind: productType?.kind || ProductTypeKindEnum.NORMAL,
-    privateMetadata: [],
-    productAttributes:
-      maybe(() => productType.productAttributes) !== undefined
-        ? productType.productAttributes.map(attribute => ({
-            label: attribute.name,
-            value: attribute.id,
-          }))
-        : [],
-    taxClassId: productType?.taxClass?.id ?? "",
-    variantAttributes:
-      maybe(() => productType.variantAttributes) !== undefined
-        ? productType.variantAttributes.map(attribute => ({
-            label: attribute.name,
-            value: attribute.id,
-          }))
-        : [],
-    weight: maybe(() => productType.weight.value),
-  };
+  const formInitialData = useMemo<ProductTypeForm>(
+    () => ({
+      hasVariants:
+        maybe(() => productType.hasVariants) !== undefined ? productType.hasVariants : false,
+      isShippingRequired:
+        maybe(() => productType.isShippingRequired) !== undefined
+          ? productType.isShippingRequired
+          : false,
+      metadata: [],
+      name: maybe(() => productType.name) !== undefined ? productType.name : "",
+      kind: productType?.kind || ProductTypeKindEnum.NORMAL,
+      privateMetadata: [],
+      productAttributes:
+        maybe(() => productType.productAttributes) !== undefined
+          ? productType.productAttributes.map(attribute => ({
+              label: attribute.name,
+              value: attribute.id,
+            }))
+          : [],
+      taxClassId: productType?.taxClass?.id ?? "",
+      variantAttributes:
+        maybe(() => productType.variantAttributes) !== undefined
+          ? productType.variantAttributes.map(attribute => ({
+              label: attribute.name,
+              value: attribute.id,
+            }))
+          : [],
+      weight: maybe(() => productType.weight.value),
+    }),
+    [productType],
+  );
+  const initialVariantSelection = useMemo(
+    () => getVariantSelectionFromAssigned(productType?.assignedVariantAttributes),
+    [productType?.assignedVariantAttributes],
+  );
+  const checkIfSaveIsDisabled = useCallback(
+    (data: ProductTypeForm) => {
+      if (disabled) {
+        return true;
+      }
+
+      if (!productType) {
+        return true;
+      }
+
+      return isProductTypeUpdateFormPristine(
+        data,
+        formInitialData,
+        selectedVariantAttributes,
+        initialVariantSelection,
+      );
+    },
+    [disabled, formInitialData, initialVariantSelection, productType, selectedVariantAttributes],
+  );
   const menuItems = useMemo(
     () => [
       {
@@ -165,102 +195,120 @@ const ProductTypeDetailsPage = ({
   );
 
   return (
-    <Form initial={formInitialData} onSubmit={onSubmit} confirmLeave disabled={disabled}>
-      {({ change, data, isSaveDisabled, submit }) => (
-        <DetailPageLayout>
-          <TopNav
-            href={productTypeListBackLink}
-            title={
-              <ProductTypeDetailsTitle
-                productType={productType ? { name: productType.name } : null}
-                loading={disabled}
-              />
-            }
-            actionsGap={3}
-          >
-            <TopNav.MetadataButton
-              onClick={onShowMetadata}
-              disabled={!productType}
-              data-test-id="show-product-type-metadata"
-              title={intl.formatMessage(messages.editProductTypeMetadata)}
-            />
-            <TopNav.Menu items={menuItems} dataTestId="menu" />
-          </TopNav>
-          <DetailPageLayout.Content paddingBottom={10}>
-            <ProductTypeAttributes
-              testId="assign-products-attributes"
-              attributes={maybe(() => productType.productAttributes)}
-              disabled={disabled}
-              type={ProductAttributeType.PRODUCT}
-              onAttributeAssign={onAttributeAdd}
-              onAttributeCreate={onAttributeCreate}
-              onAttributeReorder={(event: ReorderEvent) =>
-                onAttributeReorder(event, ProductAttributeType.PRODUCT)
-              }
-              onAttributeUnassign={onAttributeUnassign}
-              {...productAttributeList}
-            />
-            <CardSpacer />
-            <ProductTypeVariantMode
-              hasVariants={data.hasVariants}
-              disabled={disabled}
-              onHasVariantsToggle={onHasVariantsToggle}
-            />
-            {data.hasVariants && (
-              <>
-                <CardSpacer />
-                <ProductTypeVariantAttributes
-                  testId="assign-variants-attributes"
-                  assignedVariantAttributes={productType?.assignedVariantAttributes}
-                  disabled={disabled}
-                  type={ProductAttributeType.VARIANT}
-                  onAttributeAssign={onAttributeAdd}
-                  onAttributeCreate={onAttributeCreate}
-                  onAttributeReorder={(event: ReorderEvent) =>
-                    onAttributeReorder(event, ProductAttributeType.VARIANT)
-                  }
-                  onAttributeUnassign={onAttributeUnassign}
-                  setSelectedVariantAttributes={setSelectedVariantAttributes}
-                  selectedVariantAttributes={selectedVariantAttributes}
-                  {...variantAttributeList}
+    <Form
+      initial={formInitialData}
+      onSubmit={onSubmit}
+      confirmLeave
+      disabled={disabled}
+      checkIfSaveIsDisabled={checkIfSaveIsDisabled}
+    >
+      {({ change, data, isSaveDisabled, submit, triggerChange }) => (
+        <>
+          <FormDirtyStateSync
+            enabled={!!productType}
+            isSaveDisabled={isSaveDisabled}
+            triggerChange={triggerChange}
+          />
+          <DetailPageLayout>
+            <TopNav
+              href={productTypeListBackLink}
+              title={
+                <ProductTypeDetailsTitle
+                  productType={productType ? { name: productType.name } : null}
+                  loading={disabled}
                 />
-              </>
-            )}
-          </DetailPageLayout.Content>
-          <DetailPageLayout.RightSidebar>
-            <ProductTypeDetails data={data} disabled={disabled} errors={errors} onChange={change} />
-            <CardSpacer />
-            <ProductTypeConfiguration data={data} disabled={disabled} onKindChange={change} />
-            <CardSpacer />
-            <ProductTypeShipping
-              disabled={disabled}
-              data={data}
-              weightUnit={productType?.weight?.unit || defaultWeightUnit}
-              onChange={change}
-            />
-            <CardSpacer />
-            <ProductTypeTaxes
-              disabled={disabled}
-              data={data}
-              taxClasses={taxClasses}
-              taxClassDisplayName={taxClassDisplayName}
-              onChange={event =>
-                handleTaxClassChange(event, taxClasses, change, setTaxClassDisplayName)
               }
-              onFetchMore={onFetchMoreTaxClasses}
-            />
-          </DetailPageLayout.RightSidebar>
-          <Savebar>
-            <Savebar.DeleteButton onClick={onDelete} />
-            <Savebar.Spacer />
-            <Savebar.CancelButton onClick={() => navigate(productTypeListBackLink)} />
-            <Savebar.ConfirmButton
-              transitionState={saveButtonBarState}
-              onClick={submit}
-              disabled={isSaveDisabled}
-            />
-          </Savebar>
-        </DetailPageLayout>
+              actionsGap={3}
+            >
+              <TopNav.MetadataButton
+                onClick={onShowMetadata}
+                disabled={!productType}
+                data-test-id="show-product-type-metadata"
+                title={intl.formatMessage(messages.editProductTypeMetadata)}
+              />
+              <TopNav.Menu items={menuItems} dataTestId="menu" />
+            </TopNav>
+            <DetailPageLayout.Content paddingBottom={10}>
+              <ProductTypeAttributes
+                testId="assign-products-attributes"
+                attributes={maybe(() => productType.productAttributes)}
+                disabled={disabled}
+                type={ProductAttributeType.PRODUCT}
+                onAttributeAssign={onAttributeAdd}
+                onAttributeCreate={onAttributeCreate}
+                onAttributeReorder={(event: ReorderEvent) =>
+                  onAttributeReorder(event, ProductAttributeType.PRODUCT)
+                }
+                onAttributeUnassign={onAttributeUnassign}
+                {...productAttributeList}
+              />
+              <CardSpacer />
+              <ProductTypeVariantMode
+                hasVariants={data.hasVariants}
+                disabled={disabled}
+                onHasVariantsToggle={onHasVariantsToggle}
+              />
+              {data.hasVariants && (
+                <>
+                  <CardSpacer />
+                  <ProductTypeVariantAttributes
+                    testId="assign-variants-attributes"
+                    assignedVariantAttributes={productType?.assignedVariantAttributes}
+                    disabled={disabled}
+                    type={ProductAttributeType.VARIANT}
+                    onAttributeAssign={onAttributeAdd}
+                    onAttributeCreate={onAttributeCreate}
+                    onAttributeReorder={(event: ReorderEvent) =>
+                      onAttributeReorder(event, ProductAttributeType.VARIANT)
+                    }
+                    onAttributeUnassign={onAttributeUnassign}
+                    setSelectedVariantAttributes={setSelectedVariantAttributes}
+                    selectedVariantAttributes={selectedVariantAttributes}
+                    {...variantAttributeList}
+                  />
+                </>
+              )}
+            </DetailPageLayout.Content>
+            <DetailPageLayout.RightSidebar>
+              <ProductTypeDetails
+                data={data}
+                disabled={disabled}
+                errors={errors}
+                onChange={change}
+              />
+              <CardSpacer />
+              <ProductTypeConfiguration data={data} disabled={disabled} onKindChange={change} />
+              <CardSpacer />
+              <ProductTypeShipping
+                disabled={disabled}
+                data={data}
+                weightUnit={productType?.weight?.unit || defaultWeightUnit}
+                onChange={change}
+              />
+              <CardSpacer />
+              <ProductTypeTaxes
+                disabled={disabled}
+                data={data}
+                taxClasses={taxClasses}
+                taxClassDisplayName={taxClassDisplayName}
+                onChange={event =>
+                  handleTaxClassChange(event, taxClasses, change, setTaxClassDisplayName)
+                }
+                onFetchMore={onFetchMoreTaxClasses}
+              />
+            </DetailPageLayout.RightSidebar>
+            <Savebar>
+              <Savebar.DeleteButton onClick={onDelete} />
+              <Savebar.Spacer />
+              <Savebar.CancelButton onClick={() => navigate(productTypeListBackLink)} />
+              <Savebar.ConfirmButton
+                transitionState={saveButtonBarState}
+                onClick={submit}
+                disabled={isSaveDisabled}
+              />
+            </Savebar>
+          </DetailPageLayout>
+        </>
       )}
     </Form>
   );

--- a/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -30,16 +30,17 @@ import {
   type ReorderEvent,
   type UserError,
 } from "@dashboard/types";
-import { Box, Text, Toggle } from "@saleor/macaw-ui-next";
 import { Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { useIntl } from "react-intl";
 
 import ProductTypeAttributes from "../ProductTypeAttributes/ProductTypeAttributes";
+import { ProductTypeConfiguration } from "../ProductTypeConfiguration/ProductTypeConfiguration";
 import ProductTypeDetails from "../ProductTypeDetails/ProductTypeDetails";
 import ProductTypeShipping from "../ProductTypeShipping/ProductTypeShipping";
 import { ProductTypeTaxes } from "../ProductTypeTaxes/ProductTypeTaxes";
 import ProductTypeVariantAttributes from "../ProductTypeVariantAttributes/ProductTypeVariantAttributes";
+import { ProductTypeVariantMode } from "../ProductTypeVariantMode/ProductTypeVariantMode";
 import { messages } from "./messages";
 import { ProductTypeDetailsTitle } from "./Title";
 
@@ -186,25 +187,6 @@ const ProductTypeDetailsPage = ({
             <TopNav.Menu items={menuItems} dataTestId="menu" />
           </TopNav>
           <DetailPageLayout.Content paddingBottom={10}>
-            <ProductTypeDetails
-              data={data}
-              disabled={disabled}
-              errors={errors}
-              onChange={change}
-              onKindChange={change}
-            />
-            <CardSpacer />
-            <ProductTypeTaxes
-              disabled={disabled}
-              data={data}
-              taxClasses={taxClasses}
-              taxClassDisplayName={taxClassDisplayName}
-              onChange={event =>
-                handleTaxClassChange(event, taxClasses, change, setTaxClassDisplayName)
-              }
-              onFetchMore={onFetchMoreTaxClasses}
-            />
-            <CardSpacer />
             <ProductTypeAttributes
               testId="assign-products-attributes"
               attributes={maybe(() => productType.productAttributes)}
@@ -219,23 +201,11 @@ const ProductTypeDetailsPage = ({
               {...productAttributeList}
             />
             <CardSpacer />
-
-            <Box marginLeft={6}>
-              <Toggle
-                pressed={data.hasVariants}
-                disabled={disabled}
-                name="hasVariants"
-                onPressedChange={pressed => onHasVariantsToggle(pressed)}
-              >
-                <Text>
-                  <FormattedMessage
-                    id="5pHBSU"
-                    defaultMessage="Product type uses Variant Attributes"
-                    description="switch button"
-                  />
-                </Text>
-              </Toggle>
-            </Box>
+            <ProductTypeVariantMode
+              hasVariants={data.hasVariants}
+              disabled={disabled}
+              onHasVariantsToggle={onHasVariantsToggle}
+            />
             {data.hasVariants && (
               <>
                 <CardSpacer />
@@ -258,11 +228,26 @@ const ProductTypeDetailsPage = ({
             )}
           </DetailPageLayout.Content>
           <DetailPageLayout.RightSidebar>
+            <ProductTypeDetails data={data} disabled={disabled} errors={errors} onChange={change} />
+            <CardSpacer />
+            <ProductTypeConfiguration data={data} disabled={disabled} onKindChange={change} />
+            <CardSpacer />
             <ProductTypeShipping
               disabled={disabled}
               data={data}
               weightUnit={productType?.weight?.unit || defaultWeightUnit}
               onChange={change}
+            />
+            <CardSpacer />
+            <ProductTypeTaxes
+              disabled={disabled}
+              data={data}
+              taxClasses={taxClasses}
+              taxClassDisplayName={taxClassDisplayName}
+              onChange={event =>
+                handleTaxClassChange(event, taxClasses, change, setTaxClassDisplayName)
+              }
+              onFetchMore={onFetchMoreTaxClasses}
             />
           </DetailPageLayout.RightSidebar>
           <Savebar>

--- a/src/productTypes/components/ProductTypeDetailsPage/Title.test.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/Title.test.tsx
@@ -1,0 +1,42 @@
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import { type ReactElement, type ReactNode } from "react";
+
+import { ProductTypeDetailsTitle } from "./Title";
+
+const productType = {
+  name: "E-books",
+};
+
+const Wrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <ThemeProvider>{children}</ThemeProvider>
+);
+
+const renderTitle = (ui: ReactElement) => render(ui, { wrapper: Wrapper });
+
+describe("ProductTypeDetailsTitle", () => {
+  it("renders skeleton on initial load", () => {
+    // Arrange & Act
+    renderTitle(<ProductTypeDetailsTitle loading />);
+
+    // Assert
+    expect(screen.getByTestId("product-type-details-title-skeleton")).toBeInTheDocument();
+  });
+
+  it("keeps header content during background refetch", () => {
+    // Arrange & Act
+    renderTitle(<ProductTypeDetailsTitle productType={productType} loading />);
+
+    // Assert
+    expect(screen.getByText("E-books")).toBeInTheDocument();
+    expect(screen.queryByTestId("product-type-details-title-skeleton")).not.toBeInTheDocument();
+  });
+
+  it("renders product type name when loaded", () => {
+    // Arrange & Act
+    renderTitle(<ProductTypeDetailsTitle productType={productType} />);
+
+    // Assert
+    expect(screen.getByText("E-books")).toBeInTheDocument();
+  });
+});

--- a/src/productTypes/components/ProductTypeDetailsPage/Title.tsx
+++ b/src/productTypes/components/ProductTypeDetailsPage/Title.tsx
@@ -1,0 +1,53 @@
+import { makeStyles } from "@saleor/macaw-ui";
+import { Box, Skeleton } from "@saleor/macaw-ui-next";
+
+interface ProductTypeDetailsHeaderProductType {
+  name: string;
+}
+
+interface ProductTypeDetailsTitleProps {
+  productType?: ProductTypeDetailsHeaderProductType | null;
+  loading?: boolean;
+}
+
+const useStyles = makeStyles(
+  theme => ({
+    container: {
+      alignItems: "center",
+      display: "flex",
+      gap: theme.spacing(2),
+    },
+    name: {
+      minWidth: 0,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+    },
+  }),
+  { name: "ProductTypeDetailsTitle" },
+);
+
+export const ProductTypeDetailsTitle = ({ productType, loading }: ProductTypeDetailsTitleProps) => {
+  const classes = useStyles();
+  const isHeaderLoading = loading && !productType;
+
+  if (isHeaderLoading) {
+    return (
+      <div className={classes.container}>
+        <Skeleton __width="12em" data-test-id="product-type-details-title-skeleton" />
+      </div>
+    );
+  }
+
+  if (!productType) {
+    return null;
+  }
+
+  return (
+    <div className={classes.container}>
+      <Box className={classes.name} title={productType.name}>
+        {productType.name}
+      </Box>
+    </div>
+  );
+};

--- a/src/productTypes/components/ProductTypeDetailsPage/messages.ts
+++ b/src/productTypes/components/ProductTypeDetailsPage/messages.ts
@@ -1,0 +1,9 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  editProductTypeMetadata: {
+    id: "JkUOSW",
+    defaultMessage: "Edit product type metadata",
+    description: "product type detail page, top-bar metadata button tooltip",
+  },
+});

--- a/src/productTypes/components/ProductTypeDetailsPage/messages.ts
+++ b/src/productTypes/components/ProductTypeDetailsPage/messages.ts
@@ -6,4 +6,13 @@ export const messages = defineMessages({
     defaultMessage: "Edit product type metadata",
     description: "product type detail page, top-bar metadata button tooltip",
   },
+  openGraphiQL: {
+    id: "d+F7sb",
+    defaultMessage: "Open this product type in GraphiQL",
+  },
+  deleteProductType: {
+    id: "MqFTyz",
+    defaultMessage: "Delete product type",
+    description: "product type detail cogs menu, opens the delete-confirmation dialog",
+  },
 });

--- a/src/productTypes/components/ProductTypeMetadataDialog/ProductTypeMetadataDialog.test.tsx
+++ b/src/productTypes/components/ProductTypeMetadataDialog/ProductTypeMetadataDialog.test.tsx
@@ -15,7 +15,7 @@ jest.mock("@dashboard/components/MetadataDialog/useHandleMetadataSubmit", () => 
 }));
 
 const mockProductType: NonNullable<ProductTypeDetailsQuery["productType"]> = {
-  ...productType,
+  ...productType!,
   metadata: [{ key: "test-key", value: "test-value", __typename: "MetadataItem" }],
   privateMetadata: [{ key: "private-key", value: "private-value", __typename: "MetadataItem" }],
 };

--- a/src/productTypes/components/ProductTypeMetadataDialog/ProductTypeMetadataDialog.test.tsx
+++ b/src/productTypes/components/ProductTypeMetadataDialog/ProductTypeMetadataDialog.test.tsx
@@ -1,0 +1,116 @@
+import { type ProductTypeDetailsQuery } from "@dashboard/graphql";
+import { productType } from "@dashboard/productTypes/fixtures";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { ProductTypeMetadataDialog } from "./ProductTypeMetadataDialog";
+
+const mockOnSubmit = jest.fn();
+
+jest.mock("@dashboard/components/MetadataDialog/useHandleMetadataSubmit", () => ({
+  useHandleMetadataSubmit: jest.fn(() => ({
+    onSubmit: mockOnSubmit,
+    lastSubmittedData: undefined,
+    submitInProgress: false,
+  })),
+}));
+
+const mockProductType: NonNullable<ProductTypeDetailsQuery["productType"]> = {
+  ...productType,
+  metadata: [{ key: "test-key", value: "test-value", __typename: "MetadataItem" }],
+  privateMetadata: [{ key: "private-key", value: "private-value", __typename: "MetadataItem" }],
+};
+
+describe("ProductTypeMetadataDialog", () => {
+  const onCloseMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders dialog with correct title when open", () => {
+    // Arrange & Act
+    render(
+      <ProductTypeMetadataDialog open={true} onClose={onCloseMock} productType={mockProductType} />,
+    );
+
+    // Assert
+    expect(screen.getByText("Product Type Metadata")).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    // Arrange & Act
+    render(
+      <ProductTypeMetadataDialog
+        open={false}
+        onClose={onCloseMock}
+        productType={mockProductType}
+      />,
+    );
+
+    // Assert
+    expect(screen.queryByText("Product Type Metadata")).not.toBeInTheDocument();
+  });
+
+  it("closes when user clicks close button", () => {
+    // Arrange
+    render(
+      <ProductTypeMetadataDialog open={true} onClose={onCloseMock} productType={mockProductType} />,
+    );
+
+    // Act
+    fireEvent.click(screen.getByTestId("back"));
+
+    // Assert
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+
+  it("renders with undefined product type", () => {
+    // Arrange & Act
+    render(<ProductTypeMetadataDialog open={true} onClose={onCloseMock} productType={undefined} />);
+
+    // Assert
+    expect(screen.getByText("Product Type Metadata")).toBeInTheDocument();
+  });
+
+  it("displays metadata when section is expanded", () => {
+    // Arrange
+    render(
+      <ProductTypeMetadataDialog open={true} onClose={onCloseMock} productType={mockProductType} />,
+    );
+
+    const metadataEditors = screen.getAllByTestId("metadata-editor");
+    const publicMetadataEditor = metadataEditors.find(
+      editor => editor.getAttribute("data-test-is-private") === "false",
+    )!;
+
+    // Act
+    const expandButton = within(publicMetadataEditor).getByTestId("expand");
+
+    fireEvent.click(expandButton);
+
+    // Assert
+    expect(within(publicMetadataEditor).getByDisplayValue("test-key")).toBeInTheDocument();
+    expect(within(publicMetadataEditor).getByDisplayValue("test-value")).toBeInTheDocument();
+  });
+
+  it("displays private metadata when section is expanded", () => {
+    // Arrange
+    render(
+      <ProductTypeMetadataDialog open={true} onClose={onCloseMock} productType={mockProductType} />,
+    );
+
+    const metadataEditors = screen.getAllByTestId("metadata-editor");
+    const privateMetadataEditor = metadataEditors.find(
+      editor => editor.getAttribute("data-test-is-private") === "true",
+    )!;
+
+    // Act
+    const expandButton = within(privateMetadataEditor).getByTestId("expand");
+
+    fireEvent.click(expandButton);
+
+    // Assert
+    expect(within(privateMetadataEditor).getByDisplayValue("private-key")).toBeInTheDocument();
+    expect(within(privateMetadataEditor).getByDisplayValue("private-value")).toBeInTheDocument();
+  });
+});

--- a/src/productTypes/components/ProductTypeMetadataDialog/ProductTypeMetadataDialog.tsx
+++ b/src/productTypes/components/ProductTypeMetadataDialog/ProductTypeMetadataDialog.tsx
@@ -1,0 +1,108 @@
+import { type ApolloQueryResult } from "@apollo/client";
+import { MetadataDialog } from "@dashboard/components/MetadataDialog/MetadataDialog";
+import { useHandleMetadataSubmit } from "@dashboard/components/MetadataDialog/useHandleMetadataSubmit";
+import { useMetadataForm } from "@dashboard/components/MetadataDialog/useMetadataForm";
+import { mapFieldArrayToMetadataInput } from "@dashboard/components/MetadataDialog/validation";
+import { ProductTypeDetailsDocument, type ProductTypeDetailsQuery } from "@dashboard/graphql";
+import { mapMetadataItemToInput } from "@dashboard/utils/maps";
+import { useEffect, useMemo, useRef } from "react";
+import { useIntl } from "react-intl";
+
+type ProductTypeMetadataDialogData = NonNullable<ProductTypeDetailsQuery["productType"]>;
+
+interface ProductTypeMetadataDialogProps {
+  open: boolean;
+  onClose: () => void;
+  productType: ProductTypeMetadataDialogData | undefined | null;
+  refetchProductType?: () => Promise<ApolloQueryResult<ProductTypeDetailsQuery>>;
+}
+
+export const ProductTypeMetadataDialog = ({
+  onClose,
+  open,
+  productType,
+  refetchProductType,
+}: ProductTypeMetadataDialogProps) => {
+  const intl = useIntl();
+  const normalizedProductType = useMemo(
+    () =>
+      productType
+        ? {
+            ...productType,
+            metadata: productType.metadata ?? [],
+            privateMetadata: productType.privateMetadata ?? [],
+          }
+        : undefined,
+    [productType],
+  );
+  const { onSubmit, lastSubmittedData, submitInProgress } = useHandleMetadataSubmit({
+    initialData: normalizedProductType,
+    onClose,
+    refetchDocument: ProductTypeDetailsDocument,
+    refetch: refetchProductType,
+  });
+
+  const {
+    metadataFields,
+    privateMetadataFields,
+    metadataErrors,
+    privateMetadataErrors,
+    reset,
+    formIsDirty,
+    handleChange,
+    getFormData,
+  } = useMetadataForm({
+    graphqlData: normalizedProductType,
+    submitInProgress,
+    lastSubmittedData,
+  });
+
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      wasOpenRef.current = false;
+      reset();
+
+      return;
+    }
+
+    if (!normalizedProductType || wasOpenRef.current) {
+      return;
+    }
+
+    reset({
+      metadata: normalizedProductType.metadata.map(mapMetadataItemToInput),
+      privateMetadata: normalizedProductType.privateMetadata.map(mapMetadataItemToInput),
+    });
+    wasOpenRef.current = true;
+  }, [open, normalizedProductType, reset]);
+
+  return (
+    <MetadataDialog
+      open={open}
+      onClose={onClose}
+      onSave={async () => {
+        await onSubmit(getFormData());
+      }}
+      title={intl.formatMessage({
+        defaultMessage: "Product Type Metadata",
+        description: "product type metadata dialog header",
+        id: "VxRMgP",
+      })}
+      data={{
+        metadata: mapFieldArrayToMetadataInput(metadataFields),
+        privateMetadata: mapFieldArrayToMetadataInput(privateMetadataFields),
+      }}
+      onChange={handleChange}
+      loading={submitInProgress}
+      errors={{
+        metadata: metadataErrors.length ? metadataErrors.join(", ") : undefined,
+        privateMetadata: privateMetadataErrors.length
+          ? privateMetadataErrors.join(", ")
+          : undefined,
+      }}
+      formIsDirty={formIsDirty}
+    />
+  );
+};

--- a/src/productTypes/components/ProductTypeVariantMode/ProductTypeVariantMode.tsx
+++ b/src/productTypes/components/ProductTypeVariantMode/ProductTypeVariantMode.tsx
@@ -1,0 +1,32 @@
+import { DashboardCard } from "@dashboard/components/Card";
+import { Text, Toggle } from "@saleor/macaw-ui-next";
+import { FormattedMessage } from "react-intl";
+
+import { messages } from "./messages";
+
+interface ProductTypeVariantModeProps {
+  hasVariants: boolean;
+  disabled: boolean;
+  onHasVariantsToggle: (hasVariants: boolean) => void;
+}
+
+export const ProductTypeVariantMode = ({
+  hasVariants,
+  disabled,
+  onHasVariantsToggle,
+}: ProductTypeVariantModeProps) => (
+  <DashboardCard>
+    <DashboardCard.Content>
+      <Toggle
+        pressed={hasVariants}
+        disabled={disabled}
+        name="hasVariants"
+        onPressedChange={pressed => onHasVariantsToggle(pressed)}
+      >
+        <Text>
+          <FormattedMessage {...messages.usesVariantAttributes} />
+        </Text>
+      </Toggle>
+    </DashboardCard.Content>
+  </DashboardCard>
+);

--- a/src/productTypes/components/ProductTypeVariantMode/messages.ts
+++ b/src/productTypes/components/ProductTypeVariantMode/messages.ts
@@ -1,0 +1,9 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  usesVariantAttributes: {
+    id: "5pHBSU",
+    defaultMessage: "Product type uses Variant Attributes",
+    description: "switch button",
+  },
+});

--- a/src/productTypes/hooks/useProductTypeDelete/resolveProductTypesForViewLink.test.ts
+++ b/src/productTypes/hooks/useProductTypeDelete/resolveProductTypesForViewLink.test.ts
@@ -1,0 +1,33 @@
+import { resolveProductTypesForViewLink } from "./resolveProductTypesForViewLink";
+
+describe("resolveProductTypesForViewLink", () => {
+  const productType = {
+    id: "UHJvZHVjdFR5cGU6MQ",
+    name: "Audiobooks",
+    slug: "audiobooks",
+  };
+
+  it("returns undefined when no type ids are provided", () => {
+    // Arrange & Act
+    const result = resolveProductTypesForViewLink([], [productType]);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("returns matched product types by id", () => {
+    // Arrange & Act
+    const result = resolveProductTypesForViewLink([productType.id], [productType]);
+
+    // Assert
+    expect(result).toEqual([productType]);
+  });
+
+  it("falls back to a single type entry when ids do not match but only one type is provided", () => {
+    // Arrange & Act
+    const result = resolveProductTypesForViewLink(["different-id"], [productType]);
+
+    // Assert
+    expect(result).toEqual([productType]);
+  });
+});

--- a/src/productTypes/hooks/useProductTypeDelete/resolveProductTypesForViewLink.ts
+++ b/src/productTypes/hooks/useProductTypeDelete/resolveProductTypesForViewLink.ts
@@ -1,0 +1,22 @@
+import { type ProductTypeBaseData } from "@dashboard/components/TypeDeleteWarningDialog/useViewProducts";
+
+export const resolveProductTypesForViewLink = (
+  typeIds: string[],
+  typeBaseData?: ProductTypeBaseData[],
+): ProductTypeBaseData[] | undefined => {
+  if (!typeIds.length || !typeBaseData?.length) {
+    return undefined;
+  }
+
+  const matched = typeBaseData.filter(type => typeIds.includes(type.id));
+
+  if (matched.length > 0) {
+    return matched;
+  }
+
+  if (typeIds.length === 1 && typeBaseData.length === 1) {
+    return typeBaseData;
+  }
+
+  return undefined;
+};

--- a/src/productTypes/hooks/useProductTypeDelete/useProductTypeDelete.tsx
+++ b/src/productTypes/hooks/useProductTypeDelete/useProductTypeDelete.tsx
@@ -1,8 +1,5 @@
 import { type TypeBaseData } from "@dashboard/components/TypeDeleteWarningDialog/types";
-import {
-  type ProductTypeBaseData,
-  useViewProducts,
-} from "@dashboard/components/TypeDeleteWarningDialog/useViewProducts";
+import { useViewProducts } from "@dashboard/components/TypeDeleteWarningDialog/useViewProducts";
 import { type ProductCountQueryVariables, useProductCountQuery } from "@dashboard/graphql";
 import {
   type UseTypeDeleteData,
@@ -15,9 +12,14 @@ import {
 import { useMemo } from "react";
 
 import * as messages from "./messages";
+import { resolveProductTypesForViewLink } from "./resolveProductTypesForViewLink";
 
 type UseProductTypeDeleteProps<T = ProductTypeListUrlQueryParams | ProductTypeUrlQueryParams> =
   UseTypeDeleteProps<T> & { typeBaseData: ProductTypeBaseData[] | undefined };
+
+interface ProductTypeBaseData extends TypeBaseData {
+  slug?: string | null;
+}
 
 function useProductTypeDelete({
   params,
@@ -25,34 +27,36 @@ function useProductTypeDelete({
   selectedTypes,
   typeBaseData,
 }: UseProductTypeDeleteProps): UseTypeDeleteData {
-  const productTypes = useMemo(() => selectedTypes || [singleId], [selectedTypes, singleId]);
+  const productTypes = useMemo(() => {
+    if (selectedTypes?.length) {
+      return selectedTypes.filter((type): type is string => !!type);
+    }
 
-  const filteredTypes = productTypes.filter((type): type is string => !!type);
+    return singleId ? [singleId] : [];
+  }, [selectedTypes, singleId]);
 
   const isDeleteDialogOpen = params.action === "remove";
   const productsAssignedToSelectedTypesQueryVars = useMemo<ProductCountQueryVariables>(
     () =>
-      filteredTypes.length
+      productTypes.length
         ? {
             filter: {
-              productTypes: filteredTypes,
+              productTypes,
             },
           }
         : {},
     [productTypes],
   );
   const shouldSkipProductListQuery = !productTypes.length || !isDeleteDialogOpen;
-  const {
-    data: productsAssignedToSelectedTypesData,
-    loading: loadingProductsAssignedToSelectedTypes,
-  } = useProductCountQuery({
+  const { data: productsAssignedToSelectedTypesData } = useProductCountQuery({
     variables: productsAssignedToSelectedTypesQueryVars,
     skip: shouldSkipProductListQuery,
   });
 
-  const typesToLink = Array.isArray(typeBaseData)
-    ? typeBaseData.filter((type: TypeBaseData) => productTypes.includes(type.id))
-    : undefined;
+  const typesToLink = useMemo(
+    () => resolveProductTypesForViewLink(productTypes, typeBaseData),
+    [productTypes, typeBaseData],
+  );
 
   const viewProductsURL = useViewProducts({
     productTypeBaseData: typesToLink,
@@ -65,8 +69,7 @@ function useProductTypeDelete({
     isOpen: isDeleteDialogOpen,
     assignedItemsCount: assignedItemsCount ?? undefined,
     viewAssignedItemsUrl: viewProductsURL,
-    isLoading: loadingProductsAssignedToSelectedTypes,
-    typesToDelete: filteredTypes,
+    typesToDelete: productTypes,
   };
 }
 

--- a/src/productTypes/queries.ts
+++ b/src/productTypes/queries.ts
@@ -40,6 +40,14 @@ export const productTypeDetailsQuery = gql`
   }
 `;
 
+export const defaultGraphiQLQuery = `query ProductTypeDetails($id: ID!) {
+  productType(id: $id) {
+    id
+    name
+    slug
+  }
+}`;
+
 export const productTypeCreateDataQuery = gql`
   query ProductTypeCreateData {
     shop {

--- a/src/productTypes/urls.ts
+++ b/src/productTypes/urls.ts
@@ -46,13 +46,14 @@ export const productTypeAddUrl = (params?: ProductTypeAddUrlQueryParams) =>
   productTypeAddPath + "?" + stringifyQs(params);
 
 export const productTypePath = (id: string) => urlJoin(productTypeSection, id);
-type ProductTypeUrlDialog =
+export type ProductTypeUrlDialog =
   | "assign-attribute"
   | "create-attribute"
   | "unassign-attribute"
   | "unassign-product-attributes"
   | "unassign-variant-attributes"
-  | "remove";
+  | "remove"
+  | "view-metadata";
 export type ProductTypeUrlQueryParams = BulkAction &
   Dialog<ProductTypeUrlDialog> &
   SingleAction & {

--- a/src/productTypes/utils/productTypePageForm.test.ts
+++ b/src/productTypes/utils/productTypePageForm.test.ts
@@ -1,0 +1,119 @@
+import { ProductTypeKindEnum } from "@dashboard/graphql";
+import { type ProductTypeForm } from "@dashboard/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage";
+
+import {
+  getVariantSelectionFromAssigned,
+  isProductTypeUpdateFormPristine,
+} from "./productTypePageForm";
+
+const initialData: ProductTypeForm = {
+  hasVariants: true,
+  isShippingRequired: false,
+  kind: ProductTypeKindEnum.NORMAL,
+  metadata: [],
+  name: "E-books",
+  privateMetadata: [],
+  productAttributes: [{ label: "Author", value: "attr-1" }],
+  taxClassId: "tax-1",
+  variantAttributes: [{ label: "Size", value: "attr-2" }],
+  weight: 1,
+};
+
+const initialVariantSelection = ["variant-1"];
+
+describe("getVariantSelectionFromAssigned", () => {
+  it("returns sorted ids for attributes with variant selection enabled", () => {
+    // Arrange & Act
+    const selection = getVariantSelectionFromAssigned([
+      {
+        variantSelection: false,
+        attribute: { id: "b" },
+      },
+      {
+        variantSelection: true,
+        attribute: { id: "a" },
+      },
+    ]);
+
+    // Assert
+    expect(selection).toEqual(["a"]);
+  });
+});
+
+describe("isProductTypeUpdateFormPristine", () => {
+  it("returns true when only attribute lists differ", () => {
+    // Arrange
+    const current: ProductTypeForm = {
+      ...initialData,
+      productAttributes: [{ label: "Publisher", value: "attr-3" }],
+    };
+
+    // Act
+    const pristine = isProductTypeUpdateFormPristine(
+      current,
+      initialData,
+      initialVariantSelection,
+      initialVariantSelection,
+    );
+
+    // Assert
+    expect(pristine).toBe(true);
+  });
+
+  it("returns false when name changes", () => {
+    // Arrange
+    const current: ProductTypeForm = {
+      ...initialData,
+      name: "Print books",
+    };
+
+    // Act
+    const pristine = isProductTypeUpdateFormPristine(
+      current,
+      initialData,
+      initialVariantSelection,
+      initialVariantSelection,
+    );
+
+    // Assert
+    expect(pristine).toBe(false);
+  });
+
+  it("returns false when variant selection changes", () => {
+    // Arrange
+    const current: ProductTypeForm = {
+      ...initialData,
+    };
+
+    // Act
+    const pristine = isProductTypeUpdateFormPristine(
+      current,
+      initialData,
+      ["variant-1", "variant-2"],
+      initialVariantSelection,
+    );
+
+    // Assert
+    expect(pristine).toBe(false);
+  });
+
+  it("returns true when edits are reverted", () => {
+    // Arrange
+    const current: ProductTypeForm = {
+      ...initialData,
+      name: "E-books",
+      weight: 1,
+    };
+
+    // Act
+    const pristine = isProductTypeUpdateFormPristine(
+      current,
+      initialData,
+      initialVariantSelection,
+      initialVariantSelection,
+    );
+
+    // Assert
+    expect(pristine).toBe(true);
+  });
+});

--- a/src/productTypes/utils/productTypePageForm.ts
+++ b/src/productTypes/utils/productTypePageForm.ts
@@ -1,0 +1,58 @@
+import { type ProductTypeKindEnum } from "@dashboard/graphql";
+import { type ProductTypeForm } from "@dashboard/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage";
+import isEqual from "lodash/isEqual";
+
+export interface ProductTypeUpdateComparableData {
+  name: string;
+  kind: ProductTypeKindEnum;
+  isShippingRequired: boolean;
+  taxClassId: string;
+  weight: number | undefined;
+  variantSelection: string[];
+}
+
+interface AssignedVariantAttribute {
+  variantSelection: boolean;
+  attribute: {
+    id: string;
+  };
+}
+
+export function getVariantSelectionIds(selectedVariantAttributes: string[]): string[] {
+  return [...selectedVariantAttributes].sort();
+}
+
+export function getVariantSelectionFromAssigned(
+  assignedVariantAttributes: AssignedVariantAttribute[] | undefined | null,
+): string[] {
+  return (assignedVariantAttributes ?? [])
+    .filter(item => item.variantSelection)
+    .map(item => item.attribute.id)
+    .sort();
+}
+
+export function getProductTypeUpdateComparableData(
+  data: ProductTypeForm,
+  selectedVariantAttributes: string[],
+): ProductTypeUpdateComparableData {
+  return {
+    name: data.name,
+    kind: data.kind,
+    isShippingRequired: data.isShippingRequired,
+    taxClassId: data.taxClassId,
+    weight: data.weight,
+    variantSelection: getVariantSelectionIds(selectedVariantAttributes),
+  };
+}
+
+export function isProductTypeUpdateFormPristine(
+  data: ProductTypeForm,
+  initialData: ProductTypeForm,
+  selectedVariantAttributes: string[],
+  initialVariantSelection: string[],
+): boolean {
+  return isEqual(
+    getProductTypeUpdateComparableData(data, selectedVariantAttributes),
+    getProductTypeUpdateComparableData(initialData, initialVariantSelection),
+  );
+}

--- a/src/productTypes/views/ProductTypeCreate.tsx
+++ b/src/productTypes/views/ProductTypeCreate.tsx
@@ -39,6 +39,8 @@ const ProductTypeCreate = ({ params }: ProductTypeCreateProps) => {
   });
   const { taxClasses, fetchMoreTaxClasses } = useTaxClassFetchMore();
   const [createProductType, createProductTypeOpts] = useProductTypeCreateMutation({
+    // Name and other field errors are rendered inline on the create form.
+    disableErrorHandling: true,
     onCompleted: data => {
       if (data.productTypeCreate.errors.length === 0) {
         notify({

--- a/src/productTypes/views/ProductTypeList/ProductTypeList.tsx
+++ b/src/productTypes/views/ProductTypeList/ProductTypeList.tsx
@@ -111,9 +111,10 @@ const ProductTypeList = ({ params }: ProductTypeListProps) => {
   });
   const handleSort = createSortHandler(navigate, productTypeListUrl, params);
   const productTypesData = mapEdgesToItems(data?.productTypes) ?? [];
+  const typesToDeleteForDialog = params.ids?.length ? params.ids : selectedProductTypes;
 
   const productTypeDeleteData = useProductTypeDelete({
-    selectedTypes: selectedProductTypes,
+    selectedTypes: typesToDeleteForDialog,
     params,
     typeBaseData: productTypesData,
   });
@@ -186,7 +187,7 @@ const ProductTypeList = ({ params }: ProductTypeListProps) => {
         <TypeDeleteWarningDialog
           {...productTypeDeleteData}
           typesData={productTypesData}
-          typesToDelete={selectedProductTypes}
+          typesToDelete={typesToDeleteForDialog}
           onClose={closeModal}
           onDelete={onProductTypeBulkDelete}
           deleteButtonState={productTypeBulkDeleteOpts.status}

--- a/src/productTypes/views/ProductTypeUpdate/index.tsx
+++ b/src/productTypes/views/ProductTypeUpdate/index.tsx
@@ -41,8 +41,8 @@ import useAvailableProductAttributeSearch from "@dashboard/searches/useAvailable
 import { useTaxClassFetchMore } from "@dashboard/taxes/utils/useTaxClassFetchMore";
 import { type ReorderEvent } from "@dashboard/types";
 import { getProductErrorMessage } from "@dashboard/utils/errors";
+import createDialogActionHandlers from "@dashboard/utils/handlers/dialogActionHandlers";
 import createMetadataCreateHandler from "@dashboard/utils/handlers/metadataCreateHandler";
-import createMetadataUpdateHandler from "@dashboard/utils/handlers/metadataUpdateHandler";
 import { mapEdgesToItems } from "@dashboard/utils/maps";
 import { useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -50,8 +50,14 @@ import { FormattedMessage, useIntl } from "react-intl";
 import ProductTypeDetailsPage, {
   type ProductTypeForm,
 } from "../../components/ProductTypeDetailsPage";
+import { ProductTypeMetadataDialog } from "../../components/ProductTypeMetadataDialog/ProductTypeMetadataDialog";
 import { executeProductTypeAttributeCreate } from "../../handlers/productTypeAttributeCreateHandler";
-import { productTypeListUrl, productTypeUrl, type ProductTypeUrlQueryParams } from "../../urls";
+import {
+  productTypeListUrl,
+  productTypeUrl,
+  type ProductTypeUrlDialog,
+  type ProductTypeUrlQueryParams,
+} from "../../urls";
 
 interface ProductTypeUpdateProps {
   id: string;
@@ -61,6 +67,10 @@ interface ProductTypeUpdateProps {
 const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
   const navigate = useNavigator();
   const notify = useNotifier();
+  const [openModal, closeModal] = createDialogActionHandlers<
+    ProductTypeUrlDialog,
+    ProductTypeUrlQueryParams
+  >(navigate, dialogParams => productTypeUrl(id, dialogParams), params);
   const productAttributeListActions = useBulkActions();
   const variantAttributeListActions = useBulkActions();
   const assignAttributesActions = useListSelectedItems<string>();
@@ -148,7 +158,11 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
       ...productAttributeUpdateResult.data.productAttributeAssignmentUpdate.errors,
     ];
   };
-  const { data, loading: dataLoading } = useProductTypeDetailsQuery({
+  const {
+    data,
+    loading: dataLoading,
+    refetch,
+  } = useProductTypeDetailsQuery({
     displayLoader: true,
     variables: { id },
   });
@@ -160,7 +174,6 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
     params,
     typeBaseData: productType ? [productType] : undefined,
   });
-  const closeModal = () => navigate(productTypeUrl(id), { replace: true });
   const createAttributeAssignmentType = ProductAttributeType[params.type];
   const handleAttributeAssignSuccess = (data: AssignProductAttributeMutation) => {
     if (data.productAttributeAssign.errors.length === 0) {
@@ -218,12 +231,6 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
       onUnassignAttribute: handleAttributeUnassignSuccess,
       productType: data?.productType,
     });
-  const handleSubmit = createMetadataUpdateHandler(
-    data?.productType,
-    handleProductTypeUpdate,
-    variables => updateMetadata({ variables }),
-    variables => updatePrivateMetadata({ variables }),
-  );
   const handleProductTypeDelete = () => deleteProductType.mutate({ id });
   const handleProductTypeVariantsToggle = (hasVariants: boolean) =>
     updateProductType({
@@ -344,61 +351,38 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
         defaultWeightUnit={maybe(() => data.shop.defaultWeightUnit)}
         disabled={loading}
         errors={errors.formErrors}
-        pageTitle={maybe(() => data.productType.name)}
         productType={maybe(() => data.productType)}
         saveButtonBarState={updateProductTypeOpts.status || updateProductAttributesOpts.status}
         taxClasses={taxClasses ?? []}
         selectedVariantAttributes={selectedVariantAttributes}
         setSelectedVariantAttributes={setSelectedVariantAttributes}
         onAttributeAdd={type =>
-          navigate(
-            productTypeUrl(id, {
-              action: "assign-attribute",
-              type,
-            }),
-          )
+          openModal("assign-attribute", {
+            type,
+          })
         }
         onAttributeCreate={type =>
-          navigate(
-            productTypeUrl(id, {
-              action: "create-attribute",
-              type,
-            }),
-          )
+          openModal("create-attribute", {
+            type,
+          })
         }
         onAttributeReorder={handleAttributeReorder}
         onAttributeUnassign={attributeId =>
-          navigate(
-            productTypeUrl(id, {
-              action: "unassign-attribute",
-              id: attributeId,
-            }),
-          )
+          openModal("unassign-attribute", {
+            id: attributeId,
+          })
         }
-        onDelete={() =>
-          navigate(
-            productTypeUrl(id, {
-              action: "remove",
-            }),
-          )
-        }
+        onDelete={() => openModal("remove")}
+        onShowMetadata={() => openModal("view-metadata", { id: undefined })}
         onHasVariantsToggle={handleProductTypeVariantsToggle}
-        onSubmit={handleSubmit}
+        onSubmit={handleProductTypeUpdate}
         productAttributeList={{
           isChecked: productAttributeListActions.isSelected,
           selected: productAttributeListActions.listElements.length,
           toggle: productAttributeListActions.toggle,
           toggleAll: productAttributeListActions.toggleAll,
           toolbar: (
-            <Button
-              onClick={() =>
-                navigate(
-                  productTypeUrl(id, {
-                    action: "unassign-product-attributes",
-                  }),
-                )
-              }
-            >
+            <Button onClick={() => openModal("unassign-product-attributes")}>
               <FormattedMessage
                 id="S7j+Wf"
                 defaultMessage="Unassign"
@@ -413,15 +397,7 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
           toggle: variantAttributeListActions.toggle,
           toggleAll: variantAttributeListActions.toggleAll,
           toolbar: (
-            <Button
-              onClick={() =>
-                navigate(
-                  productTypeUrl(id, {
-                    action: "unassign-variant-attributes",
-                  }),
-                )
-              }
-            >
+            <Button onClick={() => openModal("unassign-variant-attributes")}>
               <FormattedMessage
                 id="S7j+Wf"
                 defaultMessage="Unassign"
@@ -465,20 +441,30 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
             />
           ))}
           {productType && (
-            <CreateAttributeDialog
-              attributeType={AttributeTypeEnum.PRODUCT_TYPE}
-              confirmButtonState={
-                attributeCreateOpts.loading || assignCreatedAttributeOpts.loading
-                  ? "loading"
-                  : attributeCreateOpts.status
-              }
-              contextName={productType.name}
-              disabled={attributeCreateOpts.loading || assignCreatedAttributeOpts.loading}
-              errors={attributeCreateOpts.data?.attributeCreate?.errors ?? []}
-              open={params.action === "create-attribute" && Boolean(createAttributeAssignmentType)}
-              onClose={closeModal}
-              onSubmit={handleCreateAttribute}
-            />
+            <>
+              <ProductTypeMetadataDialog
+                open={params.action === "view-metadata" && !!productType}
+                onClose={closeModal}
+                productType={productType}
+                refetchProductType={refetch}
+              />
+              <CreateAttributeDialog
+                attributeType={AttributeTypeEnum.PRODUCT_TYPE}
+                confirmButtonState={
+                  attributeCreateOpts.loading || assignCreatedAttributeOpts.loading
+                    ? "loading"
+                    : attributeCreateOpts.status
+                }
+                contextName={productType.name}
+                disabled={attributeCreateOpts.loading || assignCreatedAttributeOpts.loading}
+                errors={attributeCreateOpts.data?.attributeCreate?.errors ?? []}
+                open={
+                  params.action === "create-attribute" && Boolean(createAttributeAssignmentType)
+                }
+                onClose={closeModal}
+                onSubmit={handleCreateAttribute}
+              />
+            </>
           )}
           {productType && (
             <TypeDeleteWarningDialog

--- a/src/productTypes/views/ProductTypeUpdate/index.tsx
+++ b/src/productTypes/views/ProductTypeUpdate/index.tsx
@@ -87,6 +87,8 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
     formErrors: [],
   });
   const [updateProductType, updateProductTypeOpts] = useProductTypeUpdateMutation({
+    // Field errors are rendered inline on the product type form.
+    disableErrorHandling: true,
     onCompleted: updateData => {
       if (
         !updateData.productTypeUpdate.errors ||
@@ -109,6 +111,8 @@ const ProductTypeUpdate = ({ id, params }: ProductTypeUpdateProps) => {
   });
   const [updateProductAttributes, updateProductAttributesOpts] =
     useProductAttributeAssignmentUpdateMutation({
+      // Field errors are rendered inline on the product type form.
+      disableErrorHandling: true,
       onCompleted: updateData => {
         if (
           updateData.productAttributeAssignmentUpdate.errors !== null &&

--- a/src/products/urls.test.ts
+++ b/src/products/urls.test.ts
@@ -1,4 +1,8 @@
-import { productListPath, productListUrlWithProductType } from "./urls";
+import {
+  productListPath,
+  productListUrlWithProductType,
+  productListUrlWithProductTypes,
+} from "./urls";
 
 describe("productListUrlWithProductType", () => {
   it("should return productListPath when product type is undefined", () => {
@@ -36,5 +40,57 @@ describe("productListUrlWithProductType", () => {
     expect(result).toContain("/products?");
     expect(result).toContain("productType");
     expect(result).toContain("apparel");
+  });
+});
+
+describe("productListUrlWithProductTypes", () => {
+  const productTypeBaseData = [
+    {
+      id: "UHJvZHVjdFR5cGU6MQ",
+      name: "Audiobooks",
+      slug: "audiobooks",
+    },
+  ];
+
+  it("returns null when no product types are provided", () => {
+    // Arrange & Act
+    const result = productListUrlWithProductTypes(undefined);
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it("builds URL with conditional filter token for a single product type slug", () => {
+    // Arrange & Act
+    const result = productListUrlWithProductTypes(productTypeBaseData);
+
+    // Assert
+    expect(result).not.toBeNull();
+    expect(result).toContain("/products?");
+    expect(result).toContain("productType");
+    expect(result).toContain("audiobooks");
+  });
+
+  it("builds URL with conditional filter tokens for multiple product types", () => {
+    // Arrange
+    const multipleProductTypeBaseData = [
+      ...productTypeBaseData,
+      {
+        id: "UHJvZHVjdFR5cGU6Mg",
+        name: "Shirts",
+        slug: "shirts",
+      },
+    ];
+
+    // Act
+    const result = productListUrlWithProductTypes(multipleProductTypeBaseData);
+
+    // Assert
+    expect(result).not.toBeNull();
+
+    const expectedQuery = "0[s2.productType][0]=audiobooks&0[s2.productType][1]=shirts";
+    const receivedQuery = decodeURIComponent(result!.split("?")[1]);
+
+    expect(receivedQuery).toBe(expectedQuery);
   });
 });

--- a/src/products/urls.ts
+++ b/src/products/urls.ts
@@ -130,6 +130,59 @@ export const productListUrlWithProductType = (productType?: {
   return urlJoin(productListPath, "?" + stringify(queryParams));
 };
 
+/**
+ * Builds the product list URL pre-filtered by one or more product types.
+ */
+export const productListUrlWithProductTypes = (
+  productTypes?: Array<{
+    id: string;
+    name: string;
+    slug?: string | null;
+  }>,
+): string | null => {
+  if (!productTypes?.length) {
+    return null;
+  }
+
+  if (productTypes.length === 1) {
+    const [productType] = productTypes;
+
+    if (!productType.slug) {
+      return null;
+    }
+
+    return productListUrlWithProductType({
+      id: productType.id,
+      name: productType.name,
+      slug: productType.slug,
+    });
+  }
+
+  const productTypesWithSlug = productTypes.filter(
+    (productType): productType is typeof productType & { slug: string } => !!productType.slug,
+  );
+
+  if (!productTypesWithSlug.length) {
+    return null;
+  }
+
+  const productFilterElement = FilterElement.createStaticBySlug("productType");
+  const condition = productFilterElement.condition.options[1];
+
+  productFilterElement.updateCondition(condition);
+  productFilterElement.updateRightOperator(
+    productTypesWithSlug.map(productType => ({
+      label: productType.name,
+      slug: productType.slug,
+      value: productType.id,
+    })),
+  );
+
+  const queryParams = prepareStructure([productFilterElement]);
+
+  return urlJoin(productListPath, "?" + stringify(queryParams));
+};
+
 export const productPath = (id: string) => urlJoin(productSection + id);
 export type ProductUrlDialog =
   | "remove"

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -10,13 +10,21 @@ export function stringifyQs(
   });
 }
 
-export function getArrayQueryParam(param: string | string[]): string[] | undefined {
+export function getArrayQueryParam(
+  param: string | string[] | Record<string, string> | undefined,
+): string[] | undefined {
   if (!param) {
     return undefined;
   }
 
   if (Array.isArray(param)) {
-    return param;
+    return param.filter(Boolean);
+  }
+
+  if (typeof param === "object") {
+    const values = Object.values(param).filter(Boolean);
+
+    return values.length ? values : undefined;
   }
 
   return [param];


### PR DESCRIPTION


https://github.com/user-attachments/assets/9f2b416e-7915-4cc5-9190-c269e2ae4b8b



- Model type and product type metadata now opens from a header button on the detail page, in a dedicated dialog. Create flows still use the inline metadata card until the type is saved.

- Model type and product type detail pages now expose Delete in the header cogs menu (with icon and destructive styling), alongside GraphiQL and extension actions. Delete remains in the save bar for discoverability.

- Product type and model type pages now use a consistent layout: attribute schema in the main column, and type identity plus configuration (name, kind, shipping, taxes) in the sidebar. The variant attributes toggle stays in the main column because it controls the attribute schema below it.

- Product type and model type create/update forms no longer show duplicate error toasts when validation errors are already displayed inline on the affected fields.

- Product type and model type delete dialogs now follow the standard delete modal pattern.

- Type delete dialogs link "View products" / "View models" to lists filtered by the type being deleted, use model-type terminology consistently, and open immediately without a blocking loading spinner.
