### PR TITLE
Fix fulfilment warehouse guard

### DIFF
--- a/.changeset/order-fulfill-warehouse-guard.md
+++ b/.changeset/order-fulfill-warehouse-guard.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed order fulfillment crashing when fulfilling a single line from a multi-line order. The fulfill page now uses consistent quantity and warehouse controls, disables warehouse selection for zero-quantity lines, pre-selects a warehouse from stock when no allocation exists, and truncates long variant details with a tooltip.

--- a/src/orders/components/OrderFulfillLine/OrderFulfillLine.module.css
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillLine.module.css
@@ -1,0 +1,15 @@
+.warehouseCell {
+  padding: 0 !important;
+}
+
+.warehouseInput {
+  cursor: pointer;
+}
+
+.warehouseInput input {
+  cursor: pointer;
+}
+
+.warehouseInputDisabled {
+  cursor: not-allowed;
+}

--- a/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillLine.tsx
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { QuantityInput } from "@dashboard/components/QuantityInput";
 import TableCellAvatar from "@dashboard/components/TableCellAvatar";
 import TableRowLink from "@dashboard/components/TableRowLink";
 import { type OrderFulfillLineFragment } from "@dashboard/graphql";
@@ -9,13 +10,16 @@ import {
   getWarehouseStock,
   type OrderFulfillLineFormData,
 } from "@dashboard/orders/utils/data";
-import { TableCell, TextField } from "@material-ui/core";
-import { ChevronIcon, IconButton, WarningIcon } from "@saleor/macaw-ui";
-import { Box, Skeleton, Text, Tooltip } from "@saleor/macaw-ui-next";
+import { TableCell } from "@material-ui/core";
+import { WarningIcon } from "@saleor/macaw-ui";
+import { Box, Input, Skeleton, Tooltip } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
+import { ChevronDown } from "lucide-react";
 import { useIntl } from "react-intl";
 
 import { messages } from "./messages";
+import styles from "./OrderFulfillLine.module.css";
+import { OrderFulfillProductCellContent } from "./OrderFulfillProductCellContent";
 import { useStyles } from "./styles";
 
 interface OrderFulfillLineProps {
@@ -34,10 +38,10 @@ const OrderFulfillLine = (props: OrderFulfillLineProps) => {
   const isPreorder = !!line.variant?.preorder;
   const lineFormQuantity = isPreorder ? 0 : formsetData[lineIndex]?.value?.[0]?.quantity;
   const lineFormWarehouse = formsetData[lineIndex]?.value?.[0]?.warehouse;
+  const isFulfillingLine = (lineFormQuantity ?? 0) > 0;
   const overfulfill = lineFormQuantity > line.quantityToFulfill;
   const warehouseStock = getWarehouseStock(line?.variant?.stocks, lineFormWarehouse?.id);
   const availableQuantity = getOrderLineAvailableQuantity(line, warehouseStock);
-  const isStockExceeded = lineFormQuantity > availableQuantity;
 
   if (!line) {
     return (
@@ -54,7 +58,7 @@ const OrderFulfillLine = (props: OrderFulfillLineProps) => {
         <TableCell className={classes.colStock}>
           <Skeleton />
         </TableCell>
-        <TableCell className={classes.colWarehouse}>
+        <TableCell className={clsx(classes.colWarehouse, styles.warehouseCell)}>
           <Skeleton />
         </TableCell>
       </TableRowLink>
@@ -86,10 +90,10 @@ const OrderFulfillLine = (props: OrderFulfillLineProps) => {
           ) : undefined
         }
       >
-        {line.productName}
-        <Text color="default2" size={2} fontWeight="light">
-          {getAttributesCaption(line.variant?.attributes)}
-        </Text>
+        <OrderFulfillProductCellContent
+          productName={line.productName}
+          attributesCaption={getAttributesCaption(line.variant?.attributes)}
+        />
       </TableCellAvatar>
       <TableCell className={classes.colSku}>{line.variant?.sku}</TableCell>
       {isPreorder ? (
@@ -99,37 +103,19 @@ const OrderFulfillLine = (props: OrderFulfillLineProps) => {
           className={classes.colQuantity}
           key={warehouseStock?.id ?? "deletedVariant" + lineIndex}
         >
-          <TextField
-            type="number"
-            inputProps={{
-              className: clsx(classes.quantityInnerInput, {
-                [classes.quantityInnerInputNoRemaining]: !line.variant?.trackInventory,
-              }),
-              min: 0,
-              style: { textAlign: "right" },
-            }}
-            fullWidth
-            value={lineFormQuantity}
-            onChange={event =>
+          <QuantityInput
+            value={lineFormQuantity ?? 0}
+            max={line.quantityToFulfill}
+            isError={overfulfill}
+            onChange={event => {
+              const quantity = parseInt(event.target.value, 10);
+
               formsetChange(line.id, [
                 {
-                  quantity: parseInt(event.target.value, 10),
+                  quantity: Number.isNaN(quantity) ? 0 : quantity,
                   warehouse: lineFormWarehouse,
                 },
-              ])
-            }
-            error={overfulfill}
-            variant="outlined"
-            InputProps={{
-              classes: {
-                ...(isStockExceeded &&
-                  !overfulfill && {
-                    notchedOutline: classes.warning,
-                  }),
-              },
-              endAdornment: (
-                <div className={classes.remainingQuantity}>/ {line.quantityToFulfill}</div>
-              ),
+              ]);
             }}
           />
         </TableCell>
@@ -137,25 +123,41 @@ const OrderFulfillLine = (props: OrderFulfillLineProps) => {
       <TableCell className={classes.colStock} key="total">
         {lineFormWarehouse ? (isPreorder || isDeletedVariant ? undefined : availableQuantity) : "-"}
       </TableCell>
-      <TableCell className={classes.colWarehouse}>
+      <TableCell className={clsx(classes.colWarehouse, styles.warehouseCell)}>
         {isPreorder ? (
           "-"
         ) : (
-          <IconButton
-            onClick={onWarehouseChange}
-            className={clsx(
-              classes.warehouseButton,
-              "MuiInputBase-root MuiOutlinedInput-root MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd",
-            )}
-            data-test-id="select-warehouse-button"
+          <Box
+            role="button"
+            tabIndex={isFulfillingLine ? 0 : -1}
+            aria-disabled={!isFulfillingLine}
+            onClick={isFulfillingLine ? onWarehouseChange : undefined}
+            onKeyDown={event => {
+              if (!isFulfillingLine) {
+                return;
+              }
+
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onWarehouseChange();
+              }
+            }}
+            className={isFulfillingLine ? styles.warehouseInput : styles.warehouseInputDisabled}
+            padding={2}
+            width="100%"
           >
-            <div className={classes.warehouseButtonContent}>
-              <Text className={classes.warehouseButtonContentText}>
-                {lineFormWarehouse?.name ?? intl.formatMessage(messages.selectWarehouse)}
-              </Text>
-              <ChevronIcon onPointerEnterCapture={undefined} onPointerLeaveCapture={undefined} />
-            </div>
-          </IconButton>
+            <Input
+              readOnly
+              disabled={!isFulfillingLine}
+              size="small"
+              width="100%"
+              aria-label={intl.formatMessage(messages.warehouse)}
+              placeholder={intl.formatMessage(messages.selectWarehouse)}
+              value={lineFormWarehouse?.name}
+              endAdornment={<ChevronDown size={16} />}
+              data-test-id="select-warehouse-button"
+            />
+          </Box>
         )}
       </TableCell>
     </TableRowLink>

--- a/src/orders/components/OrderFulfillLine/OrderFulfillProductCellContent.module.css
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillProductCellContent.module.css
@@ -1,0 +1,8 @@
+.content {
+  min-width: 0;
+}
+
+.productName {
+  font-size: var(--mu-fontSizes-3);
+  line-height: var(--mu-lineHeights-3);
+}

--- a/src/orders/components/OrderFulfillLine/OrderFulfillProductCellContent.tsx
+++ b/src/orders/components/OrderFulfillLine/OrderFulfillProductCellContent.tsx
@@ -1,0 +1,70 @@
+import { useOverflowDetection } from "@dashboard/hooks/useOverflowDetection/useOverflowDetection";
+import { Box, Text, Tooltip } from "@saleor/macaw-ui-next";
+import { type ReactNode } from "react";
+
+import styles from "./OrderFulfillProductCellContent.module.css";
+
+interface OrderFulfillProductCellContentProps {
+  productName: string;
+  attributesCaption?: string;
+  children?: ReactNode;
+}
+
+export const OrderFulfillProductCellContent = ({
+  productName,
+  attributesCaption,
+  children,
+}: OrderFulfillProductCellContentProps): JSX.Element => {
+  const { elementRef: productNameRef, isOverflowing: isProductNameOverflowing } =
+    useOverflowDetection<HTMLDivElement>();
+  const { elementRef: attributesRef, isOverflowing: isAttributesOverflowing } =
+    useOverflowDetection<HTMLDivElement>();
+  const showTooltip = Boolean(
+    isProductNameOverflowing() || (attributesCaption && isAttributesOverflowing()),
+  );
+
+  return (
+    <Tooltip open={showTooltip ? undefined : false}>
+      <Tooltip.Trigger>
+        <Box className={styles.content} overflow="hidden" minWidth={0} width="100%">
+          <Box
+            ref={productNameRef}
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
+            className={styles.productName}
+          >
+            {productName}
+          </Box>
+          {attributesCaption ? (
+            <Box ref={attributesRef} overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap">
+              <Text
+                color="default2"
+                size={2}
+                fontWeight="light"
+                textOverflow="ellipsis"
+                overflow="hidden"
+                whiteSpace="nowrap"
+              >
+                {attributesCaption}
+              </Text>
+            </Box>
+          ) : null}
+          {children}
+        </Box>
+      </Tooltip.Trigger>
+      <Tooltip.Content side="bottom">
+        <Tooltip.Arrow />
+        <Box display="flex" flexDirection="column" gap={1} __maxWidth={320} wordBreak="break-word">
+          <Text size={2}>{productName}</Text>
+          {attributesCaption ? (
+            <Text size={2} color="default2">
+              {attributesCaption}
+            </Text>
+          ) : null}
+          {children}
+        </Box>
+      </Tooltip.Content>
+    </Tooltip>
+  );
+};

--- a/src/orders/components/OrderFulfillLine/styles.ts
+++ b/src/orders/components/OrderFulfillLine/styles.ts
@@ -26,48 +26,6 @@ export const useStyles = makeStyles(
       color: theme.palette.saleor.warning.mid,
       marginRight: theme.spacing(2),
     },
-    error: {
-      color: theme.palette.error.main,
-    },
-    warning: {
-      borderColor: theme.palette.saleor.warning.dark + " !important",
-      boxShadow: `0 0 0 3px ${theme.palette.saleor.warning.light}`,
-    },
-    quantityInnerInput: {
-      paddingBottom: theme.spacing(2),
-      paddingTop: theme.spacing(2),
-    },
-    quantityInnerInputNoRemaining: {
-      paddingRight: 0,
-    },
-    remainingQuantity: {
-      paddingBottom: theme.spacing(2),
-      paddingTop: theme.spacing(2),
-      color: theme.palette.text.secondary,
-      whiteSpace: "nowrap",
-    },
-    warehouseButton: {
-      padding: theme.spacing(1.5),
-      width: "100%",
-      justifyContent: "right",
-      cursor: "pointer",
-      border: `1px solid ${theme.palette.primary.dark}`,
-      "&:hover": {
-        borderColor: "transparent",
-      },
-    },
-    warehouseButtonContent: {
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-      width: "100%",
-      cursor: "pointer",
-    },
-    warehouseButtonContentText: {
-      overflow: "hidden",
-      textOverflow: "ellipsis",
-      whiteSpace: "nowrap",
-    },
   }),
   { name: "OrderFulfillLine" },
 );

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -29,7 +29,8 @@ import {
 } from "@dashboard/orders/urls";
 import {
   getAttributesCaption,
-  getLineAllocationWithHighestQuantity,
+  getDefaultFulfillWarehouse,
+  getOrderFulfillSubmitItems,
   getToFulfillOrderLines,
   type OrderFulfillLineFormData,
 } from "@dashboard/orders/utils/data";
@@ -40,6 +41,7 @@ import { useEffect, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
 import OrderFulfillLine from "../OrderFulfillLine/OrderFulfillLine";
+import fulfillLineStyles from "../OrderFulfillLine/OrderFulfillLine.module.css";
 import { OrderFulfillStockExceededDialog } from "../OrderFulfillStockExceededDialog/OrderFulfillStockExceededDialog";
 import { messages } from "./messages";
 import { useStyles } from "./styles";
@@ -86,8 +88,6 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
   const navigate = useNavigator();
   const { change: formsetChange, data: formsetData } = useFormset<null, OrderFulfillLineFormData[]>(
     (getToFulfillOrderLines(order?.lines) as OrderFulfillLineFragment[]).map(line => {
-      const highestQuantityAllocation = getLineAllocationWithHighestQuantity(line);
-
       return {
         data: null,
         id: line.id,
@@ -97,7 +97,7 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
           : [
               {
                 quantity: line.quantityToFulfill,
-                warehouse: highestQuantityAllocation?.warehouse,
+                warehouse: getDefaultFulfillWarehouse(line),
               },
             ],
       };
@@ -116,17 +116,7 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
     return onSubmit({
       ...formData,
       allowStockToBeExceeded,
-      items: formsetData
-        .map(item => ({
-          ...item,
-          value: (item.value ?? [])
-            .filter(value => value.quantity > 0 && value.warehouse?.id)
-            .map(value => ({
-              quantity: value.quantity,
-              warehouse: value.warehouse.id,
-            })),
-        }))
-        .filter(item => item.value.length > 0),
+      items: getOrderFulfillSubmitItems(formsetData),
     });
   };
 
@@ -215,8 +205,12 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
                           <TableCell className={classes.colStock}>
                             <FormattedMessage {...messages.stock} />
                           </TableCell>
-                          <TableCell className={classes.colWarehouse}>
-                            <FormattedMessage {...messages.warehouse} />
+                          <TableCell
+                            className={clsx(classes.colWarehouse, fulfillLineStyles.warehouseCell)}
+                          >
+                            <Box padding={2}>
+                              <FormattedMessage {...messages.warehouse} />
+                            </Box>
                           </TableCell>
                         </TableRowLink>
                       </TableHead>

--- a/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
+++ b/src/orders/components/OrderFulfillPage/OrderFulfillPage.tsx
@@ -117,14 +117,16 @@ const OrderFulfillPage = (props: OrderFulfillPageProps) => {
       ...formData,
       allowStockToBeExceeded,
       items: formsetData
-        .filter(item => !!item.value)
         .map(item => ({
           ...item,
-          value: item.value.map(value => ({
-            quantity: value.quantity,
-            warehouse: value.warehouse.id,
-          })),
-        })),
+          value: (item.value ?? [])
+            .filter(value => value.quantity > 0 && value.warehouse?.id)
+            .map(value => ({
+              quantity: value.quantity,
+              warehouse: value.warehouse.id,
+            })),
+        }))
+        .filter(item => item.value.length > 0),
     });
   };
 

--- a/src/orders/components/OrderFulfillStockExceededDialogLine/OrderFulfillStockExceededDialogLine.tsx
+++ b/src/orders/components/OrderFulfillStockExceededDialogLine/OrderFulfillStockExceededDialogLine.tsx
@@ -11,6 +11,7 @@ import {
 import { TableCell } from "@material-ui/core";
 import { Text } from "@saleor/macaw-ui-next";
 
+import { OrderFulfillProductCellContent } from "../OrderFulfillLine/OrderFulfillProductCellContent";
 import { useStyles } from "../OrderFulfillStockExceededDialog/styles";
 
 interface OrderFulfillStockExceededDialogLineProps {
@@ -38,17 +39,20 @@ export const OrderFulfillStockExceededDialogLine = (
   return (
     <TableRowLink key={line?.id}>
       <TableCellAvatar className={classes.colName} thumbnail={line?.thumbnail?.url}>
-        {line?.productName}
-        {line.variant && "attributes" in line.variant && (
-          <Text color="default2" size={2} fontWeight="light">
-            {getAttributesCaption(line.variant?.attributes)}
-          </Text>
-        )}
-        {warehouse?.name && (
-          <Text color="default2" size={2} fontWeight="light">
-            {warehouse.name}
-          </Text>
-        )}
+        <OrderFulfillProductCellContent
+          productName={line?.productName}
+          attributesCaption={
+            line.variant && "attributes" in line.variant
+              ? getAttributesCaption(line.variant?.attributes)
+              : undefined
+          }
+        >
+          {warehouse?.name ? (
+            <Text color="default2" size={2} fontWeight="light">
+              {warehouse.name}
+            </Text>
+          ) : null}
+        </OrderFulfillProductCellContent>
       </TableCellAvatar>
       <TableCell className={classes.colQuantity}>{toFulfill}</TableCell>
       <TableCell className={classes.colWarehouseStock}>

--- a/src/orders/utils/data.test.ts
+++ b/src/orders/utils/data.test.ts
@@ -11,6 +11,7 @@ import {
   PaymentChargeStatusEnum,
 } from "@dashboard/graphql";
 import { type FormsetData } from "@dashboard/hooks/useFormset";
+import { warehouseList } from "@dashboard/warehouses/fixtures";
 import { testIntlInstance } from "@test/intl";
 
 import { type LineItemData } from "../components/OrderReturnPage/form";
@@ -18,8 +19,10 @@ import { type OrderRefundSharedType } from "../types";
 import {
   getAllFulfillmentLinesPriceSum,
   getAttributesCaption,
+  getDefaultFulfillWarehouse,
   getDiscountTypeLabel,
   getOrderFulfillStockFormsetLineId,
+  getOrderFulfillSubmitItems,
   getPreviouslyRefundedPrice,
   getRefundedLinesPriceSum,
   getReplacedProductsAmount,
@@ -3543,6 +3546,108 @@ describe("getAttributesCaption", () => {
 
     // Assert
     expect(result).toBe("");
+  });
+});
+
+describe("getDefaultFulfillWarehouse", () => {
+  it("prefers the warehouse from the highest quantity allocation", () => {
+    // Arrange
+    const line = {
+      allocations: [
+        {
+          quantity: 2,
+          warehouse: { id: "warehouse-low", name: "Low stock warehouse" },
+        },
+        {
+          quantity: 5,
+          warehouse: { id: "warehouse-high", name: "Allocated warehouse" },
+        },
+      ],
+      variant: { stocks: [] },
+    } as Parameters<typeof getDefaultFulfillWarehouse>[0];
+
+    // Act // Assert
+    expect(getDefaultFulfillWarehouse(line)?.id).toBe("warehouse-high");
+  });
+
+  it("falls back to the warehouse with the most available stock when there is no allocation", () => {
+    // Arrange
+    const line = {
+      allocations: [],
+      variant: {
+        stocks: [
+          {
+            quantity: 10,
+            quantityAllocated: 0,
+            warehouse: { id: "warehouse-a", name: "Warehouse A" },
+          },
+          {
+            quantity: 50,
+            quantityAllocated: 0,
+            warehouse: { id: "warehouse-b", name: "Warehouse B" },
+          },
+        ],
+      },
+    } as Parameters<typeof getDefaultFulfillWarehouse>[0];
+
+    // Act // Assert
+    expect(getDefaultFulfillWarehouse(line)?.id).toBe("warehouse-b");
+  });
+});
+
+describe("getOrderFulfillSubmitItems", () => {
+  it("returns only lines with positive quantity and assigned warehouse", () => {
+    // Arrange
+    const formsetData = [
+      {
+        id: "line-1",
+        value: [{ quantity: 2, warehouse: warehouseList[0] }],
+      },
+      {
+        id: "line-2",
+        value: [{ quantity: 0, warehouse: undefined }],
+      },
+      {
+        id: "line-3",
+        value: [{ quantity: 1, warehouse: undefined }],
+      },
+    ];
+
+    // Act
+    const result = getOrderFulfillSubmitItems(formsetData);
+
+    // Assert
+    expect(result).toEqual([
+      {
+        id: "line-1",
+        value: [{ quantity: 2, warehouse: warehouseList[0].id }],
+      },
+    ]);
+  });
+
+  it("skips preorder lines without stock allocations", () => {
+    // Arrange
+    const formsetData = [
+      {
+        id: "line-1",
+        value: null,
+      },
+      {
+        id: "line-2",
+        value: [{ quantity: 1, warehouse: warehouseList[1] }],
+      },
+    ];
+
+    // Act
+    const result = getOrderFulfillSubmitItems(formsetData);
+
+    // Assert
+    expect(result).toEqual([
+      {
+        id: "line-2",
+        value: [{ quantity: 1, warehouse: warehouseList[1].id }],
+      },
+    ]);
   });
 });
 

--- a/src/orders/utils/data.ts
+++ b/src/orders/utils/data.ts
@@ -10,6 +10,7 @@ import {
   type OrderDiscountFragment,
   OrderDiscountType,
   type OrderFulfillLineFragment,
+  type OrderFulfillStockInput,
   type OrderLineFragment,
   type OrderLineStockDataFragment,
   type OrderRefundDataQuery,
@@ -340,9 +341,37 @@ export interface OrderFulfillLineFormData {
   warehouse: WarehouseFragment;
 }
 
+type OrderFulfillLineValueInput = {
+  quantity: number;
+  warehouse?: WarehouseFragment | null;
+};
+
 export type OrderFulfillStockFormsetData = Array<
   Pick<FormsetData<null, OrderFulfillLineFormData[]>[0], "id" | "value">
 >;
+
+export const getOrderFulfillSubmitItems = <
+  TItem extends { id: string; value?: OrderFulfillLineValueInput[] | null },
+>(
+  formsetData: TItem[],
+): Array<Omit<TItem, "value"> & { value: OrderFulfillStockInput[] }> =>
+  formsetData
+    .map(item => ({
+      ...item,
+      value: (item.value ?? []).flatMap(value => {
+        if (value.quantity <= 0 || !value.warehouse?.id) {
+          return [];
+        }
+
+        return [
+          {
+            quantity: value.quantity,
+            warehouse: value.warehouse.id,
+          },
+        ];
+      }),
+    }))
+    .filter(item => item.value.length > 0);
 
 export const getOrderFulfillStockFormsetLineId = (
   line: NonNullable<FulfillmentFragment["lines"]>[number] | OrderFulfillLineFragment,
@@ -392,6 +421,29 @@ export const getLineAllocationWithHighestQuantity = (
     },
     null as NonNullable<OrderFulfillLineFragment["allocations"]>[number] | null,
   );
+
+export const getDefaultFulfillWarehouse = (
+  line: OrderFulfillLineFragment,
+): WarehouseFragment | undefined => {
+  const allocatedWarehouse = getLineAllocationWithHighestQuantity(line)?.warehouse;
+
+  if (allocatedWarehouse) {
+    return allocatedWarehouse;
+  }
+
+  const stocks = line.variant?.stocks;
+
+  if (!stocks?.length) {
+    return undefined;
+  }
+
+  return stocks.reduce((bestStock, stock) => {
+    const bestAvailable = getOrderLineAvailableQuantity(line, bestStock);
+    const stockAvailable = getOrderLineAvailableQuantity(line, stock);
+
+    return stockAvailable > bestAvailable ? stock : bestStock;
+  }).warehouse;
+};
 
 export const transformFuflillmentLinesToStockFormsetData = (
   lines: FulfillmentFragment["lines"],


### PR DESCRIPTION
Fulfillment crashed when submitting a single line from a multi-line order because zero-quantity lines without a warehouse were still sent to the API.

This PR fixes that crash and improves the fulfill page: macaw quantity/warehouse inputs, warehouse disabled at qty 0, auto-select warehouse from stock when unallocated, and truncated variant captions with tooltip.

### Changes

- Add `getOrderFulfillSubmitItems()` and `getDefaultFulfillWarehouse()` with unit tests
- Replace legacy MUI fulfill line controls with macaw `QuantityInput` / `Input`
- Disable warehouse selector for lines with quantity 0
- Truncate long product/variant text with overflow-only tooltip

<img width="1521" height="389" alt="image" src="https://github.com/user-attachments/assets/bb3bef35-ede8-4c44-b16f-46215b945b8b" />
