### PR TITLE
Add Store details section to site settings

### DIFF
--- a/.changeset/store-details-settings.md
+++ b/.changeset/store-details-settings.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Added a "Store details" section at the top of the Site Settings page where you can edit your store's name and description. The store name was previously not editable from the dashboard, and the description had no dedicated field.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -2831,6 +2831,10 @@
     "context": "page header",
     "string": "Order no. {orderNumber} - Add Fulfillment"
   },
+  "CJu4Rl": {
+    "context": "store details card title",
+    "string": "Store details"
+  },
   "CKP9+i": {
     "string": "Webhook errors detected."
   },
@@ -5382,6 +5386,10 @@
     "context": "Label prefix for the last occurrence date of a recurring problem",
     "string": "last occurred at"
   },
+  "Owgj18": {
+    "context": "section description",
+    "string": "Your store's public name and description, used across the storefront and in SEO metadata."
+  },
   "Oy1LhB": {
     "context": "button error state label",
     "string": "Try again"
@@ -6356,6 +6364,10 @@
   "TfzIXS": {
     "context": "tax classes card header",
     "string": "General information"
+  },
+  "TihW9+": {
+    "context": "section title",
+    "string": "Store details"
   },
   "TjGYna": {
     "context": "product inventory, checkbox",
@@ -10650,6 +10662,10 @@
     "context": "translation context bar without known source language",
     "string": "Translating original content to {targetLanguage}"
   },
+  "omdhZg": {
+    "context": "store name field label",
+    "string": "Store name"
+  },
   "opSGsa": {
     "context": "create attribute dialog step one label",
     "string": "General"
@@ -12026,6 +12042,10 @@
   },
   "v8UngX": {
     "string": "Search warehouses..."
+  },
+  "v8cgy/": {
+    "context": "store description field label",
+    "string": "Store description"
   },
   "v8e93p": {
     "context": "hint for order total option",

--- a/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -30,6 +30,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 import SiteCheckoutSettingsCard from "../SiteCheckoutSettingsCard";
 import { SitePasswordLoginCard } from "../SitePasswordLoginCard/SitePasswordLoginCard";
 import { messages } from "./messages";
+import { StoreDetailsCard } from "./StoreDetailsCard/StoreDetailsCard";
 
 const stockAvailabilityWebhooks = [
   WebhookEventTypeAsyncEnum.PRODUCT_VARIANT_OUT_OF_STOCK_IN_CHANNEL,
@@ -53,6 +54,7 @@ interface SiteSettingsPageAddressFormData {
 }
 
 export interface SiteSettingsPageFormData extends SiteSettingsPageAddressFormData {
+  name: string;
   description: string;
   reserveStockDurationAnonymousUser: number;
   reserveStockDurationAuthenticatedUser: number;
@@ -109,6 +111,7 @@ const SiteSettingsPage = (props: SiteSettingsPageProps) => {
   };
   const initialForm: SiteSettingsPageFormData = {
     ...initialFormAddress,
+    name: shop?.name || "",
     description: shop?.description || "",
     reserveStockDurationAnonymousUser: shop?.reserveStockDurationAnonymousUser ?? 0,
     reserveStockDurationAuthenticatedUser: shop?.reserveStockDurationAuthenticatedUser ?? 0,
@@ -160,6 +163,19 @@ const SiteSettingsPage = (props: SiteSettingsPageProps) => {
             />
             <DetailPageLayout.Content>
               <Box gap={2}>
+                <Box display="grid" __gridTemplateColumns="1fr 3fr" paddingLeft={6}>
+                  <PageSectionHeader
+                    title={intl.formatMessage(messages.sectionStoreDetailsTitle)}
+                    description={intl.formatMessage(messages.sectionStoreDetailsDescription)}
+                  />
+                  <StoreDetailsCard
+                    data={data}
+                    errors={errors}
+                    disabled={disabled}
+                    onChange={change}
+                  />
+                </Box>
+                <Divider />
                 <Box display="grid" __gridTemplateColumns="1fr 3fr" paddingLeft={6}>
                   <PageSectionHeader
                     title={intl.formatMessage(messages.sectionCheckoutTitle)}

--- a/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/StoreDetailsCard.stories.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/StoreDetailsCard.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { StoreDetailsCard } from "./StoreDetailsCard";
+
+const meta: Meta<typeof StoreDetailsCard> = {
+  title: "Site Settings / StoreDetailsCard",
+  component: StoreDetailsCard,
+  args: {
+    errors: [],
+    disabled: false,
+    onChange: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StoreDetailsCard>;
+
+export const Default: Story = {
+  args: {
+    data: {
+      name: "Saleor e-commerce",
+      description: "The best place to shop online.",
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    data: {
+      name: "",
+      description: "",
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    data: {
+      name: "Saleor e-commerce",
+      description: "The best place to shop online.",
+    },
+  },
+};

--- a/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/StoreDetailsCard.test.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/StoreDetailsCard.test.tsx
@@ -1,0 +1,74 @@
+import { ShopErrorCode, type ShopErrorFragment } from "@dashboard/graphql";
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+import { StoreDetailsCard } from "./StoreDetailsCard";
+
+jest.mock("react-intl", () => ({
+  FormattedMessage: ({ defaultMessage }: { defaultMessage: string }) => <>{defaultMessage}</>,
+  useIntl: () => ({
+    formatMessage: ({ defaultMessage }: { defaultMessage: string }) => defaultMessage,
+  }),
+  defineMessages: (messages: Record<string, unknown>) => messages,
+}));
+
+const renderCard = (props: Partial<Parameters<typeof StoreDetailsCard>[0]> = {}) => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <ThemeProvider>{children}</ThemeProvider>
+  );
+
+  return render(
+    <StoreDetailsCard
+      data={{ name: "My store", description: "Best shop around" }}
+      errors={[]}
+      disabled={false}
+      onChange={jest.fn()}
+      {...props}
+    />,
+    { wrapper },
+  );
+};
+
+describe("StoreDetailsCard", () => {
+  it("renders name and description values from data", () => {
+    // Arrange & Act
+    renderCard();
+
+    // Assert
+    expect(screen.getByDisplayValue("My store")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Best shop around")).toBeInTheDocument();
+  });
+
+  it("calls onChange when a field is edited", async () => {
+    // Arrange
+    const onChange = jest.fn();
+
+    renderCard({ data: { name: "", description: "" }, onChange });
+
+    // Act
+    await userEvent.type(screen.getByTestId("store-name-input"), "A");
+
+    // Assert
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("surfaces API errors for the fields", () => {
+    // Arrange
+    const errors: ShopErrorFragment[] = [
+      {
+        __typename: "ShopError",
+        code: ShopErrorCode.REQUIRED,
+        field: "name",
+        message: "This field is required.",
+      },
+    ];
+
+    // Act
+    renderCard({ errors });
+
+    // Assert
+    expect(screen.getByText("This field is required")).toBeInTheDocument();
+  });
+});

--- a/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/StoreDetailsCard.tsx
+++ b/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/StoreDetailsCard.tsx
@@ -1,0 +1,56 @@
+import { DashboardCard } from "@dashboard/components/Card";
+import { type ShopErrorFragment } from "@dashboard/graphql";
+import { getFormErrors } from "@dashboard/utils/errors";
+import getShopErrorMessage from "@dashboard/utils/errors/shop";
+import { Box, Input, Textarea } from "@saleor/macaw-ui-next";
+import { type ChangeEvent } from "react";
+import { useIntl } from "react-intl";
+
+import { type SiteSettingsPageFormData } from "../SiteSettingsPage";
+import { messages } from "./messages";
+
+interface StoreDetailsCardProps {
+  data: Pick<SiteSettingsPageFormData, "name" | "description">;
+  errors: ShopErrorFragment[];
+  disabled: boolean;
+  onChange: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+}
+
+export const StoreDetailsCard = ({ data, disabled, errors, onChange }: StoreDetailsCardProps) => {
+  const intl = useIntl();
+  const formErrors = getFormErrors(["name", "description"], errors);
+
+  return (
+    <DashboardCard>
+      <DashboardCard.Header>
+        <DashboardCard.Title>{intl.formatMessage(messages.cardTitle)}</DashboardCard.Title>
+      </DashboardCard.Header>
+      <DashboardCard.Content>
+        <Box display="flex" flexDirection="column" gap={5}>
+          <Input
+            data-test-id="store-name-input"
+            name="name"
+            label={intl.formatMessage(messages.nameLabel)}
+            value={data.name}
+            disabled={disabled}
+            error={!!formErrors.name}
+            helperText={getShopErrorMessage(formErrors.name, intl)}
+            onChange={onChange}
+          />
+          <Textarea
+            data-test-id="store-description-input"
+            name="description"
+            label={intl.formatMessage(messages.descriptionLabel)}
+            value={data.description}
+            disabled={disabled}
+            error={!!formErrors.description}
+            helperText={getShopErrorMessage(formErrors.description, intl)}
+            onChange={onChange}
+          />
+        </Box>
+      </DashboardCard.Content>
+    </DashboardCard>
+  );
+};
+
+StoreDetailsCard.displayName = "StoreDetailsCard";

--- a/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/messages.ts
+++ b/src/siteSettings/components/SiteSettingsPage/StoreDetailsCard/messages.ts
@@ -1,0 +1,19 @@
+import { defineMessages } from "react-intl";
+
+export const messages = defineMessages({
+  cardTitle: {
+    id: "CJu4Rl",
+    defaultMessage: "Store details",
+    description: "store details card title",
+  },
+  nameLabel: {
+    id: "omdhZg",
+    defaultMessage: "Store name",
+    description: "store name field label",
+  },
+  descriptionLabel: {
+    id: "v8cgy/",
+    defaultMessage: "Store description",
+    description: "store description field label",
+  },
+});

--- a/src/siteSettings/components/SiteSettingsPage/messages.ts
+++ b/src/siteSettings/components/SiteSettingsPage/messages.ts
@@ -1,6 +1,17 @@
 import { defineMessages } from "react-intl";
 
 export const messages = defineMessages({
+  sectionStoreDetailsTitle: {
+    id: "TihW9+",
+    defaultMessage: "Store details",
+    description: "section title",
+  },
+  sectionStoreDetailsDescription: {
+    id: "Owgj18",
+    defaultMessage:
+      "Your store's public name and description, used across the storefront and in SEO metadata.",
+    description: "section description",
+  },
   sectionCheckoutTitle: {
     id: "DASYUF",
     defaultMessage: "Checkout Configuration",

--- a/src/siteSettings/views/index.tsx
+++ b/src/siteSettings/views/index.tsx
@@ -66,6 +66,7 @@ const SiteSettings = () => {
         };
 
     const shopSettingsInput: ShopSettingsInput = {
+      name: data.name,
       description: data.description,
       reserveStockDurationAnonymousUser: data.reserveStockDurationAnonymousUser || null,
       reserveStockDurationAuthenticatedUser: data.reserveStockDurationAuthenticatedUser || null,


### PR DESCRIPTION
Adds a "Store details" section at the top of the Site Settings page with editable store name and description fields, wired to shopSettingsUpdate.
