### PR TITLE
Fix secondary text contrast

### DIFF
--- a/.changeset/secondary-text-contrast.md
+++ b/.changeset/secondary-text-contrast.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Improve contrast of secondary text (helper copy and subtitles) across the dashboard.

--- a/src/theme/provider.tsx
+++ b/src/theme/provider.tsx
@@ -10,15 +10,33 @@ import { defaultTheme, localStorageKey } from "./consts";
 import { secondaryTextCssVar, secondaryTextDefault2 } from "./secondaryTextContrast";
 
 /**
- * Runs after Macaw applies theme CSS vars on `documentElement`, then
- * nudges secondary text contrast dashboard-wide.
+ * Nudges secondary text contrast dashboard-wide.
+ *
+ * Macaw's ThemeProvider writes all theme CSS vars in a parent `useEffect`.
+ * Child effects run first, so a synchronous write here would be overwritten.
+ * Queue a microtask so our value sticks after Macaw's apply.
  */
 const SecondaryTextContrastOverride = (): null => {
   const { theme } = useTheme();
 
   useEffect(
     function applySecondaryTextContrast() {
-      document.documentElement.style.setProperty(secondaryTextCssVar, secondaryTextDefault2[theme]);
+      let cancelled = false;
+
+      queueMicrotask(() => {
+        if (cancelled) {
+          return;
+        }
+
+        document.documentElement.style.setProperty(
+          secondaryTextCssVar,
+          secondaryTextDefault2[theme],
+        );
+      });
+
+      return (): void => {
+        cancelled = true;
+      };
     },
     [theme],
   );

--- a/src/theme/provider.tsx
+++ b/src/theme/provider.tsx
@@ -1,11 +1,38 @@
 import useLocalStorage from "@dashboard/hooks/useLocalStorage";
-import { type DefaultTheme, ThemeProvider as MacawThemeProvider } from "@saleor/macaw-ui-next";
-import type * as React from "react";
+import {
+  type DefaultTheme,
+  ThemeProvider as MacawThemeProvider,
+  useTheme,
+} from "@saleor/macaw-ui-next";
+import { type ReactNode, useEffect } from "react";
 
 import { defaultTheme, localStorageKey } from "./consts";
+import { secondaryTextCssVar, secondaryTextDefault2 } from "./secondaryTextContrast";
 
-export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+/**
+ * Runs after Macaw applies theme CSS vars on `documentElement`, then
+ * nudges secondary text contrast dashboard-wide.
+ */
+const SecondaryTextContrastOverride = (): null => {
+  const { theme } = useTheme();
+
+  useEffect(
+    function applySecondaryTextContrast() {
+      document.documentElement.style.setProperty(secondaryTextCssVar, secondaryTextDefault2[theme]);
+    },
+    [theme],
+  );
+
+  return null;
+};
+
+export const ThemeProvider = ({ children }: { children: ReactNode }): JSX.Element => {
   const [activeTheme] = useLocalStorage<DefaultTheme>(localStorageKey, defaultTheme);
 
-  return <MacawThemeProvider defaultTheme={activeTheme}>{children}</MacawThemeProvider>;
+  return (
+    <MacawThemeProvider defaultTheme={activeTheme}>
+      <SecondaryTextContrastOverride />
+      {children}
+    </MacawThemeProvider>
+  );
 };

--- a/src/theme/secondaryTextContrast.ts
+++ b/src/theme/secondaryTextContrast.ts
@@ -1,0 +1,13 @@
+import { type DefaultTheme } from "@saleor/macaw-ui-next";
+
+/**
+ * Macaw `text.default2` is a bit light for secondary/helper copy
+ * (~4.1:1 on white). Slightly darker/lighter values clear WCAG AA
+ * for small text while staying visually secondary.
+ */
+export const secondaryTextDefault2: Record<DefaultTheme, string> = {
+  defaultLight: "hsla(180, 1%, 40%, 1)", // was 49% (~4.1:1) → ~5.7:1
+  defaultDark: "hsla(230, 10%, 62%, 1)", // was 53% (~5.3:1) → ~7.3:1
+};
+
+export const secondaryTextCssVar = "--mu-colors-text-default2";


### PR DESCRIPTION
* Improve secondary text legibility by raising `text.default2` contrast from ~4.1:1 → ~5.7:1 on light backgrounds (helper copy and subtitles), clearing WCAG AA (4.5:1) for normal text.

* Dark theme also nudged (~5.3:1 → ~7.3:1).