### PR TITLE
Improve media management

### DIFF
--- a/.changeset/calm-media-uploads.md
+++ b/.changeset/calm-media-uploads.md
@@ -1,0 +1,12 @@
+---
+"saleor-dashboard": patch
+---
+
+Improved product media and file attribute uploads:
+
+- Dropping or selecting images shows upload previews immediately, including on an empty gallery
+- Multiple uploads report one summary notification instead of a toast per file
+- Product media can be selected and deleted in bulk
+- Reordering media is smoother, with clearer drag feedback; reordering is blocked while uploads are still in progress
+- Invalid or oversized files are rejected before upload, with a clear warning
+- File attributes (for example images on products and models) support drag and drop to upload or replace, and show a thumbnail when the file is an image

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -962,6 +962,10 @@
     "context": "order history message",
     "string": "Payment was captured"
   },
+  "2z3+WY": {
+    "context": "error notification when all product image uploads in a batch failed",
+    "string": "{count, plural, one {Failed to upload image} other {Failed to upload # images}}"
+  },
   "2zCmiR": {
     "context": "tabel column header",
     "string": "Cost price"
@@ -2052,6 +2056,10 @@
     "context": "Warning when channel has no shipping zones",
     "string": "No shipping zones for \"{channelName}\""
   },
+  "8XSZSL": {
+    "context": "product media bulk delete dialog content",
+    "string": "{counter,plural,one{Are you sure you want to delete this media item?} other{Are you sure you want to delete {displayQuantity} media items?}}"
+  },
   "8a4uf/": {
     "context": "dialog content",
     "string": "{counter,plural,one{Are you sure you want to delete this model?} other{Are you sure you want to delete {displayQuantity} models?}}"
@@ -2790,6 +2798,10 @@
     "context": "address removed from a customer's address book, success toast",
     "string": "Address deleted"
   },
+  "C87+/n": {
+    "context": "button to select all product media items",
+    "string": "Select all"
+  },
   "C90nKP": {
     "context": "error with deactivatation alert message",
     "string": "Errors deactivating gift {count,plural,one{card} other{cards}}"
@@ -3177,6 +3189,10 @@
   "EAGfdH": {
     "string": "Page updated"
   },
+  "ECnjbS": {
+    "context": "product media bulk delete dialog header",
+    "string": "Delete Media"
+  },
   "ECpTeb": {
     "context": "Add filter button text",
     "string": "Add filter"
@@ -3208,6 +3224,10 @@
   },
   "EM730i": {
     "string": "Manage Channel Availability"
+  },
+  "EMQgvH": {
+    "context": "file attribute empty dropzone hint",
+    "string": "Drag and drop or click to upload"
   },
   "EP+jcU": {
     "context": "checkbox",
@@ -3328,6 +3348,10 @@
   },
   "F2kF9e": {
     "string": "You must select transaction that you want to refund"
+  },
+  "F2xa5K": {
+    "context": "success notification when product media items are deleted",
+    "string": "{counter,plural,one{Media deleted} other{# media items deleted}}"
   },
   "F3Upht": {
     "string": "Product type deleted"
@@ -3718,9 +3742,6 @@
     "context": "header",
     "string": "Create Warehouse"
   },
-  "Gi8zwc": {
-    "string": "Image deleted"
-  },
   "GiDxS4": {
     "context": "add metadata field,button",
     "string": "Add Field"
@@ -4034,6 +4055,10 @@
   "I7HyJZ": {
     "context": "order refund amount",
     "string": "Max Refund"
+  },
+  "I7X2uK": {
+    "context": "button to clear selected product media items",
+    "string": "Clear"
   },
   "IBw72y": {
     "context": "switch button",
@@ -4514,6 +4539,10 @@
     "context": "grant refund table, column header",
     "string": "Unit price"
   },
+  "KXX8oX": {
+    "context": "product media gallery dropzone hint when click-to-upload is disabled",
+    "string": "Drag and drop to upload"
+  },
   "KYMCYg": {
     "string": "Shipping rate deleted"
   },
@@ -4782,6 +4811,10 @@
   "Lx1ima": {
     "context": "button",
     "string": "Upload image"
+  },
+  "LzdG4r": {
+    "context": "warning when client-side validation rejects product media files before upload",
+    "string": "{count, plural, one {# file was skipped} other {# files were skipped}} (not an image or larger than {maxSize} MB)"
   },
   "M3OlSr": {
     "context": "error message",
@@ -6130,6 +6163,10 @@
   "SRMNCS": {
     "string": "Pending & failed deliveries (last 10)"
   },
+  "SRnxlw": {
+    "context": "button to delete selected product media items",
+    "string": "Delete ({quantity})"
+  },
   "SSWFo8": {
     "context": "window title",
     "string": "Create Product Type"
@@ -7418,6 +7455,10 @@
   "Yxnwa3": {
     "context": "dialog content",
     "string": "Are you sure you want to send this invoice: <strong>{invoiceNumber}</strong> to the customer?"
+  },
+  "Yxoq3Y": {
+    "context": "success notification when one or more product images finish uploading",
+    "string": "{count, plural, one {# image added} other {# images added}}"
   },
   "Yy/yDL": {
     "string": "Reset password"
@@ -10126,6 +10167,10 @@
   "lwjzVj": {
     "string": "Edit order"
   },
+  "lxP7Rb": {
+    "context": "warning notification when some product image uploads in a batch failed",
+    "string": "{success, plural, one {# image} other {# images}} added, {failed, plural, one {# failed} other {# failed}}"
+  },
   "lz7o8y": {
     "context": "tooltip when generate button is disabled because over variant limit",
     "string": "Cannot create more than {limit} variants at once"
@@ -12363,6 +12408,10 @@
   },
   "wFVOKJ": {
     "string": "Go to warehouses"
+  },
+  "wFsAkW": {
+    "context": "file attribute dropzone hint when replacing an existing file",
+    "string": "Drop to replace"
   },
   "wJep/X": {
     "context": "refund amounts were settled",

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,19 @@
+# Docs: https://docs.socket.dev/docs/socket-yml
+version: 2
+
+# Only trigger pull request scans when these files change.
+triggerPaths:
+  - "package.json"
+  - "package-lock.json"
+  - "pnpm-lock.yaml"
+  - "bun.lock"
+  - "uv.lock"
+  - "poetry.lock"
+  - "requirements*.txt"
+
+githubApp:
+  enabled: true
+  dependencyOverviewEnabled: true
+  ignoreUsers:
+    - "saleor-deployments[bot]"
+  disableCommentsAndCheckRuns: false

--- a/src/components/Draggable/Draggable.tsx
+++ b/src/components/Draggable/Draggable.tsx
@@ -1,5 +1,5 @@
 import { type DraggableAttributes } from "@dnd-kit/core";
-import { useSortable } from "@dnd-kit/sortable";
+import { type AnimateLayoutChanges, useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type * as React from "react";
 
@@ -15,18 +15,23 @@ interface DraggableProps {
   disabled?: boolean;
 }
 
+/** Skip post-drop layout tween — flex/grid reflows look like a slide from the left. */
+const animateLayoutChanges: AnimateLayoutChanges = () => false;
+
 /** This element is used as wrapper in @dnd-kit sortable list
  * in order to make children element interactive */
 export const Draggable = ({ id, children, disabled }: DraggableProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
     disabled,
+    animateLayoutChanges,
   });
 
-  const style = {
+  const style: React.CSSProperties = {
     transform: CSS.Translate.toString(transform),
-    transition,
-  } as React.CSSProperties;
+    // Only keep the live-drag transition; never animate into the post-drop layout
+    transition: isDragging ? transition : undefined,
+  };
 
   return children({
     ref: setNodeRef,

--- a/src/components/FileUploadField/FileUploadField.module.css
+++ b/src/components/FileUploadField/FileUploadField.module.css
@@ -1,0 +1,104 @@
+.uploadRoot {
+  position: relative;
+  width: 100%;
+  min-width: 0;
+}
+
+.uploadRoot:focus,
+.uploadRoot:focus-visible {
+  outline: none;
+}
+
+.dropzone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 12px;
+  border-style: dashed;
+  border-width: 1px;
+  border-color: var(--mu-colors-border-default1);
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.dropzone:hover {
+  border-color: var(--mu-colors-border-default2);
+}
+
+.dropzoneActive {
+  border-color: var(--mu-colors-border-default2);
+  background-color: var(--mu-colors-background-default2);
+}
+
+.dropzoneDisabled {
+  cursor: default;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.filled {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  min-height: 40px;
+  padding: 4px 4px 4px 12px;
+  border-radius: 6px;
+}
+
+.fileMeta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1;
+}
+
+.thumbnail {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid var(--mu-colors-border-default1);
+  background-color: var(--mu-colors-background-default2);
+}
+
+.fileName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.fileName a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.fileName a:hover {
+  text-decoration: underline;
+}
+
+.replaceHint {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--mu-colors-border-default2);
+  border-radius: 6px;
+  background-color: var(--mu-colors-background-default1);
+  pointer-events: none;
+}
+
+.hiddenInput {
+  display: none;
+}

--- a/src/components/FileUploadField/FileUploadField.test.tsx
+++ b/src/components/FileUploadField/FileUploadField.test.tsx
@@ -1,0 +1,137 @@
+import Wrapper from "@test/wrapper";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { FileUploadField } from "./FileUploadField";
+import { UPLOADED_FILE } from "./fixtures";
+
+describe("FileUploadField", () => {
+  it("shows an empty dropzone hint", () => {
+    // Arrange / Act
+    render(
+      <Wrapper>
+        <FileUploadField
+          disabled={false}
+          loading={false}
+          file={{ label: "", value: "" }}
+          onFileUpload={jest.fn()}
+          onFileDelete={jest.fn()}
+        />
+      </Wrapper>,
+    );
+
+    // Assert
+    expect(screen.getByTestId("button-upload-file")).toHaveTextContent(
+      "Drag and drop or click to upload",
+    );
+    expect(screen.getByTestId("file-upload-dropzone")).toBeInTheDocument();
+  });
+
+  it("uploads a file selected via the hidden input", async () => {
+    // Arrange
+    const onFileUpload = jest.fn();
+
+    render(
+      <Wrapper>
+        <FileUploadField
+          disabled={false}
+          loading={false}
+          file={{ label: "", value: "" }}
+          onFileUpload={onFileUpload}
+          onFileDelete={jest.fn()}
+        />
+      </Wrapper>,
+    );
+
+    const file = new File(["bytes"], "hero.png", { type: "image/png" });
+
+    // Act
+    await userEvent.upload(screen.getByTestId("upload-file-input"), file);
+
+    // Assert
+    expect(onFileUpload).toHaveBeenCalledTimes(1);
+    expect(onFileUpload.mock.calls[0][0]).toEqual(file);
+  });
+
+  it("shows the uploaded image thumbnail, file name, and delete control", () => {
+    // Arrange
+    const onFileDelete = jest.fn();
+
+    render(
+      <Wrapper>
+        <FileUploadField
+          disabled={false}
+          loading={false}
+          file={{
+            label: "hero.png",
+            value: "file-1",
+            file: UPLOADED_FILE,
+          }}
+          onFileUpload={jest.fn()}
+          onFileDelete={onFileDelete}
+        />
+      </Wrapper>,
+    );
+
+    // Assert
+    expect(screen.getByText("hero.png")).toBeInTheDocument();
+    expect(screen.getByTestId("file-upload-thumbnail")).toHaveAttribute("src", UPLOADED_FILE.url);
+    expect(screen.getByTestId("button-delete-file")).toBeInTheDocument();
+
+    // Act
+    fireEvent.click(screen.getByTestId("button-delete-file"));
+
+    // Assert
+    expect(onFileDelete).toHaveBeenCalled();
+  });
+
+  it("does not show a thumbnail for non-image files", () => {
+    // Arrange / Act
+    render(
+      <Wrapper>
+        <FileUploadField
+          disabled={false}
+          loading={false}
+          file={{
+            label: "notes.pdf",
+            value: "file-2",
+            file: {
+              __typename: "File",
+              url: "https://example.com/notes.pdf",
+              contentType: "application/pdf",
+            },
+          }}
+          onFileUpload={jest.fn()}
+          onFileDelete={jest.fn()}
+        />
+      </Wrapper>,
+    );
+
+    // Assert
+    expect(screen.queryByTestId("file-upload-thumbnail")).not.toBeInTheDocument();
+    expect(screen.getByText("notes.pdf")).toBeInTheDocument();
+  });
+
+  it("renders the label as plain text when the file has no URL", () => {
+    // Arrange / Act
+    render(
+      <Wrapper>
+        <FileUploadField
+          disabled={false}
+          loading={false}
+          file={{
+            label: "pending-upload.png",
+            value: "pending",
+          }}
+          onFileUpload={jest.fn()}
+          onFileDelete={jest.fn()}
+        />
+      </Wrapper>,
+    );
+
+    // Assert
+    expect(screen.getByText("pending-upload.png")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("file-upload-thumbnail")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/FileUploadField/FileUploadField.tsx
+++ b/src/components/FileUploadField/FileUploadField.tsx
@@ -1,11 +1,14 @@
-// @ts-strict-ignore
+import Dropzone from "@dashboard/components/Dropzone";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { type FileFragment } from "@dashboard/graphql";
-import { commonMessages } from "@dashboard/intl";
 import { Box, Button, Skeleton, Text } from "@saleor/macaw-ui-next";
+import clsx from "clsx";
 import { Trash2 } from "lucide-react";
-import * as React from "react";
-import { useIntl } from "react-intl";
+import { type InputHTMLAttributes, useEffect, useState } from "react";
+import { defineMessages, FormattedMessage } from "react-intl";
+
+import styles from "./FileUploadField.module.css";
+import { isImageFileChoice } from "./isImageFileChoice";
 
 export interface FileChoiceType {
   label: string;
@@ -14,10 +17,7 @@ export interface FileChoiceType {
 }
 
 interface FileUploadFieldProps {
-  inputProps?: React.DetailedHTMLProps<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    HTMLInputElement
-  >;
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
   disabled: boolean;
   loading: boolean;
   file: FileChoiceType;
@@ -27,73 +27,152 @@ interface FileUploadFieldProps {
   onFileDelete: () => void;
 }
 
-const FileUploadField = (props: FileUploadFieldProps) => {
-  const { loading, disabled, file, error, helperText, onFileUpload, onFileDelete, inputProps } =
-    props;
-  const intl = useIntl();
-  const fileInputAnchor = React.createRef<HTMLInputElement>();
-  const clickFileInput = () => fileInputAnchor.current.click();
-  const handleFileDelete = () => {
-    fileInputAnchor.current.value = "";
-    onFileDelete();
+const messages = defineMessages({
+  uploadHint: {
+    id: "EMQgvH",
+    defaultMessage: "Drag and drop or click to upload",
+    description: "file attribute empty dropzone hint",
+  },
+  replaceHint: {
+    id: "wFsAkW",
+    defaultMessage: "Drop to replace",
+    description: "file attribute dropzone hint when replacing an existing file",
+  },
+});
+
+export { isImageFileChoice } from "./isImageFileChoice";
+
+export const FileUploadField = ({
+  loading,
+  disabled,
+  file,
+  error,
+  helperText,
+  onFileUpload,
+  onFileDelete,
+  inputProps,
+}: FileUploadFieldProps) => {
+  const hasFile = Boolean(file.label);
+  const isDisabled = disabled || loading;
+  const fileUrl = file.file?.url;
+  const [thumbnailFailed, setThumbnailFailed] = useState(false);
+  const showThumbnail =
+    !loading && !thumbnailFailed && isImageFileChoice(file.file) && Boolean(fileUrl);
+
+  useEffect(() => {
+    setThumbnailFailed(false);
+  }, [fileUrl]);
+
+  const handleDrop = (files: File[] | FileList) => {
+    if (isDisabled) {
+      return;
+    }
+
+    const [firstFile] = Array.from(files);
+
+    if (!firstFile) {
+      return;
+    }
+
+    onFileUpload(firstFile);
   };
 
-  React.useEffect(() => {
-    if (!file.value) {
-      fileInputAnchor.current.value = "";
-    }
-  }, [file]);
-
   return (
-    <>
-      <Box display="flex" justifyContent="flex-start" alignItems="center">
-        {file.label ? (
-          <Box display="flex" gap={2} alignItems="center">
-            <Text size={2}>
-              {loading ? (
-                <Skeleton />
+    <Box display="flex" flexDirection="column" gap={1} __minWidth={0} width="100%">
+      {/* Remount when cleared so the same file can be chosen again */}
+      <Dropzone
+        key={file.value || "empty"}
+        noClick={hasFile || isDisabled}
+        disabled={isDisabled}
+        multiple={false}
+        onDrop={handleDrop}
+      >
+        {({ isDragActive, getInputProps, getRootProps }) => {
+          const dropzoneInputProps = getInputProps();
+
+          return (
+            <div
+              {...getRootProps()}
+              className={styles.uploadRoot}
+              data-test-id="file-upload-dropzone"
+            >
+              <input
+                {...dropzoneInputProps}
+                name={inputProps?.name}
+                accept={inputProps?.accept}
+                className={styles.hiddenInput}
+                data-test-id="upload-file-input"
+              />
+              {hasFile ? (
+                <div className={styles.filled}>
+                  <div className={styles.fileMeta}>
+                    {showThumbnail ? (
+                      <img
+                        src={fileUrl}
+                        alt={file.label}
+                        className={styles.thumbnail}
+                        data-test-id="file-upload-thumbnail"
+                        onError={() => setThumbnailFailed(true)}
+                      />
+                    ) : null}
+                    <Text size={2} className={styles.fileName}>
+                      {loading ? (
+                        <Skeleton />
+                      ) : fileUrl ? (
+                        <a href={fileUrl} target="_blank" rel="noreferrer">
+                          {file.label}
+                        </a>
+                      ) : (
+                        file.label
+                      )}
+                    </Text>
+                  </div>
+                  <Button
+                    icon={
+                      <Trash2 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />
+                    }
+                    variant="secondary"
+                    onClick={event => {
+                      event.stopPropagation();
+                      event.preventDefault();
+                      onFileDelete();
+                    }}
+                    disabled={isDisabled}
+                    data-test-id="button-delete-file"
+                    type="button"
+                  />
+                  {isDragActive && !isDisabled ? (
+                    <div className={styles.replaceHint} data-test-id="file-upload-replace-hint">
+                      <Text size={2} color="default2">
+                        <FormattedMessage {...messages.replaceHint} />
+                      </Text>
+                    </div>
+                  ) : null}
+                </div>
               ) : (
-                <a href={file.file?.url} target="blank">
-                  {file.label}
-                </a>
+                <div
+                  className={clsx(
+                    styles.dropzone,
+                    isDragActive && styles.dropzoneActive,
+                    isDisabled && styles.dropzoneDisabled,
+                  )}
+                  data-test-id="button-upload-file"
+                >
+                  <Text size={2} color="default2">
+                    {loading ? <Skeleton /> : <FormattedMessage {...messages.uploadHint} />}
+                  </Text>
+                </div>
               )}
-            </Text>
-            <Button
-              icon={<Trash2 size={iconSize.small} strokeWidth={iconStrokeWidthBySize.small} />}
-              variant="secondary"
-              onClick={handleFileDelete}
-              disabled={disabled || loading}
-              data-test-id="button-delete-file"
-              type="button"
-            />
-          </Box>
-        ) : (
-          <Button
-            onClick={clickFileInput}
-            disabled={disabled || loading}
-            variant="secondary"
-            data-test-id="button-upload-file"
-            type="button"
-          >
-            {intl.formatMessage(commonMessages.chooseFile)}
-          </Button>
-        )}
-        {error && (
-          <Text size={2} color="critical1" paddingLeft={3}>
-            {helperText}
-          </Text>
-        )}
-      </Box>
-      <input
-        style={{ display: "none" }}
-        id="fileUpload"
-        onChange={event => onFileUpload(event.target.files[0])}
-        type="file"
-        data-test-id="upload-file-input"
-        ref={fileInputAnchor}
-        {...inputProps}
-      />
-    </>
+            </div>
+          );
+        }}
+      </Dropzone>
+      {error ? (
+        <Text size={2} color="critical1">
+          {helperText}
+        </Text>
+      ) : null}
+    </Box>
   );
 };
 

--- a/src/components/FileUploadField/FileUploadField.tsx
+++ b/src/components/FileUploadField/FileUploadField.tsx
@@ -5,6 +5,7 @@ import { Box, Button, Skeleton, Text } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
 import { Trash2 } from "lucide-react";
 import { type InputHTMLAttributes, useEffect, useState } from "react";
+import type { DropzoneState } from "react-dropzone";
 import { defineMessages, FormattedMessage } from "react-intl";
 
 import styles from "./FileUploadField.module.css";
@@ -87,7 +88,7 @@ export const FileUploadField = ({
         multiple={false}
         onDrop={handleDrop}
       >
-        {({ isDragActive, getInputProps, getRootProps }) => {
+        {({ isDragActive, getInputProps, getRootProps }: DropzoneState) => {
           const dropzoneInputProps = getInputProps();
 
           return (

--- a/src/components/FileUploadField/index.ts
+++ b/src/components/FileUploadField/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./FileUploadField";
-export * from "./FileUploadField";
+export type { FileChoiceType } from "./FileUploadField";
+export { default, FileUploadField } from "./FileUploadField";

--- a/src/components/FileUploadField/isImageFileChoice.test.ts
+++ b/src/components/FileUploadField/isImageFileChoice.test.ts
@@ -1,0 +1,43 @@
+import { isImageFileChoice } from "./isImageFileChoice";
+
+describe("isImageFileChoice", () => {
+  it("returns true for image content types", () => {
+    // Arrange / Act / Assert
+    expect(
+      isImageFileChoice({
+        __typename: "File",
+        url: "https://example.com/file.bin",
+        contentType: "image/png",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for non-image content types", () => {
+    // Arrange / Act / Assert
+    expect(
+      isImageFileChoice({
+        __typename: "File",
+        url: "https://example.com/doc.pdf",
+        contentType: "application/pdf",
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to the URL extension when contentType is missing", () => {
+    // Arrange / Act / Assert
+    expect(
+      isImageFileChoice({
+        __typename: "File",
+        url: "https://example.com/photo.JPEG?size=1",
+        contentType: null,
+      }),
+    ).toBe(true);
+    expect(
+      isImageFileChoice({
+        __typename: "File",
+        url: "https://example.com/notes.pdf",
+        contentType: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/components/FileUploadField/isImageFileChoice.ts
+++ b/src/components/FileUploadField/isImageFileChoice.ts
@@ -1,0 +1,18 @@
+import { type FileFragment } from "@dashboard/graphql";
+
+/** Prefer MIME type from the API; fall back to URL extension when contentType is missing. */
+export const isImageFileChoice = (file?: FileFragment | null): boolean => {
+  if (!file?.url) {
+    return false;
+  }
+
+  if (file.contentType?.startsWith("image/")) {
+    return true;
+  }
+
+  if (file.contentType) {
+    return false;
+  }
+
+  return /\.(avif|bmp|gif|jpe?g|png|webp)(\?|#|$)/i.test(file.url);
+};

--- a/src/components/MediaTile/MediaTile.tsx
+++ b/src/components/MediaTile/MediaTile.tsx
@@ -3,7 +3,7 @@ import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { MediaWithFallback } from "@dashboard/components/MediaWithFallback/MediaWithFallback";
 import { parseOembedData } from "@dashboard/products/utils/parseOembedData";
 import { makeStyles } from "@saleor/macaw-ui";
-import { vars } from "@saleor/macaw-ui-next";
+import { Checkbox, vars } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
 import { Pencil, Trash2 } from "lucide-react";
 import type * as React from "react";
@@ -23,6 +23,10 @@ const useStyles = makeStyles(
         "& $mediaOverlay": {
           display: "block",
         },
+        "& $selectionCheckbox": {
+          opacity: 1,
+          pointerEvents: "auto",
+        },
       },
       background: theme.palette.background.paper,
       border: `1px solid ${theme.palette.divider}`,
@@ -32,6 +36,10 @@ const useStyles = makeStyles(
       padding: vars.spacing[1],
       position: "relative",
       width: 148,
+    },
+    mediaContainerSelected: {
+      borderColor: theme.palette.saleor.active[1],
+      boxShadow: `0 0 0 1px ${theme.palette.saleor.active[1]}`,
     },
     mediaOverlay: {
       background: theme.palette.background.default,
@@ -57,6 +65,23 @@ const useStyles = makeStyles(
     mediaOverlayToolbar: {
       display: "flex",
       justifyContent: "flex-end",
+    },
+    selectionCheckbox: {
+      position: "absolute",
+      top: theme.spacing(2),
+      left: theme.spacing(2),
+      zIndex: 2,
+      background: theme.palette.background.paper,
+      borderRadius: theme.spacing(0.5),
+      opacity: 0,
+      pointerEvents: "none",
+      transition: theme.transitions.create("opacity", {
+        duration: theme.transitions.duration.shorter,
+      }),
+    },
+    selectionCheckboxVisible: {
+      opacity: 1,
+      pointerEvents: "auto",
     },
     controlButton: {
       color: theme.palette.saleor.main[1],
@@ -86,6 +111,8 @@ interface MediaTileBaseProps {
   };
   disableOverlay?: boolean;
   loading?: boolean;
+  selected?: boolean;
+  onSelectionChange?: (selected: boolean) => void;
   placeholderSrc?: string | null;
   onPlaceholderUnused?: () => void;
   onDelete?: () => void;
@@ -114,12 +141,36 @@ const MediaTile = (props: MediaTileProps) => {
     disableOverlay = false,
     placeholderSrc,
     onPlaceholderUnused,
+    selected = false,
+    onSelectionChange,
   } = props;
   const classes = useStyles(props);
   const mediaUrl = parseOembedData(media.oembedData).thumbnail_url || media.url;
 
   return (
-    <div className={classes.mediaContainer} data-test-id="product-image">
+    <div
+      className={clsx(classes.mediaContainer, {
+        [classes.mediaContainerSelected]: selected,
+      })}
+      data-test-id="product-image"
+      data-test-selected={selected ? "true" : "false"}
+    >
+      {onSelectionChange && !loading ? (
+        <div
+          className={clsx(classes.selectionCheckbox, {
+            [classes.selectionCheckboxVisible]: selected,
+          })}
+          onClick={event => event.stopPropagation()}
+          onMouseDown={event => event.stopPropagation()}
+          data-test-id="product-media-select"
+        >
+          <Checkbox
+            checked={selected}
+            onCheckedChange={checked => onSelectionChange(checked === true)}
+            tabIndex={-1}
+          />
+        </div>
+      ) : null}
       <div
         className={clsx(classes.mediaOverlay, {
           [classes.mediaOverlayLoading]: loading,

--- a/src/components/MediaTile/MediaTile.tsx
+++ b/src/components/MediaTile/MediaTile.tsx
@@ -49,12 +49,10 @@ const useStyles = makeStyles(
         display: "none !important",
       },
     },
-    mediaOverlayShadow: {
-      $mediaOverlay: {
-        alignItems: "center",
-        display: "flex",
-        justifyContent: "center",
-      },
+    mediaOverlayLoading: {
+      alignItems: "center",
+      display: "flex",
+      justifyContent: "center",
     },
     mediaOverlayToolbar: {
       display: "flex",
@@ -88,6 +86,8 @@ interface MediaTileBaseProps {
   };
   disableOverlay?: boolean;
   loading?: boolean;
+  placeholderSrc?: string | null;
+  onPlaceholderUnused?: () => void;
   onDelete?: () => void;
   onEdit?: (event: React.ChangeEvent<any>) => void;
 }
@@ -105,7 +105,16 @@ type MediaTileProps = MediaTileBaseProps &
   );
 
 const MediaTile = (props: MediaTileProps) => {
-  const { loading, onDelete, onEdit, editHref, media, disableOverlay = false } = props;
+  const {
+    loading,
+    onDelete,
+    onEdit,
+    editHref,
+    media,
+    disableOverlay = false,
+    placeholderSrc,
+    onPlaceholderUnused,
+  } = props;
   const classes = useStyles(props);
   const mediaUrl = parseOembedData(media.oembedData).thumbnail_url || media.url;
 
@@ -113,12 +122,12 @@ const MediaTile = (props: MediaTileProps) => {
     <div className={classes.mediaContainer} data-test-id="product-image">
       <div
         className={clsx(classes.mediaOverlay, {
-          [classes.mediaOverlayShadow]: loading,
+          [classes.mediaOverlayLoading]: loading,
           [classes.disableOverlay]: disableOverlay,
         })}
       >
         {loading ? (
-          <SaleorThrobber size={32} />
+          <SaleorThrobber size={32} data-test-id="media-tile-loading" />
         ) : (
           <div className={classes.mediaOverlayToolbar}>
             {(onEdit || editHref) && (
@@ -145,7 +154,14 @@ const MediaTile = (props: MediaTileProps) => {
           </div>
         )}
       </div>
-      <MediaWithFallback key={mediaUrl} className={classes.media} src={mediaUrl} alt={media.alt} />
+      <MediaWithFallback
+        key={mediaUrl}
+        className={classes.media}
+        src={mediaUrl}
+        alt={media.alt}
+        placeholderSrc={placeholderSrc}
+        onPlaceholderUnused={onPlaceholderUnused}
+      />
     </div>
   );
 };

--- a/src/components/MediaWithFallback/MediaWithFallback.tsx
+++ b/src/components/MediaWithFallback/MediaWithFallback.tsx
@@ -8,6 +8,9 @@ import { mediaFallbackMessages } from "./messages";
 interface MediaWithFallbackProps extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "alt"> {
   // Extend to allow "null" because GraphQL can return it. It's suger to avoid extra mapping in parents
   alt?: string | null;
+  /** Shown instead of a skeleton while `src` is loading (e.g. local blob preview after upload). */
+  placeholderSrc?: string | null;
+  onPlaceholderUnused?: () => void;
 }
 
 export const MediaWithFallback = ({
@@ -15,6 +18,8 @@ export const MediaWithFallback = ({
   alt,
   className,
   style,
+  placeholderSrc,
+  onPlaceholderUnused,
   ...rest
 }: MediaWithFallbackProps) => {
   const [loadingStatus, setLoadingStatus] = useState<"loading" | "loaded" | "error">("loading");
@@ -42,15 +47,33 @@ export const MediaWithFallback = ({
     );
   }
 
+  const handleLoad = () => {
+    setLoadingStatus("loaded");
+    onPlaceholderUnused?.();
+  };
+
   return (
     <>
-      {!isLoaded && <Skeleton __width="100%" __height="100%" />}
+      {!isLoaded && placeholderSrc ? (
+        <img
+          className={className}
+          src={placeholderSrc}
+          alt=""
+          aria-hidden
+          style={style}
+          data-test-id="media-placeholder"
+        />
+      ) : null}
+      {!isLoaded && !placeholderSrc ? <Skeleton __width="100%" __height="100%" /> : null}
       <img
         className={className}
         src={src}
         alt={alt ?? undefined}
-        onLoad={() => setLoadingStatus("loaded")}
-        onError={() => setLoadingStatus("error")}
+        onLoad={handleLoad}
+        onError={() => {
+          setLoadingStatus("error");
+          onPlaceholderUnused?.();
+        }}
         style={isLoaded ? { ...style } : { ...style, display: "none" }}
         {...rest}
       />

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -15224,6 +15224,9 @@ export const ProductMediaCreateDocument = gql`
     errors {
       ...ProductError
     }
+    media {
+      id
+    }
     product {
       id
       media {
@@ -15671,6 +15674,42 @@ export function useProductMediaDeleteMutation(baseOptions?: ApolloReactHooks.Mut
 export type ProductMediaDeleteMutationHookResult = ReturnType<typeof useProductMediaDeleteMutation>;
 export type ProductMediaDeleteMutationResult = Apollo.MutationResult<Types.ProductMediaDeleteMutation>;
 export type ProductMediaDeleteMutationOptions = Apollo.BaseMutationOptions<Types.ProductMediaDeleteMutation, Types.ProductMediaDeleteMutationVariables>;
+export const ProductMediaBulkDeleteDocument = gql`
+    mutation ProductMediaBulkDelete($ids: [ID!]!) {
+  productMediaBulkDelete(ids: $ids) {
+    errors {
+      ...ProductError
+    }
+    count
+  }
+}
+    ${ProductErrorFragmentDoc}`;
+export type ProductMediaBulkDeleteMutationFn = Apollo.MutationFunction<Types.ProductMediaBulkDeleteMutation, Types.ProductMediaBulkDeleteMutationVariables>;
+
+/**
+ * __useProductMediaBulkDeleteMutation__
+ *
+ * To run a mutation, you first call `useProductMediaBulkDeleteMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useProductMediaBulkDeleteMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [productMediaBulkDeleteMutation, { data, loading, error }] = useProductMediaBulkDeleteMutation({
+ *   variables: {
+ *      ids: // value for 'ids'
+ *   },
+ * });
+ */
+export function useProductMediaBulkDeleteMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<Types.ProductMediaBulkDeleteMutation, Types.ProductMediaBulkDeleteMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return ApolloReactHooks.useMutation<Types.ProductMediaBulkDeleteMutation, Types.ProductMediaBulkDeleteMutationVariables>(ProductMediaBulkDeleteDocument, options);
+      }
+export type ProductMediaBulkDeleteMutationHookResult = ReturnType<typeof useProductMediaBulkDeleteMutation>;
+export type ProductMediaBulkDeleteMutationResult = Apollo.MutationResult<Types.ProductMediaBulkDeleteMutation>;
+export type ProductMediaBulkDeleteMutationOptions = Apollo.BaseMutationOptions<Types.ProductMediaBulkDeleteMutation, Types.ProductMediaBulkDeleteMutationVariables>;
 export const ProductMediaUpdateDocument = gql`
     mutation ProductMediaUpdate($id: ID!, $alt: String!) {
   productMediaUpdate(id: $id, input: {alt: $alt}) {
@@ -16545,7 +16584,7 @@ export const ProductMediaByIdDocument = gql`
     }
     media {
       id
-      url(size: 48)
+      url(size: 128, format: WEBP)
       alt
       type
       oembedData

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -12914,7 +12914,7 @@ export type ProductMediaCreateMutationVariables = Exact<{
 }>;
 
 
-export type ProductMediaCreateMutation = { __typename: 'Mutation', productMediaCreate: { __typename: 'ProductMediaCreate', errors: Array<{ __typename: 'ProductError', code: ProductErrorCode, field: string | null, message: string | null }>, product: { __typename: 'Product', id: string, media: Array<{ __typename: 'ProductMedia', id: string, alt: string, sortOrder: number | null, url: string, type: ProductMediaType, oembedData: string }> | null } | null } | null };
+export type ProductMediaCreateMutation = { __typename: 'Mutation', productMediaCreate: { __typename: 'ProductMediaCreate', errors: Array<{ __typename: 'ProductError', code: ProductErrorCode, field: string | null, message: string | null }>, media: { __typename: 'ProductMedia', id: string } | null, product: { __typename: 'Product', id: string, media: Array<{ __typename: 'ProductMedia', id: string, alt: string, sortOrder: number | null, url: string, type: ProductMediaType, oembedData: string }> | null } | null } | null };
 
 export type ProductDeleteMutationVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -12999,6 +12999,13 @@ export type ProductMediaDeleteMutationVariables = Exact<{
 
 
 export type ProductMediaDeleteMutation = { __typename: 'Mutation', productMediaDelete: { __typename: 'ProductMediaDelete', errors: Array<{ __typename: 'ProductError', code: ProductErrorCode, field: string | null, message: string | null }>, product: { __typename: 'Product', id: string, media: Array<{ __typename: 'ProductMedia', id: string, alt: string, sortOrder: number | null, url: string, type: ProductMediaType, oembedData: string }> | null } | null } | null };
+
+export type ProductMediaBulkDeleteMutationVariables = Exact<{
+  ids: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
+}>;
+
+
+export type ProductMediaBulkDeleteMutation = { __typename: 'Mutation', productMediaBulkDelete: { __typename: 'ProductMediaBulkDelete', count: number, errors: Array<{ __typename: 'ProductError', code: ProductErrorCode, field: string | null, message: string | null }> } | null };
 
 export type ProductMediaUpdateMutationVariables = Exact<{
   id: Scalars['ID']['input'];

--- a/src/products/components/ProductMedia/ProductMedia.module.css
+++ b/src/products/components/ProductMedia/ProductMedia.module.css
@@ -22,6 +22,12 @@
   background-color: var(--mu-colors-background-default2);
 }
 
+.dropzoneDisabled {
+  cursor: default;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
 .dropzoneContent {
   padding: 16px;
   text-align: center;

--- a/src/products/components/ProductMedia/ProductMedia.module.css
+++ b/src/products/components/ProductMedia/ProductMedia.module.css
@@ -68,6 +68,37 @@
   pointer-events: none;
 }
 
+.sortableTile {
+  outline: none;
+}
+
+.sortableTile:focus,
+.sortableTile:focus-visible {
+  outline: none;
+}
+
+/* In-list ghost while DragOverlay holds the floating tile */
+.sortableTilePlaceholder {
+  opacity: 0.35;
+}
+
+.sortableTilePlaceholder > * {
+  pointer-events: none;
+}
+
+.dragOverlayTile {
+  cursor: grabbing;
+  border-radius: 8px;
+  background-color: var(--mu-colors-background-default1);
+  /* Barely-there multi-layer elevation */
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.03),
+    0 2px 4px rgba(0, 0, 0, 0.02),
+    0 8px 16px rgba(0, 0, 0, 0.03),
+    0 16px 32px rgba(0, 0, 0, 0.03);
+  transform: scale(1.02);
+}
+
 .hiddenInput {
   display: none;
 }

--- a/src/products/components/ProductMedia/ProductMedia.module.css
+++ b/src/products/components/ProductMedia/ProductMedia.module.css
@@ -1,4 +1,7 @@
 .dropzone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border-style: dashed;
   border-width: 1px;
   border-color: var(--mu-colors-border-default1);
@@ -20,10 +23,7 @@
 }
 
 .dropzoneContent {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 16px;
+  padding: 16px;
   text-align: center;
 }
 

--- a/src/products/components/ProductMedia/ProductMedia.test.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.test.tsx
@@ -1,4 +1,5 @@
-import { ProductMediaType } from "@dashboard/graphql";
+import { type FetchResult } from "@apollo/client";
+import { type ProductMediaCreateMutation, ProductMediaType } from "@dashboard/graphql";
 import Wrapper from "@test/wrapper";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -6,6 +7,22 @@ import { type ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import ProductMedia from "./ProductMedia";
+
+const uploadSuccessResult = (mediaId: string): FetchResult<ProductMediaCreateMutation> => ({
+  data: {
+    __typename: "Mutation",
+    productMediaCreate: {
+      __typename: "ProductMediaCreate",
+      media: { __typename: "ProductMedia", id: mediaId },
+      product: {
+        __typename: "Product",
+        id: "product-1",
+        media: [],
+      },
+      errors: [],
+    },
+  },
+});
 
 const TestWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
   <MemoryRouter>
@@ -20,7 +37,7 @@ const savedMedia = {
   sortOrder: 0,
   type: ProductMediaType.IMAGE,
   url: "https://example.com/existing.png",
-  oembedData: null,
+  oembedData: "{}",
 };
 
 describe("ProductMedia", () => {
@@ -41,9 +58,9 @@ describe("ProductMedia", () => {
 
   it("shows uploading tiles immediately when files are selected on an empty gallery", async () => {
     // Arrange
-    let resolveUpload: (value?: unknown) => void = () => undefined;
+    let resolveUpload: (value: FetchResult<ProductMediaCreateMutation>) => void = () => undefined;
     const onImageUpload = jest.fn(
-      () =>
+      (): Promise<FetchResult<ProductMediaCreateMutation>> =>
         new Promise(resolve => {
           resolveUpload = resolve;
         }),
@@ -81,15 +98,7 @@ describe("ProductMedia", () => {
 
     // Act — upload finishes with created media id, but saved media has not arrived yet
     await act(async () => {
-      resolveUpload({
-        data: {
-          productMediaCreate: {
-            media: { id: "media-uploaded" },
-            product: { id: "product-1", media: [] },
-            errors: [],
-          },
-        },
-      });
+      resolveUpload(uploadSuccessResult("media-uploaded"));
     });
 
     // Assert — keep the pending tile until media prop updates (no empty flash)
@@ -113,7 +122,7 @@ describe("ProductMedia", () => {
               sortOrder: 0,
               type: ProductMediaType.IMAGE,
               url: "https://example.com/uploaded.png",
-              oembedData: null,
+              oembedData: "{}",
             },
           ]}
           getImageEditUrl={(id): string => `/media/${id}`}
@@ -147,7 +156,9 @@ describe("ProductMedia", () => {
 
   it("appends uploading tiles next to existing media", async () => {
     // Arrange
-    const onImageUpload = jest.fn(() => new Promise(() => undefined));
+    const onImageUpload = jest.fn(
+      (): Promise<FetchResult<ProductMediaCreateMutation>> => new Promise(() => undefined),
+    );
 
     render(
       <TestWrapper>
@@ -189,7 +200,10 @@ describe("ProductMedia", () => {
           getImageEditUrl={(id): string => `/media/${id}`}
           onImageDelete={() => () => undefined}
           onImagesDelete={onImagesDelete}
-          onImageUpload={jest.fn()}
+          onImageUpload={jest.fn(
+            (): Promise<FetchResult<ProductMediaCreateMutation>> =>
+              Promise.resolve(uploadSuccessResult("unused")),
+          )}
           openMediaUrlModal={() => undefined}
         />
       </TestWrapper>,
@@ -209,7 +223,9 @@ describe("ProductMedia", () => {
 
   it("removes the pending tile when upload fails", async () => {
     // Arrange
-    const onImageUpload = jest.fn(() => Promise.reject(new Error("network")));
+    const onImageUpload = jest.fn(
+      (): Promise<FetchResult<ProductMediaCreateMutation>> => Promise.reject(new Error("network")),
+    );
     const onImagesUploadComplete = jest.fn();
 
     jest.spyOn(console, "error").mockImplementation(() => undefined);
@@ -248,17 +264,7 @@ describe("ProductMedia", () => {
 
   it("skips invalid files and uploads only valid images", async () => {
     // Arrange
-    const onImageUpload = jest.fn(() =>
-      Promise.resolve({
-        data: {
-          productMediaCreate: {
-            media: { id: "media-new" },
-            product: { id: "product-1", media: [] },
-            errors: [],
-          },
-        },
-      }),
-    );
+    const onImageUpload = jest.fn(() => Promise.resolve(uploadSuccessResult("media-new")));
 
     render(
       <TestWrapper>

--- a/src/products/components/ProductMedia/ProductMedia.test.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.test.tsx
@@ -1,6 +1,6 @@
 import { ProductMediaType } from "@dashboard/graphql";
 import Wrapper from "@test/wrapper";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
@@ -56,6 +56,7 @@ describe("ProductMedia", () => {
           media={[]}
           getImageEditUrl={(id): string => `/media/${id}`}
           onImageDelete={() => () => undefined}
+          onImagesDelete={() => undefined}
           onImageUpload={onImageUpload}
           onImagesUploadComplete={onImagesUploadComplete}
           openMediaUrlModal={() => undefined}
@@ -78,9 +79,17 @@ describe("ProductMedia", () => {
     expect(screen.queryByTestId("product-media-dropzone")).not.toBeInTheDocument();
     expect(onImageUpload).toHaveBeenCalledWith(file, 0);
 
-    // Act — upload finishes, but saved media has not arrived yet
+    // Act — upload finishes with created media id, but saved media has not arrived yet
     await act(async () => {
-      resolveUpload();
+      resolveUpload({
+        data: {
+          productMediaCreate: {
+            media: { id: "media-uploaded" },
+            product: { id: "product-1", media: [] },
+            errors: [],
+          },
+        },
+      });
     });
 
     // Assert — keep the pending tile until media prop updates (no empty flash)
@@ -109,6 +118,7 @@ describe("ProductMedia", () => {
           ]}
           getImageEditUrl={(id): string => `/media/${id}`}
           onImageDelete={() => () => undefined}
+          onImagesDelete={() => undefined}
           onImageUpload={onImageUpload}
           onImagesUploadComplete={onImagesUploadComplete}
           openMediaUrlModal={() => undefined}
@@ -145,6 +155,7 @@ describe("ProductMedia", () => {
           media={[savedMedia]}
           getImageEditUrl={(id): string => `/media/${id}`}
           onImageDelete={() => () => undefined}
+          onImagesDelete={() => undefined}
           onImageUpload={onImageUpload}
           openMediaUrlModal={() => undefined}
         />
@@ -162,6 +173,40 @@ describe("ProductMedia", () => {
     expect(screen.getByTestId("media-tile-loading")).toBeInTheDocument();
   });
 
+  it("calls onImagesDelete with selected media ids", async () => {
+    // Arrange
+    const onImagesDelete = jest.fn();
+    const secondMedia = {
+      ...savedMedia,
+      id: "media-2",
+      url: "https://example.com/second.png",
+    };
+
+    render(
+      <TestWrapper>
+        <ProductMedia
+          media={[savedMedia, secondMedia]}
+          getImageEditUrl={(id): string => `/media/${id}`}
+          onImageDelete={() => () => undefined}
+          onImagesDelete={onImagesDelete}
+          onImageUpload={jest.fn()}
+          openMediaUrlModal={() => undefined}
+        />
+      </TestWrapper>,
+    );
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const selectionControls = screen.getAllByTestId("product-media-select");
+
+    // Act — checkboxes are hover-only in the UI; jsdom does not apply :hover
+    await user.click(within(selectionControls[0]).getByRole("checkbox"));
+    await user.click(within(selectionControls[1]).getByRole("checkbox"));
+    await user.click(screen.getByTestId("product-media-delete-selected"));
+
+    // Assert
+    expect(onImagesDelete).toHaveBeenCalledWith(["media-1", "media-2"]);
+  });
+
   it("removes the pending tile when upload fails", async () => {
     // Arrange
     const onImageUpload = jest.fn(() => Promise.reject(new Error("network")));
@@ -175,6 +220,7 @@ describe("ProductMedia", () => {
           media={[]}
           getImageEditUrl={(id): string => `/media/${id}`}
           onImageDelete={() => () => undefined}
+          onImagesDelete={() => undefined}
           onImageUpload={onImageUpload}
           onImagesUploadComplete={onImagesUploadComplete}
           openMediaUrlModal={() => undefined}
@@ -198,5 +244,45 @@ describe("ProductMedia", () => {
       successCount: 0,
       failureCount: 1,
     });
+  });
+
+  it("skips invalid files and uploads only valid images", async () => {
+    // Arrange
+    const onImageUpload = jest.fn(() =>
+      Promise.resolve({
+        data: {
+          productMediaCreate: {
+            media: { id: "media-new" },
+            product: { id: "product-1", media: [] },
+            errors: [],
+          },
+        },
+      }),
+    );
+
+    render(
+      <TestWrapper>
+        <ProductMedia
+          media={[savedMedia]}
+          getImageEditUrl={(id): string => `/media/${id}`}
+          onImageDelete={() => () => undefined}
+          onImagesDelete={() => undefined}
+          onImageUpload={onImageUpload}
+          openMediaUrlModal={() => undefined}
+        />
+      </TestWrapper>,
+    );
+
+    const pdf = new File(["pdf-bytes"], "doc.pdf", { type: "application/pdf" });
+    const image = new File(["image-bytes"], "new.png", { type: "image/png" });
+    const input = screen.getByTestId("product-media-file-input");
+
+    // Act
+    await userEvent.upload(input, [pdf, image]);
+
+    // Assert
+    expect(onImageUpload).toHaveBeenCalledTimes(1);
+    expect(onImageUpload).toHaveBeenCalledWith(image, 0);
+    expect(screen.getByTestId("media-tile-loading")).toBeInTheDocument();
   });
 });

--- a/src/products/components/ProductMedia/ProductMedia.test.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.test.tsx
@@ -48,6 +48,7 @@ describe("ProductMedia", () => {
           resolveUpload = resolve;
         }),
     );
+    const onImagesUploadComplete = jest.fn();
 
     const { rerender } = render(
       <TestWrapper>
@@ -56,6 +57,7 @@ describe("ProductMedia", () => {
           getImageEditUrl={(id): string => `/media/${id}`}
           onImageDelete={() => () => undefined}
           onImageUpload={onImageUpload}
+          onImagesUploadComplete={onImagesUploadComplete}
           openMediaUrlModal={() => undefined}
         />
       </TestWrapper>,
@@ -83,6 +85,12 @@ describe("ProductMedia", () => {
 
     // Assert — keep the pending tile until media prop updates (no empty flash)
     expect(screen.getByTestId("media-tile-loading")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(onImagesUploadComplete).toHaveBeenCalledWith({
+        successCount: 1,
+        failureCount: 0,
+      });
+    });
 
     // Act — Apollo cache delivers the saved media
     rerender(
@@ -102,6 +110,7 @@ describe("ProductMedia", () => {
           getImageEditUrl={(id): string => `/media/${id}`}
           onImageDelete={() => () => undefined}
           onImageUpload={onImageUpload}
+          onImagesUploadComplete={onImagesUploadComplete}
           openMediaUrlModal={() => undefined}
         />
       </TestWrapper>,
@@ -156,6 +165,7 @@ describe("ProductMedia", () => {
   it("removes the pending tile when upload fails", async () => {
     // Arrange
     const onImageUpload = jest.fn(() => Promise.reject(new Error("network")));
+    const onImagesUploadComplete = jest.fn();
 
     jest.spyOn(console, "error").mockImplementation(() => undefined);
 
@@ -166,6 +176,7 @@ describe("ProductMedia", () => {
           getImageEditUrl={(id): string => `/media/${id}`}
           onImageDelete={() => () => undefined}
           onImageUpload={onImageUpload}
+          onImagesUploadComplete={onImagesUploadComplete}
           openMediaUrlModal={() => undefined}
         />
       </TestWrapper>,
@@ -183,5 +194,9 @@ describe("ProductMedia", () => {
     });
     expect(screen.getByTestId("product-media-dropzone")).toBeInTheDocument();
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:pending-preview");
+    expect(onImagesUploadComplete).toHaveBeenCalledWith({
+      successCount: 0,
+      failureCount: 1,
+    });
   });
 });

--- a/src/products/components/ProductMedia/ProductMedia.test.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.test.tsx
@@ -1,0 +1,187 @@
+import { ProductMediaType } from "@dashboard/graphql";
+import Wrapper from "@test/wrapper";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+import ProductMedia from "./ProductMedia";
+
+const TestWrapper = ({ children }: { children: ReactNode }): JSX.Element => (
+  <MemoryRouter>
+    <Wrapper>{children}</Wrapper>
+  </MemoryRouter>
+);
+
+const savedMedia = {
+  __typename: "ProductMedia" as const,
+  id: "media-1",
+  alt: "Existing",
+  sortOrder: 0,
+  type: ProductMediaType.IMAGE,
+  url: "https://example.com/existing.png",
+  oembedData: null,
+};
+
+describe("ProductMedia", () => {
+  const createObjectURL = jest.fn(() => "blob:pending-preview");
+  const revokeObjectURL = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(URL, "createObjectURL", {
+      writable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      writable: true,
+      value: revokeObjectURL,
+    });
+  });
+
+  it("shows uploading tiles immediately when files are selected on an empty gallery", async () => {
+    // Arrange
+    let resolveUpload: (value?: unknown) => void = () => undefined;
+    const onImageUpload = jest.fn(
+      () =>
+        new Promise(resolve => {
+          resolveUpload = resolve;
+        }),
+    );
+
+    const { rerender } = render(
+      <TestWrapper>
+        <ProductMedia
+          media={[]}
+          getImageEditUrl={(id): string => `/media/${id}`}
+          onImageDelete={() => () => undefined}
+          onImageUpload={onImageUpload}
+          openMediaUrlModal={() => undefined}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByTestId("product-media-dropzone")).toBeInTheDocument();
+
+    const file = new File(["image-bytes"], "shoe.png", { type: "image/png" });
+    const input = screen.getByTestId("product-media-file-input");
+
+    // Act
+    await userEvent.upload(input, file);
+
+    // Assert — pending tile appears before the upload promise resolves
+    expect(createObjectURL).toHaveBeenCalledWith(file);
+    expect(screen.getByTestId("product-media-gallery")).toBeInTheDocument();
+    expect(screen.getByTestId("media-tile-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("product-media-dropzone")).not.toBeInTheDocument();
+    expect(onImageUpload).toHaveBeenCalledWith(file, 0);
+
+    // Act — upload finishes, but saved media has not arrived yet
+    await act(async () => {
+      resolveUpload();
+    });
+
+    // Assert — keep the pending tile until media prop updates (no empty flash)
+    expect(screen.getByTestId("media-tile-loading")).toBeInTheDocument();
+
+    // Act — Apollo cache delivers the saved media
+    rerender(
+      <TestWrapper>
+        <ProductMedia
+          media={[
+            {
+              __typename: "ProductMedia",
+              id: "media-uploaded",
+              alt: "",
+              sortOrder: 0,
+              type: ProductMediaType.IMAGE,
+              url: "https://example.com/uploaded.png",
+              oembedData: null,
+            },
+          ]}
+          getImageEditUrl={(id): string => `/media/${id}`}
+          onImageDelete={() => () => undefined}
+          onImageUpload={onImageUpload}
+          openMediaUrlModal={() => undefined}
+        />
+      </TestWrapper>,
+    );
+
+    // Assert — pending uploading tile is gone; local blob is kept as placeholder
+    expect(screen.queryByTestId("media-tile-loading")).not.toBeInTheDocument();
+    expect(screen.getByTestId("product-image")).toBeInTheDocument();
+    expect(screen.getByTestId("media-placeholder")).toHaveAttribute("src", "blob:pending-preview");
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+
+    // Act — remote image finishes loading
+    const remoteImage = document.querySelector(
+      'img[src="https://example.com/uploaded.png"]',
+    ) as HTMLImageElement;
+
+    fireEvent.load(remoteImage);
+
+    await waitFor(() => {
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:pending-preview");
+    });
+    expect(screen.queryByTestId("media-placeholder")).not.toBeInTheDocument();
+  });
+
+  it("appends uploading tiles next to existing media", async () => {
+    // Arrange
+    const onImageUpload = jest.fn(() => new Promise(() => undefined));
+
+    render(
+      <TestWrapper>
+        <ProductMedia
+          media={[savedMedia]}
+          getImageEditUrl={(id): string => `/media/${id}`}
+          onImageDelete={() => () => undefined}
+          onImageUpload={onImageUpload}
+          openMediaUrlModal={() => undefined}
+        />
+      </TestWrapper>,
+    );
+
+    const file = new File(["image-bytes"], "new.png", { type: "image/png" });
+    const input = screen.getByTestId("product-media-file-input");
+
+    // Act
+    await userEvent.upload(input, file);
+
+    // Assert
+    expect(screen.getAllByTestId("product-image")).toHaveLength(2);
+    expect(screen.getByTestId("media-tile-loading")).toBeInTheDocument();
+  });
+
+  it("removes the pending tile when upload fails", async () => {
+    // Arrange
+    const onImageUpload = jest.fn(() => Promise.reject(new Error("network")));
+
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+    render(
+      <TestWrapper>
+        <ProductMedia
+          media={[]}
+          getImageEditUrl={(id): string => `/media/${id}`}
+          onImageDelete={() => () => undefined}
+          onImageUpload={onImageUpload}
+          openMediaUrlModal={() => undefined}
+        />
+      </TestWrapper>,
+    );
+
+    const file = new File(["image-bytes"], "shoe.png", { type: "image/png" });
+    const input = screen.getByTestId("product-media-file-input");
+
+    // Act
+    await userEvent.upload(input, file);
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.queryByTestId("media-tile-loading")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("product-media-dropzone")).toBeInTheDocument();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:pending-preview");
+  });
+});

--- a/src/products/components/ProductMedia/ProductMedia.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.tsx
@@ -1,72 +1,98 @@
 // @ts-strict-ignore
+import { type FetchResult } from "@apollo/client";
 import { DashboardCard } from "@dashboard/components/Card";
+import { Draggable } from "@dashboard/components/Draggable/Draggable";
 import MediaTile from "@dashboard/components/MediaTile";
-import { type ProductMediaFragment, ProductMediaType } from "@dashboard/graphql";
+import {
+  type ProductMediaCreateMutation,
+  type ProductMediaFragment,
+  ProductMediaType,
+} from "@dashboard/graphql";
+import { useNotifier } from "@dashboard/hooks/useNotifier";
 import { type ReorderAction } from "@dashboard/types";
 import createMultiFileUploadHandler from "@dashboard/utils/handlers/multiFileUploadHandler";
+import { closestCenter, DndContext, DragOverlay } from "@dnd-kit/core";
+import { SortableContext } from "@dnd-kit/sortable";
 import { Box, Button, Dropdown, List, Skeleton, Text } from "@saleor/macaw-ui-next";
 import clsx from "clsx";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import { FormattedMessage, useIntl } from "react-intl";
-import { SortableContainer, SortableElement } from "react-sortable-hoc";
 
 import { messages } from "./messages";
 import styles from "./ProductMedia.module.css";
 import { ProductMediaGalleryDropzone } from "./ProductMediaGalleryDropzone";
+import { useProductMediaDrag } from "./useProductMediaDrag";
+import {
+  PRODUCT_MEDIA_MAX_FILE_SIZE_BYTES,
+  validateProductMediaFiles,
+} from "./validateProductMediaFiles";
 
-interface SortableMediaProps {
-  media: {
-    id: string;
-    alt?: string;
-    url: string;
-  };
-  editHref: string;
-  onDelete: () => void;
-  placeholderSrc?: string | null;
-  onPlaceholderUnused?: () => void;
+const UPLOAD_CONCURRENCY = 3;
+
+/**
+ * Flex-wrap galleries cannot use rectSortingStrategy — transforms fight the reflow
+ * and animate items in from the left on drop. Same approach as SortableChipsField.
+ * @see https://github.com/clauderic/dnd-kit/issues/44#issuecomment-757312037
+ */
+function disableSortingStrategy() {
+  return null;
 }
 
-const SortableMedia = SortableElement<SortableMediaProps>(
-  ({ media, editHref, onDelete, placeholderSrc, onPlaceholderUnused }) => (
-    <MediaTile
-      media={media}
-      editHref={editHref}
-      onDelete={onDelete}
-      placeholderSrc={placeholderSrc}
-      onPlaceholderUnused={onPlaceholderUnused}
-    />
-  ),
-);
-
-interface MediaListContainerProps {
+interface MediaListProps {
   className: string;
   media: ProductMediaFragment[];
   preview: ProductMediaFragment[];
   placeholders: Record<string, string>;
+  selectedIds: Set<string>;
+  disabled?: boolean;
   onDelete: (id: string) => () => void;
+  onSelectionChange: (id: string, selected: boolean) => void;
   getEditHref: (id: string) => string;
   onPlaceholderUnused: (id: string) => void;
 }
 
-const MediaListContainer = SortableContainer<MediaListContainerProps>(
-  ({ media, preview, placeholders, onDelete, getEditHref, onPlaceholderUnused, ...props }) => (
-    <div {...props}>
-      {media.map((mediaObj, index) => (
-        <SortableMedia
-          key={mediaObj.id}
-          index={index}
-          media={mediaObj}
-          editHref={getEditHref(mediaObj.id)}
-          onDelete={onDelete(mediaObj.id)}
-          placeholderSrc={placeholders[mediaObj.id]}
-          onPlaceholderUnused={() => onPlaceholderUnused(mediaObj.id)}
-        />
-      ))}
-      {preview.map(mediaObj => (
-        <MediaTile loading={true} media={mediaObj} key={mediaObj.id} />
-      ))}
-    </div>
-  ),
+const MediaList = ({
+  className,
+  media,
+  preview,
+  placeholders,
+  selectedIds,
+  disabled = false,
+  onDelete,
+  onSelectionChange,
+  getEditHref,
+  onPlaceholderUnused,
+}: MediaListProps) => (
+  <div className={className}>
+    {media.map(mediaObj => (
+      <Draggable key={mediaObj.id} id={mediaObj.id} disabled={disabled}>
+        {({ ref, style, isDragging, ...draggableProps }) => (
+          <div
+            ref={ref}
+            // Park the ghost in the list slot; DragOverlay follows the pointer above siblings
+            style={isDragging ? { ...style, transform: undefined, transition: undefined } : style}
+            className={clsx(styles.sortableTile, isDragging && styles.sortableTilePlaceholder)}
+            {...draggableProps}
+          >
+            <MediaTile
+              media={mediaObj}
+              editHref={getEditHref(mediaObj.id)}
+              onDelete={onDelete(mediaObj.id)}
+              selected={selectedIds.has(mediaObj.id)}
+              onSelectionChange={selected => onSelectionChange(mediaObj.id, selected)}
+              placeholderSrc={placeholders[mediaObj.id]}
+              onPlaceholderUnused={() => onPlaceholderUnused(mediaObj.id)}
+              disableOverlay={isDragging}
+            />
+          </div>
+        )}
+      </Draggable>
+    ))}
+    {preview.map(mediaObj => (
+      <MediaTile loading={true} media={mediaObj} key={mediaObj.id} />
+    ))}
+  </div>
 );
 
 interface ProductMediaProps {
@@ -74,8 +100,9 @@ interface ProductMediaProps {
   loading?: boolean;
   getImageEditUrl: (id: string) => string;
   onImageDelete: (id: string) => () => void;
+  onImagesDelete: (ids: string[]) => void;
   onImageReorder?: ReorderAction;
-  onImageUpload: (file: File) => any;
+  onImageUpload: (file: File) => Promise<FetchResult<ProductMediaCreateMutation>>;
   onImagesUploadComplete?: (result: { successCount: number; failureCount: number }) => void;
   openMediaUrlModal: () => any;
 }
@@ -111,29 +138,47 @@ const revokeObjectUrl = (url: string) => {
 const getMediaIdsSignature = (media: ProductMediaFragment[] | undefined) =>
   media === undefined ? null : media.map(item => item.id).join("\0");
 
-/** @deprecated This component should use @dnd-kit instead of react-sortable-hoc */
 const ProductMedia = (props: ProductMediaProps) => {
   const {
     media,
     getImageEditUrl,
     onImageDelete,
+    onImagesDelete,
     onImageReorder,
     onImageUpload,
     onImagesUploadComplete,
     openMediaUrlModal,
   } = props;
   const intl = useIntl();
+  const notify = useNotifier();
   const imagesUpload = React.useRef<HTMLInputElement>(null);
   const anchor = React.useRef<HTMLButtonElement>();
   const [pendingMedia, setPendingMedia] = React.useState<ProductMediaFragment[]>([]);
   const [placeholders, setPlaceholders] = React.useState<Record<string, string>>({});
-  const [isUploadBatchInFlight, setIsUploadBatchInFlight] = React.useState(false);
+  /** Maps pending client ids to server media ids once each upload mutation returns. */
+  const [pendingHandoffs, setPendingHandoffs] = React.useState<Record<string, string>>({});
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(() => new Set());
   const pendingMediaRef = React.useRef(pendingMedia);
   const placeholdersRef = React.useRef(placeholders);
-  const previousMediaIdsRef = React.useRef<string[] | null>(null);
   const [mediaIdsSignature, setMediaIdsSignature] = React.useState(() =>
     getMediaIdsSignature(media),
   );
+
+  const isUploading = pendingMedia.length > 0;
+  const {
+    orderedMedia,
+    activeMedia,
+    items,
+    sensors,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    handleDragCancel,
+  } = useProductMediaDrag({
+    media: media ?? [],
+    onReorder: onImageReorder,
+    disabled: isUploading,
+  });
 
   React.useEffect(
     function syncObjectUrlRefs() {
@@ -143,34 +188,82 @@ const ProductMedia = (props: ProductMediaProps) => {
     [pendingMedia, placeholders],
   );
 
-  // Adjust pending/placeholder state during render when saved media arrives,
-  // so React re-renders before paint and never shows pending + saved tiles together.
+  // Adjust pending/placeholder/selection when saved media arrives or handoffs resolve.
   // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
   const nextMediaIdsSignature = getMediaIdsSignature(media);
+  const currentIds = media?.map(item => item.id) ?? [];
+  const mediaIdsChanged =
+    nextMediaIdsSignature !== null && media && nextMediaIdsSignature !== mediaIdsSignature;
 
-  if (nextMediaIdsSignature !== null && media && nextMediaIdsSignature !== mediaIdsSignature) {
-    const currentIds = media.map(item => item.id);
-    const previousIds = previousMediaIdsRef.current;
-    const addedIds = previousIds === null ? [] : currentIds.filter(id => !previousIds.includes(id));
-
-    previousMediaIdsRef.current = currentIds;
+  if (mediaIdsChanged) {
     setMediaIdsSignature(nextMediaIdsSignature);
 
-    if (addedIds.length > 0 && pendingMedia.length > 0) {
-      const removeCount = Math.min(addedIds.length, pendingMedia.length);
-      const handedOff = pendingMedia.slice(0, removeCount);
-      const nextPlaceholders = { ...placeholders };
+    setSelectedIds(prev => {
+      const next = new Set([...prev].filter(id => currentIds.includes(id)));
 
+      return next.size === prev.size ? prev : next;
+    });
+  }
+
+  let nextPendingMedia = pendingMedia;
+  let nextPlaceholders = placeholders;
+  let nextPendingHandoffs = pendingHandoffs;
+  let pendingStateChanged = false;
+
+  // ID-based handoff (parallel-safe): pending client id → server id from mutation result
+  const readyHandoffs = nextPendingMedia
+    .map(item => ({
+      pending: item,
+      serverId: nextPendingHandoffs[item.id],
+    }))
+    .filter(
+      (entry): entry is { pending: ProductMediaFragment; serverId: string } =>
+        Boolean(entry.serverId) && currentIds.includes(entry.serverId),
+    );
+
+  if (readyHandoffs.length > 0) {
+    const handedOffClientIds = new Set<string>();
+
+    nextPlaceholders = { ...nextPlaceholders };
+    readyHandoffs.forEach(({ pending, serverId }) => {
+      nextPlaceholders[serverId] = pending.url;
+      handedOffClientIds.add(pending.id);
+    });
+    nextPendingMedia = nextPendingMedia.filter(item => !handedOffClientIds.has(item.id));
+    nextPendingHandoffs = { ...nextPendingHandoffs };
+    handedOffClientIds.forEach(clientId => {
+      delete nextPendingHandoffs[clientId];
+    });
+    pendingStateChanged = true;
+  }
+
+  // FIFO fallback for uploads that did not return productMediaCreate.media.id
+  if (mediaIdsChanged) {
+    const previousSignatureIds =
+      mediaIdsSignature === null || mediaIdsSignature === ""
+        ? []
+        : mediaIdsSignature.split("\0").filter(Boolean);
+    const addedIds = currentIds.filter(id => !previousSignatureIds.includes(id));
+    const unmappedPending = nextPendingMedia.filter(item => !nextPendingHandoffs[item.id]);
+
+    if (addedIds.length > 0 && unmappedPending.length > 0) {
+      const removeCount = Math.min(addedIds.length, unmappedPending.length);
+      const handedOff = unmappedPending.slice(0, removeCount);
+      const handedOffClientIds = new Set(handedOff.map(item => item.id));
+
+      nextPlaceholders = { ...nextPlaceholders };
       handedOff.forEach((item, index) => {
         nextPlaceholders[addedIds[index]] = item.url;
       });
-
-      setPlaceholders(nextPlaceholders);
-      setPendingMedia(pendingMedia.slice(removeCount));
+      nextPendingMedia = nextPendingMedia.filter(item => !handedOffClientIds.has(item.id));
+      pendingStateChanged = true;
     }
-  } else if (nextMediaIdsSignature !== null && media && previousMediaIdsRef.current === null) {
-    previousMediaIdsRef.current = media.map(item => item.id);
-    setMediaIdsSignature(nextMediaIdsSignature);
+  }
+
+  if (pendingStateChanged) {
+    setPlaceholders(nextPlaceholders);
+    setPendingMedia(nextPendingMedia);
+    setPendingHandoffs(nextPendingHandoffs);
   }
 
   React.useEffect(function revokeObjectUrlsOnUnmount() {
@@ -190,6 +283,15 @@ const ProductMedia = (props: ProductMediaProps) => {
 
       return prev.filter(mediaItem => mediaItem.id !== clientId);
     });
+    setPendingHandoffs(prev => {
+      if (!(clientId in prev)) {
+        return prev;
+      }
+
+      const { [clientId]: _, ...rest } = prev;
+
+      return rest;
+    });
   }, []);
 
   const handlePlaceholderUnused = React.useCallback((mediaId: string) => {
@@ -208,25 +310,74 @@ const ProductMedia = (props: ProductMediaProps) => {
     });
   }, []);
 
+  const handleSelectionChange = React.useCallback((id: string, selected: boolean) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+
+      if (selected) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+
+      return next;
+    });
+  }, []);
+
+  const handleSelectAll = React.useCallback(() => {
+    setSelectedIds(new Set((media ?? []).map(item => item.id)));
+  }, [media]);
+
+  const handleClearSelection = React.useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const handleDeleteSelected = React.useCallback(() => {
+    if (selectedIds.size === 0) {
+      return;
+    }
+
+    onImagesDelete([...selectedIds]);
+  }, [onImagesDelete, selectedIds]);
+
   const handleImageUpload = React.useCallback(
     (files: FileList | File[]) => {
-      const fileArray = Array.from(files);
+      const { validFiles, rejected } = validateProductMediaFiles(files);
 
-      if (fileArray.length === 0 || isUploadBatchInFlight) {
+      if (rejected.length > 0) {
+        notify({
+          status: "warning",
+          text: intl.formatMessage(messages.uploadRejected, {
+            count: rejected.length,
+            maxSize: Math.round(PRODUCT_MEDIA_MAX_FILE_SIZE_BYTES / (1024 * 1024)),
+          }),
+        });
+      }
+
+      if (validFiles.length === 0) {
         return;
       }
 
-      const pendingItems = fileArray.map((file, fileIndex) => createPendingMedia(file, fileIndex));
+      const pendingItems = validFiles.map((file, fileIndex) => createPendingMedia(file, fileIndex));
       const clientIds = pendingItems.map(item => item.id);
       let successCount = 0;
       let failureCount = 0;
 
-      setIsUploadBatchInFlight(true);
       setPendingMedia(prev => [...prev, ...pendingItems]);
 
       return createMultiFileUploadHandler(onImageUpload, {
-        onAfterUpload: () => {
+        concurrency: UPLOAD_CONCURRENCY,
+        onAfterUpload: (index, _files, result) => {
           successCount += 1;
+
+          const serverId = result.data?.productMediaCreate?.media?.id;
+
+          if (serverId) {
+            setPendingHandoffs(prev => ({
+              ...prev,
+              [clientIds[index]]: serverId,
+            }));
+          }
         },
         onError: index => {
           failureCount += 1;
@@ -235,14 +386,14 @@ const ProductMedia = (props: ProductMediaProps) => {
         onCompleted: () => {
           onImagesUploadComplete?.({ successCount, failureCount });
         },
-      })(fileArray).finally(() => {
-        setIsUploadBatchInFlight(false);
-      });
+      })(validFiles);
     },
-    [isUploadBatchInFlight, onImageUpload, onImagesUploadComplete, removePendingMedia],
+    [intl, notify, onImageUpload, onImagesUploadComplete, removePendingMedia],
   );
 
-  const isUploading = isUploadBatchInFlight || pendingMedia.length > 0;
+  const selectedCount = selectedIds.size;
+  const hasSelection = selectedCount > 0;
+  const allSelected = (media?.length ?? 0) > 0 && selectedCount === media.length;
   const showGallery = (media?.length ?? 0) > 0 || pendingMedia.length > 0;
 
   return (
@@ -252,50 +403,72 @@ const ProductMedia = (props: ProductMediaProps) => {
           <FormattedMessage {...messages.media} />
         </DashboardCard.Title>
         <DashboardCard.Toolbar>
-          <Dropdown>
-            <Dropdown.Trigger>
-              <Button
-                variant="secondary"
-                type="button"
-                data-test-id="button-upload-image"
-                ref={anchor}
-                disabled={isUploading}
-              >
-                {intl.formatMessage(messages.upload)}
-              </Button>
-            </Dropdown.Trigger>
-            <Dropdown.Content align="end">
-              <List
-                padding={2}
-                borderRadius={4}
-                boxShadow="defaultOverlay"
-                backgroundColor="default1"
-              >
-                <Dropdown.Item>
-                  <List.Item
-                    borderRadius={4}
-                    paddingX={1.5}
-                    paddingY={2}
-                    onClick={() => imagesUpload.current.click()}
-                    data-test-id="upload-images"
-                  >
-                    <Text>{intl.formatMessage(messages.uploadImages)}</Text>
-                  </List.Item>
-                </Dropdown.Item>
-                <Dropdown.Item>
-                  <List.Item
-                    borderRadius={4}
-                    paddingX={1.5}
-                    paddingY={2}
-                    onClick={openMediaUrlModal}
-                    data-test-id="upload-media-url"
-                  >
-                    <Text>{intl.formatMessage(messages.uploadUrl)}</Text>
-                  </List.Item>
-                </Dropdown.Item>
-              </List>
-            </Dropdown.Content>
-          </Dropdown>
+          <Box display="flex" gap={2} alignItems="center">
+            {hasSelection ? (
+              <>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  onClick={allSelected ? handleClearSelection : handleSelectAll}
+                  data-test-id="product-media-select-all"
+                >
+                  {intl.formatMessage(allSelected ? messages.clearSelection : messages.selectAll)}
+                </Button>
+                <Button
+                  variant="error"
+                  type="button"
+                  onClick={handleDeleteSelected}
+                  disabled={isUploading}
+                  data-test-id="product-media-delete-selected"
+                >
+                  {intl.formatMessage(messages.deleteSelected, { quantity: selectedCount })}
+                </Button>
+              </>
+            ) : null}
+            <Dropdown>
+              <Dropdown.Trigger>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  data-test-id="button-upload-image"
+                  ref={anchor}
+                >
+                  {intl.formatMessage(messages.upload)}
+                </Button>
+              </Dropdown.Trigger>
+              <Dropdown.Content align="end">
+                <List
+                  padding={2}
+                  borderRadius={4}
+                  boxShadow="defaultOverlay"
+                  backgroundColor="default1"
+                >
+                  <Dropdown.Item>
+                    <List.Item
+                      borderRadius={4}
+                      paddingX={1.5}
+                      paddingY={2}
+                      onClick={() => imagesUpload.current.click()}
+                      data-test-id="upload-images"
+                    >
+                      <Text>{intl.formatMessage(messages.uploadImages)}</Text>
+                    </List.Item>
+                  </Dropdown.Item>
+                  <Dropdown.Item>
+                    <List.Item
+                      borderRadius={4}
+                      paddingX={1.5}
+                      paddingY={2}
+                      onClick={openMediaUrlModal}
+                      data-test-id="upload-media-url"
+                    >
+                      <Text>{intl.formatMessage(messages.uploadUrl)}</Text>
+                    </List.Item>
+                  </Dropdown.Item>
+                </List>
+              </Dropdown.Content>
+            </Dropdown>
+          </Box>
         </DashboardCard.Toolbar>
       </DashboardCard.Header>
       <DashboardCard.Content>
@@ -315,7 +488,6 @@ const ProductMedia = (props: ProductMediaProps) => {
           type="file"
           ref={imagesUpload}
           accept="image/*"
-          disabled={isUploading}
         />
         <Box position="relative">
           {media === undefined ? (
@@ -326,32 +498,46 @@ const ProductMedia = (props: ProductMediaProps) => {
             <ProductMediaGalleryDropzone
               variant="gallery"
               disableClick={true}
-              disabled={isUploading}
               onImageUpload={handleImageUpload}
             >
               {({ isDragActive }) => (
-                <MediaListContainer
-                  distance={20}
-                  helperClass="dragged"
-                  axis="xy"
-                  shouldCancelStart={isUploading ? () => true : undefined}
-                  media={media ?? []}
-                  preview={pendingMedia}
-                  placeholders={placeholders}
-                  onSortEnd={onImageReorder}
-                  className={clsx(styles.mediaList, isDragActive && styles.mediaListDimmed)}
-                  onDelete={onImageDelete}
-                  getEditHref={getImageEditUrl}
-                  onPlaceholderUnused={handlePlaceholderUnused}
-                />
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragStart={handleDragStart}
+                  onDragOver={handleDragOver}
+                  onDragEnd={handleDragEnd}
+                  onDragCancel={handleDragCancel}
+                >
+                  <SortableContext items={items} strategy={disableSortingStrategy}>
+                    <MediaList
+                      media={orderedMedia}
+                      preview={pendingMedia}
+                      placeholders={placeholders}
+                      selectedIds={selectedIds}
+                      disabled={isUploading}
+                      className={clsx(styles.mediaList, isDragActive && styles.mediaListDimmed)}
+                      onDelete={onImageDelete}
+                      onSelectionChange={handleSelectionChange}
+                      getEditHref={getImageEditUrl}
+                      onPlaceholderUnused={handlePlaceholderUnused}
+                    />
+                  </SortableContext>
+                  {createPortal(
+                    <DragOverlay dropAnimation={null} style={{ zIndex: 1000 }}>
+                      {activeMedia ? (
+                        <div className={styles.dragOverlayTile}>
+                          <MediaTile media={activeMedia} disableOverlay />
+                        </div>
+                      ) : null}
+                    </DragOverlay>,
+                    document.body,
+                  )}
+                </DndContext>
               )}
             </ProductMediaGalleryDropzone>
           ) : (
-            <ProductMediaGalleryDropzone
-              variant="empty"
-              disabled={isUploading}
-              onImageUpload={handleImageUpload}
-            />
+            <ProductMediaGalleryDropzone variant="empty" onImageUpload={handleImageUpload} />
           )}
         </Box>
       </DashboardCard.Content>

--- a/src/products/components/ProductMedia/ProductMedia.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.tsx
@@ -76,6 +76,7 @@ interface ProductMediaProps {
   onImageDelete: (id: string) => () => void;
   onImageReorder?: ReorderAction;
   onImageUpload: (file: File) => any;
+  onImagesUploadComplete?: (result: { successCount: number; failureCount: number }) => void;
   openMediaUrlModal: () => any;
 }
 
@@ -118,6 +119,7 @@ const ProductMedia = (props: ProductMediaProps) => {
     onImageDelete,
     onImageReorder,
     onImageUpload,
+    onImagesUploadComplete,
     openMediaUrlModal,
   } = props;
   const intl = useIntl();
@@ -125,6 +127,7 @@ const ProductMedia = (props: ProductMediaProps) => {
   const anchor = React.useRef<HTMLButtonElement>();
   const [pendingMedia, setPendingMedia] = React.useState<ProductMediaFragment[]>([]);
   const [placeholders, setPlaceholders] = React.useState<Record<string, string>>({});
+  const [isUploadBatchInFlight, setIsUploadBatchInFlight] = React.useState(false);
   const pendingMediaRef = React.useRef(pendingMedia);
   const placeholdersRef = React.useRef(placeholders);
   const previousMediaIdsRef = React.useRef<string[] | null>(null);
@@ -209,22 +212,37 @@ const ProductMedia = (props: ProductMediaProps) => {
     (files: FileList | File[]) => {
       const fileArray = Array.from(files);
 
-      if (fileArray.length === 0) {
+      if (fileArray.length === 0 || isUploadBatchInFlight) {
         return;
       }
 
       const pendingItems = fileArray.map((file, fileIndex) => createPendingMedia(file, fileIndex));
       const clientIds = pendingItems.map(item => item.id);
+      let successCount = 0;
+      let failureCount = 0;
 
+      setIsUploadBatchInFlight(true);
       setPendingMedia(prev => [...prev, ...pendingItems]);
 
       return createMultiFileUploadHandler(onImageUpload, {
-        onError: index => removePendingMedia(clientIds[index]),
-      })(fileArray);
+        onAfterUpload: () => {
+          successCount += 1;
+        },
+        onError: index => {
+          failureCount += 1;
+          removePendingMedia(clientIds[index]);
+        },
+        onCompleted: () => {
+          onImagesUploadComplete?.({ successCount, failureCount });
+        },
+      })(fileArray).finally(() => {
+        setIsUploadBatchInFlight(false);
+      });
     },
-    [onImageUpload, removePendingMedia],
+    [isUploadBatchInFlight, onImageUpload, onImagesUploadComplete, removePendingMedia],
   );
 
+  const isUploading = isUploadBatchInFlight || pendingMedia.length > 0;
   const showGallery = (media?.length ?? 0) > 0 || pendingMedia.length > 0;
 
   return (
@@ -241,6 +259,7 @@ const ProductMedia = (props: ProductMediaProps) => {
                 type="button"
                 data-test-id="button-upload-image"
                 ref={anchor}
+                disabled={isUploading}
               >
                 {intl.formatMessage(messages.upload)}
               </Button>
@@ -296,6 +315,7 @@ const ProductMedia = (props: ProductMediaProps) => {
           type="file"
           ref={imagesUpload}
           accept="image/*"
+          disabled={isUploading}
         />
         <Box position="relative">
           {media === undefined ? (
@@ -306,6 +326,7 @@ const ProductMedia = (props: ProductMediaProps) => {
             <ProductMediaGalleryDropzone
               variant="gallery"
               disableClick={true}
+              disabled={isUploading}
               onImageUpload={handleImageUpload}
             >
               {({ isDragActive }) => (
@@ -313,6 +334,7 @@ const ProductMedia = (props: ProductMediaProps) => {
                   distance={20}
                   helperClass="dragged"
                   axis="xy"
+                  shouldCancelStart={isUploading ? () => true : undefined}
                   media={media ?? []}
                   preview={pendingMedia}
                   placeholders={placeholders}
@@ -325,7 +347,11 @@ const ProductMedia = (props: ProductMediaProps) => {
               )}
             </ProductMediaGalleryDropzone>
           ) : (
-            <ProductMediaGalleryDropzone variant="empty" onImageUpload={handleImageUpload} />
+            <ProductMediaGalleryDropzone
+              variant="empty"
+              disabled={isUploading}
+              onImageUpload={handleImageUpload}
+            />
           )}
         </Box>
       </DashboardCard.Content>

--- a/src/products/components/ProductMedia/ProductMedia.tsx
+++ b/src/products/components/ProductMedia/ProductMedia.tsx
@@ -22,22 +22,34 @@ interface SortableMediaProps {
   };
   editHref: string;
   onDelete: () => void;
+  placeholderSrc?: string | null;
+  onPlaceholderUnused?: () => void;
 }
 
-const SortableMedia = SortableElement<SortableMediaProps>(({ media, editHref, onDelete }) => (
-  <MediaTile media={media} editHref={editHref} onDelete={onDelete} />
-));
+const SortableMedia = SortableElement<SortableMediaProps>(
+  ({ media, editHref, onDelete, placeholderSrc, onPlaceholderUnused }) => (
+    <MediaTile
+      media={media}
+      editHref={editHref}
+      onDelete={onDelete}
+      placeholderSrc={placeholderSrc}
+      onPlaceholderUnused={onPlaceholderUnused}
+    />
+  ),
+);
 
 interface MediaListContainerProps {
   className: string;
   media: ProductMediaFragment[];
   preview: ProductMediaFragment[];
+  placeholders: Record<string, string>;
   onDelete: (id: string) => () => void;
   getEditHref: (id: string) => string;
+  onPlaceholderUnused: (id: string) => void;
 }
 
 const MediaListContainer = SortableContainer<MediaListContainerProps>(
-  ({ media, preview, onDelete, getEditHref, ...props }) => (
+  ({ media, preview, placeholders, onDelete, getEditHref, onPlaceholderUnused, ...props }) => (
     <div {...props}>
       {media.map((mediaObj, index) => (
         <SortableMedia
@@ -46,13 +58,13 @@ const MediaListContainer = SortableContainer<MediaListContainerProps>(
           media={mediaObj}
           editHref={getEditHref(mediaObj.id)}
           onDelete={onDelete(mediaObj.id)}
+          placeholderSrc={placeholders[mediaObj.id]}
+          onPlaceholderUnused={() => onPlaceholderUnused(mediaObj.id)}
         />
       ))}
-      {preview
-        .sort((a, b) => (a.sortOrder > b.sortOrder ? 1 : -1))
-        .map((mediaObj, index) => (
-          <MediaTile loading={true} media={mediaObj} key={index} />
-        ))}
+      {preview.map(mediaObj => (
+        <MediaTile loading={true} media={mediaObj} key={mediaObj.id} />
+      ))}
     </div>
   ),
 );
@@ -67,6 +79,37 @@ interface ProductMediaProps {
   openMediaUrlModal: () => any;
 }
 
+let pendingMediaIdCounter = 0;
+
+const createPendingMediaId = () => {
+  pendingMediaIdCounter += 1;
+
+  return `pending-${Date.now()}-${pendingMediaIdCounter}`;
+};
+
+const createPendingMedia = (file: File, sortOrder: number): ProductMediaFragment => {
+  const clientId = createPendingMediaId();
+
+  return {
+    __typename: "ProductMedia",
+    alt: "",
+    id: clientId,
+    sortOrder,
+    type: ProductMediaType.IMAGE,
+    url: URL.createObjectURL(file),
+    oembedData: null,
+  };
+};
+
+const revokeObjectUrl = (url: string) => {
+  if (url.startsWith("blob:")) {
+    URL.revokeObjectURL(url);
+  }
+};
+
+const getMediaIdsSignature = (media: ProductMediaFragment[] | undefined) =>
+  media === undefined ? null : media.map(item => item.id).join("\0");
+
 /** @deprecated This component should use @dnd-kit instead of react-sortable-hoc */
 const ProductMedia = (props: ProductMediaProps) => {
   const {
@@ -80,31 +123,109 @@ const ProductMedia = (props: ProductMediaProps) => {
   const intl = useIntl();
   const imagesUpload = React.useRef<HTMLInputElement>(null);
   const anchor = React.useRef<HTMLButtonElement>();
-  const [imagesToUpload, setImagesToUpload] = React.useState<ProductMediaFragment[]>([]);
-  const handleImageUpload = createMultiFileUploadHandler(onImageUpload, {
-    onAfterUpload: () => setImagesToUpload(prevImagesToUpload => prevImagesToUpload.slice(1)),
-    onStart: files => {
-      Array.from(files).forEach((file, fileIndex) => {
-        const reader = new FileReader();
+  const [pendingMedia, setPendingMedia] = React.useState<ProductMediaFragment[]>([]);
+  const [placeholders, setPlaceholders] = React.useState<Record<string, string>>({});
+  const pendingMediaRef = React.useRef(pendingMedia);
+  const placeholdersRef = React.useRef(placeholders);
+  const previousMediaIdsRef = React.useRef<string[] | null>(null);
+  const [mediaIdsSignature, setMediaIdsSignature] = React.useState(() =>
+    getMediaIdsSignature(media),
+  );
 
-        reader.onload = event => {
-          setImagesToUpload(prevImagesToUpload => [
-            ...prevImagesToUpload,
-            {
-              __typename: "ProductMedia",
-              alt: "",
-              id: "",
-              sortOrder: fileIndex,
-              type: ProductMediaType.IMAGE,
-              url: event.target.result as string,
-              oembedData: null,
-            },
-          ]);
-        };
-        reader.readAsDataURL(file);
-      });
+  React.useEffect(
+    function syncObjectUrlRefs() {
+      pendingMediaRef.current = pendingMedia;
+      placeholdersRef.current = placeholders;
     },
-  });
+    [pendingMedia, placeholders],
+  );
+
+  // Adjust pending/placeholder state during render when saved media arrives,
+  // so React re-renders before paint and never shows pending + saved tiles together.
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const nextMediaIdsSignature = getMediaIdsSignature(media);
+
+  if (nextMediaIdsSignature !== null && media && nextMediaIdsSignature !== mediaIdsSignature) {
+    const currentIds = media.map(item => item.id);
+    const previousIds = previousMediaIdsRef.current;
+    const addedIds = previousIds === null ? [] : currentIds.filter(id => !previousIds.includes(id));
+
+    previousMediaIdsRef.current = currentIds;
+    setMediaIdsSignature(nextMediaIdsSignature);
+
+    if (addedIds.length > 0 && pendingMedia.length > 0) {
+      const removeCount = Math.min(addedIds.length, pendingMedia.length);
+      const handedOff = pendingMedia.slice(0, removeCount);
+      const nextPlaceholders = { ...placeholders };
+
+      handedOff.forEach((item, index) => {
+        nextPlaceholders[addedIds[index]] = item.url;
+      });
+
+      setPlaceholders(nextPlaceholders);
+      setPendingMedia(pendingMedia.slice(removeCount));
+    }
+  } else if (nextMediaIdsSignature !== null && media && previousMediaIdsRef.current === null) {
+    previousMediaIdsRef.current = media.map(item => item.id);
+    setMediaIdsSignature(nextMediaIdsSignature);
+  }
+
+  React.useEffect(function revokeObjectUrlsOnUnmount() {
+    return function revokeObjectUrls() {
+      pendingMediaRef.current.forEach(item => revokeObjectUrl(item.url));
+      Object.values(placeholdersRef.current).forEach(revokeObjectUrl);
+    };
+  }, []);
+
+  const removePendingMedia = React.useCallback((clientId: string) => {
+    setPendingMedia(prev => {
+      const item = prev.find(mediaItem => mediaItem.id === clientId);
+
+      if (item) {
+        revokeObjectUrl(item.url);
+      }
+
+      return prev.filter(mediaItem => mediaItem.id !== clientId);
+    });
+  }, []);
+
+  const handlePlaceholderUnused = React.useCallback((mediaId: string) => {
+    setPlaceholders(prev => {
+      const url = prev[mediaId];
+
+      if (!url) {
+        return prev;
+      }
+
+      revokeObjectUrl(url);
+
+      const { [mediaId]: _, ...rest } = prev;
+
+      return rest;
+    });
+  }, []);
+
+  const handleImageUpload = React.useCallback(
+    (files: FileList | File[]) => {
+      const fileArray = Array.from(files);
+
+      if (fileArray.length === 0) {
+        return;
+      }
+
+      const pendingItems = fileArray.map((file, fileIndex) => createPendingMedia(file, fileIndex));
+      const clientIds = pendingItems.map(item => item.id);
+
+      setPendingMedia(prev => [...prev, ...pendingItems]);
+
+      return createMultiFileUploadHandler(onImageUpload, {
+        onError: index => removePendingMedia(clientIds[index]),
+      })(fileArray);
+    },
+    [onImageUpload, removePendingMedia],
+  );
+
+  const showGallery = (media?.length ?? 0) > 0 || pendingMedia.length > 0;
 
   return (
     <DashboardCard>
@@ -159,26 +280,29 @@ const ProductMedia = (props: ProductMediaProps) => {
         </DashboardCard.Toolbar>
       </DashboardCard.Header>
       <DashboardCard.Content>
-        <Box>
-          <Box
-            as="input"
-            display="none"
-            id="fileUpload"
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              handleImageUpload(event.target.files)
+        <input
+          className={styles.hiddenInput}
+          data-test-id="product-media-file-input"
+          id="product-media-file-upload"
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            if (event.target.files) {
+              handleImageUpload(event.target.files);
             }
-            multiple
-            type="file"
-            ref={imagesUpload}
-            accept="image/*"
-          />
-        </Box>
+
+            // Allow selecting the same file again
+            event.target.value = "";
+          }}
+          multiple
+          type="file"
+          ref={imagesUpload}
+          accept="image/*"
+        />
         <Box position="relative">
           {media === undefined ? (
             <Box padding={5}>
               <Skeleton />
             </Box>
-          ) : media.length > 0 ? (
+          ) : showGallery ? (
             <ProductMediaGalleryDropzone
               variant="gallery"
               disableClick={true}
@@ -189,12 +313,14 @@ const ProductMedia = (props: ProductMediaProps) => {
                   distance={20}
                   helperClass="dragged"
                   axis="xy"
-                  media={media}
-                  preview={imagesToUpload}
+                  media={media ?? []}
+                  preview={pendingMedia}
+                  placeholders={placeholders}
                   onSortEnd={onImageReorder}
                   className={clsx(styles.mediaList, isDragActive && styles.mediaListDimmed)}
                   onDelete={onImageDelete}
                   getEditHref={getImageEditUrl}
+                  onPlaceholderUnused={handlePlaceholderUnused}
                 />
               )}
             </ProductMediaGalleryDropzone>

--- a/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
+++ b/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
@@ -9,7 +9,7 @@ import { messages } from "./messages";
 import styles from "./ProductMedia.module.css";
 
 interface ProductMediaGalleryDropzoneProps {
-  onImageUpload: (files: FileList) => void;
+  onImageUpload: (files: FileList | File[]) => void;
   disableClick?: boolean;
   variant: "empty" | "gallery";
   children?: (props: { isDragActive: boolean }) => React.ReactNode;
@@ -52,7 +52,7 @@ export const ProductMediaGalleryDropzone = ({
             <div className={styles.dropOverlayWrapper}>
               <div className={styles.dropOverlay}>
                 <Text size={2} color="default2">
-                  <FormattedMessage {...messages.uploadHint} />
+                  <FormattedMessage {...messages.uploadHintDrop} />
                 </Text>
               </div>
             </div>

--- a/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
+++ b/src/products/components/ProductMedia/ProductMediaGalleryDropzone.tsx
@@ -11,6 +11,7 @@ import styles from "./ProductMedia.module.css";
 interface ProductMediaGalleryDropzoneProps {
   onImageUpload: (files: FileList | File[]) => void;
   disableClick?: boolean;
+  disabled?: boolean;
   variant: "empty" | "gallery";
   children?: (props: { isDragActive: boolean }) => React.ReactNode;
 }
@@ -18,16 +19,21 @@ interface ProductMediaGalleryDropzoneProps {
 export const ProductMediaGalleryDropzone = ({
   onImageUpload,
   disableClick = false,
+  disabled = false,
   variant,
   children,
 }: ProductMediaGalleryDropzoneProps) => (
-  <Dropzone noClick={disableClick} onDrop={onImageUpload}>
+  <Dropzone noClick={disableClick || disabled} disabled={disabled} onDrop={onImageUpload}>
     {({ isDragActive, getInputProps, getRootProps }: DropzoneState) => {
       if (variant === "empty") {
         return (
           <div
             {...getRootProps()}
-            className={clsx(styles.dropzone, isDragActive && styles.dropzoneActive)}
+            className={clsx(
+              styles.dropzone,
+              isDragActive && styles.dropzoneActive,
+              disabled && styles.dropzoneDisabled,
+            )}
             data-test-id="product-media-dropzone"
           >
             <input {...getInputProps()} className={styles.hiddenInput} accept="image/*" multiple />
@@ -47,8 +53,8 @@ export const ProductMediaGalleryDropzone = ({
           data-test-id="product-media-gallery"
         >
           <input {...getInputProps()} className={styles.hiddenInput} accept="image/*" multiple />
-          {children?.({ isDragActive })}
-          {isDragActive && (
+          {children?.({ isDragActive: disabled ? false : isDragActive })}
+          {isDragActive && !disabled && (
             <div className={styles.dropOverlayWrapper}>
               <div className={styles.dropOverlay}>
                 <Text size={2} color="default2">

--- a/src/products/components/ProductMedia/messages.ts
+++ b/src/products/components/ProductMedia/messages.ts
@@ -26,4 +26,9 @@ export const messages = defineMessages({
     defaultMessage: "Drag and drop or click to upload",
     description: "product media gallery dropzone hint",
   },
+  uploadHintDrop: {
+    id: "KXX8oX",
+    defaultMessage: "Drag and drop to upload",
+    description: "product media gallery dropzone hint when click-to-upload is disabled",
+  },
 });

--- a/src/products/components/ProductMedia/messages.ts
+++ b/src/products/components/ProductMedia/messages.ts
@@ -31,4 +31,25 @@ export const messages = defineMessages({
     defaultMessage: "Drag and drop to upload",
     description: "product media gallery dropzone hint when click-to-upload is disabled",
   },
+  deleteSelected: {
+    id: "SRnxlw",
+    defaultMessage: "Delete ({quantity})",
+    description: "button to delete selected product media items",
+  },
+  selectAll: {
+    id: "C87+/n",
+    defaultMessage: "Select all",
+    description: "button to select all product media items",
+  },
+  clearSelection: {
+    id: "I7X2uK",
+    defaultMessage: "Clear",
+    description: "button to clear selected product media items",
+  },
+  uploadRejected: {
+    id: "LzdG4r",
+    defaultMessage:
+      "{count, plural, one {# file was skipped} other {# files were skipped}} (not an image or larger than {maxSize} MB)",
+    description: "warning when client-side validation rejects product media files before upload",
+  },
 });

--- a/src/products/components/ProductMedia/useProductMediaDrag.test.ts
+++ b/src/products/components/ProductMedia/useProductMediaDrag.test.ts
@@ -1,0 +1,164 @@
+import { ProductMediaType } from "@dashboard/graphql";
+import { act, renderHook } from "@testing-library/react";
+
+import { useProductMediaDrag } from "./useProductMediaDrag";
+
+const media = [
+  {
+    __typename: "ProductMedia" as const,
+    id: "a",
+    alt: "",
+    sortOrder: 0,
+    type: ProductMediaType.IMAGE,
+    url: "https://example.com/a.png",
+    oembedData: null,
+  },
+  {
+    __typename: "ProductMedia" as const,
+    id: "b",
+    alt: "",
+    sortOrder: 1,
+    type: ProductMediaType.IMAGE,
+    url: "https://example.com/b.png",
+    oembedData: null,
+  },
+  {
+    __typename: "ProductMedia" as const,
+    id: "c",
+    alt: "",
+    sortOrder: 2,
+    type: ProductMediaType.IMAGE,
+    url: "https://example.com/c.png",
+    oembedData: null,
+  },
+];
+
+describe("useProductMediaDrag", () => {
+  it("reorders locally on drag over and commits indices on drag end", () => {
+    // Arrange
+    const onReorder = jest.fn();
+    const { result } = renderHook(() => useProductMediaDrag({ media, onReorder }));
+
+    // Act — start dragging "a", move over "c"
+    act(() => {
+      result.current.handleDragStart({
+        active: { id: "a" },
+      } as never);
+    });
+    act(() => {
+      result.current.handleDragOver({
+        active: { id: "a" },
+        over: { id: "c" },
+      } as never);
+    });
+
+    // Assert — local order updated for live feedback
+    expect(result.current.orderedMedia.map(item => item.id)).toEqual(["b", "c", "a"]);
+
+    // Act
+    act(() => {
+      result.current.handleDragEnd({} as never);
+    });
+
+    // Assert — single mutation with indices relative to drag-start order
+    expect(onReorder).toHaveBeenCalledWith({ oldIndex: 0, newIndex: 2 });
+    expect(result.current.activeId).toBeNull();
+  });
+
+  it("restores prop order on drag cancel", () => {
+    // Arrange
+    const { result } = renderHook(() => useProductMediaDrag({ media }));
+
+    act(() => {
+      result.current.handleDragStart({
+        active: { id: "a" },
+      } as never);
+    });
+    act(() => {
+      result.current.handleDragOver({
+        active: { id: "a" },
+        over: { id: "b" },
+      } as never);
+    });
+
+    // Act
+    act(() => {
+      result.current.handleDragCancel();
+    });
+
+    // Assert
+    expect(result.current.orderedMedia.map(item => item.id)).toEqual(["a", "b", "c"]);
+    expect(result.current.activeId).toBeNull();
+  });
+
+  it("does not commit reorder when media changed during the drag", () => {
+    // Arrange
+    const onReorder = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ media: nextMedia }) => useProductMediaDrag({ media: nextMedia, onReorder }),
+      { initialProps: { media } },
+    );
+
+    act(() => {
+      result.current.handleDragStart({
+        active: { id: "a" },
+      } as never);
+    });
+    act(() => {
+      result.current.handleDragOver({
+        active: { id: "a" },
+        over: { id: "c" },
+      } as never);
+    });
+
+    // Act — upload completed while dragging
+    const mediaWithUpload = [
+      ...media,
+      {
+        __typename: "ProductMedia" as const,
+        id: "d",
+        alt: "",
+        sortOrder: 3,
+        type: ProductMediaType.IMAGE,
+        url: "https://example.com/d.png",
+        oembedData: null,
+      },
+    ];
+
+    rerender({ media: mediaWithUpload });
+
+    act(() => {
+      result.current.handleDragEnd({} as never);
+    });
+
+    // Assert
+    expect(onReorder).not.toHaveBeenCalled();
+    expect(result.current.orderedMedia.map(item => item.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("commits indices relative to the live media list", () => {
+    // Arrange
+    const onReorder = jest.fn();
+    const { result } = renderHook(() => useProductMediaDrag({ media, onReorder }));
+
+    act(() => {
+      result.current.handleDragStart({
+        active: { id: "c" },
+      } as never);
+    });
+    act(() => {
+      result.current.handleDragOver({
+        active: { id: "c" },
+        over: { id: "a" },
+      } as never);
+    });
+
+    // Act
+    act(() => {
+      result.current.handleDragEnd({} as never);
+    });
+
+    // Assert — c moved from index 2 to 0 against current media order
+    expect(onReorder).toHaveBeenCalledWith({ oldIndex: 2, newIndex: 0 });
+  });
+});

--- a/src/products/components/ProductMedia/useProductMediaDrag.test.ts
+++ b/src/products/components/ProductMedia/useProductMediaDrag.test.ts
@@ -1,35 +1,35 @@
-import { ProductMediaType } from "@dashboard/graphql";
+import { type ProductMediaFragment, ProductMediaType } from "@dashboard/graphql";
 import { act, renderHook } from "@testing-library/react";
 
 import { useProductMediaDrag } from "./useProductMediaDrag";
 
-const media = [
+const media: ProductMediaFragment[] = [
   {
-    __typename: "ProductMedia" as const,
+    __typename: "ProductMedia",
     id: "a",
     alt: "",
     sortOrder: 0,
     type: ProductMediaType.IMAGE,
     url: "https://example.com/a.png",
-    oembedData: null,
+    oembedData: "{}",
   },
   {
-    __typename: "ProductMedia" as const,
+    __typename: "ProductMedia",
     id: "b",
     alt: "",
     sortOrder: 1,
     type: ProductMediaType.IMAGE,
     url: "https://example.com/b.png",
-    oembedData: null,
+    oembedData: "{}",
   },
   {
-    __typename: "ProductMedia" as const,
+    __typename: "ProductMedia",
     id: "c",
     alt: "",
     sortOrder: 2,
     type: ProductMediaType.IMAGE,
     url: "https://example.com/c.png",
-    oembedData: null,
+    oembedData: "{}",
   },
 ];
 
@@ -112,16 +112,16 @@ describe("useProductMediaDrag", () => {
     });
 
     // Act — upload completed while dragging
-    const mediaWithUpload = [
+    const mediaWithUpload: ProductMediaFragment[] = [
       ...media,
       {
-        __typename: "ProductMedia" as const,
+        __typename: "ProductMedia",
         id: "d",
         alt: "",
         sortOrder: 3,
         type: ProductMediaType.IMAGE,
         url: "https://example.com/d.png",
-        oembedData: null,
+        oembedData: "{}",
       },
     ];
 

--- a/src/products/components/ProductMedia/useProductMediaDrag.ts
+++ b/src/products/components/ProductMedia/useProductMediaDrag.ts
@@ -1,0 +1,144 @@
+import { type ProductMediaFragment } from "@dashboard/graphql";
+import { type ReorderAction } from "@dashboard/types";
+import {
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+  PointerSensor,
+  type UniqueIdentifier,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+interface UseProductMediaDragProps {
+  media: ProductMediaFragment[];
+  onReorder?: ReorderAction;
+  disabled?: boolean;
+}
+
+export const useProductMediaDrag = ({
+  media,
+  onReorder,
+  disabled = false,
+}: UseProductMediaDragProps) => {
+  const [orderedMedia, setOrderedMedia] = useState(media);
+  const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+  const orderedMediaRef = useRef(orderedMedia);
+
+  orderedMediaRef.current = orderedMedia;
+
+  useEffect(() => {
+    if (activeId === null) {
+      setOrderedMedia(media);
+    }
+  }, [media, activeId]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        // Match previous react-sortable-hoc `distance={20}` so clicks still work
+        distance: 20,
+      },
+    }),
+  );
+
+  const items: UniqueIdentifier[] = useMemo(
+    () => orderedMedia.map(item => item.id),
+    [orderedMedia],
+  );
+
+  const activeMedia = useMemo(
+    () => orderedMedia.find(item => item.id === activeId) ?? null,
+    [activeId, orderedMedia],
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    if (disabled) {
+      return;
+    }
+
+    setActiveId(event.active.id);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    if (disabled) {
+      return;
+    }
+
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    setOrderedMedia(current => {
+      const oldIndex = current.findIndex(item => item.id === active.id);
+      const newIndex = current.findIndex(item => item.id === over.id);
+
+      if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) {
+        return current;
+      }
+
+      return arrayMove(current, oldIndex, newIndex);
+    });
+  };
+
+  const finishDrag = () => {
+    const draggedId = activeId;
+
+    setActiveId(null);
+
+    if (disabled || !onReorder || draggedId == null) {
+      return;
+    }
+
+    const endIds = orderedMediaRef.current.map(item => item.id);
+    const currentIds = media.map(item => item.id);
+    const draggedIdString = String(draggedId);
+
+    // Media set must be unchanged (upload/delete during drag) and a pure reordering
+    const isSameSet =
+      endIds.length === currentIds.length &&
+      currentIds.every(id => endIds.includes(id)) &&
+      endIds.every(id => currentIds.includes(id));
+
+    if (!isSameSet) {
+      setOrderedMedia(media);
+
+      return;
+    }
+
+    // Indices relative to the live product.media list the mutation will arrayMove
+    const oldIndex = currentIds.indexOf(draggedIdString);
+    const newIndex = endIds.indexOf(draggedIdString);
+
+    if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) {
+      return;
+    }
+
+    onReorder({ oldIndex, newIndex });
+  };
+
+  const handleDragEnd = (_event: DragEndEvent) => {
+    finishDrag();
+  };
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+    setOrderedMedia(media);
+  };
+
+  return {
+    orderedMedia,
+    activeId,
+    activeMedia,
+    items,
+    sensors,
+    handleDragStart,
+    handleDragOver,
+    handleDragEnd,
+    handleDragCancel,
+  };
+};

--- a/src/products/components/ProductMedia/validateProductMediaFiles.test.ts
+++ b/src/products/components/ProductMedia/validateProductMediaFiles.test.ts
@@ -1,0 +1,55 @@
+import {
+  PRODUCT_MEDIA_MAX_FILE_SIZE_BYTES,
+  validateProductMediaFiles,
+} from "./validateProductMediaFiles";
+
+describe("validateProductMediaFiles", () => {
+  it("accepts image files under the size limit", () => {
+    // Arrange
+    const file = new File(["bytes"], "photo.png", { type: "image/png" });
+
+    // Act
+    const result = validateProductMediaFiles([file]);
+
+    // Assert
+    expect(result.validFiles).toEqual([file]);
+    expect(result.rejected).toEqual([]);
+  });
+
+  it("rejects non-image files", () => {
+    // Arrange
+    const file = new File(["bytes"], "notes.pdf", { type: "application/pdf" });
+
+    // Act
+    const result = validateProductMediaFiles([file]);
+
+    // Assert
+    expect(result.validFiles).toEqual([]);
+    expect(result.rejected).toEqual([{ file, reason: "invalidType" }]);
+  });
+
+  it("rejects files over the size limit", () => {
+    // Arrange
+    const largeContent = new Uint8Array(PRODUCT_MEDIA_MAX_FILE_SIZE_BYTES + 1);
+    const file = new File([largeContent], "huge.png", { type: "image/png" });
+
+    // Act
+    const result = validateProductMediaFiles([file]);
+
+    // Assert
+    expect(result.validFiles).toEqual([]);
+    expect(result.rejected).toEqual([{ file, reason: "tooLarge" }]);
+  });
+
+  it("accepts images with an empty mime type when the extension is known", () => {
+    // Arrange
+    const file = new File(["bytes"], "photo.JPEG", { type: "" });
+
+    // Act
+    const result = validateProductMediaFiles([file]);
+
+    // Assert
+    expect(result.validFiles).toEqual([file]);
+    expect(result.rejected).toEqual([]);
+  });
+});

--- a/src/products/components/ProductMedia/validateProductMediaFiles.ts
+++ b/src/products/components/ProductMedia/validateProductMediaFiles.ts
@@ -1,0 +1,44 @@
+/** Matches Saleor's common Django `FILE_UPLOAD_MAX_MEMORY_SIZE` default (10 MiB). */
+export const PRODUCT_MEDIA_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+export type ProductMediaFileValidationReason = "invalidType" | "tooLarge";
+
+export interface ProductMediaFileValidationResult {
+  validFiles: File[];
+  rejected: Array<{ file: File; reason: ProductMediaFileValidationReason }>;
+}
+
+const isImageFile = (file: File): boolean => {
+  if (file.type.startsWith("image/")) {
+    return true;
+  }
+
+  // Some browsers leave type empty for certain picks; fall back to extension.
+  return /\.(avif|bmp|gif|jpe?g|png|webp)$/i.test(file.name);
+};
+
+export const validateProductMediaFiles = (
+  files: FileList | File[],
+  maxSizeBytes: number = PRODUCT_MEDIA_MAX_FILE_SIZE_BYTES,
+): ProductMediaFileValidationResult => {
+  const validFiles: File[] = [];
+  const rejected: ProductMediaFileValidationResult["rejected"] = [];
+
+  Array.from(files).forEach(file => {
+    if (!isImageFile(file)) {
+      rejected.push({ file, reason: "invalidType" });
+
+      return;
+    }
+
+    if (file.size > maxSizeBytes) {
+      rejected.push({ file, reason: "tooLarge" });
+
+      return;
+    }
+
+    validFiles.push(file);
+  });
+
+  return { validFiles, rejected };
+};

--- a/src/products/components/ProductMediaDeleteDialog/ProductMediaDeleteDialog.tsx
+++ b/src/products/components/ProductMediaDeleteDialog/ProductMediaDeleteDialog.tsx
@@ -11,7 +11,8 @@ import { productMediaDeleteDialogMessages as messages } from "./messages";
 
 interface ProductMediaDeleteDialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
-  isVideo: boolean;
+  quantity: number;
+  isVideo?: boolean;
   open: boolean;
   onClose: () => void;
   onConfirm: () => void;
@@ -19,20 +20,36 @@ interface ProductMediaDeleteDialogProps {
 
 export const ProductMediaDeleteDialog = ({
   confirmButtonState,
-  isVideo,
+  quantity,
+  isVideo = false,
   open,
   onClose,
   onConfirm,
 }: ProductMediaDeleteDialogProps) => {
-  const titleMessage = isVideo ? messages.deleteVideoTitle : messages.deleteImageTitle;
-  const subtitleMessage = isVideo
-    ? messages.deleteVideoConfirmation
-    : messages.deleteImageConfirmation;
+  const isBulk = quantity > 1;
+  const titleMessage = isBulk
+    ? messages.deleteMediaTitle
+    : isVideo
+      ? messages.deleteVideoTitle
+      : messages.deleteImageTitle;
+  const subtitle = isBulk ? (
+    <FormattedMessage
+      {...messages.deleteMediaConfirmation}
+      values={{
+        counter: quantity,
+        displayQuantity: <strong>{quantity}</strong>,
+      }}
+    />
+  ) : isVideo ? (
+    <FormattedMessage {...messages.deleteVideoConfirmation} />
+  ) : (
+    <FormattedMessage {...messages.deleteImageConfirmation} />
+  );
 
   return (
     <DashboardModal onChange={onClose} open={open}>
       <DashboardModal.Content size="xs">
-        <DashboardModal.Header subtitle={<FormattedMessage {...subtitleMessage} />}>
+        <DashboardModal.Header subtitle={subtitle}>
           <FormattedMessage {...titleMessage} />
         </DashboardModal.Header>
 

--- a/src/products/components/ProductMediaDeleteDialog/messages.ts
+++ b/src/products/components/ProductMediaDeleteDialog/messages.ts
@@ -11,6 +11,11 @@ export const productMediaDeleteDialogMessages = defineMessages({
     defaultMessage: "Delete Video",
     description: "product media delete dialog header",
   },
+  deleteMediaTitle: {
+    id: "ECnjbS",
+    defaultMessage: "Delete Media",
+    description: "product media bulk delete dialog header",
+  },
   deleteImageConfirmation: {
     id: "VEext+",
     defaultMessage: "Are you sure you want to delete this image?",
@@ -19,5 +24,11 @@ export const productMediaDeleteDialogMessages = defineMessages({
     id: "/uu/aV",
     defaultMessage: "Are you sure you want to delete this video?",
     description: "product media delete dialog content",
+  },
+  deleteMediaConfirmation: {
+    id: "8XSZSL",
+    defaultMessage:
+      "{counter,plural,one{Are you sure you want to delete this media item?} other{Are you sure you want to delete {displayQuantity} media items?}}",
+    description: "product media bulk delete dialog content",
   },
 });

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.topNav.test.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.topNav.test.tsx
@@ -127,6 +127,7 @@ const renderPage = (onShowMetadata = jest.fn()) =>
           onDelete={jest.fn()}
           onShowMetadata={onShowMetadata}
           onImageDelete={jest.fn()}
+          onImagesDelete={jest.fn()}
           onImageUpload={jest.fn()}
           onMediaUrlUpload={jest.fn()}
           onVariantShow={jest.fn()}
@@ -194,6 +195,7 @@ describe("ProductUpdatePage top nav", () => {
             onDelete={jest.fn()}
             onShowMetadata={jest.fn()}
             onImageDelete={jest.fn()}
+            onImagesDelete={jest.fn()}
             onImageUpload={jest.fn()}
             onMediaUrlUpload={jest.fn()}
             onVariantShow={jest.fn()}

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -131,6 +131,7 @@ interface ProductUpdatePageProps {
   onAssignReferencesClick: (attribute: AttributeInput) => void;
   onCloseDialog: () => void;
   onImageDelete: (id: string) => () => void;
+  onImagesDelete: (ids: string[]) => void;
   onSubmit: (data: ProductUpdateSubmitData) => SubmitPromise;
   onVariantShow: (id: string) => void;
   onAttributeSelectBlur: () => void;
@@ -176,6 +177,7 @@ const ProductUpdatePage = ({
   onDelete,
   onShowMetadata,
   onImageDelete,
+  onImagesDelete,
   onImageReorder,
   onImageUpload,
   onImagesUploadComplete,
@@ -497,6 +499,7 @@ const ProductUpdatePage = ({
                 <ProductMedia
                   media={media}
                   onImageDelete={onImageDelete}
+                  onImagesDelete={onImagesDelete}
                   onImageReorder={onImageReorder}
                   onImageUpload={onImageUpload}
                   onImagesUploadComplete={onImagesUploadComplete}

--- a/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/src/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -138,6 +138,7 @@ interface ProductUpdatePageProps {
   onShowMetadata: () => void;
   onImageReorder?: (event: { oldIndex: number; newIndex: number }) => any;
   onImageUpload: (file: File) => any;
+  onImagesUploadComplete?: (result: { successCount: number; failureCount: number }) => void;
   onMediaUrlUpload: (mediaUrl: string) => SubmitPromise<ProductErrorFragment[]>;
   onSeoClick?: () => any;
   onFilterChange?: AssignAttributeValueDialogFilterChangeMap;
@@ -177,6 +178,7 @@ const ProductUpdatePage = ({
   onImageDelete,
   onImageReorder,
   onImageUpload,
+  onImagesUploadComplete,
   onMediaUrlUpload,
   onVariantShow,
   onSeoClick,
@@ -497,6 +499,7 @@ const ProductUpdatePage = ({
                   onImageDelete={onImageDelete}
                   onImageReorder={onImageReorder}
                   onImageUpload={onImageUpload}
+                  onImagesUploadComplete={onImagesUploadComplete}
                   openMediaUrlModal={() => setMediaUrlModalStatus(true)}
                   getImageEditUrl={imageId => productImageUrl(productId, imageId)}
                 />

--- a/src/products/mutations.ts
+++ b/src/products/mutations.ts
@@ -8,6 +8,9 @@ export const productMediaCreateMutation = gql`
       errors {
         ...ProductError
       }
+      media {
+        id
+      }
       product {
         id
         media {
@@ -199,6 +202,17 @@ export const productMediaDeleteMutation = gql`
           ...ProductMedia
         }
       }
+    }
+  }
+`;
+
+export const productMediaBulkDeleteMutation = gql`
+  mutation ProductMediaBulkDelete($ids: [ID!]!) {
+    productMediaBulkDelete(ids: $ids) {
+      errors {
+        ...ProductError
+      }
+      count
     }
   }
 `;

--- a/src/products/queries.ts
+++ b/src/products/queries.ts
@@ -182,7 +182,7 @@ export const productMediaQuery = gql`
       }
       media {
         id
-        url(size: 48)
+        url(size: 128, format: WEBP)
         alt
         type
         oembedData

--- a/src/products/views/ProductImage.tsx
+++ b/src/products/views/ProductImage.tsx
@@ -108,6 +108,7 @@ const ProductImage = ({ mediaId, productId, params }: ProductMediaProps) => {
         onClose={() => navigate(productImageUrl(productId, mediaId), { replace: true })}
         onConfirm={handleDelete}
         open={params.action === "remove"}
+        quantity={1}
         isVideo={isVideo}
         confirmButtonState={deleteResult.status}
       />

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -16,8 +16,8 @@ import {
   type ProductVariantBulkCreateInput,
   useProductDeleteMutation,
   useProductDetailsQuery,
+  useProductMediaBulkDeleteMutation,
   useProductMediaCreateMutation,
-  useProductMediaDeleteMutation,
   useProductMediaReorderMutation,
   useProductVariantBulkCreateMutation,
 } from "@dashboard/graphql";
@@ -194,9 +194,9 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     ProductUrlDialog,
     ProductUrlQueryParams
   >(navigate, params => productUrl(id, params), params);
-  const [deleteProductImage, deleteProductImageOpts] = useProductMediaDeleteMutation({
+  const [bulkDeleteProductMedia, bulkDeleteProductMediaOpts] = useProductMediaBulkDeleteMutation({
     onCompleted: data => {
-      const result = data.productMediaDelete;
+      const result = data.productMediaBulkDelete;
 
       if (!result) {
         notify({
@@ -223,15 +223,15 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
       closeModal();
       notify({
         status: "success",
-        text: intl.formatMessage({
-          id: "Gi8zwc",
-          defaultMessage: "Image deleted",
+        text: intl.formatMessage(messages.mediaDeleteSuccess, {
+          counter: result.count,
         }),
       });
     },
   });
   const product = data?.product;
   const [deleteMediaType, setDeleteMediaType] = useState<ProductMediaType | null>(null);
+  const mediaIdsToDelete = params.ids ?? [];
 
   useEffect(() => {
     if (params.action !== "remove-media") {
@@ -239,7 +239,8 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     }
   }, [params.action]);
 
-  const isVideoMediaToDelete = deleteMediaType === ProductMediaType.VIDEO;
+  const isVideoMediaToDelete =
+    mediaIdsToDelete.length === 1 && deleteMediaType === ProductMediaType.VIDEO;
   const getAttributeValuesSuggestions = useSearchAttributeValuesSuggestions();
   const [createProductMedia, createProductMediaOpts] = useProductMediaCreateMutation({
     onCompleted: handleProductMediaCreateCompleted,
@@ -352,32 +353,56 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     [bulkCreateVariants, id, intl, notify, refetch],
   );
   const handleImageDelete = (mediaId: string) => () => {
-    const media = product?.media?.find(item => item.id === mediaId);
+    const mediaItem = product?.media?.find(item => item.id === mediaId);
 
-    setDeleteMediaType(media?.type ?? null);
-    openModal("remove-media", { id: mediaId });
+    setDeleteMediaType(mediaItem?.type ?? null);
+    openModal("remove-media", { ids: [mediaId] });
   };
-  const handleConfirmMediaDelete = () => {
-    const mediaId = params.id;
-    const currentMedia = product?.media;
-
-    if (!mediaId || !product || !currentMedia) {
+  const handleImagesDelete = (mediaIds: string[]) => {
+    if (mediaIds.length === 0) {
       return;
     }
 
-    deleteProductImage({
-      variables: { id: mediaId },
+    if (mediaIds.length === 1) {
+      const mediaItem = product?.media?.find(item => item.id === mediaIds[0]);
+
+      setDeleteMediaType(mediaItem?.type ?? null);
+    } else {
+      setDeleteMediaType(null);
+    }
+
+    openModal("remove-media", { ids: mediaIds });
+  };
+  const handleConfirmMediaDelete = () => {
+    const currentMedia = product?.media;
+
+    if (!product || !currentMedia || mediaIdsToDelete.length === 0) {
+      return;
+    }
+
+    const idsToDelete = new Set(mediaIdsToDelete);
+
+    bulkDeleteProductMedia({
+      variables: { ids: mediaIdsToDelete },
       optimisticResponse: {
         __typename: "Mutation",
-        productMediaDelete: {
-          __typename: "ProductMediaDelete",
+        productMediaBulkDelete: {
+          __typename: "ProductMediaBulkDelete",
           errors: [],
-          product: {
-            __typename: "Product",
-            id: product.id,
-            media: currentMedia.filter(media => media.id !== mediaId),
-          },
+          count: mediaIdsToDelete.length,
         },
+      },
+      update: cache => {
+        cache.modify({
+          id: cache.identify(product),
+          fields: {
+            media(existingMedia = [], { readField }) {
+              return existingMedia.filter(
+                mediaRef => !idsToDelete.has(readField("id", mediaRef) as string),
+              );
+            },
+          },
+        });
       },
     });
   };
@@ -511,6 +536,7 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
         onImageUpload={handleImageUpload}
         onImagesUploadComplete={handleImagesUploadComplete}
         onImageDelete={handleImageDelete}
+        onImagesDelete={handleImagesDelete}
         fetchMoreCategories={fetchMoreCategories}
         fetchMoreCollections={fetchMoreCollections}
         assignReferencesAttributeId={params.action === "assign-attribute-value" && params.id}
@@ -548,9 +574,10 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
         onConfirm={() => deleteProduct({ variables: { id } })}
       />
       <ProductMediaDeleteDialog
-        open={params.action === "remove-media" && !!params.id}
+        open={params.action === "remove-media" && mediaIdsToDelete.length > 0}
         onClose={closeModal}
-        confirmButtonState={deleteProductImageOpts.status}
+        confirmButtonState={bulkDeleteProductMediaOpts.status}
+        quantity={mediaIdsToDelete.length}
         isVideo={isVideoMediaToDelete}
         onConfirm={handleConfirmMediaDelete}
       />

--- a/src/products/views/ProductUpdate/ProductUpdate.tsx
+++ b/src/products/views/ProductUpdate/ProductUpdate.tsx
@@ -55,7 +55,11 @@ import {
   type ProductUrlQueryParams,
   productVariantEditUrl,
 } from "../../urls";
-import { createImageReorderHandler, createImageUploadHandler } from "./handlers";
+import {
+  createImageReorderHandler,
+  createImagesUploadCompleteHandler,
+  createImageUploadHandler,
+} from "./handlers";
 import { useProductUpdateHandler } from "./handlers/useProductUpdateHandler";
 import { productUpdatePageMessages as messages } from "./messages";
 
@@ -182,9 +186,9 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     },
     [intl, notify],
   );
-  const [createProductImage, createProductImageOpts] = useProductMediaCreateMutation({
-    onCompleted: handleProductMediaCreateCompleted,
-  });
+  // File uploads report a single batch toast from ProductMedia; keep per-upload
+  // notifications only for URL/oEmbed uploads via createProductMedia.
+  const [createProductImage] = useProductMediaCreateMutation();
   const [bulkCreateVariants] = useProductVariantBulkCreateMutation();
   const [openModal, closeModal] = createDialogActionHandlers<
     ProductUrlDialog,
@@ -381,6 +385,7 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
   const handleImageUpload = createImageUploadHandler(id, variables =>
     createProductImage({ variables }),
   );
+  const handleImagesUploadComplete = createImagesUploadCompleteHandler(notify, intl);
   const handleImageReorder = createImageReorderHandler(product, options =>
     reorderProductImages(options),
   );
@@ -388,10 +393,8 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
     openModal("assign-attribute-value", { id: attribute.id });
   const disableFormSave =
     submitOpts.loading ||
-    createProductImageOpts.loading ||
     deleteProductOpts.loading ||
     reorderProductImagesOpts.loading ||
-    createProductMediaOpts.loading ||
     (loading && !product);
   const formTransitionState = getMutationState(
     submitOpts.called,
@@ -506,6 +509,7 @@ const ProductUpdate = ({ id, params }: ProductUpdateProps) => {
           })
         }
         onImageUpload={handleImageUpload}
+        onImagesUploadComplete={handleImagesUploadComplete}
         onImageDelete={handleImageDelete}
         fetchMoreCategories={fetchMoreCategories}
         fetchMoreCollections={fetchMoreCollections}

--- a/src/products/views/ProductUpdate/handlers/index.test.ts
+++ b/src/products/views/ProductUpdate/handlers/index.test.ts
@@ -1,6 +1,10 @@
 import { type ProductFragment, ProductMediaType } from "@dashboard/graphql";
 
-import { createImageReorderHandler, createImageUploadHandler } from "./index";
+import {
+  createImageReorderHandler,
+  createImagesUploadCompleteHandler,
+  createImageUploadHandler,
+} from "./index";
 
 function createProductWithMedia(mediaIds: string[]): ProductFragment {
   return {
@@ -57,6 +61,63 @@ describe("createImageUploadHandler", () => {
 
     // Act & Assert
     await expect(handler(file)).rejects.toThrow("Failed to upload product media");
+  });
+});
+
+describe("createImagesUploadCompleteHandler", () => {
+  const intl = {
+    formatMessage: jest.fn((_message, values) => JSON.stringify(values)),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("notifies success for a fully successful batch", () => {
+    // Arrange
+    const notify = jest.fn();
+    const handler = createImagesUploadCompleteHandler(notify, intl);
+
+    // Act
+    handler({ successCount: 3, failureCount: 0 });
+
+    // Assert
+    expect(notify).toHaveBeenCalledWith({
+      status: "success",
+      text: JSON.stringify({ count: 3 }),
+    });
+  });
+
+  it("notifies error when every upload failed", () => {
+    // Arrange
+    const notify = jest.fn();
+    const handler = createImagesUploadCompleteHandler(notify, intl);
+
+    // Act
+    handler({ successCount: 0, failureCount: 2 });
+
+    // Assert
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "error",
+        text: JSON.stringify({ count: 2 }),
+      }),
+    );
+  });
+
+  it("notifies warning for a partial batch", () => {
+    // Arrange
+    const notify = jest.fn();
+    const handler = createImagesUploadCompleteHandler(notify, intl);
+
+    // Act
+    handler({ successCount: 2, failureCount: 1 });
+
+    // Assert
+    expect(notify).toHaveBeenCalledWith({
+      status: "warning",
+      text: JSON.stringify({ success: 2, failed: 1 }),
+    });
   });
 });
 

--- a/src/products/views/ProductUpdate/handlers/index.test.ts
+++ b/src/products/views/ProductUpdate/handlers/index.test.ts
@@ -1,6 +1,6 @@
 import { type ProductFragment, ProductMediaType } from "@dashboard/graphql";
 
-import { createImageReorderHandler } from "./index";
+import { createImageReorderHandler, createImageUploadHandler } from "./index";
 
 function createProductWithMedia(mediaIds: string[]): ProductFragment {
   return {
@@ -16,6 +16,49 @@ function createProductWithMedia(mediaIds: string[]): ProductFragment {
     })),
   } as ProductFragment;
 }
+
+describe("createImageUploadHandler", () => {
+  const file = new File(["image-bytes"], "shoe.png", { type: "image/png" });
+
+  it("uploads the file and resolves when the mutation succeeds", async () => {
+    // Arrange
+    const createProductImage = jest.fn().mockResolvedValue({
+      data: {
+        productMediaCreate: {
+          errors: [],
+          product: { id: "product-1", media: [] },
+        },
+      },
+    });
+    const handler = createImageUploadHandler("product-1", createProductImage);
+
+    // Act
+    await handler(file);
+
+    // Assert
+    expect(createProductImage).toHaveBeenCalledWith({
+      alt: "",
+      image: file,
+      product: "product-1",
+    });
+  });
+
+  it("rejects when the mutation returns errors", async () => {
+    // Arrange
+    const createProductImage = jest.fn().mockResolvedValue({
+      data: {
+        productMediaCreate: {
+          errors: [{ field: "image", code: "INVALID", message: "Invalid image" }],
+          product: null,
+        },
+      },
+    });
+    const handler = createImageUploadHandler("product-1", createProductImage);
+
+    // Act & Assert
+    await expect(handler(file)).rejects.toThrow("Failed to upload product media");
+  });
+});
 
 describe("createImageReorderHandler", () => {
   it("does not call reorder when product is undefined", () => {

--- a/src/products/views/ProductUpdate/handlers/index.ts
+++ b/src/products/views/ProductUpdate/handlers/index.ts
@@ -9,10 +9,14 @@ import {
   type ProductMediaReorderMutationVariables,
   type ProductVariantReorderMutationFn,
 } from "@dashboard/graphql";
+import { errorMessages } from "@dashboard/intl";
 import { getMutationErrors } from "@dashboard/misc";
 import { type ReorderEvent } from "@dashboard/types";
 import { move } from "@dashboard/utils/lists";
+import { type IntlShape } from "react-intl";
 import { arrayMove } from "react-sortable-hoc";
+
+import { productUpdatePageMessages } from "../messages";
 
 export function createImageUploadHandler(
   id: string,
@@ -33,6 +37,57 @@ export function createImageUploadHandler(
     }
 
     return result;
+  };
+}
+
+export interface ImagesUploadCompleteResult {
+  successCount: number;
+  failureCount: number;
+}
+
+export function createImagesUploadCompleteHandler(
+  notify: (notification: {
+    status: "success" | "error" | "warning";
+    title?: string;
+    text: string;
+  }) => void,
+  intl: Pick<IntlShape, "formatMessage">,
+) {
+  return ({ successCount, failureCount }: ImagesUploadCompleteResult) => {
+    if (successCount === 0 && failureCount === 0) {
+      return;
+    }
+
+    if (failureCount === 0) {
+      notify({
+        status: "success",
+        text: intl.formatMessage(productUpdatePageMessages.mediaUploadSuccessCount, {
+          count: successCount,
+        }),
+      });
+
+      return;
+    }
+
+    if (successCount === 0) {
+      notify({
+        status: "error",
+        title: intl.formatMessage(errorMessages.imgageUploadErrorTitle),
+        text: intl.formatMessage(productUpdatePageMessages.mediaUploadAllFailed, {
+          count: failureCount,
+        }),
+      });
+
+      return;
+    }
+
+    notify({
+      status: "warning",
+      text: intl.formatMessage(productUpdatePageMessages.mediaUploadPartial, {
+        success: successCount,
+        failed: failureCount,
+      }),
+    });
   };
 }
 

--- a/src/products/views/ProductUpdate/handlers/index.ts
+++ b/src/products/views/ProductUpdate/handlers/index.ts
@@ -1,27 +1,39 @@
 // @ts-strict-ignore
-import { type MutationFunctionOptions } from "@apollo/client";
+import { type FetchResult, type MutationFunctionOptions } from "@apollo/client";
 import {
   type Node,
   type ProductFragment,
+  type ProductMediaCreateMutation,
   type ProductMediaCreateMutationVariables,
   type ProductMediaReorderMutation,
   type ProductMediaReorderMutationVariables,
   type ProductVariantReorderMutationFn,
 } from "@dashboard/graphql";
+import { getMutationErrors } from "@dashboard/misc";
 import { type ReorderEvent } from "@dashboard/types";
 import { move } from "@dashboard/utils/lists";
 import { arrayMove } from "react-sortable-hoc";
 
 export function createImageUploadHandler(
   id: string,
-  createProductImage: (variables: ProductMediaCreateMutationVariables) => void,
+  createProductImage: (
+    variables: ProductMediaCreateMutationVariables,
+  ) => Promise<FetchResult<ProductMediaCreateMutation>>,
 ) {
-  return (file: File) =>
-    createProductImage({
+  return async (file: File) => {
+    const result = await createProductImage({
       alt: "",
       image: file,
       product: id,
     });
+    const errors = getMutationErrors(result);
+
+    if (errors.length > 0 || !result.data?.productMediaCreate?.product) {
+      throw new Error("Failed to upload product media");
+    }
+
+    return result;
+  };
 }
 
 type ProductMediaReorderOptions = Pick<

--- a/src/products/views/ProductUpdate/handlers/index.ts
+++ b/src/products/views/ProductUpdate/handlers/index.ts
@@ -13,8 +13,8 @@ import { errorMessages } from "@dashboard/intl";
 import { getMutationErrors } from "@dashboard/misc";
 import { type ReorderEvent } from "@dashboard/types";
 import { move } from "@dashboard/utils/lists";
+import { arrayMove } from "@dnd-kit/sortable";
 import { type IntlShape } from "react-intl";
-import { arrayMove } from "react-sortable-hoc";
 
 import { productUpdatePageMessages } from "../messages";
 
@@ -96,7 +96,6 @@ type ProductMediaReorderOptions = Pick<
   "variables" | "optimisticResponse"
 >;
 
-/** @deprecated This component should use @dnd-kit instead of react-sortable-hoc */
 export function createImageReorderHandler(
   product: ProductFragment | undefined,
   reorderProductImages: (options: ProductMediaReorderOptions) => void,
@@ -105,6 +104,16 @@ export function createImageReorderHandler(
     const media = product?.media;
 
     if (!product || !media?.length) {
+      return;
+    }
+
+    if (
+      oldIndex < 0 ||
+      newIndex < 0 ||
+      oldIndex >= media.length ||
+      newIndex >= media.length ||
+      oldIndex === newIndex
+    ) {
       return;
     }
 

--- a/src/products/views/ProductUpdate/messages.ts
+++ b/src/products/views/ProductUpdate/messages.ts
@@ -56,4 +56,9 @@ export const productUpdatePageMessages = defineMessages({
       "{success, plural, one {# image} other {# images}} added, {failed, plural, one {# failed} other {# failed}}",
     description: "warning notification when some product image uploads in a batch failed",
   },
+  mediaDeleteSuccess: {
+    id: "F2xa5K",
+    defaultMessage: "{counter,plural,one{Media deleted} other{# media items deleted}}",
+    description: "success notification when product media items are deleted",
+  },
 });

--- a/src/products/views/ProductUpdate/messages.ts
+++ b/src/products/views/ProductUpdate/messages.ts
@@ -39,4 +39,21 @@ export const productUpdatePageMessages = defineMessages({
     defaultMessage: "Image added",
     description: "success notification when product media is uploaded",
   },
+  mediaUploadSuccessCount: {
+    id: "Yxoq3Y",
+    defaultMessage: "{count, plural, one {# image added} other {# images added}}",
+    description: "success notification when one or more product images finish uploading",
+  },
+  mediaUploadAllFailed: {
+    id: "2z3+WY",
+    defaultMessage:
+      "{count, plural, one {Failed to upload image} other {Failed to upload # images}}",
+    description: "error notification when all product image uploads in a batch failed",
+  },
+  mediaUploadPartial: {
+    id: "lxP7Rb",
+    defaultMessage:
+      "{success, plural, one {# image} other {# images}} added, {failed, plural, one {# failed} other {# failed}}",
+    description: "warning notification when some product image uploads in a batch failed",
+  },
 });

--- a/src/utils/handlers/multiFileUploadHandler.test.ts
+++ b/src/utils/handlers/multiFileUploadHandler.test.ts
@@ -37,7 +37,6 @@ describe("Multiple file upload handler", () => {
       onBeforeUpload: jest.fn(),
       onCompleted: jest.fn(files => expect(files.length).toBe(testFiles.length)),
       onError: jest.fn(),
-      onStart: jest.fn(),
     };
     const handle = createMultiFileUploadHandler((_, fileIndex) => {
       const promise = new Promise<void>((resolve, reject) => {
@@ -58,5 +57,40 @@ describe("Multiple file upload handler", () => {
       expect(cbs.onError).toBeCalledTimes(1);
       done();
     });
+  });
+
+  it("uploads with limited concurrency", async () => {
+    // Arrange
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const uploadOrder: number[] = [];
+    const cbs = {
+      onAfterUpload: jest.fn(),
+      onError: jest.fn(),
+      onCompleted: jest.fn(),
+    };
+    const handle = createMultiFileUploadHandler(
+      async (_file, fileIndex) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        uploadOrder.push(fileIndex);
+        await Promise.resolve();
+        inFlight -= 1;
+
+        return `result-${fileIndex}`;
+      },
+      { ...cbs, concurrency: 2 },
+    );
+
+    // Act
+    await handle(testFiles);
+
+    // Assert
+    expect(maxInFlight).toBe(2);
+    expect(cbs.onAfterUpload).toHaveBeenCalledTimes(testFiles.length);
+    expect(cbs.onAfterUpload.mock.calls[0][2]).toBe("result-0");
+    expect(cbs.onError).not.toHaveBeenCalled();
+    expect(cbs.onCompleted).toHaveBeenCalledTimes(1);
+    expect(uploadOrder).toHaveLength(testFiles.length);
   });
 });

--- a/src/utils/handlers/multiFileUploadHandler.ts
+++ b/src/utils/handlers/multiFileUploadHandler.ts
@@ -40,7 +40,7 @@ function createMultiFileUploadHandler<T>(
     }
   }
 
-  return async (files: FileList): Promise<void> => {
+  return async (files: FileList | File[]): Promise<void> => {
     const fileArray = Array.from(files);
 
     if (onStart) {

--- a/src/utils/handlers/multiFileUploadHandler.ts
+++ b/src/utils/handlers/multiFileUploadHandler.ts
@@ -1,10 +1,50 @@
-type CreateMultiFileUploadHandlerCallbacks = Partial<{
-  onAfterUpload: (index: number, files: File[]) => void;
+type CreateMultiFileUploadHandlerCallbacks<T> = Partial<{
+  onAfterUpload: (index: number, files: File[], result: T) => void;
   onBeforeUpload: (index: number, files: File[]) => void;
   onCompleted: (files: File[]) => void;
   onError: (index: number, files: File[]) => void;
   onStart: (files: File[]) => void;
+  /**
+   * Max number of uploads in flight at once. Defaults to 1 (sequential).
+   */
+  concurrency: number;
 }>;
+
+async function uploadWithConcurrency<T>(
+  files: File[],
+  concurrency: number,
+  upload: (file: File, fileIndex: number) => Promise<T>,
+  {
+    onAfterUpload,
+    onBeforeUpload,
+    onError,
+  }: Pick<CreateMultiFileUploadHandlerCallbacks<T>, "onAfterUpload" | "onBeforeUpload" | "onError">,
+): Promise<void> {
+  let nextIndex = 0;
+
+  const worker = async () => {
+    while (nextIndex < files.length) {
+      const fileIndex = nextIndex;
+
+      nextIndex += 1;
+
+      try {
+        onBeforeUpload?.(fileIndex, files);
+
+        const result = await upload(files[fileIndex], fileIndex);
+
+        onAfterUpload?.(fileIndex, files, result);
+      } catch (exception) {
+        console.error(`Could not upload file #${fileIndex + 1}. Reason: ${exception}`);
+        onError?.(fileIndex, files);
+      }
+    }
+  };
+
+  const workerCount = Math.max(1, Math.min(concurrency, files.length));
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+}
 
 function createMultiFileUploadHandler<T>(
   upload: (file: File, fileIndex: number) => Promise<T>,
@@ -14,44 +54,21 @@ function createMultiFileUploadHandler<T>(
     onCompleted,
     onError,
     onStart,
-  }: CreateMultiFileUploadHandlerCallbacks,
+    concurrency = 1,
+  }: CreateMultiFileUploadHandlerCallbacks<T> = {},
 ) {
-  async function uploadImage(files: File[], fileIndex: number): Promise<void> {
-    if (files.length > fileIndex) {
-      try {
-        if (onBeforeUpload) {
-          onBeforeUpload(fileIndex, files);
-        }
-
-        await upload(files[fileIndex], fileIndex);
-
-        if (onAfterUpload) {
-          onAfterUpload(fileIndex, files);
-        }
-      } catch (exception) {
-        console.error(`Could not upload file #${fileIndex + 1}. Reason: ${exception}`);
-
-        if (onError) {
-          onError(fileIndex, files);
-        }
-      } finally {
-        await uploadImage(files, fileIndex + 1);
-      }
-    }
-  }
-
   return async (files: FileList | File[]): Promise<void> => {
     const fileArray = Array.from(files);
 
-    if (onStart) {
-      onStart(fileArray);
-    }
+    onStart?.(fileArray);
 
-    await uploadImage(fileArray, 0);
+    await uploadWithConcurrency(fileArray, concurrency, upload, {
+      onAfterUpload,
+      onBeforeUpload,
+      onError,
+    });
 
-    if (onCompleted) {
-      onCompleted(fileArray);
-    }
+    onCompleted?.(fileArray);
   };
 }
 


### PR DESCRIPTION
Improves product media and file attribute uploads:

- Dropping or selecting images shows upload previews immediately, including on an empty gallery
- Multiple uploads report one summary notification instead of a toast per file
- Product media can be selected and deleted in bulk
- Reordering media is smoother, with clearer drag feedback; reordering is blocked while uploads are still in progress
- Invalid or oversized files are rejected before upload, with a clear warning
- File attributes (for example hero images on products and models) support drag and drop to upload or replace, and show a thumbnail when the file is an image

https://github.com/user-attachments/assets/50bbe454-a652-49e4-830e-460421b51c48

<img width="1008" height="263" alt="image" src="https://github.com/user-attachments/assets/67e54063-7f5c-47c0-9dd8-86f9f360e3ca" />