### PR TITLE
feat: add SEARCH_ACTION extension mount for the command palette

### DIFF
--- a/.changeset/search-action-extension-mount.md
+++ b/.changeset/search-action-extension-mount.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+Add a `SEARCH_ACTION` extension mount that surfaces app actions in the global command palette (Cmd+K).
+
+Apps can register `SEARCH_ACTION` extensions to appear in the command bar with `POPUP`, `NEW_TAB`, or `APP_PAGE` targets (`WIDGET` is not supported). Actions can be scoped to specific pages via the new `options.views` manifest field (e.g. `["PRODUCT_DETAILS", "ORDER_DETAILS"]`); when omitted the action is available everywhere. When opened from an entity page, the current entity's context (e.g. product id, order id) is passed to the app just as it would be from that page's "more actions" menu. Actions are shown only when the current user holds the extension's required permissions.

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -40,7 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: ./.github/actions
+          sparse-checkout: |
+            ./.github/actions
+            ./.github/scripts
           persist-credentials: false
 
       - name: Load secrets for initialize-cloud

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -13434,6 +13434,10 @@
     "context": "delete shipping method",
     "string": "Are you sure you want to delete {name}?"
   },
+  "yOcWZe": {
+    "context": "command palette section grouping app-provided actions",
+    "string": "App actions"
+  },
   "yPMIz3": {
     "context": "Label for enabled auto-confirm row in tooltip",
     "string": "On"

--- a/src/components/NavigatorSearch/CommandContent.tsx
+++ b/src/components/NavigatorSearch/CommandContent.tsx
@@ -8,6 +8,7 @@ import { getShortcutLeadingKey } from "../Sidebar/shortcuts/utils";
 import { Actions } from "./Actions";
 import NavigatorSearchInput from "./NavigatorSearchInput";
 import { ResourcesTable } from "./ResourcesTable";
+import { SearchActions } from "./SearchActions";
 import { SettingsActions } from "./SettingsActions";
 import { useKeyboardNavigation } from "./useKeyboardNavigation";
 import { useNavigatorSearchContext } from "./useNavigatorSearchContext";
@@ -45,6 +46,11 @@ export const CommandContent = () => {
         paddingTop={2}
         paddingBottom={2}
       >
+        <SearchActions
+          query={query}
+          onActionSelected={handleClick}
+          onActionsChange={handleItemsChange}
+        />
         <Actions query={query} onActionClick={handleClick} />
         <SettingsActions query={query} onActionClick={handleClick} />
         <Box marginTop={3}>

--- a/src/components/NavigatorSearch/SearchActions.tsx
+++ b/src/components/NavigatorSearch/SearchActions.tsx
@@ -1,0 +1,29 @@
+import { useSearchActions } from "@dashboard/extensions/search-actions/useSearchActions";
+import { useEffect } from "react";
+
+import { SearchActionsList } from "./SearchActionsList";
+
+interface SearchActionsProps {
+  query: string;
+  onActionSelected: () => void;
+  onActionsChange: () => void;
+}
+
+export const SearchActions = ({ query, onActionSelected, onActionsChange }: SearchActionsProps) => {
+  const { actions, context } = useSearchActions();
+
+  // Extensions load asynchronously; let the keyboard navigation re-collect items
+  // once the available action list changes.
+  useEffect(() => {
+    onActionsChange();
+  }, [actions.length, onActionsChange]);
+
+  return (
+    <SearchActionsList
+      actions={actions}
+      context={context}
+      query={query}
+      onActionSelected={onActionSelected}
+    />
+  );
+};

--- a/src/components/NavigatorSearch/SearchActionsList.stories.tsx
+++ b/src/components/NavigatorSearch/SearchActionsList.stories.tsx
@@ -1,0 +1,64 @@
+import { type SearchActionContext } from "@dashboard/extensions/search-actions/resolveSearchActionContext";
+import { type ContextualSearchAction } from "@dashboard/extensions/search-actions/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SearchActionsList } from "./SearchActionsList";
+
+const context: SearchActionContext = {
+  view: "PRODUCT_DETAILS",
+  params: { productId: "UHJvZHVjdDox" },
+};
+
+const actions: ContextualSearchAction[] = [
+  {
+    id: "extension-1",
+    label: "Generate product description",
+    section: "App actions",
+    onSelect: () => undefined,
+  },
+  {
+    id: "extension-2",
+    label: "Sync to external catalog",
+    section: "App actions",
+    onSelect: () => undefined,
+  },
+  {
+    id: "native-1",
+    label: "Duplicate product",
+    section: "Dashboard actions",
+    onSelect: () => undefined,
+  },
+];
+
+const meta: Meta<typeof SearchActionsList> = {
+  title: "NavigatorSearch/SearchActionsList",
+  component: SearchActionsList,
+  args: {
+    context,
+    query: "",
+    onActionSelected: () => undefined,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SearchActionsList>;
+
+export const Default: Story = {
+  args: {
+    actions,
+  },
+};
+
+export const Filtered: Story = {
+  args: {
+    actions,
+    query: "sync",
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    actions: [],
+  },
+};

--- a/src/components/NavigatorSearch/SearchActionsList.test.tsx
+++ b/src/components/NavigatorSearch/SearchActionsList.test.tsx
@@ -1,0 +1,69 @@
+import { type SearchActionContext } from "@dashboard/extensions/search-actions/resolveSearchActionContext";
+import { type ContextualSearchAction } from "@dashboard/extensions/search-actions/types";
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { render, screen } from "@testing-library/react";
+
+import { SearchActionsList } from "./SearchActionsList";
+
+const context: SearchActionContext = {
+  view: "PRODUCT_DETAILS",
+  params: { productId: "UHJvZHVjdDox" },
+};
+
+// Neither label contains "avatax" - only the owning app's name does.
+const actions: ContextualSearchAction[] = [
+  {
+    id: "extension-1",
+    label: "Configure tax classes",
+    section: "App actions",
+    appName: "AvaTax",
+    onSelect: () => undefined,
+  },
+  {
+    id: "extension-2",
+    label: "Sync to external catalog",
+    section: "App actions",
+    appName: "Catalog Sync",
+    onSelect: () => undefined,
+  },
+];
+
+const renderList = (query: string) =>
+  render(
+    <ThemeProvider>
+      <SearchActionsList
+        actions={actions}
+        context={context}
+        query={query}
+        onActionSelected={() => undefined}
+      />
+    </ThemeProvider>,
+  );
+
+describe("SearchActionsList", () => {
+  it("finds an action by its app name", () => {
+    // Arrange & Act
+    renderList("avatax");
+
+    // Assert
+    expect(screen.getByText("Configure tax classes")).toBeInTheDocument();
+    expect(screen.queryByText("Sync to external catalog")).not.toBeInTheDocument();
+  });
+
+  it("tolerates a typo in the app name", () => {
+    // Arrange & Act
+    renderList("avtax");
+
+    // Assert
+    expect(screen.getByText("Configure tax classes")).toBeInTheDocument();
+    expect(screen.queryByText("Sync to external catalog")).not.toBeInTheDocument();
+  });
+
+  it("still finds an action by its label", () => {
+    // Arrange & Act
+    renderList("tax classes");
+
+    // Assert
+    expect(screen.getByText("Configure tax classes")).toBeInTheDocument();
+  });
+});

--- a/src/components/NavigatorSearch/SearchActionsList.tsx
+++ b/src/components/NavigatorSearch/SearchActionsList.tsx
@@ -1,0 +1,70 @@
+import { type SearchActionContext } from "@dashboard/extensions/search-actions/resolveSearchActionContext";
+import { type ContextualSearchAction } from "@dashboard/extensions/search-actions/types";
+import { fuzzySearch } from "@dashboard/misc";
+import { Box, Text } from "@saleor/macaw-ui-next";
+
+interface SearchActionsListProps {
+  actions: ContextualSearchAction[];
+  context: SearchActionContext;
+  query: string;
+  onActionSelected: () => void;
+}
+
+export const SearchActionsList = ({
+  actions,
+  context,
+  query,
+  onActionSelected,
+}: SearchActionsListProps) => {
+  const searchResults = fuzzySearch(actions, query, ["label"]);
+
+  if (searchResults.length === 0) {
+    return null;
+  }
+
+  const groupedBySection = Object.groupBy(searchResults, action => action.section);
+
+  return (
+    <Box>
+      {Object.entries(groupedBySection).map(([section, sectionActions]) => (
+        <Box key={section} paddingY={1}>
+          <Text fontWeight="medium" size={2} color="default2" paddingX={6}>
+            {section}
+          </Text>
+          {sectionActions?.map(action => (
+            <button
+              key={action.id}
+              id={action.id}
+              type="button"
+              className="command-menu-item"
+              data-test-id={action.id}
+              onClick={() => {
+                onActionSelected();
+                action.onSelect(context);
+              }}
+            >
+              <Box
+                className="command-menu-item-content"
+                display="flex"
+                alignItems="center"
+                color="default1"
+                gap={2}
+                paddingX={6}
+                paddingY={1.5}
+                role="option"
+                tabIndex={-1}
+              >
+                {action.avatar && (
+                  <img src={action.avatar} alt="" width={20} height={20} loading="lazy" />
+                )}
+                <Text size={2} fontWeight="medium" color="default1">
+                  {action.label}
+                </Text>
+              </Box>
+            </button>
+          ))}
+        </Box>
+      ))}
+    </Box>
+  );
+};

--- a/src/components/NavigatorSearch/SearchActionsList.tsx
+++ b/src/components/NavigatorSearch/SearchActionsList.tsx
@@ -16,7 +16,7 @@ export const SearchActionsList = ({
   query,
   onActionSelected,
 }: SearchActionsListProps) => {
-  const searchResults = fuzzySearch(actions, query, ["label"]);
+  const searchResults = fuzzySearch(actions, query, ["label", "appName"]);
 
   if (searchResults.length === 0) {
     return null;

--- a/src/components/NavigatorSearch/useActionItems.ts
+++ b/src/components/NavigatorSearch/useActionItems.ts
@@ -109,9 +109,17 @@ export const useActionItems = () => {
   const takeAction = () => {
     const element = getActiveFocusedElement();
 
-    if (!element || !element.dataset.href) return;
+    if (!element) return;
 
-    navigate(element.dataset.href);
+    // Link/row items navigate to their href; action items (e.g. search actions)
+    // handle activation via their own click handler.
+    if (element.dataset.href) {
+      navigate(element.dataset.href);
+
+      return;
+    }
+
+    element.click();
   };
 
   return {

--- a/src/components/Sidebar/menu/utils.test.ts
+++ b/src/components/Sidebar/menu/utils.test.ts
@@ -358,6 +358,7 @@ describe("getMenuItemExtension", () => {
     GIFT_CARD_DETAILS_WIDGETS: [],
     TRANSLATIONS_MORE_ACTIONS: [],
     HOMEPAGE_WIDGETS: [],
+    SEARCH_ACTION: [],
   };
 
   const emptyExtensionsRecord: Record<AllAppExtensionMounts, Extension[]> = {
@@ -412,6 +413,7 @@ describe("getMenuItemExtension", () => {
     GIFT_CARD_DETAILS_WIDGETS: [],
     TRANSLATIONS_MORE_ACTIONS: [],
     HOMEPAGE_WIDGETS: [],
+    SEARCH_ACTION: [],
   };
 
   it("should return the corresponding Extension object when a menu item ID represents a registered extension", () => {

--- a/src/extensions/domain/app-extension-manifest-available-mounts.ts
+++ b/src/extensions/domain/app-extension-manifest-available-mounts.ts
@@ -89,6 +89,9 @@ const TRANSLATIONS_MOUNTS = ["TRANSLATIONS_MORE_ACTIONS"] as const;
 
 const HOMEPAGE_MOUNTS = ["HOMEPAGE_WIDGETS"] as const;
 
+// Global mount rendered in the command palette (Cmd+K), not bound to a single page.
+const SEARCH_MOUNTS = ["SEARCH_ACTION"] as const;
+
 // Create a const array with all mounts to preserve literal types
 const ALL_MOUNTS_ARRAY = [
   ...CATEGORY_MOUNTS,
@@ -105,6 +108,7 @@ const ALL_MOUNTS_ARRAY = [
   ...PRODUCT_MOUNTS,
   ...VOUCHER_MOUNTS,
   ...TRANSLATIONS_MOUNTS,
+  ...SEARCH_MOUNTS,
 ] as const;
 
 // Create the zod enum from the tuple, ensuring proper type inference

--- a/src/extensions/domain/app-extension-manifest-options.ts
+++ b/src/extensions/domain/app-extension-manifest-options.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { AppExtensionViews } from "./app-extension-manifest-views";
+
 const httpMethodSchema = z
   .enum(["GET", "POST"], { message: "Method must be either GET or POST" })
   .default("GET");
@@ -22,6 +24,15 @@ export const appExtensionManifestOptionsSchema = z
     newTabTarget: newTabTargetOptionsSchema.optional().nullable(),
     widgetTarget: widgetTargetOptionsSchema.optional().nullable(),
     homeWidgetTarget: homeWidgetTargetOptionsSchema.optional().nullable(),
+    // Only valid on the SEARCH_ACTION mount (enforced in app-extension-manifest.ts).
+    // Absent/null = render in every view; when provided must name at least one view.
+    views: z
+      .array(AppExtensionViews, {
+        message: "views must be an array of valid view names",
+      })
+      .min(1, { message: "views must contain at least one view when provided" })
+      .optional()
+      .nullable(),
   })
   .refine(
     data => {

--- a/src/extensions/domain/app-extension-manifest-search-action.test.ts
+++ b/src/extensions/domain/app-extension-manifest-search-action.test.ts
@@ -1,0 +1,132 @@
+import { type AppExtensionManifest, appExtensionManifest } from "./app-extension-manifest";
+
+describe("App Extension Manifest Schema - SEARCH_ACTION mount", () => {
+  it("accepts a SEARCH_ACTION extension without views (renders everywhere)", () => {
+    // Arrange
+    const data: AppExtensionManifest = {
+      label: "Search action",
+      url: "https://example.com/action",
+      mountName: "SEARCH_ACTION",
+      targetName: "POPUP",
+      permissions: [],
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a SEARCH_ACTION extension scoped to specific views", () => {
+    // Arrange
+    const data: AppExtensionManifest = {
+      label: "Search action",
+      url: "https://example.com/action",
+      mountName: "SEARCH_ACTION",
+      targetName: "POPUP",
+      permissions: [],
+      options: { views: ["PRODUCT_DETAILS", "ORDER_DETAILS"] },
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts SEARCH_ACTION with NEW_TAB and APP_PAGE targets", () => {
+    // Act / Assert
+    expect(
+      appExtensionManifest.safeParse({
+        label: "Search action",
+        url: "https://example.com/action",
+        mountName: "SEARCH_ACTION",
+        targetName: "NEW_TAB",
+        permissions: [],
+      }).success,
+    ).toBe(true);
+
+    expect(
+      appExtensionManifest.safeParse({
+        label: "Search action",
+        url: "/app/action",
+        mountName: "SEARCH_ACTION",
+        targetName: "APP_PAGE",
+        permissions: [],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects SEARCH_ACTION with the WIDGET target", () => {
+    // Arrange
+    const data = {
+      label: "Search action",
+      url: "https://example.com/action",
+      mountName: "SEARCH_ACTION",
+      targetName: "WIDGET",
+      permissions: [],
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty views array", () => {
+    // Arrange
+    const data = {
+      label: "Search action",
+      url: "https://example.com/action",
+      mountName: "SEARCH_ACTION",
+      targetName: "POPUP",
+      permissions: [],
+      options: { views: [] },
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown view name", () => {
+    // Arrange
+    const data = {
+      label: "Search action",
+      url: "https://example.com/action",
+      mountName: "SEARCH_ACTION",
+      targetName: "POPUP",
+      permissions: [],
+      options: { views: ["NOT_A_VIEW"] },
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects the views option on a non-SEARCH_ACTION mount", () => {
+    // Arrange
+    const data = {
+      label: "Product action",
+      url: "https://example.com/action",
+      mountName: "PRODUCT_DETAILS_MORE_ACTIONS",
+      targetName: "POPUP",
+      permissions: [],
+      options: { views: ["PRODUCT_DETAILS"] },
+    };
+
+    // Act
+    const result = appExtensionManifest.safeParse(data);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/extensions/domain/app-extension-manifest-views.ts
+++ b/src/extensions/domain/app-extension-manifest-views.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+/**
+ * Dashboard "views" a SEARCH_ACTION extension can be scoped to. These mirror the
+ * react-router page structure (list + detail pages per entity) and double as the
+ * vocabulary for the `options.views` manifest field.
+ *
+ * Detail views resolve a single entity id as context (see resolveSearchActionContext);
+ * list views are surfaced without an id in the current version.
+ */
+const VIEWS_ARRAY = [
+  "PRODUCT_LIST",
+  "PRODUCT_DETAILS",
+  "ORDER_LIST",
+  "ORDER_DETAILS",
+  "DRAFT_ORDER_LIST",
+  "DRAFT_ORDER_DETAILS",
+  "CUSTOMER_LIST",
+  "CUSTOMER_DETAILS",
+  "COLLECTION_LIST",
+  "COLLECTION_DETAILS",
+  "CATEGORY_LIST",
+  "CATEGORY_DETAILS",
+  "GIFT_CARD_LIST",
+  "GIFT_CARD_DETAILS",
+  "VOUCHER_LIST",
+  "VOUCHER_DETAILS",
+  "DISCOUNT_LIST",
+  "DISCOUNT_DETAILS",
+  "PAGE_LIST",
+  "PAGE_DETAILS",
+  "PAGE_TYPE_LIST",
+  "PAGE_TYPE_DETAILS",
+  "MENU_LIST",
+  "MENU_DETAILS",
+] as const;
+
+export const AppExtensionViews = z.enum(VIEWS_ARRAY);
+
+export type AppExtensionView = z.infer<typeof AppExtensionViews>;

--- a/src/extensions/domain/app-extension-manifest.ts
+++ b/src/extensions/domain/app-extension-manifest.ts
@@ -99,6 +99,19 @@ export const appExtensionManifest = z
     {
       message: "homeWidgetTarget options can only be set on WIDGET target",
     },
+  )
+  .refine(
+    data => {
+      // views option is specific to the SEARCH_ACTION mount
+      if (data.options?.views && data.mountName !== "SEARCH_ACTION") {
+        return false;
+      }
+
+      return true;
+    },
+    {
+      message: "views option can only be set on SEARCH_ACTION mount",
+    },
   );
 
 export type AppExtensionManifest = z.infer<typeof appExtensionManifest>;

--- a/src/extensions/extensionMountPoints.ts
+++ b/src/extensions/extensionMountPoints.ts
@@ -34,4 +34,5 @@ export const extensionMountPoints = {
     "NAVIGATION_TRANSLATIONS",
   ],
   TRANSLATION_DETAILS: ["TRANSLATIONS_MORE_ACTIONS"],
+  GLOBAL_SEARCH: ["SEARCH_ACTION"],
 } as const satisfies Record<string, Array<AllAppExtensionMounts>>;

--- a/src/extensions/search-actions/filterSearchActions.test.ts
+++ b/src/extensions/search-actions/filterSearchActions.test.ts
@@ -1,0 +1,108 @@
+import { PermissionEnum, type UserFragment } from "@dashboard/graphql";
+
+import { filterSearchActions } from "./filterSearchActions";
+import { type SearchActionContext } from "./resolveSearchActionContext";
+import { type ContextualSearchAction } from "./types";
+
+const makeAction = (overrides: Partial<ContextualSearchAction>): ContextualSearchAction => ({
+  id: "action",
+  label: "Action",
+  section: "App actions",
+  onSelect: jest.fn(),
+  ...overrides,
+});
+
+const makeUser = (permissions: PermissionEnum[]): UserFragment =>
+  ({
+    userPermissions: permissions.map(code => ({ code, name: code })),
+  }) as UserFragment;
+
+const productDetailsContext: SearchActionContext = {
+  view: "PRODUCT_DETAILS",
+  params: { productId: "p1" },
+};
+
+const noViewContext: SearchActionContext = { view: null, params: {} };
+
+describe("filterSearchActions", () => {
+  it("keeps actions without a views restriction in every view", () => {
+    // Arrange
+    const action = makeAction({ views: undefined });
+
+    // Act
+    const result = filterSearchActions([action], noViewContext, makeUser([]));
+
+    // Assert
+    expect(result).toEqual([action]);
+  });
+
+  it("keeps an action whose views include the current view", () => {
+    // Arrange
+    const action = makeAction({ views: ["PRODUCT_DETAILS", "ORDER_DETAILS"] });
+
+    // Act
+    const result = filterSearchActions([action], productDetailsContext, makeUser([]));
+
+    // Assert
+    expect(result).toEqual([action]);
+  });
+
+  it("drops an action whose views do not include the current view", () => {
+    // Arrange
+    const action = makeAction({ views: ["ORDER_DETAILS"] });
+
+    // Act
+    const result = filterSearchActions([action], productDetailsContext, makeUser([]));
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("drops a view-scoped action when there is no current view", () => {
+    // Arrange
+    const action = makeAction({ views: ["PRODUCT_DETAILS"] });
+
+    // Act
+    const result = filterSearchActions([action], noViewContext, makeUser([]));
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("keeps an action when the user holds all required permissions", () => {
+    // Arrange
+    const action = makeAction({ permissions: [PermissionEnum.MANAGE_PRODUCTS] });
+
+    // Act
+    const result = filterSearchActions(
+      [action],
+      noViewContext,
+      makeUser([PermissionEnum.MANAGE_PRODUCTS]),
+    );
+
+    // Assert
+    expect(result).toEqual([action]);
+  });
+
+  it("drops an action when the user is missing a required permission", () => {
+    // Arrange
+    const action = makeAction({ permissions: [PermissionEnum.MANAGE_PRODUCTS] });
+
+    // Act
+    const result = filterSearchActions([action], noViewContext, makeUser([]));
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("drops a permission-gated action when there is no user", () => {
+    // Arrange
+    const action = makeAction({ permissions: [PermissionEnum.MANAGE_PRODUCTS] });
+
+    // Act
+    const result = filterSearchActions([action], noViewContext, undefined);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+});

--- a/src/extensions/search-actions/filterSearchActions.ts
+++ b/src/extensions/search-actions/filterSearchActions.ts
@@ -1,0 +1,29 @@
+import { hasAllPermissions } from "@dashboard/auth/misc";
+import { type UserFragment } from "@dashboard/graphql";
+
+import { type SearchActionContext } from "./resolveSearchActionContext";
+import { type ContextualSearchAction } from "./types";
+
+/**
+ * Keeps only the actions visible for the current view and the current user's
+ * permissions. An action with no `views` shows everywhere; an action with no
+ * `permissions` is ungated.
+ */
+export const filterSearchActions = (
+  actions: ContextualSearchAction[],
+  context: SearchActionContext,
+  user: UserFragment | null | undefined,
+): ContextualSearchAction[] =>
+  actions.filter(action => {
+    const matchesView =
+      !action.views || (context.view !== null && action.views.includes(context.view));
+
+    if (!matchesView) {
+      return false;
+    }
+
+    const hasRequiredPermissions =
+      !action.permissions?.length || (!!user && hasAllPermissions(action.permissions, user));
+
+    return hasRequiredPermissions;
+  });

--- a/src/extensions/search-actions/resolveSearchActionContext.test.ts
+++ b/src/extensions/search-actions/resolveSearchActionContext.test.ts
@@ -1,0 +1,120 @@
+import { resolveSearchActionContext } from "./resolveSearchActionContext";
+
+describe("resolveSearchActionContext", () => {
+  it("resolves a product detail route to PRODUCT_DETAILS with productId", () => {
+    // Arrange
+    const pathname = "/products/UHJvZHVjdDox";
+
+    // Act
+    const result = resolveSearchActionContext(pathname);
+
+    // Assert
+    expect(result).toEqual({
+      view: "PRODUCT_DETAILS",
+      params: { productId: "UHJvZHVjdDox" },
+    });
+  });
+
+  it("resolves a product list route to PRODUCT_LIST without params", () => {
+    // Arrange
+    const pathname = "/products/";
+
+    // Act
+    const result = resolveSearchActionContext(pathname);
+
+    // Assert
+    expect(result).toEqual({ view: "PRODUCT_LIST", params: {} });
+  });
+
+  it("treats the product create page as a non-detail route (no product context)", () => {
+    // Arrange
+    const pathname = "/products/add";
+
+    // Act
+    const result = resolveSearchActionContext(pathname);
+
+    // Assert
+    expect(result.params).toEqual({});
+    expect(result.view).not.toBe("PRODUCT_DETAILS");
+  });
+
+  it("collapses a nested product variant route to the parent product", () => {
+    // Arrange
+    const pathname = "/products/UHJvZHVjdDox/variant/VmFyaWFudDox";
+
+    // Act
+    const result = resolveSearchActionContext(pathname);
+
+    // Assert
+    expect(result).toEqual({
+      view: "PRODUCT_DETAILS",
+      params: { productId: "UHJvZHVjdDox" },
+    });
+  });
+
+  it("resolves a draft order detail route ahead of the order route", () => {
+    // Arrange
+    const pathname = "/orders/drafts/T3JkZXI6MQ==";
+
+    // Act
+    const result = resolveSearchActionContext(pathname);
+
+    // Assert
+    expect(result).toEqual({
+      view: "DRAFT_ORDER_DETAILS",
+      params: { draftOrderId: "T3JkZXI6MQ==" },
+    });
+  });
+
+  it("resolves the draft order list route without treating 'drafts' as an order id", () => {
+    // Arrange
+    const pathname = "/orders/drafts";
+
+    // Act
+    const result = resolveSearchActionContext(pathname);
+
+    // Assert
+    expect(result).toEqual({ view: "DRAFT_ORDER_LIST", params: {} });
+  });
+
+  it("collapses an order fulfillment sub-route to the parent order", () => {
+    // Arrange
+    const pathname = "/orders/T3JkZXI6MQ==/fulfill";
+
+    // Act
+    const result = resolveSearchActionContext(pathname);
+
+    // Assert
+    expect(result).toEqual({
+      view: "ORDER_DETAILS",
+      params: { orderId: "T3JkZXI6MQ==" },
+    });
+  });
+
+  it("resolves voucher and discount detail routes under /discounts", () => {
+    // Act / Assert
+    expect(resolveSearchActionContext("/discounts/vouchers/VjE=")).toEqual({
+      view: "VOUCHER_DETAILS",
+      params: { voucherId: "VjE=" },
+    });
+    expect(resolveSearchActionContext("/discounts/sales/RDE=")).toEqual({
+      view: "DISCOUNT_DETAILS",
+      params: { discountId: "RDE=" },
+    });
+  });
+
+  it("resolves a menu (structure) detail route", () => {
+    // Act
+    const result = resolveSearchActionContext("/structures/TWVudTox");
+
+    // Assert
+    expect(result).toEqual({ view: "MENU_DETAILS", params: { menuId: "TWVudTox" } });
+  });
+
+  it("returns no view for non-entity routes", () => {
+    // Act / Assert
+    expect(resolveSearchActionContext("/")).toEqual({ view: null, params: {} });
+    expect(resolveSearchActionContext("/configuration")).toEqual({ view: null, params: {} });
+    expect(resolveSearchActionContext("/gift-cards/settings")).toEqual({ view: null, params: {} });
+  });
+});

--- a/src/extensions/search-actions/resolveSearchActionContext.ts
+++ b/src/extensions/search-actions/resolveSearchActionContext.ts
@@ -1,0 +1,95 @@
+import { matchPath } from "react-router";
+
+import { type AppExtensionView } from "../domain/app-extension-manifest-views";
+import { type AppDetailsUrlMountQueryParams } from "../urls";
+
+export interface SearchActionContext {
+  /** The dashboard view the user is currently on, or null on non-entity routes. */
+  view: AppExtensionView | null;
+  /** Entity id context for the current view (empty on list / non-entity routes). */
+  params: AppDetailsUrlMountQueryParams;
+}
+
+interface ViewMatcher {
+  view: AppExtensionView;
+  path: string;
+  /** Present for detail views — the query param the captured id maps to. */
+  param?: keyof AppDetailsUrlMountQueryParams;
+  /** List views match exactly; detail views match loosely so nested routes collapse to the parent. */
+  exact?: boolean;
+}
+
+/**
+ * URL path segments that look like an entity id but are actually create pages or
+ * sub-sections. When a detail matcher captures one of these we skip it, letting the
+ * route fall through to its list view or to "no view".
+ */
+const RESERVED_IDS = new Set(["add", "settings", "drafts", "sales", "vouchers"]);
+
+/**
+ * Ordered most-specific-first. Detail matchers precede their list matchers, and
+ * nested sections (draft orders) precede their parent (orders).
+ */
+const MATCHERS: ViewMatcher[] = [
+  { view: "DRAFT_ORDER_DETAILS", path: "/orders/drafts/:id", param: "draftOrderId" },
+  { view: "DRAFT_ORDER_LIST", path: "/orders/drafts", exact: true },
+  { view: "ORDER_DETAILS", path: "/orders/:id", param: "orderId" },
+  { view: "ORDER_LIST", path: "/orders", exact: true },
+  { view: "PRODUCT_DETAILS", path: "/products/:id", param: "productId" },
+  { view: "PRODUCT_LIST", path: "/products", exact: true },
+  { view: "CUSTOMER_DETAILS", path: "/customers/:id", param: "customerId" },
+  { view: "CUSTOMER_LIST", path: "/customers", exact: true },
+  { view: "COLLECTION_DETAILS", path: "/collections/:id", param: "collectionId" },
+  { view: "COLLECTION_LIST", path: "/collections", exact: true },
+  { view: "CATEGORY_DETAILS", path: "/categories/:id", param: "categoryId" },
+  { view: "CATEGORY_LIST", path: "/categories", exact: true },
+  { view: "GIFT_CARD_DETAILS", path: "/gift-cards/:id", param: "giftCardId" },
+  { view: "GIFT_CARD_LIST", path: "/gift-cards", exact: true },
+  { view: "VOUCHER_DETAILS", path: "/discounts/vouchers/:id", param: "voucherId" },
+  { view: "VOUCHER_LIST", path: "/discounts/vouchers", exact: true },
+  { view: "DISCOUNT_DETAILS", path: "/discounts/sales/:id", param: "discountId" },
+  { view: "DISCOUNT_LIST", path: "/discounts/sales", exact: true },
+  { view: "PAGE_DETAILS", path: "/models/:id", param: "pageId" },
+  { view: "PAGE_LIST", path: "/models", exact: true },
+  { view: "PAGE_TYPE_DETAILS", path: "/model-types/:id", param: "pageTypeId" },
+  { view: "PAGE_TYPE_LIST", path: "/model-types", exact: true },
+  { view: "MENU_DETAILS", path: "/structures/:id", param: "menuId" },
+  { view: "MENU_LIST", path: "/structures", exact: true },
+];
+
+const EMPTY_CONTEXT: SearchActionContext = { view: null, params: {} };
+
+/**
+ * Derives the current dashboard view and its entity-id context from a pathname.
+ *
+ * Detail routes resolve a single id (nested routes such as a product variant or an
+ * order fulfilment collapse to the parent entity). List routes resolve a view with no
+ * id. Non-entity routes (home, settings, configuration) resolve to no view — only
+ * "everywhere" actions apply there.
+ */
+export const resolveSearchActionContext = (pathname: string): SearchActionContext => {
+  for (const matcher of MATCHERS) {
+    const match = matchPath<{ id?: string }>(pathname, {
+      path: matcher.path,
+      exact: matcher.exact ?? false,
+    });
+
+    if (!match) {
+      continue;
+    }
+
+    if (matcher.param) {
+      const id = match.params.id;
+
+      if (!id || RESERVED_IDS.has(id)) {
+        continue;
+      }
+
+      return { view: matcher.view, params: { [matcher.param]: id } };
+    }
+
+    return { view: matcher.view, params: {} };
+  }
+
+  return EMPTY_CONTEXT;
+};

--- a/src/extensions/search-actions/types.ts
+++ b/src/extensions/search-actions/types.ts
@@ -1,0 +1,25 @@
+import { type PermissionEnum } from "@dashboard/graphql";
+
+import { type AppExtensionView } from "../domain/app-extension-manifest-views";
+import { type SearchActionContext } from "./resolveSearchActionContext";
+
+/**
+ * A single action rendered in the command palette (Cmd+K), contributed either by an
+ * installed app (SEARCH_ACTION extension) or by native dashboard code. The palette
+ * filters actions by the current view and the user's permissions, then invokes
+ * `onSelect` with the resolved context.
+ */
+export interface ContextualSearchAction {
+  id: string;
+  label: string;
+  /** Group heading under which the action is listed in the palette. */
+  section: string;
+  /** Views the action is scoped to. Undefined = shown in every view. */
+  views?: AppExtensionView[];
+  /** Permissions the user must hold for the action to appear. Undefined/empty = always. */
+  permissions?: PermissionEnum[];
+  /** Optional icon (app logo for extension-provided actions). */
+  avatar?: string;
+  /** Invoked when the action is activated, receiving the current view + entity context. */
+  onSelect: (context: SearchActionContext) => void;
+}

--- a/src/extensions/search-actions/types.ts
+++ b/src/extensions/search-actions/types.ts
@@ -18,6 +18,8 @@ export interface ContextualSearchAction {
   views?: AppExtensionView[];
   /** Permissions the user must hold for the action to appear. Undefined/empty = always. */
   permissions?: PermissionEnum[];
+  /** Owning app's name for extension-provided actions. Searchable, not displayed. */
+  appName?: string;
   /** Optional icon (app logo for extension-provided actions). */
   avatar?: string;
   /** Invoked when the action is activated, receiving the current view + entity context. */

--- a/src/extensions/search-actions/useNativeSearchActions.ts
+++ b/src/extensions/search-actions/useNativeSearchActions.ts
@@ -1,0 +1,15 @@
+import { type ContextualSearchAction } from "./types";
+
+/**
+ * Central aggregator for native (non-extension) command-palette actions.
+ *
+ * Feature modules contribute contextual actions here by spreading their own action
+ * arrays into the returned list. Being a hook, contributors may use `useIntl`,
+ * `useNavigator`, permissions, etc. when building their actions.
+ *
+ * Actions are filtered by view + permissions in {@link useSearchActions}, so authors
+ * only need to declare `views`/`permissions` — no manual gating required.
+ */
+export const useNativeSearchActions = (): ContextualSearchAction[] => {
+  return [];
+};

--- a/src/extensions/search-actions/useSearchActions.ts
+++ b/src/extensions/search-actions/useSearchActions.ts
@@ -1,0 +1,65 @@
+import { useUser } from "@dashboard/auth/useUser";
+import { useMemo } from "react";
+import { defineMessages, useIntl } from "react-intl";
+import { useLocation } from "react-router";
+
+import { appExtensionManifestOptionsSchema } from "../domain/app-extension-manifest-options";
+import { type AppExtensionView } from "../domain/app-extension-manifest-views";
+import { extensionMountPoints } from "../extensionMountPoints";
+import { useExtensions } from "../hooks/useExtensions";
+import { type ExtensionWithParams } from "../types";
+import { filterSearchActions } from "./filterSearchActions";
+import { resolveSearchActionContext } from "./resolveSearchActionContext";
+import { type ContextualSearchAction } from "./types";
+import { useNativeSearchActions } from "./useNativeSearchActions";
+
+const messages = defineMessages({
+  appActionsSection: {
+    id: "yOcWZe",
+    defaultMessage: "App actions",
+    description: "command palette section grouping app-provided actions",
+  },
+});
+
+const parseExtensionViews = (
+  settings: ExtensionWithParams["settings"],
+): AppExtensionView[] | undefined => {
+  const result = appExtensionManifestOptionsSchema.safeParse(settings);
+
+  return result.success ? (result.data.views ?? undefined) : undefined;
+};
+
+/**
+ * Collects the command-palette actions available on the current page: native
+ * dashboard actions plus installed apps' SEARCH_ACTION extensions, filtered by the
+ * current view and the user's permissions. Returns the resolved context so callers
+ * can invoke `action.onSelect(context)`.
+ */
+export const useSearchActions = () => {
+  const intl = useIntl();
+  const location = useLocation();
+  const { user } = useUser();
+  const nativeActions = useNativeSearchActions();
+  const { SEARCH_ACTION } = useExtensions(extensionMountPoints.GLOBAL_SEARCH);
+
+  const context = useMemo(() => resolveSearchActionContext(location.pathname), [location.pathname]);
+
+  const actions = useMemo(() => {
+    // Extension.open loses its params in the map's type; the runtime objects accept them.
+    const extensions: ExtensionWithParams[] = SEARCH_ACTION;
+
+    const extensionActions: ContextualSearchAction[] = extensions.map(extension => ({
+      id: `extension-${extension.id}`,
+      label: extension.label,
+      section: intl.formatMessage(messages.appActionsSection),
+      views: parseExtensionViews(extension.settings),
+      permissions: extension.permissions,
+      avatar: extension.app.brand?.logo.default,
+      onSelect: context => extension.open(context.params),
+    }));
+
+    return filterSearchActions([...nativeActions, ...extensionActions], context, user);
+  }, [SEARCH_ACTION, nativeActions, context, user, intl]);
+
+  return { actions, context };
+};

--- a/src/extensions/search-actions/useSearchActions.ts
+++ b/src/extensions/search-actions/useSearchActions.ts
@@ -54,6 +54,7 @@ export const useSearchActions = () => {
       section: intl.formatMessage(messages.appActionsSection),
       views: parseExtensionViews(extension.settings),
       permissions: extension.permissions,
+      appName: extension.app.name ?? undefined,
       avatar: extension.app.brand?.logo.default,
       onSelect: context => extension.open(context.params),
     }));

--- a/src/index.css
+++ b/src/index.css
@@ -117,6 +117,18 @@ a.command-menu-item {
   display: block;
 }
 
+button.command-menu-item {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
 .command-menu-item:hover .command-menu-item-content,
 .command-menu-item[data-focus="true"] .command-menu-item-content {
   background-color: var(--mu-colors-background-default1-hovered) !important;


### PR DESCRIPTION
Introduce a global SEARCH_ACTION extension mount that surfaces app actions in the Cmd+K command palette, plus a unified contextual-action model shared by app extensions and native dashboard actions.

- Add SEARCH_ACTION mount and an AppExtensionViews enum (react-router list + detail pages); new optional options.views manifest field, gated to SEARCH_ACTION and validated (enum, non-empty). WIDGET target rejected.
- Resolve the current route to a view + entity context (product id, order id, etc.); nested routes collapse to their parent, non-entity routes get no context.
- Filter actions by view and the user's permissions; app extensions dispatch via the existing POPUP / NEW_TAB / APP_PAGE flow with context params.
- Render a dedicated, fuzzy-searchable section in NavigatorSearch shown on open; Enter activates non-link rows via their own click handler.

<img width="761" height="463" alt="CleanShot 2026-07-20 at 10 56 45" src="https://github.com/user-attachments/assets/1949ac8f-a1d3-4906-860a-11d3f310957e" />
<img width="776" height="476" alt="CleanShot 2026-07-20 at 10 56 18" src="https://github.com/user-attachments/assets/21c856ff-4a5e-4d81-9c84-69f2cf9ddb1b" />

example manifest 

```js
const searchActionExtensions = [
      {
        // POPUP target, no `views` -> action is available in every Dashboard view.
        url: iframeBaseUrl + "/actions",
        permissions: [],
        mount: "SEARCH_ACTION",
        label: "Open app in popup",
        target: "POPUP",
      },
      {
        // APP_PAGE target, scoped to entity detail views. Saleor passes the current
        // product / order id to the app as context when the action is triggered.
        // APP_PAGE targets must use a relative URL (path within the app).
        url: "/actions",
        permissions: [],
        mount: "SEARCH_ACTION",
        label: "Run action on this record",
        target: "APP_PAGE",
        options: {
          views: ["PRODUCT_DETAILS", "ORDER_DETAILS", "CUSTOMER_DETAILS"],
        },
      },
      {
        // NEW_TAB target, scoped to entity list views. `newTabTarget.method` controls
        // how Saleor opens the URL (GET opens directly, POST submits a form).
        url: iframeBaseUrl + "/actions",
        permissions: [],
        mount: "SEARCH_ACTION",
        label: "Export current list",
        target: "NEW_TAB",
        options: {
          views: ["PRODUCT_LIST", "ORDER_LIST", "CUSTOMER_LIST"],
          newTabTarget: {
            method: "GET",
          },
        },
      },
    ] as AppExtension[];
```

https://github.com/saleor/app-sdk/pull/518
