### PR TITLE
Redesign home empty state as centered dashed card

### DIFF
--- a/src/home/HomeEmptyState.module.css
+++ b/src/home/HomeEmptyState.module.css
@@ -1,0 +1,6 @@
+/* Note: `borderStyle: "dashed"` lives in a CSS module because
+   macaw-ui-next's `borderStyle` sprinkle only ships `"none" | "solid"`. */
+.card {
+  border-style: dashed;
+  max-width: 480px;
+}

--- a/src/home/HomeEmptyState.stories.tsx
+++ b/src/home/HomeEmptyState.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { HomeEmptyState } from "./HomeEmptyState";
+
+const meta: Meta<typeof HomeEmptyState> = {
+  title: "Home / HomeEmptyState",
+  component: HomeEmptyState,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HomeEmptyState>;
+
+export const Default: Story = {};

--- a/src/home/HomeEmptyState.tsx
+++ b/src/home/HomeEmptyState.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from "@saleor/macaw-ui-next";
+import { Blocks } from "lucide-react";
+import { FormattedMessage } from "react-intl";
+
+import styles from "./HomeEmptyState.module.css";
+
+export const HomeEmptyState = () => (
+  <Box display="flex" alignItems="center" justifyContent="center" height="100%" padding={6}>
+    <Box
+      className={styles.card}
+      display="flex"
+      alignItems="center"
+      gap={5}
+      padding={7}
+      borderRadius={4}
+      borderWidth={1}
+      borderColor="default1"
+    >
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        flexShrink="0"
+        borderRadius={3}
+        backgroundColor="default2"
+        color="default2"
+        __width="48px"
+        __height="48px"
+      >
+        <Blocks size={24} />
+      </Box>
+      <Box display="flex" flexDirection="column" gap={1}>
+        <Text size={4} fontWeight="bold">
+          <FormattedMessage
+            id="fTLvHX"
+            defaultMessage="Welcome"
+            description="empty home page title"
+          />
+        </Text>
+        <Text size={2} color="default2">
+          <FormattedMessage
+            id="cxUBO1"
+            defaultMessage="Install an app that registers a HOMEPAGE_WIDGETS extension to see it here."
+            description="empty home page description"
+          />
+        </Text>
+      </Box>
+    </Box>
+  </Box>
+);

--- a/src/home/HomePage.tsx
+++ b/src/home/HomePage.tsx
@@ -1,11 +1,11 @@
 import { useUser } from "@dashboard/auth/useUser";
 import { useExtensionsWithLoadingState } from "@dashboard/extensions/hooks/useExtensions";
-import { Box, Text } from "@saleor/macaw-ui-next";
-import { FormattedMessage } from "react-intl";
+import { Box } from "@saleor/macaw-ui-next";
 import { useParams, useRouteMatch } from "react-router";
 import { Redirect } from "react-router-dom";
 
 import { filterHomeExtensions } from "./filterHomeExtensions";
+import { HomeEmptyState } from "./HomeEmptyState";
 import { HomeWidgetsGrid } from "./HomeWidgetsGrid";
 import { type HomeActiveTab, HomeWidgetTabs } from "./HomeWidgetTabs";
 import { HomeWidgetView } from "./HomeWidgetView";
@@ -56,26 +56,7 @@ export const HomePage = () => {
   }
 
   if (fullscreen.length === 0 && widgets.length === 0) {
-    return (
-      <Box paddingX={8} paddingY={9}>
-        <Text size={6} fontWeight="bold">
-          <FormattedMessage
-            id="fTLvHX"
-            defaultMessage="Welcome"
-            description="empty home page title"
-          />
-        </Text>
-        <Box marginTop={4}>
-          <Text>
-            <FormattedMessage
-              id="cxUBO1"
-              defaultMessage="Install an app that registers a HOMEPAGE_WIDGETS extension to see it here."
-              description="empty home page description"
-            />
-          </Text>
-        </Box>
-      </Box>
-    );
+    return <HomeEmptyState />;
   }
 
   const leftmostUrl = resolveLeftmostTabUrl(fullscreen, widgets);


### PR DESCRIPTION
Replace the plain top-left "Welcome" text with a centered card that has a dashed border, an extension icon, and the install message. Extract it into a dedicated HomeEmptyState component with a Storybook story.

<img width="554" height="194" alt="CleanShot 2026-07-20 at 10 47 50" src="https://github.com/user-attachments/assets/6530f59e-19dc-4026-8eef-6ab7d149b8df" />
