### PR TITLE
Make fulfillment tracking numbers clickable when they are URLs

### DIFF
--- a/.changeset/tracking-number-clickable.md
+++ b/.changeset/tracking-number-clickable.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+On the order details page, fulfillment tracking numbers that are URLs are now clickable links that open in a new tab. Non-URL tracking numbers keep their plain-text display, and copying to clipboard still works in both cases.

--- a/src/orders/components/OrderCardTitle/TrackingNumberDisplay.tsx
+++ b/src/orders/components/OrderCardTitle/TrackingNumberDisplay.tsx
@@ -1,4 +1,5 @@
 import { useClipboard } from "@dashboard/hooks/useClipboard";
+import { isExternalURL } from "@dashboard/utils/urls";
 import { Box, Button, Text } from "@saleor/macaw-ui-next";
 import { useState } from "react";
 import { useIntl } from "react-intl";
@@ -17,6 +18,21 @@ export const TrackingNumberDisplay = ({
   const intl = useIntl();
   const [copied, copy] = useClipboard();
   const [showCopyButton, setShowCopyButton] = useState(false);
+  const isUrl = isExternalURL(trackingNumber);
+
+  const trackingNumberContent = (
+    <Text
+      as={isUrl ? "a" : "span"}
+      {...(isUrl ? { href: trackingNumber, target: "_blank", rel: "noopener noreferrer" } : {})}
+      size={2}
+      color={showCopyButton ? "default1" : "default2"}
+      fontWeight="medium"
+      textDecoration={isUrl ? { default: "none", hover: "underline" } : undefined}
+      __transition="color 0.15s ease-in-out"
+    >
+      {trackingNumber}
+    </Text>
+  );
 
   return (
     <Box
@@ -41,16 +57,7 @@ export const TrackingNumberDisplay = ({
             id: "vMo6/3",
           },
           {
-            trackingNumber: (
-              <Text
-                size={2}
-                color={showCopyButton ? "default1" : "default2"}
-                fontWeight="medium"
-                __transition="color 0.15s ease-in-out"
-              >
-                {trackingNumber}
-              </Text>
-            ),
+            trackingNumber: trackingNumberContent,
           },
         )}
       </Text>


### PR DESCRIPTION
> [!NOTE]
> PR description + changeset written with AI
 
### What this does

On the order details page (`orders/<id>`), each fulfillment's tracking number is now rendered as a clickable link **when the value has the shape of a URL** (`http(s)://…`). It opens in a new tab (`target="_blank"` with `rel="noopener noreferrer"`).

### Why

Carriers increasingly put a full tracking URL in the tracking number field. Previously this was plain text, forcing users to copy it and paste it into the address bar. Making it a link removes that friction.

### Notes

- Detection reuses the existing `isExternalURL` helper, so only `http(s)` values become links — this avoids turning arbitrary schemes (e.g. `javascript:`) into anchors.
- Non-URL tracking numbers keep the existing plain-text display.
- The copy-to-clipboard button still copies the raw value in both cases.

### Screenshots
<img width="384" height="72" alt="Capture d’écran 2026-07-20 à 12 21 45" src="https://github.com/user-attachments/assets/4d750e31-7e88-4cc4-a620-6dc92044269c" />
