### PR TITLE
Retry product media image loading with exponential backoff

### DIFF
--- a/.changeset/great-pianos-repeat.md
+++ b/.changeset/great-pianos-repeat.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Product media images no longer require a page refresh when the thumbnail is still being generated. Previously, when Saleor was not yet ready to serve an image, the dashboard showed a permanent "Image could not be loaded" fallback until the page was refreshed manually. Now the image is retried automatically with exponential backoff and appears as soon as it becomes available.

--- a/src/components/MediaWithFallback/MediaWithFallback.test.tsx
+++ b/src/components/MediaWithFallback/MediaWithFallback.test.tsx
@@ -1,0 +1,183 @@
+import { ThemeProvider } from "@saleor/macaw-ui-next";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { IntlProvider } from "react-intl";
+
+import { MediaWithFallback } from "./MediaWithFallback";
+
+const SRC = "https://example.com/image.jpg";
+const PLACEHOLDER_SRC = "blob:placeholder";
+// Backoff schedule from useImageLoadRetry: capped at 30s per delay, ~2min total.
+const RETRY_DELAYS_MS = [2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000];
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <IntlProvider locale="en" messages={{}}>
+    <ThemeProvider>{children}</ThemeProvider>
+  </IntlProvider>
+);
+
+const getMainImg = (container: HTMLElement): HTMLImageElement => {
+  const img = container.querySelector<HTMLImageElement>(`img[src="${SRC}"]`);
+
+  if (!img) {
+    throw new Error("Main image not found");
+  }
+
+  return img;
+};
+
+describe("MediaWithFallback", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("keeps the loading state and retries after a load error instead of failing immediately", () => {
+    // Arrange
+    const { container } = render(<MediaWithFallback src={SRC} alt="Product" />, {
+      wrapper: Wrapper,
+    });
+    const firstImg = getMainImg(container);
+
+    // Act
+    fireEvent.error(firstImg);
+
+    // Assert - still loading (skeleton visible, no error fallback), retry pending
+    expect(screen.queryByText("Image could not be loaded")).not.toBeInTheDocument();
+
+    // Act - just before the first backoff delay elapses nothing happens
+    act(() => jest.advanceTimersByTime(RETRY_DELAYS_MS[0] - 1));
+
+    // Assert
+    expect(getMainImg(container)).toBe(firstImg);
+
+    // Act - delay elapses, image element is remounted to re-request the URL
+    act(() => jest.advanceTimersByTime(1));
+
+    // Assert
+    expect(getMainImg(container)).not.toBe(firstImg);
+  });
+
+  it("shows the image when a retry succeeds", () => {
+    // Arrange
+    const onPlaceholderUnused = jest.fn();
+    const { container } = render(
+      <MediaWithFallback src={SRC} alt="Product" onPlaceholderUnused={onPlaceholderUnused} />,
+      { wrapper: Wrapper },
+    );
+
+    // Act - first attempt fails, second succeeds
+    fireEvent.error(getMainImg(container));
+    act(() => jest.advanceTimersByTime(RETRY_DELAYS_MS[0]));
+    fireEvent.load(getMainImg(container));
+
+    // Assert
+    expect(getMainImg(container).style.display).not.toBe("none");
+    expect(onPlaceholderUnused).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the placeholder visible during retries and does not release it on intermediate errors", () => {
+    // Arrange
+    const onPlaceholderUnused = jest.fn();
+    const { container } = render(
+      <MediaWithFallback
+        src={SRC}
+        alt="Product"
+        placeholderSrc={PLACEHOLDER_SRC}
+        onPlaceholderUnused={onPlaceholderUnused}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    // Act
+    fireEvent.error(getMainImg(container));
+    act(() => jest.advanceTimersByTime(RETRY_DELAYS_MS[0]));
+    fireEvent.error(getMainImg(container));
+
+    // Assert
+    expect(screen.getByTestId("media-placeholder")).toBeInTheDocument();
+    expect(onPlaceholderUnused).not.toHaveBeenCalled();
+  });
+
+  it("shows the error fallback and releases the placeholder once the retry budget is exhausted", () => {
+    // Arrange
+    const onPlaceholderUnused = jest.fn();
+    const { container } = render(
+      <MediaWithFallback src={SRC} alt="Product" onPlaceholderUnused={onPlaceholderUnused} />,
+      { wrapper: Wrapper },
+    );
+
+    // Act - fail every attempt through the whole backoff schedule
+    RETRY_DELAYS_MS.forEach(delay => {
+      fireEvent.error(getMainImg(container));
+      act(() => jest.advanceTimersByTime(delay));
+    });
+
+    // Assert - budget not yet exhausted, still loading
+    expect(screen.queryByText("Image could not be loaded")).not.toBeInTheDocument();
+
+    // Act - one more failure exceeds the total budget
+    fireEvent.error(getMainImg(container));
+
+    // Assert
+    expect(screen.getByText("Image could not be loaded")).toBeInTheDocument();
+    expect(onPlaceholderUnused).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the pending retry on unmount", () => {
+    // Arrange
+    const { container, unmount } = render(<MediaWithFallback src={SRC} alt="Product" />, {
+      wrapper: Wrapper,
+    });
+
+    // Act
+    fireEvent.error(getMainImg(container));
+    unmount();
+
+    // Assert
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("resets the backoff schedule when src changes", () => {
+    // Arrange
+    const { container, rerender } = render(
+      <Wrapper>
+        <MediaWithFallback src="https://example.com/old.jpg" alt="Product" />
+      </Wrapper>,
+    );
+    const oldImg = container.querySelector<HTMLImageElement>(
+      'img[src="https://example.com/old.jpg"]',
+    );
+
+    if (!oldImg) {
+      throw new Error("Old image not found");
+    }
+
+    // Act - burn the first delay on the old src, then swap the src
+    fireEvent.error(oldImg);
+    act(() => jest.advanceTimersByTime(RETRY_DELAYS_MS[0]));
+    rerender(
+      <Wrapper>
+        <MediaWithFallback src={SRC} alt="Product" />
+      </Wrapper>,
+    );
+
+    // Act - fail the new src; its first retry should use the initial delay again
+    const firstImg = getMainImg(container);
+
+    fireEvent.error(firstImg);
+    act(() => jest.advanceTimersByTime(RETRY_DELAYS_MS[0] - 1));
+
+    // Assert - not remounted yet
+    expect(getMainImg(container)).toBe(firstImg);
+
+    // Act
+    act(() => jest.advanceTimersByTime(1));
+
+    // Assert - remounted after the initial delay, proving the schedule was reset
+    expect(getMainImg(container)).not.toBe(firstImg);
+  });
+});

--- a/src/components/MediaWithFallback/MediaWithFallback.tsx
+++ b/src/components/MediaWithFallback/MediaWithFallback.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 
 import { mediaFallbackMessages } from "./messages";
+import { useImageLoadRetry } from "./useImageLoadRetry";
 
 interface MediaWithFallbackProps extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, "alt"> {
   // Extend to allow "null" because GraphQL can return it. It's suger to avoid extra mapping in parents
@@ -23,6 +24,7 @@ export const MediaWithFallback = ({
   ...rest
 }: MediaWithFallbackProps) => {
   const [loadingStatus, setLoadingStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const { attempt, handleError } = useImageLoadRetry(src);
 
   const hasError = loadingStatus === "error";
   const isLoaded = loadingStatus === "loaded";
@@ -66,13 +68,19 @@ export const MediaWithFallback = ({
       ) : null}
       {!isLoaded && !placeholderSrc ? <Skeleton __width="100%" __height="100%" /> : null}
       <img
+        // Remounting forces the browser to re-request the URL after each backoff delay.
+        key={attempt}
         className={className}
         src={src}
         alt={alt ?? undefined}
         onLoad={handleLoad}
         onError={() => {
-          setLoadingStatus("error");
-          onPlaceholderUnused?.();
+          // Saleor serves 503 while a thumbnail is still being generated, so keep the
+          // loading state and retry; give up only once the backoff budget is exhausted.
+          if (!handleError()) {
+            setLoadingStatus("error");
+            onPlaceholderUnused?.();
+          }
         }}
         style={isLoaded ? { ...style } : { ...style, display: "none" }}
         {...rest}

--- a/src/components/MediaWithFallback/useImageLoadRetry.ts
+++ b/src/components/MediaWithFallback/useImageLoadRetry.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const INITIAL_DELAY_MS = 2_000;
+const FACTOR = 2;
+const MAX_DELAY_MS = 30_000;
+const MAX_TOTAL_MS = 120_000;
+
+const delayForAttempt = (attempt: number): number =>
+  Math.min(INITIAL_DELAY_MS * FACTOR ** attempt, MAX_DELAY_MS);
+
+const elapsedBeforeAttempt = (attempt: number): number => {
+  let elapsed = 0;
+
+  for (let i = 0; i < attempt; i++) {
+    elapsed += delayForAttempt(i);
+  }
+
+  return elapsed;
+};
+
+interface UseImageLoadRetry {
+  /** Bumped after each backoff delay — use as `key` on the `<img>` to force a fresh request. */
+  attempt: number;
+  /** Call on image load error. Returns false when the retry budget is exhausted. */
+  handleError: () => boolean;
+}
+
+/**
+ * Retries failed image loads with exponential backoff (2s, 4s, 8s, ... capped at 30s,
+ * ~2 minutes total). Saleor generates thumbnails lazily and serves 503 until ready,
+ * so transient load errors usually resolve on their own.
+ */
+export const useImageLoadRetry = (src: string | undefined): UseImageLoadRetry => {
+  const [attempt, setAttempt] = useState(0);
+  const [prevSrc, setPrevSrc] = useState(src);
+  const timeoutRef = useRef<number>();
+
+  if (prevSrc !== src) {
+    setPrevSrc(src);
+    setAttempt(0);
+  }
+
+  useEffect(
+    function clearPendingRetry() {
+      return (): void => window.clearTimeout(timeoutRef.current);
+    },
+    [src],
+  );
+
+  const handleError = useCallback(() => {
+    const delay = delayForAttempt(attempt);
+
+    if (elapsedBeforeAttempt(attempt) + delay > MAX_TOTAL_MS) {
+      return false;
+    }
+
+    timeoutRef.current = window.setTimeout(() => setAttempt(prev => prev + 1), delay);
+
+    return true;
+  }, [attempt]);
+
+  return { attempt, handleError };
+};


### PR DESCRIPTION
Saleor generates thumbnails lazily and serves HTTP 503 until they are ready, which left a permanent "Image could not be loaded" fallback that only a manual page refresh could fix. MediaWithFallback now keeps the loading state and retries the image (2s, 4s, 8s, 16s, then 30s capped, ~2 min total) before showing the terminal fallback.
