### PR TITLE
Make homepage fullscreen widgets edge-to-edge under tabs

### DIFF
--- a/.changeset/homepage-fullscreen-full-bleed.md
+++ b/.changeset/homepage-fullscreen-full-bleed.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Homepage fullscreen widgets (e.g. Pulse) now render edge-to-edge under the tabs, without the previous content inset.

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -39,21 +39,25 @@ interface TabProps<T> {
   isActive: boolean;
   changeTab: (index: T) => void;
   testId?: string;
+  className?: string;
 }
 
 export function Tab<T>(value: T) {
   const Component = (props: TabProps<T>) => {
-    const { children, isActive, changeTab, testId } = props;
+    const { children, isActive, changeTab, testId, className } = props;
     const classes = useStyles(props);
 
     return (
       <Text
         as="span"
         data-test-id={testId}
-        className={clsx({
-          [classes.root]: true,
-          [classes.active]: isActive,
-        })}
+        className={clsx(
+          {
+            [classes.root]: true,
+            [classes.active]: isActive,
+          },
+          className,
+        )}
         onClick={() => changeTab(value)}
       >
         {children}

--- a/src/home/ExtensionIframe.tsx
+++ b/src/home/ExtensionIframe.tsx
@@ -43,7 +43,7 @@ export const ExtensionIframe = ({
 
   if (method === "POST") {
     return (
-      <Box position="relative" width="100%" height="100%">
+      <Box position="relative" __lineHeight={0} width="100%" height="100%">
         <IframePost
           appId={extension.app.id}
           accessToken={extension.accessToken}

--- a/src/home/HomePage.tsx
+++ b/src/home/HomePage.tsx
@@ -72,38 +72,36 @@ export const HomePage = () => {
   }
 
   let activeTab: HomeActiveTab;
+  let activeFullscreenExtension: (typeof fullscreen)[number] | undefined;
 
   if (isWidgetsRoute) {
     activeTab = { kind: "widgets" };
   } else {
-    const activeExtension = fullscreen.find(extension => extension.id === extensionId);
+    activeFullscreenExtension = fullscreen.find(extension => extension.id === extensionId);
 
     // URL points to a missing or unauthorized fullscreen extension - redirect to leftmost tab
-    if (!activeExtension) {
+    if (!activeFullscreenExtension) {
       return <Redirect to={leftmostUrl!} />;
     }
 
-    activeTab = { kind: "extension", id: activeExtension.id };
+    activeTab = { kind: "extension", id: activeFullscreenExtension.id };
   }
 
   const showWidgetsTab = widgets.length > 0;
+  const isFullscreenTab = activeTab.kind === "extension";
 
   return (
     <Box display="flex" flexDirection="column" height="100%">
-      <Box paddingX={6} paddingTop={6}>
-        <HomeWidgetTabs
-          fullscreenExtensions={fullscreen}
-          showWidgetsTab={showWidgetsTab}
-          activeTab={activeTab}
-        />
-      </Box>
-      <Box padding={6} width="100%" __flex="1" __minHeight={0}>
+      <HomeWidgetTabs
+        fullscreenExtensions={fullscreen}
+        showWidgetsTab={showWidgetsTab}
+        activeTab={activeTab}
+      />
+      <Box padding={isFullscreenTab ? 0 : 6} width="100%" __flex="1" __minHeight={0}>
         {activeTab.kind === "widgets" ? (
           <HomeWidgetsGrid extensions={widgets} />
         ) : (
-          <HomeWidgetView
-            extension={fullscreen.find(extension => extension.id === activeTab.id)!}
-          />
+          <HomeWidgetView extension={activeFullscreenExtension!} />
         )}
       </Box>
     </Box>

--- a/src/home/HomeWidgetTabs.module.css
+++ b/src/home/HomeWidgetTabs.module.css
@@ -1,0 +1,4 @@
+/* Doubled selector overrides Tab makeStyles `padding` shorthand. */
+.tab.tab {
+  padding: 12px 8px 10px;
+}

--- a/src/home/HomeWidgetTabs.tsx
+++ b/src/home/HomeWidgetTabs.tsx
@@ -2,10 +2,11 @@ import { Tab, TabContainer } from "@dashboard/components/Tab";
 import { type Extension } from "@dashboard/extensions/types";
 import { SaleorLogo } from "@dashboard/extensions/views/InstallCustomExtension/components/InstallSectionData/InstallExtensionManifestData/SaleorLogo";
 import useNavigator from "@dashboard/hooks/useNavigator";
-import { Box, Text } from "@saleor/macaw-ui-next";
+import { Box, sprinkles, Text } from "@saleor/macaw-ui-next";
 import { Blocks } from "lucide-react";
 import { defineMessages, useIntl } from "react-intl";
 
+import styles from "./HomeWidgetTabs.module.css";
 import { homeWidgetsUrl, homeWidgetUrl } from "./urls";
 
 const HomeTab = Tab<string>("home-widget-tab");
@@ -34,14 +35,16 @@ export const HomeWidgetTabs = ({
   const navigate = useNavigator();
   const intl = useIntl();
 
+  // paddingX on TabContainer (not a parent) so border-bottom stays edge-to-edge
   return (
-    <TabContainer>
+    <TabContainer className={sprinkles({ paddingX: 6, paddingTop: 3 })}>
       {fullscreenExtensions.map(extension => (
         <HomeTab
           key={extension.id}
           isActive={activeTab.kind === "extension" && activeTab.id === extension.id}
           changeTab={() => navigate(homeWidgetUrl(extension.id))}
           testId={`home-widget-tab-${extension.id}`}
+          className={styles.tab}
         >
           <Box display="inline-flex" alignItems="center" gap={2}>
             <Box
@@ -70,6 +73,7 @@ export const HomeWidgetTabs = ({
           isActive={activeTab.kind === "widgets"}
           changeTab={() => navigate(homeWidgetsUrl())}
           testId="home-widgets-tab"
+          className={styles.tab}
         >
           <Box display="inline-flex" alignItems="center" gap={2}>
             <Box


### PR DESCRIPTION
Fullscreen tabs like Pulse were inset by the shared content padding, which blocked full-bleed layouts; keep inset only for the widgets grid and align the tab divider edge-to-edge.