### PR TITLE
ci: pin Saleor CLI instead of resolving it at run time

### DIFF
--- a/.github/actions/cli-login/action.yml
+++ b/.github/actions/cli-login/action.yml
@@ -1,5 +1,5 @@
 name: Saleor CLI login
-description: Saleor CLI login to staging Saleor Cloud
+description: Install the pinned Saleor CLI and log in to staging Saleor Cloud
 inputs:
   token:
     description: "Cloud access token"
@@ -7,6 +7,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Version is pinned in .github/scripts/package.json - never resolve "latest" at runtime.
+    - name: Install Saleor CLI
+      shell: bash
+      working-directory: .github/scripts
+      run: |
+        pnpm install --frozen-lockfile
+        echo "$GITHUB_WORKSPACE/.github/scripts/node_modules/.bin" >> "$GITHUB_PATH"
+
     - name: Write config file
       shell: bash
       id: write-config-file

--- a/.github/actions/prepare-backups-variables/action.yml
+++ b/.github/actions/prepare-backups-variables/action.yml
@@ -36,7 +36,7 @@ runs:
       env:
         BACKUP_NAME: ${{ inputs.BACKUP_NAMESPACE }}
       run: |
-        BACKUPS=$(pnpx saleor backup list --name="$BACKUP_NAME" --latest --json)
+        BACKUPS=$(saleor backup list --name="$BACKUP_NAME" --latest --json)
         BACKUP_ID=$(echo "$BACKUPS" | jq -r '.[0].key')
         BACKUP_VER=$(echo "$BACKUPS" | jq -r '.[0].saleor_version')
         BACKUP_NAME=$(echo "$BACKUPS" | jq -r '.[0].name')

--- a/.github/actions/prepare-instance/action.yml
+++ b/.github/actions/prepare-instance/action.yml
@@ -47,7 +47,7 @@ runs:
         INSTANCE_NAME: ${{ inputs.POOL_NAME }}
       run: |
         set +o pipefail
-        INSTANCE_KEY=$(pnpx saleor env show "$INSTANCE_NAME" --json | jq .key)
+        INSTANCE_KEY=$(saleor env show "$INSTANCE_NAME" --json | jq .key)
         echo "INSTANCE_KEY=$INSTANCE_KEY" >> $GITHUB_OUTPUT
 
     - name: Reload snapshot
@@ -58,7 +58,7 @@ runs:
         BACKUP_ID: ${{ inputs.BACKUP_ID }}
         INSTANCE_NAME: ${{ inputs.POOL_NAME }}
       run: |
-        pnpx saleor backup restore "$BACKUP_ID" \
+        saleor backup restore "$BACKUP_ID" \
           --environment="$INSTANCE_NAME" \
           --skip-webhooks-update
 
@@ -70,7 +70,7 @@ runs:
         INSTANCE_NAME: ${{ inputs.POOL_NAME }}
         SALEOR_CLOUD_SERVICE: ${{ inputs.SALEOR_CLOUD_SERVICE }}
       run: |
-        pnpx saleor env create "$INSTANCE_NAME" \
+        saleor env create "$INSTANCE_NAME" \
          --project=project-for-pr-testing \
          --database=snapshot \
          --restore-from="$BACKUP_ID" \
@@ -87,4 +87,4 @@ runs:
         POOL_NAME: ${{ inputs.POOL_NAME }}
         BASE_URL: ${{ inputs.BASE_URL }}
       run: |
-        pnpx saleor env origins "$POOL_NAME" --origins="$BASE_URL"
+        saleor env origins "$POOL_NAME" --origins="$BASE_URL"

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@octokit/core": "^4.0.4",
+    "@saleor/cli": "1.42.2",
     "commander": "^9.4.0",
     "graphql": "^16.8.1",
     "graphql-request": "^5.0.0",

--- a/.github/scripts/pnpm-lock.yaml
+++ b/.github/scripts/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       "@octokit/core":
         specifier: ^4.0.4
         version: 4.2.4
+      "@saleor/cli":
+        specifier: 1.42.2
+        version: 1.42.2
       commander:
         specifier: ^9.4.0
         version: 9.5.0
@@ -305,10 +308,38 @@ packages:
       }
     engines: { node: ">= 18" }
 
+  "@saleor/cli@1.42.2":
+    resolution:
+      {
+        integrity: sha512-IVdpShyuhaUDg6oyUBiDnd699uOPyDf2Dc8oK96tJcyQ/OK6An/w8AC2O7MULBzdS03yOlHK1XWs/a22uVk9xw==,
+      }
+    engines: { node: ^20 || ^22 || ^24, pnpm: ">=10.0.0 <12.0.0" }
+    hasBin: true
+
+  "@sindresorhus/is@5.6.0":
+    resolution:
+      {
+        integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==,
+      }
+    engines: { node: ">=14.16" }
+
+  "@szmarczak/http-timer@5.0.1":
+    resolution:
+      {
+        integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==,
+      }
+    engines: { node: ">=14.16" }
+
   "@types/aws-lambda@8.10.160":
     resolution:
       {
         integrity: sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==,
+      }
+
+  "@types/http-cache-semantics@4.2.0":
+    resolution:
+      {
+        integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==,
       }
 
   asynckit@0.4.0:
@@ -334,6 +365,20 @@ packages:
       {
         integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==,
       }
+
+  cacheable-lookup@7.0.0:
+    resolution:
+      {
+        integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==,
+      }
+    engines: { node: ">=14.16" }
+
+  cacheable-request@10.2.14:
+    resolution:
+      {
+        integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==,
+      }
+    engines: { node: ">=14.16" }
 
   call-bind-apply-helpers@1.0.2:
     resolution:
@@ -361,6 +406,20 @@ packages:
       {
         integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==,
       }
+
+  decompress-response@6.0.0:
+    resolution:
+      {
+        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
+      }
+    engines: { node: ">=10" }
+
+  defer-to-connect@2.0.1:
+    resolution:
+      {
+        integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==,
+      }
+    engines: { node: ">=10" }
 
   delayed-stream@1.0.0:
     resolution:
@@ -423,6 +482,13 @@ packages:
         integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==,
       }
 
+  form-data-encoder@2.1.4:
+    resolution:
+      {
+        integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==,
+      }
+    engines: { node: ">= 14.17" }
+
   form-data@3.0.4:
     resolution:
       {
@@ -450,12 +516,26 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  get-stream@6.0.1:
+    resolution:
+      {
+        integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
+      }
+    engines: { node: ">=10" }
+
   gopd@1.2.0:
     resolution:
       {
         integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
       }
     engines: { node: ">= 0.4" }
+
+  got@12.6.1:
+    resolution:
+      {
+        integrity: sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==,
+      }
+    engines: { node: ">=14.16" }
 
   graphql-request@5.2.0:
     resolution:
@@ -493,12 +573,44 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  http-cache-semantics@4.2.0:
+    resolution:
+      {
+        integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==,
+      }
+
+  http2-wrapper@2.2.1:
+    resolution:
+      {
+        integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==,
+      }
+    engines: { node: ">=10.19.0" }
+
   is-plain-object@5.0.0:
     resolution:
       {
         integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==,
       }
     engines: { node: ">=0.10.0" }
+
+  json-buffer@3.0.1:
+    resolution:
+      {
+        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+      }
+
+  keyv@4.5.4:
+    resolution:
+      {
+        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+      }
+
+  lowercase-keys@3.0.0:
+    resolution:
+      {
+        integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   math-intrinsics@1.1.0:
     resolution:
@@ -521,6 +633,20 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
+  mimic-response@3.1.0:
+    resolution:
+      {
+        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
+      }
+    engines: { node: ">=10" }
+
+  mimic-response@4.0.0:
+    resolution:
+      {
+        integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
   node-fetch@2.7.0:
     resolution:
       {
@@ -532,6 +658,13 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  normalize-url@8.1.1:
+    resolution:
+      {
+        integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==,
+      }
+    engines: { node: ">=14.16" }
 
   octokit@4.1.4:
     resolution:
@@ -545,6 +678,33 @@ packages:
       {
         integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
       }
+
+  p-cancelable@3.0.0:
+    resolution:
+      {
+        integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==,
+      }
+    engines: { node: ">=12.20" }
+
+  quick-lru@5.1.1:
+    resolution:
+      {
+        integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==,
+      }
+    engines: { node: ">=10" }
+
+  resolve-alpn@1.2.1:
+    resolution:
+      {
+        integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==,
+      }
+
+  responselike@3.0.0:
+    resolution:
+      {
+        integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==,
+      }
+    engines: { node: ">=14.16" }
 
   toad-cache@3.7.0:
     resolution:
@@ -830,7 +990,19 @@ snapshots:
       "@octokit/request-error": 6.1.8
       "@octokit/webhooks-methods": 5.1.1
 
+  "@saleor/cli@1.42.2":
+    dependencies:
+      got: 12.6.1
+
+  "@sindresorhus/is@5.6.0": {}
+
+  "@szmarczak/http-timer@5.0.1":
+    dependencies:
+      defer-to-connect: 2.0.1
+
   "@types/aws-lambda@8.10.160": {}
+
+  "@types/http-cache-semantics@4.2.0": {}
 
   asynckit@0.4.0: {}
 
@@ -839,6 +1011,18 @@ snapshots:
   before-after-hook@3.0.2: {}
 
   bottleneck@2.19.5: {}
+
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@10.2.14:
+    dependencies:
+      "@types/http-cache-semantics": 4.2.0
+      get-stream: 6.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      mimic-response: 4.0.0
+      normalize-url: 8.1.1
+      responselike: 3.0.0
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -856,6 +1040,12 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  defer-to-connect@2.0.1: {}
 
   delayed-stream@1.0.0: {}
 
@@ -886,6 +1076,8 @@ snapshots:
 
   fast-content-type-parse@2.0.1: {}
 
+  form-data-encoder@2.1.4: {}
+
   form-data@3.0.4:
     dependencies:
       asynckit: 0.4.0
@@ -914,7 +1106,23 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@6.0.1: {}
+
   gopd@1.2.0: {}
+
+  got@12.6.1:
+    dependencies:
+      "@sindresorhus/is": 5.6.0
+      "@szmarczak/http-timer": 5.0.1
+      cacheable-lookup: 7.0.0
+      cacheable-request: 10.2.14
+      decompress-response: 6.0.0
+      form-data-encoder: 2.1.4
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 3.0.0
+      p-cancelable: 3.0.0
+      responselike: 3.0.0
 
   graphql-request@5.2.0(graphql@16.12.0):
     dependencies:
@@ -938,7 +1146,22 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  http-cache-semantics@4.2.0: {}
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
   is-plain-object@5.0.0: {}
+
+  json-buffer@3.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  lowercase-keys@3.0.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -948,9 +1171,15 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-response@3.1.0: {}
+
+  mimic-response@4.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  normalize-url@8.1.1: {}
 
   octokit@4.1.4:
     dependencies:
@@ -969,6 +1198,16 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  p-cancelable@3.0.0: {}
+
+  quick-lru@5.1.1: {}
+
+  resolve-alpn@1.2.1: {}
+
+  responselike@3.0.0:
+    dependencies:
+      lowercase-keys: 3.0.0
 
   toad-cache@3.7.0: {}
 

--- a/.github/scripts/pnpm-workspace.yaml
+++ b/.github/scripts/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 # This file makes .github/workflows an independent pnpm project
 # separate from the root dashboard workspace
 packages: []
+# Skip the release-age cooldown for the CLI - we own it, and it is pinned exactly.
+minimumReleaseAgeExclude:
+  - "@saleor/cli@1.42.2"

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: ./.github/actions
+          sparse-checkout: |
+            ./.github/actions
+            ./.github/scripts
           persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -42,4 +44,4 @@ jobs:
       - name: Remove instance
         env:
           PULL_REQUEST_NUMBER: ${{ github.event.number }}
-        run: pnpx saleor env remove "pr-${PULL_REQUEST_NUMBER}" --force
+        run: saleor env remove "pr-${PULL_REQUEST_NUMBER}" --force


### PR DESCRIPTION
Workflows ran the CLI via `pnpx saleor`, which fetches whatever npm serves at that moment. Pin @saleor/cli 1.42.2 in the .github/scripts project and run the local binary: cli-login installs with --frozen-lockfile and puts node_modules/.bin on $GITHUB_PATH, so every consumer of that action gets the same version.

