### PR TITLE
Show who installed extensions and created app tokens

### DIFF
--- a/.changeset/fresh-donkeys-repeat.md
+++ b/.changeset/fresh-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Extension pages now show who set things up. The extension management page has an "Installed by" section, the token list on custom extension pages has a "Created" column with the date and the staff member who created each token, and pending installations in the extensions list show who requested them. This data requires Saleor 3.23 and the `MANAGE_STAFF` permission; it is not shown for records created before Saleor started tracking it.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -932,6 +932,10 @@
   "2atspc": {
     "string": "Drafts"
   },
+  "2bcoCH": {
+    "context": "custom app token creation date",
+    "string": "Created"
+  },
   "2biVb2": {
     "context": "Toggle to filter inactive channels out of the order settings matrix",
     "string": "Hide inactive channels"
@@ -2042,6 +2046,10 @@
   "87rPKi": {
     "context": "Label for disabled auto-confirm row in tooltip",
     "string": "Off"
+  },
+  "89Ne4o": {
+    "context": "custom app tokens list - missing token creation data",
+    "string": "(unknown)"
   },
   "8BBMRj": {
     "context": "default tax class name for new tax classes",
@@ -6700,6 +6708,9 @@
     "context": "tabel column header",
     "string": "Refunded Qty"
   },
+  "TlWrHX": {
+    "string": "{user} installed this extension on {date}."
+  },
   "TnTi/a": {
     "context": "pricing card title",
     "string": "Pricing"
@@ -8207,6 +8218,10 @@
     "context": "voucher status",
     "string": "Active"
   },
+  "amlX8v": {
+    "context": "who started an app installation",
+    "string": "Requested by {user}"
+  },
   "anK7jD": {
     "string": "Product Type"
   },
@@ -8960,6 +8975,10 @@
   "e7yOai": {
     "context": "shipping address is not set in draft order",
     "string": "Not set"
+  },
+  "e8EAlK": {
+    "context": "custom app tokens list - token author",
+    "string": "by {author}"
   },
   "e8O72h": {
     "context": "password login mode option",
@@ -12147,6 +12166,10 @@
   "snUby7": {
     "context": "header",
     "string": "Unnamed Webhook Details"
+  },
+  "so1MpQ": {
+    "context": "section header",
+    "string": "Installed by"
   },
   "spjKeI": {
     "string": "Fulfillment approved"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "config": {
     "saleor": {
-      "schemaVersion": "3.23"
+      "schemaVersion": "5fce10cd8147d49d65108b63ef9622d895e012d2"
     }
   },
   "dependencies": {

--- a/schema-main.graphql
+++ b/schema-main.graphql
@@ -1681,6 +1681,13 @@ type Webhook implements Node @doc(category: "Webhooks") {
   """The name of webhook."""
   name: String
 
+  """
+  The unique identifier of the webhook, set by the app. Unique per app, null when not set.
+  
+  Added in Saleor 3.23.
+  """
+  identifier: String
+
   """List of webhook events."""
   events: [WebhookEvent!]! @deprecated(reason: "Use `asyncEvents` or `syncEvents` instead.")
 
@@ -3086,159 +3093,22 @@ type AppToken implements Node @doc(category: "Apps") {
 
   """Last 4 characters of the token."""
   authToken: String
-}
-
-"""Represents app data."""
-type AppExtension implements Node @doc(category: "Apps") {
-  """The ID of the app extension."""
-  id: ID!
-
-  """List of the app extension's permissions."""
-  permissions: [Permission!]!
-
-  """Label of the extension to show in the dashboard."""
-  label: String!
-
-  """URL of a view where extension's iframe is placed."""
-  url: String!
 
   """
-  Name of the extension mount point in the dashboard. Value returned in UPPERCASE.
-  
-  Added in Saleor 3.22.
-  """
-  mountName: String!
-
-  """
-  Name of the extension target in the dashboard. Value returned in UPPERCASE.
-  
-  Added in Saleor 3.22.
-  """
-  targetName: String!
-
-  """
-  App extension settings.
-  
-  Added in Saleor 3.22.
-  """
-  settings: JSON!
-
-  """
-  Extension identifier, unique per app. Null when the app does not declare one.
+  The date and time when the token was created. Null for tokens created before this was tracked.
   
   Added in Saleor 3.23.
   """
-  identifier: String
+  createdAt: DateTime
 
-  """The app assigned to app extension."""
-  app: App!
-
-  """JWT token used to authenticate by third-party app extension."""
-  accessToken: String
-}
-
-scalar JSON
-
-"""
-Represents a problem associated with an app.
-
-Added in Saleor 3.22.
-"""
-type AppProblem implements Node @doc(category: "Apps") {
   """
-  The ID of the app problem.
+  The user who created this token. Null for tokens created before this was tracked, or if the user has been deleted.
   
-  Added in Saleor 3.22.
-  """
-  id: ID!
-
-  """
-  The date and time when the problem was created.
-  
-  Added in Saleor 3.22.
-  """
-  createdAt: DateTime!
-
-  """
-  The date and time when the problem was last updated.
-  
-  Added in Saleor 3.22.
-  """
-  updatedAt: DateTime!
-
-  """
-  Number of occurrences.
-  
-  Added in Saleor 3.22.
-  """
-  count: Int!
-
-  """
-  Whether the problem has reached critical threshold.
-  
-  Added in Saleor 3.22.
-  """
-  isCritical: Boolean!
-
-  """
-  Dismissal information. Null if the problem has not been dismissed.
-  
-  Added in Saleor 3.22.
-  
-  Requires one of the following permissions: AUTHENTICATED_APP, MANAGE_APPS.
-  """
-  dismissed: AppProblemDismissed
-
-  """
-  The problem message.
-  
-  Added in Saleor 3.22.
-  """
-  message: String!
-
-  """
-  Key identifying the type of problem.
-  
-  Added in Saleor 3.22.
-  """
-  key: String!
-}
-
-"""
-Dismissal information for an app problem.
-
-Added in Saleor 3.22.
-"""
-type AppProblemDismissed {
-  """
-  Whether the problem was dismissed by an App or a User.
-  
-  Added in Saleor 3.22.
-  """
-  by: AppProblemDismissedByEnum!
-
-  """
-  The user who dismissed this problem. Null if dismissed by an app or the user was deleted.
-  
-  Added in Saleor 3.22.
+  Added in Saleor 3.23.
   
   Requires one of the following permissions: MANAGE_STAFF.
   """
-  user: User
-
-  """
-  Email of the user who dismissed this problem. Preserved even if the user is deleted.
-  
-  Added in Saleor 3.22.
-  
-  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
-  """
-  userEmail: String
-}
-
-enum AppProblemDismissedByEnum @doc(category: "Apps") {
-  APP
-  USER
+  createdBy: User
 }
 
 """Represents user data."""
@@ -13663,6 +13533,8 @@ enum TokenizedPaymentFlowEnum @doc(category: "Payments") {
   INTERACTIVE
 }
 
+scalar JSON
+
 """Represents an problem in the checkout."""
 union CheckoutProblem = CheckoutProblemDeliveryMethodStale | CheckoutProblemDeliveryMethodInvalid | CheckoutLineProblemInsufficientStock | CheckoutLineProblemVariantNotAvailable
 
@@ -14041,6 +13913,157 @@ type PaymentSource @doc(category: "Payments") {
   Can be accessed without permissions.
   """
   metadata: [MetadataItem!]!
+}
+
+"""Represents app data."""
+type AppExtension implements Node @doc(category: "Apps") {
+  """The ID of the app extension."""
+  id: ID!
+
+  """List of the app extension's permissions."""
+  permissions: [Permission!]!
+
+  """Label of the extension to show in the dashboard."""
+  label: String!
+
+  """URL of a view where extension's iframe is placed."""
+  url: String!
+
+  """
+  Name of the extension mount point in the dashboard. Value returned in UPPERCASE.
+  
+  Added in Saleor 3.22.
+  """
+  mountName: String!
+
+  """
+  Name of the extension target in the dashboard. Value returned in UPPERCASE.
+  
+  Added in Saleor 3.22.
+  """
+  targetName: String!
+
+  """
+  App extension settings.
+  
+  Added in Saleor 3.22.
+  """
+  settings: JSON!
+
+  """
+  Extension identifier, unique per app. Null when the app does not declare one.
+  
+  Added in Saleor 3.23.
+  """
+  identifier: String
+
+  """The app assigned to app extension."""
+  app: App!
+
+  """JWT token used to authenticate by third-party app extension."""
+  accessToken: String
+}
+
+"""
+Represents a problem associated with an app.
+
+Added in Saleor 3.22.
+"""
+type AppProblem implements Node @doc(category: "Apps") {
+  """
+  The ID of the app problem.
+  
+  Added in Saleor 3.22.
+  """
+  id: ID!
+
+  """
+  The date and time when the problem was created.
+  
+  Added in Saleor 3.22.
+  """
+  createdAt: DateTime!
+
+  """
+  The date and time when the problem was last updated.
+  
+  Added in Saleor 3.22.
+  """
+  updatedAt: DateTime!
+
+  """
+  Number of occurrences.
+  
+  Added in Saleor 3.22.
+  """
+  count: Int!
+
+  """
+  Whether the problem has reached critical threshold.
+  
+  Added in Saleor 3.22.
+  """
+  isCritical: Boolean!
+
+  """
+  Dismissal information. Null if the problem has not been dismissed.
+  
+  Added in Saleor 3.22.
+  
+  Requires one of the following permissions: AUTHENTICATED_APP, MANAGE_APPS.
+  """
+  dismissed: AppProblemDismissed
+
+  """
+  The problem message.
+  
+  Added in Saleor 3.22.
+  """
+  message: String!
+
+  """
+  Key identifying the type of problem.
+  
+  Added in Saleor 3.22.
+  """
+  key: String!
+}
+
+"""
+Dismissal information for an app problem.
+
+Added in Saleor 3.22.
+"""
+type AppProblemDismissed {
+  """
+  Whether the problem was dismissed by an App or a User.
+  
+  Added in Saleor 3.22.
+  """
+  by: AppProblemDismissedByEnum!
+
+  """
+  The user who dismissed this problem. Null if dismissed by an app or the user was deleted.
+  
+  Added in Saleor 3.22.
+  
+  Requires one of the following permissions: MANAGE_STAFF.
+  """
+  user: User
+
+  """
+  Email of the user who dismissed this problem. Preserved even if the user is deleted.
+  
+  Added in Saleor 3.22.
+  
+  Requires one of the following permissions: AUTHENTICATED_STAFF_USER.
+  """
+  userEmail: String
+}
+
+enum AppProblemDismissedByEnum @doc(category: "Apps") {
+  APP
+  USER
 }
 
 """Represents the app's brand data."""
@@ -17336,6 +17359,15 @@ type AppInstallation implements Node & Job @doc(category: "Apps") {
 
   """App's brand data."""
   brand: AppBrand
+
+  """
+  The staff user who requested this installation. Null for installations created before this was tracked, or if the user has been deleted.
+  
+  Added in Saleor 3.23.
+  
+  Requires one of the following permissions: MANAGE_STAFF.
+  """
+  installedBy: User
 }
 
 type AppCountableConnection @doc(category: "Apps") {
@@ -22530,6 +22562,13 @@ input WebhookCreateInput @doc(category: "Webhooks") {
   """The name of the webhook."""
   name: String
 
+  """
+  The unique identifier of the webhook, set by the app. Unique per app. Maximum length is 256 characters.
+  
+  Added in Saleor 3.23.
+  """
+  identifier: String
+
   """The url to receive the payload."""
   targetUrl: String
 
@@ -22585,6 +22624,13 @@ type WebhookUpdate @doc(category: "Webhooks") {
 input WebhookUpdateInput @doc(category: "Webhooks") {
   """The new name of the webhook."""
   name: String
+
+  """
+  The unique identifier of the webhook, set by the app. Unique per app. Maximum length is 256 characters. Pass a blank value to clear it.
+  
+  Added in Saleor 3.23.
+  """
+  identifier: String
 
   """The url to receive the payload."""
   targetUrl: String
@@ -32657,6 +32703,7 @@ enum AppErrorCode @doc(category: "Apps") {
   INVALID_MANIFEST_FORMAT
   INVALID_CUSTOM_HEADERS
   DUPLICATED_EXTENSION_IDENTIFIER
+  DUPLICATED_WEBHOOK_IDENTIFIER
   MANIFEST_URL_CANT_CONNECT
   NOT_FOUND
   REQUIRED

--- a/src/extensions/messages.ts
+++ b/src/extensions/messages.ts
@@ -98,6 +98,11 @@ export const infoMessages = defineMessages({
     defaultMessage: "Installation is pending...",
     id: "KTjTMW",
   },
+  installationRequestedBy: {
+    defaultMessage: "Requested by {user}",
+    description: "who started an app installation",
+    id: "amlX8v",
+  },
   webhookErrorDetected: {
     defaultMessage: "Webhook errors detected.",
     id: "CKP9+i",

--- a/src/extensions/mutations.ts
+++ b/src/extensions/mutations.ts
@@ -66,7 +66,11 @@ export const pluginUpdate = gql`
 `;
 
 export const appCreateMutation = gql`
-  mutation AppCreate($input: AppInput!, $hasManagedAppsPermission: Boolean = true) {
+  mutation AppCreate(
+    $input: AppInput!
+    $hasManagedAppsPermission: Boolean = true
+    $hasManageStaffPermission: Boolean = false
+  ) {
     appCreate(input: $input) {
       authToken
       app {
@@ -80,7 +84,11 @@ export const appCreateMutation = gql`
 `;
 
 export const appDeleteMutation = gql`
-  mutation AppDelete($id: ID!, $hasManagedAppsPermission: Boolean = true) {
+  mutation AppDelete(
+    $id: ID!
+    $hasManagedAppsPermission: Boolean = true
+    $hasManageStaffPermission: Boolean = false
+  ) {
     appDelete(id: $id) {
       app {
         ...App
@@ -138,7 +146,12 @@ export const appRetryInstallMutation = gql`
 `;
 
 export const appUpdateMutation = gql`
-  mutation AppUpdate($id: ID!, $input: AppInput!, $hasManagedAppsPermission: Boolean = true) {
+  mutation AppUpdate(
+    $id: ID!
+    $input: AppInput!
+    $hasManagedAppsPermission: Boolean = true
+    $hasManageStaffPermission: Boolean = false
+  ) {
     appUpdate(id: $id, input: $input) {
       app {
         ...App

--- a/src/extensions/queries.ts
+++ b/src/extensions/queries.ts
@@ -77,7 +77,7 @@ export const eventDeliveries = gql`
 `;
 
 export const appsInstallations = gql`
-  query AppsInstallations {
+  query AppsInstallations($hasManageStaffPermission: Boolean = false) {
     appsInstallations {
       ...AppInstallation
     }
@@ -85,7 +85,11 @@ export const appsInstallations = gql`
 `;
 
 export const appDetails = gql`
-  query App($id: ID!, $hasManagedAppsPermission: Boolean!) {
+  query App(
+    $id: ID!
+    $hasManagedAppsPermission: Boolean!
+    $hasManageStaffPermission: Boolean = false
+  ) {
     app(id: $id) {
       ...App
       aboutApp

--- a/src/extensions/utils.tsx
+++ b/src/extensions/utils.tsx
@@ -43,6 +43,7 @@ export const getAppErrorMessageDescriptor = (code: AppErrorCode) => {
     case AppErrorCode.NOT_FOUND:
       return appManifestErrorMessages.notFound;
     case AppErrorCode.DUPLICATED_EXTENSION_IDENTIFIER:
+    case AppErrorCode.DUPLICATED_WEBHOOK_IDENTIFIER:
       return appManifestErrorMessages.genericError;
     default:
       const _exhaustiveCheck: never = code;

--- a/src/extensions/views/EditCustomExtension/EditCustomApp.tsx
+++ b/src/extensions/views/EditCustomExtension/EditCustomApp.tsx
@@ -23,6 +23,7 @@ import {
   type WebhookDeleteMutation,
 } from "@dashboard/graphql";
 import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
+import { useHasManageStaffPermission } from "@dashboard/hooks/useHasManageStaffPermission";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { useNotifier } from "@dashboard/hooks/useNotifier";
 import useShop from "@dashboard/hooks/useShop";
@@ -58,6 +59,7 @@ export const EditCustomExtension = ({ id, params, token, onTokenClose }: OrderLi
   const intl = useIntl();
   const shop = useShop();
   const { hasManagedAppsPermission } = useHasManagedAppsPermission();
+  const { hasManageStaffPermission } = useHasManageStaffPermission();
 
   useEffect(() => onTokenClose, []);
 
@@ -67,7 +69,7 @@ export const EditCustomExtension = ({ id, params, token, onTokenClose }: OrderLi
   >(navigate, params => ExtensionsUrls.editCustomExtensionUrl(id, params), params);
   const { data, loading, refetch } = useAppQuery({
     displayLoader: true,
-    variables: { id, hasManagedAppsPermission },
+    variables: { id, hasManagedAppsPermission, hasManageStaffPermission },
   });
   const [activateApp, activateAppResult] = useAppActivateMutation({
     onCompleted: data => {

--- a/src/extensions/views/EditCustomExtension/components/CustomExtensionTokens/CustomExtensionTokens.tsx
+++ b/src/extensions/views/EditCustomExtension/components/CustomExtensionTokens/CustomExtensionTokens.tsx
@@ -1,11 +1,12 @@
 // @ts-strict-ignore
 import { DashboardCard } from "@dashboard/components/Card";
+import { Date } from "@dashboard/components/Date/Date";
 import { iconSize, iconStrokeWidthBySize } from "@dashboard/components/icons";
 import { ResponsiveTable } from "@dashboard/components/ResponsiveTable";
 import TableButtonWrapper from "@dashboard/components/TableButtonWrapper";
 import TableRowLink from "@dashboard/components/TableRowLink";
 import { type AppUpdateMutation } from "@dashboard/graphql";
-import { renderCollection } from "@dashboard/misc";
+import { getUserName, renderCollection } from "@dashboard/misc";
 import { TableBody, TableCell, TableHead } from "@material-ui/core";
 import { Box, Button, Skeleton, Text } from "@saleor/macaw-ui-next";
 import { Trash2 } from "lucide-react";
@@ -21,7 +22,45 @@ interface CustomAppTokensProps {
   isLoading: boolean;
 }
 
-const numberOfColumns = 3;
+const numberOfColumns = 4;
+
+const TokenCreationInfo = ({
+  createdAt,
+  createdBy,
+}: {
+  createdAt: string | null;
+  createdBy: { email: string; firstName: string; lastName: string } | null;
+}) => {
+  const authorName = getUserName(createdBy);
+
+  if (!createdAt) {
+    return (
+      <Box as="span" fontStyle="italic">
+        <FormattedMessage
+          defaultMessage="(unknown)"
+          description="custom app tokens list - missing token creation data"
+          id="89Ne4o"
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <>
+      <Date date={createdAt} />
+      {authorName && (
+        <Text size={2} color="default2" display="block">
+          <FormattedMessage
+            defaultMessage="by {author}"
+            description="custom app tokens list - token author"
+            id="e8EAlK"
+            values={{ author: authorName }}
+          />
+        </Text>
+      )}
+    </>
+  );
+};
 
 export const CustomExtensionTokens = (props: CustomAppTokensProps) => {
   const { tokens, onCreate, onDelete, hasManagedAppsPermission, isLoading } = props;
@@ -53,6 +92,9 @@ export const CustomExtensionTokens = (props: CustomAppTokensProps) => {
           <TableCell className={classes.colKey}>
             <Skeleton />
           </TableCell>
+          <TableCell className={classes.colCreated}>
+            <Skeleton />
+          </TableCell>
           <TableCell className={classes.colActions}></TableCell>
         </TableRowLink>
       );
@@ -74,6 +116,12 @@ export const CustomExtensionTokens = (props: CustomAppTokensProps) => {
             )}
           </TableCell>
           <TableCell className={classes.colKey}>{`**** ${token?.authToken}`}</TableCell>
+          <TableCell className={classes.colCreated}>
+            <TokenCreationInfo
+              createdAt={token.createdAt ?? null}
+              createdBy={token.createdBy ?? null}
+            />
+          </TableCell>
           <TableCell className={classes.colActions}>
             {hasManagedAppsPermission && (
               <Box display="flex" justifyContent="flex-end" width="100%">
@@ -134,6 +182,13 @@ export const CustomExtensionTokens = (props: CustomAppTokensProps) => {
                     id="MAsLIT"
                     defaultMessage="Key"
                     description="custom app token key"
+                  />
+                </TableCell>
+                <TableCell className={classes.colCreated}>
+                  <FormattedMessage
+                    id="2bcoCH"
+                    defaultMessage="Created"
+                    description="custom app token creation date"
                   />
                 </TableCell>
                 <TableCell />

--- a/src/extensions/views/EditCustomExtension/components/CustomExtensionTokens/styles.ts
+++ b/src/extensions/views/EditCustomExtension/components/CustomExtensionTokens/styles.ts
@@ -11,6 +11,9 @@ export const useStyles = makeStyles(
       textAlign: "right",
       width: 100,
     },
+    colCreated: {
+      width: 260,
+    },
     colKey: {
       width: 200,
     },

--- a/src/extensions/views/EditManifestExtension/AppManageView.tsx
+++ b/src/extensions/views/EditManifestExtension/AppManageView.tsx
@@ -18,6 +18,7 @@ import {
   useAppQuery,
 } from "@dashboard/graphql";
 import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
+import { useHasManageStaffPermission } from "@dashboard/hooks/useHasManageStaffPermission";
 import useNavigator from "@dashboard/hooks/useNavigator";
 import { useNotifier } from "@dashboard/hooks/useNotifier";
 import getAppErrorMessage from "@dashboard/utils/errors/app";
@@ -35,9 +36,10 @@ interface Props {
 export const EditManifestExtension = ({ id, params }: Props) => {
   const client = useApolloClient();
   const { hasManagedAppsPermission } = useHasManagedAppsPermission();
+  const { hasManageStaffPermission } = useHasManageStaffPermission();
   const { data, loading, refetch } = useAppQuery({
     displayLoader: true,
-    variables: { id, hasManagedAppsPermission },
+    variables: { id, hasManagedAppsPermission, hasManageStaffPermission },
   });
   const appExists = data?.app !== null;
   const navigate = useNavigator();

--- a/src/extensions/views/EditManifestExtension/components/AppDetailsPage/AppDetailsPage.tsx
+++ b/src/extensions/views/EditManifestExtension/components/AppDetailsPage/AppDetailsPage.tsx
@@ -9,6 +9,7 @@ import { AppWebhooksDisplay } from "../AppWebhooksDisplay/AppWebhooksDisplay";
 import { AboutCard } from "./AboutCard";
 import { DataPrivacyCard } from "./DataPrivacyCard";
 import { Header } from "./Header";
+import { InstalledByCard } from "./InstalledByCard";
 import { PermissionsCard } from "./PermissionsCard";
 
 const noConfigurationScreenMessages = defineMessages({
@@ -111,6 +112,14 @@ export const AppDetailsPage = ({
             borderBottomWidth={1}
             borderColor="default1"
             dataPrivacyUrl={data?.dataPrivacyUrl}
+            loading={loading}
+          />
+          <InstalledByCard
+            padding={6}
+            borderBottomStyle="solid"
+            borderBottomWidth={1}
+            borderColor="default1"
+            tokens={data?.tokens}
             loading={loading}
           />
         </Box>

--- a/src/extensions/views/EditManifestExtension/components/AppDetailsPage/InstalledByCard.test.ts
+++ b/src/extensions/views/EditManifestExtension/components/AppDetailsPage/InstalledByCard.test.ts
@@ -1,0 +1,58 @@
+import { type AppQuery } from "@dashboard/graphql";
+
+import { getInstaller } from "./InstalledByCard";
+
+type AppTokens = NonNullable<NonNullable<AppQuery["app"]>["tokens"]>;
+
+const user = (email: string): AppTokens[number]["createdBy"] => ({
+  __typename: "User",
+  id: email,
+  email,
+  firstName: "",
+  lastName: "",
+});
+
+const token = (id: string, createdAt: string | null, email?: string): AppTokens[number] => ({
+  __typename: "AppToken",
+  id,
+  name: id,
+  authToken: "1234",
+  createdAt,
+  createdBy: email ? user(email) : null,
+});
+
+describe("getInstaller", () => {
+  it("returns the author of the oldest attributed token", () => {
+    // Arrange
+    const tokens: AppTokens = [
+      token("newer", "2026-02-01T10:00:00Z", "later@example.com"),
+      token("oldest", "2026-01-01T10:00:00Z", "installer@example.com"),
+    ];
+
+    // Act
+    const installer = getInstaller(tokens);
+
+    // Assert
+    expect(installer.createdBy?.email).toBe("installer@example.com");
+  });
+
+  it("skips tokens without creation data (older Saleor versions, missing MANAGE_STAFF)", () => {
+    // Arrange
+    const tokens: AppTokens = [
+      token("untracked", null),
+      token("no-author", "2025-01-01T10:00:00Z"),
+      token("tracked", "2026-01-01T10:00:00Z", "installer@example.com"),
+    ];
+
+    // Act
+    const installer = getInstaller(tokens);
+
+    // Assert
+    expect(installer.id).toBe("tracked");
+  });
+
+  it("returns undefined when nothing is attributed", () => {
+    // Arrange // Act // Assert
+    expect(getInstaller([token("untracked", null)])).toBeUndefined();
+  });
+});

--- a/src/extensions/views/EditManifestExtension/components/AppDetailsPage/InstalledByCard.tsx
+++ b/src/extensions/views/EditManifestExtension/components/AppDetailsPage/InstalledByCard.tsx
@@ -1,0 +1,60 @@
+import { Date } from "@dashboard/components/Date/Date";
+import { type AppQuery } from "@dashboard/graphql";
+import { getUserName } from "@dashboard/misc";
+import { Box, type BoxProps, Skeleton, Text } from "@saleor/macaw-ui-next";
+import { FormattedMessage, useIntl } from "react-intl";
+
+import messages from "./messages";
+
+type AppTokens = NonNullable<NonNullable<AppQuery["app"]>["tokens"]>;
+
+/**
+ * The API exposes the installer on `AppInstallation`, which is dropped once the installation
+ * succeeds - `App` itself has no such field. Installing mints the app's first token on the
+ * installer's behalf, so the oldest token's author is the closest available answer.
+ *
+ * ponytail: heuristic - a deleted first token shifts the answer to the next oldest one.
+ * Replace with `App.installedBy` if Core ever exposes it.
+ */
+export const getInstaller = (tokens: AppTokens) =>
+  [...tokens]
+    .filter(token => token.createdAt && token.createdBy)
+    .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)))[0];
+
+type InstalledByCardProps = {
+  tokens: AppTokens | null | undefined;
+  loading: boolean;
+} & BoxProps;
+
+export const InstalledByCard = ({ tokens, loading, ...boxProps }: InstalledByCardProps) => {
+  const intl = useIntl();
+  const installer = tokens ? getInstaller(tokens) : undefined;
+
+  // `createdBy` needs MANAGE_STAFF and is null for apps installed before Saleor tracked it
+  if (!loading && !installer) {
+    return null;
+  }
+
+  return (
+    <Box {...boxProps} data-test-id="app-installed-by">
+      <Text size={5} fontWeight="bold" as="h2" marginBottom={4}>
+        {intl.formatMessage(messages.installedByTitle)}
+      </Text>
+      <Box>
+        {loading || !installer ? (
+          <Skeleton />
+        ) : (
+          <Text>
+            <FormattedMessage
+              {...messages.installedByDescription}
+              values={{
+                user: getUserName(installer.createdBy, true),
+                date: <Date date={installer.createdAt} plain />,
+              }}
+            />
+          </Text>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/src/extensions/views/EditManifestExtension/components/AppDetailsPage/messages.ts
+++ b/src/extensions/views/EditManifestExtension/components/AppDetailsPage/messages.ts
@@ -47,6 +47,15 @@ export default defineMessages({
     defaultMessage: "Edit permissions",
     id: "psmnv9",
   },
+  installedByTitle: {
+    defaultMessage: "Installed by",
+    id: "so1MpQ",
+    description: "section header",
+  },
+  installedByDescription: {
+    defaultMessage: "{user} installed this extension on {date}.",
+    id: "TlWrHX",
+  },
   appWebhooksTitle: {
     defaultMessage: "Extension Webhooks",
     id: "/z5aI6",

--- a/src/extensions/views/InstalledExtensions/hooks/usePendingInstallation.tsx
+++ b/src/extensions/views/InstalledExtensions/hooks/usePendingInstallation.tsx
@@ -1,14 +1,18 @@
 import { iconSize, iconStrokeWidth } from "@dashboard/components/icons";
+import { infoMessages } from "@dashboard/extensions/messages";
 import { type InstalledExtension } from "@dashboard/extensions/types";
 import { JobStatusEnum, useAppsInstallationsQuery } from "@dashboard/graphql";
 import { useHasManagedAppsPermission } from "@dashboard/hooks/useHasManagedAppsPermission";
-import { fuzzySearch } from "@dashboard/misc";
+import { useHasManageStaffPermission } from "@dashboard/hooks/useHasManageStaffPermission";
+import { fuzzySearch, getUserName } from "@dashboard/misc";
 import { Box } from "@saleor/macaw-ui-next";
-import { Package } from "lucide-react";
+import { Package, UserRound } from "lucide-react";
 import { useEffect, useState } from "react";
+import { FormattedMessage } from "react-intl";
 
 import { FailedInstallationActions } from "../components/FailedInstallationActions";
 import { FailedInstallationInfo } from "../components/InfoLabels/FailedInstallationInfo";
+import { InfoLabelsContainer } from "../components/InfoLabels/InfoLabelsContainer";
 import { InstallationPendingInfo } from "../components/InfoLabels/InstallationPendingInfo";
 import { useActiveAppsInstallations } from "./useActiveAppsInstallations";
 import { useInstallationNotify } from "./useInstallationNotify";
@@ -35,6 +39,7 @@ export const usePendingInstallation = ({
   searchQuery,
 }: UsePendingInstallationProps) => {
   const { hasManagedAppsPermission } = useHasManagedAppsPermission();
+  const { hasManageStaffPermission } = useHasManageStaffPermission();
 
   // Don't display loading when user doesn't have permissions
   // we don't fetch installations in that case
@@ -42,6 +47,7 @@ export const usePendingInstallation = ({
   const { data, loading, refetch } = useAppsInstallationsQuery({
     displayLoader: true,
     skip: !hasManagedAppsPermission,
+    variables: { hasManageStaffPermission },
   });
   const { installedNotify, removeInProgressAppNotify, errorNotify } = useInstallationNotify();
 
@@ -71,14 +77,30 @@ export const usePendingInstallation = ({
     "appName",
   ]);
   const pendingInstallations: InstalledExtension[] = filteredPendingInstallations.map(
-    ({ status, id, appName, brand }) => {
+    ({ status, id, appName, brand, installedBy }) => {
       const isFailed = status === JobStatusEnum.FAILED;
+      const installerName = getUserName(installedBy);
 
       return {
         id: id,
         name: appName,
         logo: getPendingInstallationLogo({ logo: brand?.logo?.default, name: appName }),
-        info: isFailed ? <FailedInstallationInfo /> : <InstallationPendingInfo />,
+        info: (
+          <Box display="flex" alignItems="center" gap={4}>
+            {isFailed ? <FailedInstallationInfo /> : <InstallationPendingInfo />}
+            {installerName && (
+              <InfoLabelsContainer
+                icon={<UserRound size={iconSize.small} strokeWidth={iconStrokeWidth} />}
+                message={
+                  <FormattedMessage
+                    {...infoMessages.installationRequestedBy}
+                    values={{ user: installerName }}
+                  />
+                }
+              />
+            )}
+          </Box>
+        ),
         actions: isFailed ? (
           <FailedInstallationActions
             onDelete={() => onFailedInstallationRemove(id)}

--- a/src/fragments/apps.ts
+++ b/src/fragments/apps.ts
@@ -64,6 +64,13 @@ export const appFragment = gql`
       authToken
       id
       name
+      createdAt
+      createdBy @include(if: $hasManageStaffPermission) {
+        id
+        email
+        firstName
+        lastName
+      }
     }
     webhooks @include(if: $hasManagedAppsPermission) {
       ...Webhook
@@ -82,6 +89,12 @@ export const appInstallationFragment = gql`
       logo {
         default(format: WEBP, size: 64)
       }
+    }
+    installedBy @include(if: $hasManageStaffPermission) {
+      id
+      email
+      firstName
+      lastName
     }
   }
 `;

--- a/src/graphql/fabbrica.generated.ts
+++ b/src/graphql/fabbrica.generated.ts
@@ -2824,6 +2824,14 @@ export type OptionalAppInstallation = {
   createdAt?: AppInstallation['createdAt'] | undefined;
   /** The ID of the app installation. */
   id?: AppInstallation['id'] | undefined;
+  /**
+ * The staff user who requested this installation. Null for installations created before this was tracked, or if the user has been deleted.
+ *
+ * Added in Saleor 3.23.
+ *
+ * Requires one of the following permissions: MANAGE_STAFF.
+ */
+  installedBy?: Maybe<OptionalUser> | undefined;
   /** The URL address of manifest for the app installation. */
   manifestUrl?: AppInstallation['manifestUrl'] | undefined;
   /** Job message. */
@@ -3403,6 +3411,20 @@ export type OptionalAppToken = {
   __typename?: 'AppToken';
   /** Last 4 characters of the token. */
   authToken?: AppToken['authToken'] | undefined;
+  /**
+ * The date and time when the token was created. Null for tokens created before this was tracked.
+ *
+ * Added in Saleor 3.23.
+ */
+  createdAt?: AppToken['createdAt'] | undefined;
+  /**
+ * The user who created this token. Null for tokens created before this was tracked, or if the user has been deleted.
+ *
+ * Added in Saleor 3.23.
+ *
+ * Requires one of the following permissions: MANAGE_STAFF.
+ */
+  createdBy?: Maybe<OptionalUser> | undefined;
   /** The ID of the app token. */
   id?: AppToken['id'] | undefined;
   /** Name of the authenticated token. */
@@ -37487,6 +37509,12 @@ export type OptionalWebhook = {
   events?: OptionalWebhookEvent[] | undefined;
   /** The ID of webhook. */
   id?: Webhook['id'] | undefined;
+  /**
+ * The unique identifier of the webhook, set by the app. Unique per app, null when not set.
+ *
+ * Added in Saleor 3.23.
+ */
+  identifier?: Webhook['identifier'] | undefined;
   /** Informs if webhook is activated. */
   isActive?: Webhook['isActive'] | undefined;
   /** The name of webhook. */
@@ -37545,6 +37573,12 @@ export type OptionalWebhookCreateInput = {
   customHeaders?: WebhookCreateInput['customHeaders'] | undefined;
   /** The events that webhook wants to subscribe. */
   events?: WebhookCreateInput['events'] | undefined;
+  /**
+ * The unique identifier of the webhook, set by the app. Unique per app. Maximum length is 256 characters.
+ *
+ * Added in Saleor 3.23.
+ */
+  identifier?: WebhookCreateInput['identifier'] | undefined;
   /** Determine if webhook will be set active or not. */
   isActive?: WebhookCreateInput['isActive'] | undefined;
   /** The name of the webhook. */
@@ -37794,6 +37828,12 @@ export type OptionalWebhookUpdateInput = {
   customHeaders?: WebhookUpdateInput['customHeaders'] | undefined;
   /** The events that webhook wants to subscribe. */
   events?: WebhookUpdateInput['events'] | undefined;
+  /**
+ * The unique identifier of the webhook, set by the app. Unique per app. Maximum length is 256 characters. Pass a blank value to clear it.
+ *
+ * Added in Saleor 3.23.
+ */
+  identifier?: WebhookUpdateInput['identifier'] | undefined;
   /** Determine if webhook will be set active or not. */
   isActive?: WebhookUpdateInput['isActive'] | undefined;
   /** The new name of the webhook. */

--- a/src/graphql/fabbricaTypes.generated.ts
+++ b/src/graphql/fabbricaTypes.generated.ts
@@ -1147,6 +1147,7 @@ export type AppError = {
 
 export type AppErrorCode =
   | 'DUPLICATED_EXTENSION_IDENTIFIER'
+  | 'DUPLICATED_WEBHOOK_IDENTIFIER'
   | 'FORBIDDEN'
   | 'GRAPHQL_ERROR'
   | 'INVALID'
@@ -1300,6 +1301,14 @@ export type AppInstallation = Job & Node & {
   createdAt: Scalars['DateTime']['output'];
   /** The ID of the app installation. */
   id: Scalars['ID']['output'];
+  /**
+   * The staff user who requested this installation. Null for installations created before this was tracked, or if the user has been deleted.
+   *
+   * Added in Saleor 3.23.
+   *
+   * Requires one of the following permissions: MANAGE_STAFF.
+   */
+  installedBy: Maybe<User>;
   /** The URL address of manifest for the app installation. */
   manifestUrl: Scalars['String']['output'];
   /** Job message. */
@@ -1663,6 +1672,20 @@ export type AppToken = Node & {
   __typename: 'AppToken';
   /** Last 4 characters of the token. */
   authToken: Maybe<Scalars['String']['output']>;
+  /**
+   * The date and time when the token was created. Null for tokens created before this was tracked.
+   *
+   * Added in Saleor 3.23.
+   */
+  createdAt: Maybe<Scalars['DateTime']['output']>;
+  /**
+   * The user who created this token. Null for tokens created before this was tracked, or if the user has been deleted.
+   *
+   * Added in Saleor 3.23.
+   *
+   * Requires one of the following permissions: MANAGE_STAFF.
+   */
+  createdBy: Maybe<User>;
   /** The ID of the app token. */
   id: Scalars['ID']['output'];
   /** Name of the authenticated token. */
@@ -32540,6 +32563,12 @@ export type Webhook = Node & {
   events: Array<WebhookEvent>;
   /** The ID of webhook. */
   id: Scalars['ID']['output'];
+  /**
+   * The unique identifier of the webhook, set by the app. Unique per app, null when not set.
+   *
+   * Added in Saleor 3.23.
+   */
+  identifier: Maybe<Scalars['String']['output']>;
   /** Informs if webhook is activated. */
   isActive: Scalars['Boolean']['output'];
   /** The name of webhook. */
@@ -32593,6 +32622,12 @@ export type WebhookCreateInput = {
    * @deprecated Use `asyncEvents` or `syncEvents` instead.
    */
   events: InputMaybe<Array<WebhookEventTypeEnum>>;
+  /**
+   * The unique identifier of the webhook, set by the app. Unique per app. Maximum length is 256 characters.
+   *
+   * Added in Saleor 3.23.
+   */
+  identifier: InputMaybe<Scalars['String']['input']>;
   /** Determine if webhook will be set active or not. */
   isActive: InputMaybe<Scalars['Boolean']['input']>;
   /** The name of the webhook. */
@@ -33639,6 +33674,12 @@ export type WebhookUpdateInput = {
    * @deprecated Use `asyncEvents` or `syncEvents` instead.
    */
   events: InputMaybe<Array<WebhookEventTypeEnum>>;
+  /**
+   * The unique identifier of the webhook, set by the app. Unique per app. Maximum length is 256 characters. Pass a blank value to clear it.
+   *
+   * Added in Saleor 3.23.
+   */
+  identifier: InputMaybe<Scalars['String']['input']>;
   /** Determine if webhook will be set active or not. */
   isActive: InputMaybe<Scalars['Boolean']['input']>;
   /** The new name of the webhook. */

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -89,6 +89,13 @@ export const AppFragmentDoc = gql`
     authToken
     id
     name
+    createdAt
+    createdBy @include(if: $hasManageStaffPermission) {
+      id
+      email
+      firstName
+      lastName
+    }
   }
   webhooks @include(if: $hasManagedAppsPermission) {
     ...Webhook
@@ -106,6 +113,12 @@ export const AppInstallationFragmentDoc = gql`
     logo {
       default(format: WEBP, size: 64)
     }
+  }
+  installedBy @include(if: $hasManageStaffPermission) {
+    id
+    email
+    firstName
+    lastName
   }
 }
     `;
@@ -9335,7 +9348,7 @@ export type PluginUpdateMutationHookResult = ReturnType<typeof usePluginUpdateMu
 export type PluginUpdateMutationResult = Apollo.MutationResult<Types.PluginUpdateMutation>;
 export type PluginUpdateMutationOptions = Apollo.BaseMutationOptions<Types.PluginUpdateMutation, Types.PluginUpdateMutationVariables>;
 export const AppCreateDocument = gql`
-    mutation AppCreate($input: AppInput!, $hasManagedAppsPermission: Boolean = true) {
+    mutation AppCreate($input: AppInput!, $hasManagedAppsPermission: Boolean = true, $hasManageStaffPermission: Boolean = false) {
   appCreate(input: $input) {
     authToken
     app {
@@ -9365,6 +9378,7 @@ export type AppCreateMutationFn = Apollo.MutationFunction<Types.AppCreateMutatio
  *   variables: {
  *      input: // value for 'input'
  *      hasManagedAppsPermission: // value for 'hasManagedAppsPermission'
+ *      hasManageStaffPermission: // value for 'hasManageStaffPermission'
  *   },
  * });
  */
@@ -9376,7 +9390,7 @@ export type AppCreateMutationHookResult = ReturnType<typeof useAppCreateMutation
 export type AppCreateMutationResult = Apollo.MutationResult<Types.AppCreateMutation>;
 export type AppCreateMutationOptions = Apollo.BaseMutationOptions<Types.AppCreateMutation, Types.AppCreateMutationVariables>;
 export const AppDeleteDocument = gql`
-    mutation AppDelete($id: ID!, $hasManagedAppsPermission: Boolean = true) {
+    mutation AppDelete($id: ID!, $hasManagedAppsPermission: Boolean = true, $hasManageStaffPermission: Boolean = false) {
   appDelete(id: $id) {
     app {
       ...App
@@ -9405,6 +9419,7 @@ export type AppDeleteMutationFn = Apollo.MutationFunction<Types.AppDeleteMutatio
  *   variables: {
  *      id: // value for 'id'
  *      hasManagedAppsPermission: // value for 'hasManagedAppsPermission'
+ *      hasManageStaffPermission: // value for 'hasManageStaffPermission'
  *   },
  * });
  */
@@ -9537,7 +9552,7 @@ export type AppRetryInstallMutationHookResult = ReturnType<typeof useAppRetryIns
 export type AppRetryInstallMutationResult = Apollo.MutationResult<Types.AppRetryInstallMutation>;
 export type AppRetryInstallMutationOptions = Apollo.BaseMutationOptions<Types.AppRetryInstallMutation, Types.AppRetryInstallMutationVariables>;
 export const AppUpdateDocument = gql`
-    mutation AppUpdate($id: ID!, $input: AppInput!, $hasManagedAppsPermission: Boolean = true) {
+    mutation AppUpdate($id: ID!, $input: AppInput!, $hasManagedAppsPermission: Boolean = true, $hasManageStaffPermission: Boolean = false) {
   appUpdate(id: $id, input: $input) {
     app {
       ...App
@@ -9573,6 +9588,7 @@ export type AppUpdateMutationFn = Apollo.MutationFunction<Types.AppUpdateMutatio
  *      id: // value for 'id'
  *      input: // value for 'input'
  *      hasManagedAppsPermission: // value for 'hasManagedAppsPermission'
+ *      hasManageStaffPermission: // value for 'hasManageStaffPermission'
  *   },
  * });
  */
@@ -9981,7 +9997,7 @@ export type EventDeliveryQueryHookResult = ReturnType<typeof useEventDeliveryQue
 export type EventDeliveryLazyQueryHookResult = ReturnType<typeof useEventDeliveryLazyQuery>;
 export type EventDeliveryQueryResult = Apollo.QueryResult<Types.EventDeliveryQuery, Types.EventDeliveryQueryVariables>;
 export const AppsInstallationsDocument = gql`
-    query AppsInstallations {
+    query AppsInstallations($hasManageStaffPermission: Boolean = false) {
   appsInstallations {
     ...AppInstallation
   }
@@ -10000,6 +10016,7 @@ export const AppsInstallationsDocument = gql`
  * @example
  * const { data, loading, error } = useAppsInstallationsQuery({
  *   variables: {
+ *      hasManageStaffPermission: // value for 'hasManageStaffPermission'
  *   },
  * });
  */
@@ -10015,7 +10032,7 @@ export type AppsInstallationsQueryHookResult = ReturnType<typeof useAppsInstalla
 export type AppsInstallationsLazyQueryHookResult = ReturnType<typeof useAppsInstallationsLazyQuery>;
 export type AppsInstallationsQueryResult = Apollo.QueryResult<Types.AppsInstallationsQuery, Types.AppsInstallationsQueryVariables>;
 export const AppDocument = gql`
-    query App($id: ID!, $hasManagedAppsPermission: Boolean!) {
+    query App($id: ID!, $hasManagedAppsPermission: Boolean!, $hasManageStaffPermission: Boolean = false) {
   app(id: $id) {
     ...App
     aboutApp
@@ -10048,6 +10065,7 @@ export const AppDocument = gql`
  *   variables: {
  *      id: // value for 'id'
  *      hasManagedAppsPermission: // value for 'hasManagedAppsPermission'
+ *      hasManageStaffPermission: // value for 'hasManageStaffPermission'
  *   },
  * });
  */

--- a/src/graphql/typePolicies.generated.ts
+++ b/src/graphql/typePolicies.generated.ts
@@ -388,12 +388,13 @@ export type AppInstallFieldPolicy = {
 	appInstallation?: FieldPolicy<any> | FieldReadFunction<any>,
 	errors?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type AppInstallationKeySpecifier = ('appName' | 'brand' | 'createdAt' | 'id' | 'manifestUrl' | 'message' | 'status' | 'updatedAt' | AppInstallationKeySpecifier)[];
+export type AppInstallationKeySpecifier = ('appName' | 'brand' | 'createdAt' | 'id' | 'installedBy' | 'manifestUrl' | 'message' | 'status' | 'updatedAt' | AppInstallationKeySpecifier)[];
 export type AppInstallationFieldPolicy = {
 	appName?: FieldPolicy<any> | FieldReadFunction<any>,
 	brand?: FieldPolicy<any> | FieldReadFunction<any>,
 	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	installedBy?: FieldPolicy<any> | FieldReadFunction<any>,
 	manifestUrl?: FieldPolicy<any> | FieldReadFunction<any>,
 	message?: FieldPolicy<any> | FieldReadFunction<any>,
 	status?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -496,9 +497,11 @@ export type AppStatusChangedFieldPolicy = {
 	recipient?: FieldPolicy<any> | FieldReadFunction<any>,
 	version?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type AppTokenKeySpecifier = ('authToken' | 'id' | 'name' | AppTokenKeySpecifier)[];
+export type AppTokenKeySpecifier = ('authToken' | 'createdAt' | 'createdBy' | 'id' | 'name' | AppTokenKeySpecifier)[];
 export type AppTokenFieldPolicy = {
 	authToken?: FieldPolicy<any> | FieldReadFunction<any>,
+	createdAt?: FieldPolicy<any> | FieldReadFunction<any>,
+	createdBy?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>
 };
@@ -7272,7 +7275,7 @@ export type WarehouseUpdatedFieldPolicy = {
 	version?: FieldPolicy<any> | FieldReadFunction<any>,
 	warehouse?: FieldPolicy<any> | FieldReadFunction<any>
 };
-export type WebhookKeySpecifier = ('app' | 'asyncEvents' | 'customHeaders' | 'eventDeliveries' | 'events' | 'id' | 'isActive' | 'name' | 'secretKey' | 'subscriptionQuery' | 'syncEvents' | 'targetUrl' | WebhookKeySpecifier)[];
+export type WebhookKeySpecifier = ('app' | 'asyncEvents' | 'customHeaders' | 'eventDeliveries' | 'events' | 'id' | 'identifier' | 'isActive' | 'name' | 'secretKey' | 'subscriptionQuery' | 'syncEvents' | 'targetUrl' | WebhookKeySpecifier)[];
 export type WebhookFieldPolicy = {
 	app?: FieldPolicy<any> | FieldReadFunction<any>,
 	asyncEvents?: FieldPolicy<any> | FieldReadFunction<any>,
@@ -7280,6 +7283,7 @@ export type WebhookFieldPolicy = {
 	eventDeliveries?: FieldPolicy<any> | FieldReadFunction<any>,
 	events?: FieldPolicy<any> | FieldReadFunction<any>,
 	id?: FieldPolicy<any> | FieldReadFunction<any>,
+	identifier?: FieldPolicy<any> | FieldReadFunction<any>,
 	isActive?: FieldPolicy<any> | FieldReadFunction<any>,
 	name?: FieldPolicy<any> | FieldReadFunction<any>,
 	secretKey?: FieldPolicy<any> | FieldReadFunction<any>,

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -259,6 +259,7 @@ export enum AnnouncementImportanceEnum {
 
 export enum AppErrorCode {
   DUPLICATED_EXTENSION_IDENTIFIER = 'DUPLICATED_EXTENSION_IDENTIFIER',
+  DUPLICATED_WEBHOOK_IDENTIFIER = 'DUPLICATED_WEBHOOK_IDENTIFIER',
   FORBIDDEN = 'FORBIDDEN',
   GRAPHQL_ERROR = 'GRAPHQL_ERROR',
   INVALID = 'INVALID',
@@ -9347,6 +9348,12 @@ export type WebhookCreateInput = {
    * @deprecated Use `asyncEvents` or `syncEvents` instead.
    */
   events?: InputMaybe<Array<WebhookEventTypeEnum>>;
+  /**
+   * The unique identifier of the webhook, set by the app. Unique per app. Maximum length is 256 characters.
+   *
+   * Added in Saleor 3.23.
+   */
+  identifier?: InputMaybe<Scalars['String']['input']>;
   /** Determine if webhook will be set active or not. */
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   /** The name of the webhook. */
@@ -10356,6 +10363,12 @@ export type WebhookUpdateInput = {
    * @deprecated Use `asyncEvents` or `syncEvents` instead.
    */
   events?: InputMaybe<Array<WebhookEventTypeEnum>>;
+  /**
+   * The unique identifier of the webhook, set by the app. Unique per app. Maximum length is 256 characters. Pass a blank value to clear it.
+   *
+   * Added in Saleor 3.23.
+   */
+  identifier?: InputMaybe<Scalars['String']['input']>;
   /** Determine if webhook will be set active or not. */
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   /** The new name of the webhook. */
@@ -11404,18 +11417,20 @@ export type PluginUpdateMutation = { __typename: 'Mutation', pluginUpdate: { __t
 export type AppCreateMutationVariables = Exact<{
   input: AppInput;
   hasManagedAppsPermission?: InputMaybe<Scalars['Boolean']['input']>;
+  hasManageStaffPermission?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 
-export type AppCreateMutation = { __typename: 'Mutation', appCreate: { __typename: 'AppCreate', authToken: string | null, app: { __typename: 'App', id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null, errors: Array<{ __typename: 'AppError', field: string | null, message: string | null, code: AppErrorCode, permissions: Array<PermissionEnum> | null }> } | null };
+export type AppCreateMutation = { __typename: 'Mutation', appCreate: { __typename: 'AppCreate', authToken: string | null, app: { __typename: 'App', id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null, createdAt: any | null, createdBy?: { __typename: 'User', id: string, email: string, firstName: string, lastName: string } | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null, errors: Array<{ __typename: 'AppError', field: string | null, message: string | null, code: AppErrorCode, permissions: Array<PermissionEnum> | null }> } | null };
 
 export type AppDeleteMutationVariables = Exact<{
   id: Scalars['ID']['input'];
   hasManagedAppsPermission?: InputMaybe<Scalars['Boolean']['input']>;
+  hasManageStaffPermission?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 
-export type AppDeleteMutation = { __typename: 'Mutation', appDelete: { __typename: 'AppDelete', app: { __typename: 'App', id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null, errors: Array<{ __typename: 'AppError', field: string | null, message: string | null, code: AppErrorCode, permissions: Array<PermissionEnum> | null }> } | null };
+export type AppDeleteMutation = { __typename: 'Mutation', appDelete: { __typename: 'AppDelete', app: { __typename: 'App', id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null, createdAt: any | null, createdBy?: { __typename: 'User', id: string, email: string, firstName: string, lastName: string } | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null, errors: Array<{ __typename: 'AppError', field: string | null, message: string | null, code: AppErrorCode, permissions: Array<PermissionEnum> | null }> } | null };
 
 export type AppFetchMutationVariables = Exact<{
   manifestUrl: Scalars['String']['input'];
@@ -11442,10 +11457,11 @@ export type AppUpdateMutationVariables = Exact<{
   id: Scalars['ID']['input'];
   input: AppInput;
   hasManagedAppsPermission?: InputMaybe<Scalars['Boolean']['input']>;
+  hasManageStaffPermission?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 
-export type AppUpdateMutation = { __typename: 'Mutation', appUpdate: { __typename: 'AppUpdate', app: { __typename: 'App', id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null, errors: Array<{ __typename: 'AppError', message: string | null, permissions: Array<PermissionEnum> | null, field: string | null, code: AppErrorCode }> } | null };
+export type AppUpdateMutation = { __typename: 'Mutation', appUpdate: { __typename: 'AppUpdate', app: { __typename: 'App', id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null, createdAt: any | null, createdBy?: { __typename: 'User', id: string, email: string, firstName: string, lastName: string } | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null, errors: Array<{ __typename: 'AppError', message: string | null, permissions: Array<PermissionEnum> | null, field: string | null, code: AppErrorCode }> } | null };
 
 export type AppTokenCreateMutationVariables = Exact<{
   input: AppTokenInput;
@@ -11524,18 +11540,21 @@ export type EventDeliveryQueryVariables = Exact<{
 
 export type EventDeliveryQuery = { __typename: 'Query', apps: { __typename: 'AppCountableConnection', pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null }, edges: Array<{ __typename: 'AppCountableEdge', node: { __typename: 'App', id: string, webhooks?: Array<{ __typename: 'Webhook', failedDelivers: { __typename: 'EventDeliveryCountableConnection', edges: Array<{ __typename: 'EventDeliveryCountableEdge', node: { __typename: 'EventDelivery', id: string, createdAt: any, attempts: { __typename: 'EventDeliveryAttemptCountableConnection', edges: Array<{ __typename: 'EventDeliveryAttemptCountableEdge', node: { __typename: 'EventDeliveryAttempt', id: string, status: EventDeliveryStatusEnum, createdAt: any } }> } | null } }> } | null, pendingDelivers: { __typename: 'EventDeliveryCountableConnection', edges: Array<{ __typename: 'EventDeliveryCountableEdge', node: { __typename: 'EventDelivery', id: string, attempts: { __typename: 'EventDeliveryAttemptCountableConnection', edges: Array<{ __typename: 'EventDeliveryAttemptCountableEdge', node: { __typename: 'EventDeliveryAttempt', id: string, status: EventDeliveryStatusEnum, createdAt: any } }> } | null } }> } | null }> | null } }> } | null };
 
-export type AppsInstallationsQueryVariables = Exact<{ [key: string]: never; }>;
+export type AppsInstallationsQueryVariables = Exact<{
+  hasManageStaffPermission?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
 
 
-export type AppsInstallationsQuery = { __typename: 'Query', appsInstallations: Array<{ __typename: 'AppInstallation', status: JobStatusEnum, message: string | null, appName: string, manifestUrl: string, id: string, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null }> };
+export type AppsInstallationsQuery = { __typename: 'Query', appsInstallations: Array<{ __typename: 'AppInstallation', status: JobStatusEnum, message: string | null, appName: string, manifestUrl: string, id: string, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, installedBy?: { __typename: 'User', id: string, email: string, firstName: string, lastName: string } | null }> };
 
 export type AppQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   hasManagedAppsPermission: Scalars['Boolean']['input'];
+  hasManageStaffPermission?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 
-export type AppQuery = { __typename: 'Query', app: { __typename: 'App', aboutApp: string | null, author: string | null, dataPrivacyUrl: string | null, id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null };
+export type AppQuery = { __typename: 'Query', app: { __typename: 'App', aboutApp: string | null, author: string | null, dataPrivacyUrl: string | null, id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null, createdAt: any | null, createdBy?: { __typename: 'User', id: string, email: string, firstName: string, lastName: string } | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null } | null };
 
 export type ExtensionListQueryVariables = Exact<{
   filter: AppExtensionFilterInput;
@@ -11615,9 +11634,9 @@ export type AddressFragment = { __typename: 'Address', city: string, cityArea: s
 
 export type AppManifestFragment = { __typename: 'Manifest', identifier: string, version: string, about: string | null, name: string, appUrl: string | null, tokenTargetUrl: string | null, dataPrivacy: string | null, dataPrivacyUrl: string | null, homepageUrl: string | null, supportUrl: string | null, extensions: Array<{ __typename: 'AppManifestExtension', targetName: string, mountName: string, url: string, label: string, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> }>, permissions: Array<{ __typename: 'Permission', code: PermissionEnum, name: string }> | null, brand: { __typename: 'AppManifestBrand', logo: { __typename: 'AppManifestBrandLogo', default: string } } | null };
 
-export type AppFragment = { __typename: 'App', id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null };
+export type AppFragment = { __typename: 'App', id: string, name: string | null, created: any | null, isActive: boolean | null, type: AppTypeEnum | null, homepageUrl: string | null, appUrl: string | null, manifestUrl: string | null, supportUrl: string | null, version: string | null, accessToken: string | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, privateMetadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, metadata?: Array<{ __typename: 'MetadataItem', key: string, value: string }>, tokens?: Array<{ __typename: 'AppToken', authToken: string | null, id: string, name: string | null, createdAt: any | null, createdBy?: { __typename: 'User', id: string, email: string, firstName: string, lastName: string } | null }> | null, webhooks?: Array<{ __typename: 'Webhook', id: string, name: string | null, isActive: boolean, app: { __typename: 'App', id: string, name: string | null } }> | null };
 
-export type AppInstallationFragment = { __typename: 'AppInstallation', status: JobStatusEnum, message: string | null, appName: string, manifestUrl: string, id: string, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null };
+export type AppInstallationFragment = { __typename: 'AppInstallation', status: JobStatusEnum, message: string | null, appName: string, manifestUrl: string, id: string, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, installedBy?: { __typename: 'User', id: string, email: string, firstName: string, lastName: string } | null };
 
 export type AppListItemFragment = { __typename: 'App', id: string, name: string | null, isActive: boolean | null, type: AppTypeEnum | null, appUrl: string | null, manifestUrl: string | null, version: string | null, created: any | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null, permissions: Array<{ __typename: 'Permission', name: string, code: PermissionEnum }> | null, webhooks?: Array<{ __typename: 'Webhook', failedDelivers: { __typename: 'EventDeliveryCountableConnection', edges: Array<{ __typename: 'EventDeliveryCountableEdge', node: { __typename: 'EventDelivery', id: string, createdAt: any, attempts: { __typename: 'EventDeliveryAttemptCountableConnection', edges: Array<{ __typename: 'EventDeliveryAttemptCountableEdge', node: { __typename: 'EventDeliveryAttempt', id: string, status: EventDeliveryStatusEnum, createdAt: any } }> } | null } }> } | null, pendingDelivers: { __typename: 'EventDeliveryCountableConnection', edges: Array<{ __typename: 'EventDeliveryCountableEdge', node: { __typename: 'EventDelivery', id: string, attempts: { __typename: 'EventDeliveryAttemptCountableConnection', edges: Array<{ __typename: 'EventDeliveryAttemptCountableEdge', node: { __typename: 'EventDeliveryAttempt', id: string, status: EventDeliveryStatusEnum, createdAt: any } }> } | null } }> } | null }> | null };
 

--- a/src/hooks/useHasManageStaffPermission.ts
+++ b/src/hooks/useHasManageStaffPermission.ts
@@ -1,0 +1,15 @@
+import { useUserPermissions } from "@dashboard/auth/hooks/useUserPermissions";
+import { PermissionEnum } from "@dashboard/graphql";
+
+/**
+ * MANAGE_STAFF gates staff-user references on other objects (e.g. `AppToken.createdBy`,
+ * `AppInstallation.installedBy`), which must be `@include`d only when the user can read them.
+ */
+export const useHasManageStaffPermission = () => {
+  const permissions = useUserPermissions();
+  const hasManageStaffPermission = !!permissions?.some(
+    ({ code }) => code === PermissionEnum.MANAGE_STAFF,
+  );
+
+  return { hasManageStaffPermission };
+};

--- a/src/links.ts
+++ b/src/links.ts
@@ -74,6 +74,7 @@ export const getSpecificManifestErrorDocLink = (errorCode?: AppErrorCode): strin
     [AppErrorCode.FORBIDDEN]: EXTENSION_MANIFEST_DOCS, // No docs section
     [AppErrorCode.OUT_OF_SCOPE_APP]: EXTENSION_MANIFEST_DOCS, // No docs sect
     [AppErrorCode.DUPLICATED_EXTENSION_IDENTIFIER]: EXTENSION_MANIFEST_DOCS, // No docs section
+    [AppErrorCode.DUPLICATED_WEBHOOK_IDENTIFIER]: EXTENSION_MANIFEST_DOCS, // No docs section
   };
 
   return codeToLinkMap[errorCode] || "";


### PR DESCRIPTION
Surfaces the new staff-user attribution from saleor/saleor#19555: AppToken.createdAt/createdBy and AppInstallation.installedBy.

- extensions list: "Requested by X" on pending/failed installations
- custom extension tokens: "Created" column with date and author
- extension management: "Installed by" section

The API has no App.installedBy - installedBy lives on AppInstallation, which Core drops once the install succeeds. Since installing mints the app's first token on the installer's behalf, the management page infers the installer from the oldest attributed token.

createdBy/installedBy need MANAGE_STAFF, so they are @include-gated on a variable defaulting to false; only the three call sites that render the data pass it.

schemaVersion is temporarily pinned to the PR head commit - revert it to "3.23" once the fields land in a stable tag.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
