### PR TITLE
fix: decode entity ids in the SEARCH_ACTION command palette mount

### DIFF
--- a/.changeset/search-action-decoded-ids.md
+++ b/.changeset/search-action-decoded-ids.md
@@ -1,0 +1,5 @@
+---
+"saleor-dashboard": patch
+---
+
+Fix entity ids being passed double-encoded to apps opened from the command palette (Cmd+K). Actions triggered from a detail page received ids such as `UHJvZHVjdDo3Mw%3D%3D` instead of `UHJvZHVjdDo3Mw==`, so app queries failed with `Invalid ID`. Affected every entity context the `SEARCH_ACTION` mount resolves (`productId`, `orderId`, `customerId`, …).

--- a/src/extensions/search-actions/resolveSearchActionContext.test.ts
+++ b/src/extensions/search-actions/resolveSearchActionContext.test.ts
@@ -111,6 +111,39 @@ describe("resolveSearchActionContext", () => {
     expect(result).toEqual({ view: "MENU_DETAILS", params: { menuId: "TWVudTox" } });
   });
 
+  it("decodes a percent-encoded id so apps receive the raw global id", () => {
+    // Arrange
+    const pathname = "/products/UHJvZHVjdDo3Mw%3D%3D";
+
+    // Act
+    const result = resolveSearchActionContext(pathname);
+
+    // Assert
+    expect(result).toEqual({
+      view: "PRODUCT_DETAILS",
+      params: { productId: "UHJvZHVjdDo3Mw==" },
+    });
+  });
+
+  it("leaves an already-decoded id untouched", () => {
+    // Act
+    const result = resolveSearchActionContext("/products/UHJvZHVjdDo3Mw==");
+
+    // Assert
+    expect(result).toEqual({
+      view: "PRODUCT_DETAILS",
+      params: { productId: "UHJvZHVjdDo3Mw==" },
+    });
+  });
+
+  it("falls back to the raw segment when the id is not a valid escape sequence", () => {
+    // Act
+    const result = resolveSearchActionContext("/products/100%");
+
+    // Assert
+    expect(result).toEqual({ view: "PRODUCT_DETAILS", params: { productId: "100%" } });
+  });
+
   it("returns no view for non-entity routes", () => {
     // Act / Assert
     expect(resolveSearchActionContext("/")).toEqual({ view: null, params: {} });

--- a/src/extensions/search-actions/resolveSearchActionContext.ts
+++ b/src/extensions/search-actions/resolveSearchActionContext.ts
@@ -60,6 +60,20 @@ const MATCHERS: ViewMatcher[] = [
 const EMPTY_CONTEXT: SearchActionContext = { view: null, params: {} };
 
 /**
+ * `matchPath` does not percent-decode params, but ids are base64 global ids whose
+ * padding is encoded in the URL ("UHJvZHVjdDo3Mw%3D%3D"). They must be decoded here —
+ * otherwise `stringifyQs` encodes them a second time and apps receive an id the API
+ * rejects. Falls back to the raw value for malformed sequences, which would throw.
+ */
+const decodeId = (id: string): string => {
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return id;
+  }
+};
+
+/**
  * Derives the current dashboard view and its entity-id context from a pathname.
  *
  * Detail routes resolve a single id (nested routes such as a product variant or an
@@ -85,7 +99,7 @@ export const resolveSearchActionContext = (pathname: string): SearchActionContex
         continue;
       }
 
-      return { view: matcher.view, params: { [matcher.param]: id } };
+      return { view: matcher.view, params: { [matcher.param]: decodeId(id) } };
     }
 
     return { view: matcher.view, params: {} };


### PR DESCRIPTION
react-router's matchPath does not percent-decode path params, so the id captured from a detail route stayed encoded ("UHJvZHVjdDo3Mw%3D%3D"). stringifyQs then encoded it a second time, leaving apps with an id the API rejects ("Invalid ID ... Expected: Product").

Decode at the single point every matcher routes through, falling back to the raw segment for malformed sequences (decodeURIComponent throws). RESERVED_IDS stays checked against the raw segment so it keeps agreeing with the dashboard router, which matches "/products/add" as a literal.

## Scope of the change

<!-- Describe changed made in this PR. You can attach screenshots or mention related issues as well. -->

<!-- External contributors: Please attach GitHub issue number. -->

- [ ] I confirm I added ripples for changes (see src/ripples) or my feature doesn't contain any user-facing changes
- [ ] I used analytics "trackEvent" for important events
