### PR TITLE
Recover cleanly when a tab wakes from sleep

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,9 @@
+---
+"saleor-dashboard": patch
+---
+
+Fixed the Dashboard becoming unresponsive after the browser tab was left inactive for a long time, for example after closing and reopening a laptop.
+
+Before: returning to a long-idle tab could fire a burst of duplicate session refresh requests, and installed apps could keep running with an expired token that was never renewed.
+
+Now: the session is refreshed once for all pending requests, and app tokens are renewed based on when they actually expire, including an immediate catch-up when you return to the tab.

--- a/src/containers/BackgroundTasks/BackgroundTasksProvider.tsx
+++ b/src/containers/BackgroundTasks/BackgroundTasksProvider.tsx
@@ -42,7 +42,9 @@ export function useBackgroundTasks(
     }, backgroundTasksRefreshTime);
 
     return () => clearInterval(intervalId);
-  });
+    // The interval only reads `tasks` through a ref, so it never needs rebuilding.
+    // Without this it was torn down and recreated on every render of the tree.
+  }, []);
 
   function cancel(id: number) {
     tasks.current = tasks.current.filter(task => task.id !== id);

--- a/src/extensions/views/ViewManifestExtension/components/AppFrame/useTokenRefresh.test.ts
+++ b/src/extensions/views/ViewManifestExtension/components/AppFrame/useTokenRefresh.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useTokenRefresh } from "./useTokenRefresh";
+
+// Minimal unsigned JWT: only the payload segment matters to jwt-decode.
+const makeToken = ({ iat, exp }: { iat: number; exp: number }) => {
+  const payload = Buffer.from(JSON.stringify({ iat, exp })).toString("base64url");
+
+  return `header.${payload}.signature`;
+};
+
+const setVisibility = (state: DocumentVisibilityState) => {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+};
+
+describe("useTokenRefresh", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("refreshes shortly before the token expires", () => {
+    // Arrange
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const refetch = jest.fn();
+    const token = makeToken({ iat: nowSeconds, exp: nowSeconds + 300 });
+
+    // Act
+    renderHook(() => useTokenRefresh(token, refetch));
+    act(() => {
+      jest.advanceTimersByTime(269 * 1000);
+    });
+
+    // Assert
+    expect(refetch).not.toHaveBeenCalled();
+
+    // Act
+    act(() => {
+      jest.advanceTimersByTime(2 * 1000);
+    });
+
+    // Assert
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules from remaining lifetime, not total lifetime", () => {
+    // Arrange: a token issued an hour ago that expires in a minute.
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const refetch = jest.fn();
+    const token = makeToken({ iat: nowSeconds - 3600, exp: nowSeconds + 60 });
+
+    // Act
+    renderHook(() => useTokenRefresh(token, refetch));
+    act(() => {
+      jest.advanceTimersByTime(31 * 1000);
+    });
+
+    // Assert
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not spin when the token is already expired", () => {
+    // Arrange: mirrors waking a tab whose token died during sleep.
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const refetch = jest.fn();
+    const token = makeToken({ iat: nowSeconds - 3600, exp: nowSeconds - 600 });
+
+    // Act
+    renderHook(() => useTokenRefresh(token, refetch));
+    act(() => {
+      jest.advanceTimersByTime(5 * 60 * 1000);
+    });
+
+    // Assert: floored retries, not one refetch per tick.
+    expect(refetch).toHaveBeenCalledTimes(10);
+  });
+
+  it("catches up immediately when the tab becomes visible with a due token", () => {
+    // Arrange
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const refetch = jest.fn();
+    const token = makeToken({ iat: nowSeconds - 3600, exp: nowSeconds - 600 });
+
+    renderHook(() => useTokenRefresh(token, refetch));
+
+    // Act
+    act(() => {
+      setVisibility("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Assert
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("arms the timer when refetch only becomes available later", () => {
+    // Arrange
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const refetch = jest.fn();
+    const token = makeToken({ iat: nowSeconds, exp: nowSeconds + 300 });
+
+    const initialProps: { onRefetch?: () => void } = { onRefetch: undefined };
+
+    const { rerender } = renderHook(
+      ({ onRefetch }: { onRefetch?: () => void }) => useTokenRefresh(token, onRefetch),
+      { initialProps },
+    );
+
+    // Act
+    rerender({ onRefetch: refetch });
+    act(() => {
+      jest.advanceTimersByTime(271 * 1000);
+    });
+
+    // Assert
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores tokens it cannot decode", () => {
+    // Arrange
+    const refetch = jest.fn();
+
+    // Act
+    renderHook(() => useTokenRefresh("not-a-jwt", refetch));
+    act(() => {
+      jest.advanceTimersByTime(10 * 60 * 1000);
+    });
+
+    // Assert
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("clears the timer on unmount", () => {
+    // Arrange
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const refetch = jest.fn();
+    const token = makeToken({ iat: nowSeconds, exp: nowSeconds + 300 });
+
+    const { unmount } = renderHook(() => useTokenRefresh(token, refetch));
+
+    // Act
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(10 * 60 * 1000);
+    });
+
+    // Assert
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/extensions/views/ViewManifestExtension/components/AppFrame/useTokenRefresh.ts
+++ b/src/extensions/views/ViewManifestExtension/components/AppFrame/useTokenRefresh.ts
@@ -1,60 +1,100 @@
 import jwt_decode from "jwt-decode";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 interface AppToken {
   exp?: number;
   iat?: number;
 }
 
-const TIME_BEFORE_REFRESH = 30 * 1000; // 30 seconds
+/** How long before the token expires we ask for a new one. */
+const TIME_BEFORE_REFRESH = 30 * 1000;
 
-export const useTokenRefresh = (token?: string, refetch?: () => void) => {
-  let decoded: AppToken = {
-    exp: 0,
-    iat: 0,
-  };
+/**
+ * Floor for a scheduled refresh.
+ *
+ * The timeout re-arms itself, so a token that is already inside its refresh
+ * window would otherwise schedule `setTimeout(…, 0)` and spin: refetch, re-arm,
+ * refetch, pinning the main thread. With a floor the worst case degrades to a
+ * retry every 30s, which is a sane recovery cadence for a token the server
+ * keeps handing back stale.
+ */
+const MIN_REFRESH_DELAY = 30 * 1000;
 
-  // For some reason jwt_decode causes seemingly unrelated error in tests
-  // It seems like at some point undefined token is passed
-  // Wrapping it in try..catch and if fixes the issue
-  try {
-    if (token) {
-      decoded = jwt_decode(token) as AppToken;
-    }
-  } catch (e) {
-    console.warn(e);
+const decodeToken = (token?: string): AppToken | null => {
+  if (!token) {
+    return null;
   }
 
-  const decodedSuccesfully = !!decoded?.iat && !!decoded?.exp;
-  const refreshTimeout = useRef<null | ReturnType<typeof setTimeout>>(null);
-  const tokenLife = ((decoded?.exp || 0) - (decoded?.iat || 0)) * 1000; // in ms
-  const refreshTime = tokenLife - TIME_BEFORE_REFRESH;
-  const setUpTimeout = () => {
-    if (refetch) {
-      refetch();
-    }
+  try {
+    return jwt_decode<AppToken>(token);
+  } catch (e) {
+    console.warn(e);
 
-    createTimeout();
-  };
-  const createTimeout = () => {
-    refreshTimeout.current = setTimeout(setUpTimeout, refreshTime);
-  };
-  const deleteTimeout = () => {
-    if (refreshTimeout?.current) {
-      clearTimeout(refreshTimeout.current);
-      refreshTimeout.current = null;
-    }
-  };
+    return null;
+  }
+};
+
+/**
+ * Keeps an app's JWT fresh while its iframe stays mounted.
+ *
+ * Scheduling is driven by the token's absolute `exp`, not by its total lifetime
+ * (`exp - iat`): a token handed to us mid-life, or one that aged while the
+ * machine slept, has far less time left than a full lifetime. Because Chrome
+ * suspends timers on a sleeping/background tab, the timeout alone is not enough
+ * to recover promptly, so returning to the tab also triggers a catch-up.
+ */
+export const useTokenRefresh = (token?: string, refetch?: () => void) => {
+  // Memoized so an undecodable token is parsed - and warned about - once rather
+  // than on every render of the frame.
+  const expiresAt = useMemo(() => decodeToken(token)?.exp, [token]);
+  const canRefetch = !!refetch;
+
+  const refetchRef = useRef(refetch);
+
+  refetchRef.current = refetch;
 
   useEffect(() => {
-    if (refetch && decodedSuccesfully) {
-      createTimeout();
+    if (!expiresAt || !canRefetch) {
+      return;
     }
 
+    const refreshAt = expiresAt * 1000 - TIME_BEFORE_REFRESH;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    const schedule = () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+
+      timeout = setTimeout(
+        () => {
+          refetchRef.current?.();
+          schedule();
+        },
+        Math.max(refreshAt - Date.now(), MIN_REFRESH_DELAY),
+      );
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible" || Date.now() < refreshAt) {
+        return;
+      }
+
+      // The timer was throttled while the tab was hidden and the token is now
+      // due (or past due) — refresh immediately instead of waiting it out.
+      refetchRef.current?.();
+      schedule();
+    };
+
+    schedule();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
     return () => {
-      if (!!refetch && decodedSuccesfully) {
-        deleteTimeout();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+
+      if (timeout) {
+        clearTimeout(timeout);
       }
     };
-  }, [token]);
+  }, [expiresAt, canRefetch]);
 };

--- a/src/legacy-sdk/apollo/client.test.ts
+++ b/src/legacy-sdk/apollo/client.test.ts
@@ -299,6 +299,47 @@ describe("createFetch", () => {
       expect(mockRefreshToken).not.toHaveBeenCalled();
     });
 
+    it("refreshes only once when concurrent requests find the token expired", async () => {
+      // Arrange
+      const expiredTimestamp = Math.floor(Date.now() / 1000) - 300;
+
+      storage.getAccessToken.mockReturnValue("expired-token");
+      jwtDecode.mockReturnValue({
+        exp: expiredTimestamp,
+        owner: "saleor",
+      });
+
+      // Keep the refresh in flight so both requests overlap, mirroring the burst
+      // of queries Apollo fires when a slept tab wakes up.
+      let resolveRefresh: (value: unknown) => void = () => undefined;
+
+      mockRefreshToken.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveRefresh = resolve;
+        }),
+      );
+
+      const fetchFn = createFetch({
+        autoTokenRefresh: true,
+        refreshOnUnauthorized: false,
+      });
+
+      mockFetch.mockResolvedValue(createMockResponse({ data: {} }));
+
+      // Act
+      const requests = Promise.all([
+        fetchFn("http://localhost:8000/graphql/", {}),
+        fetchFn("http://localhost:8000/graphql/", {}),
+      ]);
+
+      await Promise.resolve();
+      resolveRefresh({ data: { tokenRefresh: { token: "new-token" } } });
+      await requests;
+
+      // Assert
+      expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+    });
+
     it("retries request on ExpiredSignatureError when refreshOnUnauthorized is enabled", async () => {
       // Arrange
       const futureTimestamp = Math.floor(Date.now() / 1000) + 600;

--- a/src/legacy-sdk/apollo/client.ts
+++ b/src/legacy-sdk/apollo/client.ts
@@ -25,6 +25,40 @@ const isTokenRefreshExternal = (
   result: RefreshTokenMutation | ExternalRefreshMutation,
 ): result is ExternalRefreshMutation => "externalRefresh" in result;
 
+/**
+ * Single-flight token refresh shared by every in-flight request.
+ *
+ * When a slept tab wakes up, Apollo replays all of its active queries at once
+ * and each one finds the same expired token. Without coalescing, that fans out
+ * into one refresh mutation per request, and each response invalidates the
+ * others' tokens. Only the call that started the refresh clears the shared
+ * promise, so a caller that merely awaits it can never drop the reference while
+ * the request is still running.
+ */
+const runTokenRefresh = (owner: string) => {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+
+  const pending = isInternalToken(owner)
+    ? authClient.refreshToken()
+    : authClient.refreshExternalToken();
+
+  refreshPromise = pending;
+
+  void pending
+    .finally(() => {
+      if (refreshPromise === pending) {
+        refreshPromise = null;
+      }
+    })
+    // Rejections are surfaced to whoever awaits `pending`; this only keeps the
+    // bookkeeping chain itself from becoming an unhandled rejection.
+    .catch(() => undefined);
+
+  return pending;
+};
+
 export type FetchConfig = Partial<{
   /**
    * Enable auto token refreshing. Default to `true`.
@@ -81,16 +115,10 @@ export const createFetch =
         if (refreshPromise) {
           await refreshPromise;
         } else if (Date.now() >= expirationTime) {
-          if (isInternalToken(owner)) {
-            await authClient.refreshToken();
-          } else {
-            await authClient.refreshExternalToken();
-          }
+          await runTokenRefresh(owner);
         }
       } catch {
         // ignore
-      } finally {
-        refreshPromise = null;
       }
 
       token = storage.getAccessToken();
@@ -120,14 +148,7 @@ export const createFetch =
 
       if (isUnauthenticated) {
         try {
-          if (refreshPromise) {
-            refreshTokenResponse = await refreshPromise;
-          } else {
-            refreshPromise = isInternalToken(owner)
-              ? authClient.refreshToken()
-              : authClient.refreshExternalToken();
-            refreshTokenResponse = await refreshPromise;
-          }
+          refreshTokenResponse = await runTokenRefresh(owner);
 
           if (
             refreshTokenResponse.data && isTokenRefreshExternal(refreshTokenResponse.data)
@@ -146,8 +167,6 @@ export const createFetch =
           }
         } catch {
           // ignore
-        } finally {
-          refreshPromise = null;
         }
       }
 


### PR DESCRIPTION
A tab returning from a long sleep found an expired session token, and the paths meant to renew it worked against us instead of recovering quietly.

Token refresh was not actually single-flight. The proactive-expiry branch never assigned `refreshPromise`, so the coalescing guard was dead code, and the `finally` block cleared the shared promise for every caller - including ones only awaiting someone else's refresh. Since Apollo replays all active queries at once on wake, they each found the same dead token and fanned out into competing refreshes whose responses invalidated one another.

App tokens were scheduled from total lifetime (`exp - iat`) rather than time remaining, so a token that aged while the machine slept got a timer longer than its remaining life and expired unrenewed. The same arithmetic could yield `setTimeout(..., 0)` in a self-re-arming callback, which spins the main thread. Scheduling now uses absolute expiry with a floor, and returning to the tab triggers a catch-up, since Chrome throttles timers on hidden tabs.

Also gives the background-task interval a dependency array so it stops being torn down and rebuilt on every render of the tree.