### PR TITLE
Handle duplicate extension installs with a friendly already-installed message

### DIFF
--- a/.changeset/pulse-install-home-redirect.md
+++ b/.changeset/pulse-install-home-redirect.md
@@ -1,0 +1,7 @@
+---
+"saleor-dashboard": patch
+---
+
+Re-installing an extension that is already on your store no longer shows a duplicate-install error. The install page now says the extension is already installed and links you to open it.
+
+Pulse links in What's New and the homepage video announcement open Pulse directly when it is already installed, instead of sending you through the install flow again.

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -35,6 +35,10 @@
     "context": "aria label for grid view button",
     "string": "Grid view"
   },
+  "+CE3ZW": {
+    "context": "ripple video announcement CTA when Saleor Pulse is already installed",
+    "string": "Open Pulse"
+  },
   "+G2N98": {
     "string": "Install from manifest"
   },
@@ -284,6 +288,10 @@
   "/Mcvt4": {
     "context": "section header",
     "string": "Media"
+  },
+  "/PVq8j": {
+    "context": "shown when user tries to install an extension that is already installed but inactive",
+    "string": "{appName} is installed but disabled."
   },
   "/QIOpX": {
     "context": "error when fetching all variants for duplicate detection fails",
@@ -4927,6 +4935,10 @@
   "Kxiige": {
     "string": "Generated Token"
   },
+  "KynPlY": {
+    "context": "link to open an already installed extension app UI",
+    "string": "Open {appName}"
+  },
   "KzgcFV": {
     "context": "category attribute entity type",
     "string": "Categories"
@@ -7268,6 +7280,10 @@
     "context": "fulfilled fulfillment, warehouse info",
     "string": "From {warehouseName}"
   },
+  "W2mMdu": {
+    "context": "shown when user tries to install an extension that is already installed",
+    "string": "{appName} is already installed."
+  },
   "W32xfN": {
     "context": "staff member full name",
     "string": "Name"
@@ -8507,6 +8523,10 @@
   "bT71VU": {
     "context": "total of all sent refunds",
     "string": "Result"
+  },
+  "bT8nK1": {
+    "context": "ripple action to open Saleor Pulse when already installed",
+    "string": "Open Pulse"
   },
   "bVbEZ/": {
     "context": "amount filter label",
@@ -14011,6 +14031,10 @@
   },
   "zxs6G3": {
     "string": "Manage how you ship out orders"
+  },
+  "zyWNgK": {
+    "context": "link to an already installed extension settings page from the install page",
+    "string": "Open settings"
   },
   "zyXcBP": {
     "string": "Sorting by this column requires active filter: {filterName}"

--- a/locale/defaultMessages.json
+++ b/locale/defaultMessages.json
@@ -289,10 +289,6 @@
     "context": "section header",
     "string": "Media"
   },
-  "/PVq8j": {
-    "context": "shown when user tries to install an extension that is already installed but inactive",
-    "string": "{appName} is installed but disabled."
-  },
   "/QIOpX": {
     "context": "error when fetching all variants for duplicate detection fails",
     "string": "Could not load existing variants. Close the dialog and try again before generating."
@@ -7280,10 +7276,6 @@
     "context": "fulfilled fulfillment, warehouse info",
     "string": "From {warehouseName}"
   },
-  "W2mMdu": {
-    "context": "shown when user tries to install an extension that is already installed",
-    "string": "{appName} is already installed."
-  },
   "W32xfN": {
     "context": "staff member full name",
     "string": "Name"
@@ -8524,10 +8516,6 @@
     "context": "total of all sent refunds",
     "string": "Result"
   },
-  "bT8nK1": {
-    "context": "ripple action to open Saleor Pulse when already installed",
-    "string": "Open Pulse"
-  },
   "bVbEZ/": {
     "context": "amount filter label",
     "string": "Amount"
@@ -9467,6 +9455,10 @@
     "context": "payment method type other",
     "string": "Other"
   },
+  "g2P/kE": {
+    "context": "shown when user tries to install an extension that is already installed but inactive",
+    "string": "{appName} is installed but disabled."
+  },
   "g3qjSf": {
     "context": "button",
     "string": "Assign categories"
@@ -9550,6 +9542,10 @@
   },
   "gSQ0Ge": {
     "string": "Variant {name} has been set as default."
+  },
+  "gU10OX": {
+    "context": "shown when user tries to install an extension that is already installed",
+    "string": "{appName} is already installed."
   },
   "gaOXvo": {
     "context": "notification, form submitted",
@@ -12011,6 +12007,10 @@
   "r/sk/h": {
     "context": "number of included postal code ranges",
     "string": "{number, plural, one {# included postal code range} other {# included postal code ranges}}"
+  },
+  "r0blTm": {
+    "context": "ripple action to open Saleor Pulse when already installed",
+    "string": "Open Pulse"
   },
   "r1aQ2f": {
     "context": "dialog header",

--- a/src/extensions/messages.ts
+++ b/src/extensions/messages.ts
@@ -538,6 +538,27 @@ export const appManifestErrorMessages = defineMessages({
     // TODO: Add docs link when we have docs page with explanation
     defaultMessage: "The extension identifier is already in use. ({errorCode})",
   },
+  alreadyInstalled: {
+    id: "gU10OX",
+    defaultMessage: "{appName} is already installed.",
+    description: "shown when user tries to install an extension that is already installed",
+  },
+  alreadyInstalledDisabled: {
+    id: "g2P/kE",
+    defaultMessage: "{appName} is installed but disabled.",
+    description:
+      "shown when user tries to install an extension that is already installed but inactive",
+  },
+  openInstalledApp: {
+    id: "KynPlY",
+    defaultMessage: "Open {appName}",
+    description: "link to open an already installed extension app UI",
+  },
+  openInstalledExtensionSettings: {
+    id: "zyWNgK",
+    defaultMessage: "Open settings",
+    description: "link to an already installed extension settings page from the install page",
+  },
   forbidden: {
     // AppErrorCode.FORBIDDEN
     defaultMessage: "You are not allowed to perform this action. ({errorCode})",

--- a/src/extensions/utils/findInstalledAppByIdentifier.test.ts
+++ b/src/extensions/utils/findInstalledAppByIdentifier.test.ts
@@ -1,0 +1,89 @@
+import {
+  findAlreadyInstalledApp,
+  findInstalledAppByIdentifier,
+} from "./findInstalledAppByIdentifier";
+
+describe("findInstalledAppByIdentifier", () => {
+  const installedApps = [
+    {
+      id: "app-1",
+      identifier: "saleor.pulse",
+      manifestUrl: "https://pulse.saleor.app/api/manifest",
+      name: "Saleor Pulse",
+    },
+    {
+      id: "app-2",
+      identifier: "other.app",
+      manifestUrl: "https://other.app/api/manifest",
+      name: "Other App",
+    },
+  ];
+
+  it("returns the installed app with a matching identifier", () => {
+    // Arrange & Act
+    const app = findInstalledAppByIdentifier(installedApps, "saleor.pulse");
+
+    // Assert
+    expect(app?.id).toBe("app-1");
+  });
+
+  it("returns undefined when no installed app matches", () => {
+    // Arrange & Act
+    const app = findInstalledAppByIdentifier(installedApps, "unknown.app");
+
+    // Assert
+    expect(app).toBeUndefined();
+  });
+});
+
+describe("findAlreadyInstalledApp", () => {
+  const installedApps = [
+    {
+      id: "app-1",
+      identifier: "saleor.pulse",
+      manifestUrl: "https://pulse.saleor.app/api/manifest",
+      name: "Saleor Pulse",
+    },
+    {
+      id: "app-2",
+      identifier: "other.app",
+      manifestUrl: "https://other.app/api/manifest",
+      name: "Other App",
+    },
+  ];
+
+  it("prefers identifier match over manifest URL", () => {
+    // Arrange & Act
+    const app = findAlreadyInstalledApp(installedApps, {
+      identifier: "saleor.pulse",
+      manifestUrl: "https://different-host.example/api/manifest",
+    });
+
+    // Assert
+    expect(app?.id).toBe("app-1");
+  });
+
+  it("resolves the app from Saleor's UNIQUE error message", () => {
+    // Arrange & Act
+    const app = findAlreadyInstalledApp(installedApps, {
+      manifestUrl: "https://staging.pulse.saleor.app/api/manifest",
+      uniqueError: {
+        field: "identifier",
+        message: "App with the same identifier is already installed: Saleor Pulse",
+      },
+    });
+
+    // Assert
+    expect(app?.id).toBe("app-1");
+  });
+
+  it("falls back to manifest URL when identifier is missing", () => {
+    // Arrange & Act
+    const app = findAlreadyInstalledApp(installedApps, {
+      manifestUrl: "https://other.app/api/manifest",
+    });
+
+    // Assert
+    expect(app?.id).toBe("app-2");
+  });
+});

--- a/src/extensions/utils/findInstalledAppByIdentifier.ts
+++ b/src/extensions/utils/findInstalledAppByIdentifier.ts
@@ -1,0 +1,55 @@
+import { findInstalledAppByManifestUrl } from "./findInstalledAppByManifestUrl";
+import { findInstalledAppFromUniqueError } from "./findInstalledAppFromUniqueError";
+
+export const findInstalledAppByIdentifier = <
+  T extends {
+    identifier: string | null;
+  },
+>(
+  installedApps: T[],
+  identifier: string,
+): T | undefined => installedApps.find(app => app.identifier === identifier);
+
+export const findAlreadyInstalledApp = <
+  T extends {
+    identifier: string | null;
+    manifestUrl: string | null;
+    name: string | null;
+  },
+>(
+  installedApps: T[],
+  {
+    identifier,
+    manifestUrl,
+    uniqueError,
+  }: {
+    identifier?: string | null;
+    manifestUrl?: string | null;
+    uniqueError?: {
+      field?: string | null;
+      message?: string | null;
+    };
+  },
+): T | undefined => {
+  if (identifier) {
+    const appByIdentifier = findInstalledAppByIdentifier(installedApps, identifier);
+
+    if (appByIdentifier) {
+      return appByIdentifier;
+    }
+  }
+
+  if (uniqueError) {
+    const appFromUniqueError = findInstalledAppFromUniqueError(installedApps, uniqueError);
+
+    if (appFromUniqueError) {
+      return appFromUniqueError;
+    }
+  }
+
+  if (manifestUrl) {
+    return findInstalledAppByManifestUrl(installedApps, manifestUrl);
+  }
+
+  return undefined;
+};

--- a/src/extensions/utils/findInstalledAppByManifestUrl.test.ts
+++ b/src/extensions/utils/findInstalledAppByManifestUrl.test.ts
@@ -1,0 +1,42 @@
+import {
+  findInstalledAppByManifestUrl,
+  normalizeManifestUrl,
+} from "./findInstalledAppByManifestUrl";
+
+describe("normalizeManifestUrl", () => {
+  it("normalizes URLs with trailing slashes", () => {
+    // Arrange & Act & Assert
+    expect(normalizeManifestUrl("https://example.com/manifest/")).toBe(
+      "https://example.com/manifest/",
+    );
+    expect(normalizeManifestUrl("https://example.com/manifest")).toBe(
+      "https://example.com/manifest",
+    );
+  });
+});
+
+describe("findInstalledAppByManifestUrl", () => {
+  const installedApps = [
+    { id: "app-1", manifestUrl: "https://pulse.saleor.app/api/manifest" },
+    { id: "app-2", manifestUrl: "https://other.app/api/manifest" },
+  ];
+
+  it("returns the installed app with a matching manifest URL", () => {
+    // Arrange & Act
+    const app = findInstalledAppByManifestUrl(
+      installedApps,
+      "https://pulse.saleor.app/api/manifest",
+    );
+
+    // Assert
+    expect(app?.id).toBe("app-1");
+  });
+
+  it("returns undefined when no installed app matches", () => {
+    // Arrange & Act
+    const app = findInstalledAppByManifestUrl(installedApps, "https://unknown.app/api/manifest");
+
+    // Assert
+    expect(app).toBeUndefined();
+  });
+});

--- a/src/extensions/utils/findInstalledAppByManifestUrl.ts
+++ b/src/extensions/utils/findInstalledAppByManifestUrl.ts
@@ -1,0 +1,21 @@
+export const normalizeManifestUrl = (manifestUrl: string): string => {
+  try {
+    return new URL(manifestUrl).href;
+  } catch {
+    return manifestUrl;
+  }
+};
+
+export const findInstalledAppByManifestUrl = <
+  T extends {
+    manifestUrl: string | null;
+  },
+>(
+  installedApps: T[],
+  manifestUrl: string,
+): T | undefined =>
+  installedApps.find(
+    app =>
+      app.manifestUrl &&
+      normalizeManifestUrl(app.manifestUrl) === normalizeManifestUrl(manifestUrl),
+  );

--- a/src/extensions/utils/findInstalledAppFromUniqueError.test.ts
+++ b/src/extensions/utils/findInstalledAppFromUniqueError.test.ts
@@ -1,0 +1,30 @@
+import { findInstalledAppFromUniqueError } from "./findInstalledAppFromUniqueError";
+
+describe("findInstalledAppFromUniqueError", () => {
+  const installedApps = [
+    { id: "app-1", name: "Saleor Pulse" },
+    { id: "app-2", name: "Other App" },
+  ];
+
+  it("returns the installed app named in Saleor's UNIQUE error message", () => {
+    // Arrange & Act
+    const app = findInstalledAppFromUniqueError(installedApps, {
+      field: "identifier",
+      message: "App with the same identifier is already installed: Saleor Pulse",
+    });
+
+    // Assert
+    expect(app?.id).toBe("app-1");
+  });
+
+  it("returns undefined when the error is not on the identifier field", () => {
+    // Arrange & Act
+    const app = findInstalledAppFromUniqueError(installedApps, {
+      field: "manifestUrl",
+      message: "App with the same identifier is already installed: Saleor Pulse",
+    });
+
+    // Assert
+    expect(app).toBeUndefined();
+  });
+});

--- a/src/extensions/utils/findInstalledAppFromUniqueError.ts
+++ b/src/extensions/utils/findInstalledAppFromUniqueError.ts
@@ -1,0 +1,29 @@
+// Saleor raises UNIQUE on identifier with:
+// "App with the same identifier is already installed: {app.name}"
+const SALEOR_UNIQUE_IDENTIFIER_PATTERN = /already installed:\s*(.+)$/i;
+
+export const findInstalledAppFromUniqueError = <
+  T extends {
+    name: string | null;
+  },
+>(
+  installedApps: T[],
+  error: {
+    field?: string | null;
+    message?: string | null;
+  },
+): T | undefined => {
+  if (error.field !== "identifier" || !error.message) {
+    return undefined;
+  }
+
+  const match = error.message.match(SALEOR_UNIQUE_IDENTIFIER_PATTERN);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const appName = match[1].trim();
+
+  return installedApps.find(app => app.name === appName);
+};

--- a/src/extensions/utils/resolveInstalledAppHref.test.ts
+++ b/src/extensions/utils/resolveInstalledAppHref.test.ts
@@ -1,0 +1,74 @@
+import { ExtensionsUrls } from "@dashboard/extensions/urls";
+import { AppTypeEnum } from "@dashboard/graphql";
+
+import {
+  resolveAlreadyInstalledAppLinkTarget,
+  resolveInstalledAppHref,
+} from "./resolveInstalledAppHref";
+
+describe("resolveAlreadyInstalledAppLinkTarget", () => {
+  it("returns app when the extension is active and has an app URL", () => {
+    // Arrange & Act
+    const linkTarget = resolveAlreadyInstalledAppLinkTarget({
+      type: AppTypeEnum.THIRDPARTY,
+      isActive: true,
+      appUrl: "https://example.com",
+    });
+
+    // Assert
+    expect(linkTarget).toBe("app");
+  });
+
+  it("returns settings when the extension is disabled", () => {
+    // Arrange & Act
+    const linkTarget = resolveAlreadyInstalledAppLinkTarget({
+      type: AppTypeEnum.THIRDPARTY,
+      isActive: false,
+      appUrl: "https://example.com",
+    });
+
+    // Assert
+    expect(linkTarget).toBe("settings");
+  });
+});
+
+describe("resolveInstalledAppHref", () => {
+  it("returns the custom extension edit URL for local apps", () => {
+    // Arrange & Act
+    const href = resolveInstalledAppHref({
+      id: "local-app",
+      type: AppTypeEnum.LOCAL,
+      isActive: true,
+      appUrl: "https://example.com",
+    });
+
+    // Assert
+    expect(href).toBe(ExtensionsUrls.editCustomExtensionUrl("local-app"));
+  });
+
+  it("returns the manifest edit URL when the app is inactive", () => {
+    // Arrange & Act
+    const href = resolveInstalledAppHref({
+      id: "manifest-app",
+      type: AppTypeEnum.THIRDPARTY,
+      isActive: false,
+      appUrl: "https://example.com",
+    });
+
+    // Assert
+    expect(href).toBe(ExtensionsUrls.resolveEditManifestExtensionUrl("manifest-app"));
+  });
+
+  it("returns the manifest view URL for active apps with an app URL", () => {
+    // Arrange & Act
+    const href = resolveInstalledAppHref({
+      id: "manifest-app",
+      type: AppTypeEnum.THIRDPARTY,
+      isActive: true,
+      appUrl: "https://example.com",
+    });
+
+    // Assert
+    expect(href).toBe(ExtensionsUrls.resolveViewManifestExtensionUrl("manifest-app"));
+  });
+});

--- a/src/extensions/utils/resolveInstalledAppHref.ts
+++ b/src/extensions/utils/resolveInstalledAppHref.ts
@@ -1,0 +1,46 @@
+import { ExtensionsUrls } from "@dashboard/extensions/urls";
+import { AppTypeEnum } from "@dashboard/graphql";
+
+export type AlreadyInstalledAppLinkTarget = "app" | "settings";
+
+export const resolveAlreadyInstalledAppLinkTarget = ({
+  type,
+  isActive,
+  appUrl,
+}: {
+  type: AppTypeEnum | null;
+  isActive: boolean | null;
+  appUrl?: string | null;
+}): AlreadyInstalledAppLinkTarget => {
+  if (type === AppTypeEnum.LOCAL) {
+    return "settings";
+  }
+
+  if (isActive && appUrl) {
+    return "app";
+  }
+
+  return "settings";
+};
+
+export const resolveInstalledAppHref = ({
+  id,
+  type,
+  isActive,
+  appUrl,
+}: {
+  id: string;
+  type: AppTypeEnum | null;
+  isActive: boolean | null;
+  appUrl?: string | null;
+}): string => {
+  if (type === AppTypeEnum.LOCAL) {
+    return ExtensionsUrls.editCustomExtensionUrl(id);
+  }
+
+  if (!isActive || !appUrl) {
+    return ExtensionsUrls.resolveEditManifestExtensionUrl(id);
+  }
+
+  return ExtensionsUrls.resolveViewManifestExtensionUrl(id);
+};

--- a/src/extensions/views/InstallCustomExtension/InstallCustomExtension.test.tsx
+++ b/src/extensions/views/InstallCustomExtension/InstallCustomExtension.test.tsx
@@ -33,6 +33,7 @@ describe("InstallCustomExtension", () => {
       manifest: null,
       lastFetchedManifestUrl: undefined,
       isFetchingManifest: false,
+      alreadyInstalledApp: null,
     });
 
     mockUseInstallApp.mockReturnValue({

--- a/src/extensions/views/InstallCustomExtension/InstallCustomExtension.tsx
+++ b/src/extensions/views/InstallCustomExtension/InstallCustomExtension.tsx
@@ -10,7 +10,7 @@ import { type ExtensionInstallFormData } from "./types";
 export const InstallCustomExtension = ({ params }: { params: ExtensionInstallQueryParams }) => {
   const manifestUrlFromQueryParams = params[MANIFEST_ATTR];
 
-  const { control, trigger, watch, handleSubmit, setError, getValues } =
+  const { control, trigger, watch, handleSubmit, setError, clearErrors, getValues } =
     useForm<ExtensionInstallFormData>({
       resolver: zodResolver(manifestFormSchema),
       values: {
@@ -27,6 +27,7 @@ export const InstallCustomExtension = ({ params }: { params: ExtensionInstallQue
           trigger={trigger}
           handleSubmit={handleSubmit}
           setError={setError}
+          clearErrors={clearErrors}
           getValues={getValues}
           params={params}
         />
@@ -36,6 +37,7 @@ export const InstallCustomExtension = ({ params }: { params: ExtensionInstallQue
           handleSubmit={handleSubmit}
           getValues={getValues}
           setError={setError}
+          clearErrors={clearErrors}
           watch={watch}
         />
       )}

--- a/src/extensions/views/InstallCustomExtension/components/InstallCustomExtensionFromForm/InstallCustomExtensionFromForm.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/InstallCustomExtensionFromForm/InstallCustomExtensionFromForm.tsx
@@ -6,6 +6,7 @@ import { Box } from "@saleor/macaw-ui-next";
 import { useMemo } from "react";
 import {
   type Control,
+  type UseFormClearErrors,
   type UseFormGetValues,
   type UseFormHandleSubmit,
   type UseFormSetError,
@@ -28,21 +29,29 @@ export const InstallCustomExtensionFromForm = ({
   handleSubmit,
   getValues,
   setError,
+  clearErrors,
   watch,
 }: {
   control: Control<ExtensionInstallFormData>;
   handleSubmit: UseFormHandleSubmit<ExtensionInstallFormData>;
   setError: UseFormSetError<ExtensionInstallFormData>;
+  clearErrors: UseFormClearErrors<ExtensionInstallFormData>;
   getValues: UseFormGetValues<ExtensionInstallFormData>;
   watch: UseFormWatch<ExtensionInstallFormData>;
 }) => {
   const intl = useIntl();
 
-  const { submitFetchManifest, manifest, lastFetchedManifestUrl, isFetchingManifest } =
-    useFetchManifest({
-      getValues,
-      setError,
-    });
+  const {
+    submitFetchManifest,
+    manifest,
+    lastFetchedManifestUrl,
+    isFetchingManifest,
+    alreadyInstalledApp,
+  } = useFetchManifest({
+    getValues,
+    setError,
+    clearErrors,
+  });
 
   const { flush: flushDebouncedSubmit } = useAutoSubmit({
     watch,
@@ -74,6 +83,7 @@ export const InstallCustomExtensionFromForm = ({
         <ManifestUrlForm
           control={control}
           onSubmit={handleSubmit(submitFetchManifest)}
+          alreadyInstalledApp={alreadyInstalledApp}
           onPaste={() => {
             // On paste immediately submit form
             // Wait for next tick when debounced submit is scheduled and call it immedioately

--- a/src/extensions/views/InstallCustomExtension/components/InstallCustomExtensionFromUrl/InstallCustomExtensionFromUrl.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/InstallCustomExtensionFromUrl/InstallCustomExtensionFromUrl.tsx
@@ -6,6 +6,7 @@ import { Box } from "@saleor/macaw-ui-next";
 import { useMemo } from "react";
 import {
   type Control,
+  type UseFormClearErrors,
   type UseFormGetValues,
   type UseFormHandleSubmit,
   type UseFormSetError,
@@ -31,23 +32,31 @@ export const InstallCustomExtensionFromUrl = ({
   handleSubmit,
   getValues,
   setError,
+  clearErrors,
   params,
 }: {
   control: Control<ExtensionInstallFormData>;
   trigger: UseFormTrigger<ExtensionInstallFormData>;
   handleSubmit: UseFormHandleSubmit<ExtensionInstallFormData>;
   setError: UseFormSetError<ExtensionInstallFormData>;
+  clearErrors: UseFormClearErrors<ExtensionInstallFormData>;
   getValues: UseFormGetValues<ExtensionInstallFormData>;
   params: ExtensionInstallQueryParams;
 }) => {
   const intl = useIntl();
   const { errors } = useFormState({ control });
 
-  const { submitFetchManifest, manifest, lastFetchedManifestUrl, isFetchingManifest } =
-    useFetchManifest({
-      getValues,
-      setError,
-    });
+  const {
+    submitFetchManifest,
+    manifest,
+    lastFetchedManifestUrl,
+    isFetchingManifest,
+    alreadyInstalledApp,
+  } = useFetchManifest({
+    getValues,
+    setError,
+    clearErrors,
+  });
 
   useLoadQueryParamsToForm({
     trigger,
@@ -86,7 +95,10 @@ export const InstallCustomExtensionFromUrl = ({
           control={control}
           issues={issues}
         />
-        <ManifestErrorMessage error={errors.manifestUrl} />
+        <ManifestErrorMessage
+          error={alreadyInstalledApp ? undefined : errors.manifestUrl}
+          alreadyInstalledApp={alreadyInstalledApp}
+        />
       </Box>
       <Savebar>
         <Savebar.Spacer />

--- a/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.test.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { type FieldError } from "react-hook-form";
 import { IntlProvider } from "react-intl";
+import { MemoryRouter } from "react-router-dom";
 
 import { AppErrorCode } from "../../../../../graphql/types.generated";
 import {
@@ -12,15 +13,31 @@ import { ManifestErrorMessage } from "./ManifestErrorMessage";
 describe("ManifestErrorMessage", () => {
   const renderWithError = (error: FieldError | null) =>
     render(
-      <IntlProvider
-        messages={{}}
-        locale="en"
-        onError={() => {
-          /* Suppress missing translation errors in console during test if any fallbacks occur */
-        }}
-      >
-        <ManifestErrorMessage error={error} />
-      </IntlProvider>,
+      <MemoryRouter>
+        <IntlProvider
+          messages={{}}
+          locale="en"
+          onError={() => {
+            /* Suppress missing translation errors in console during test if any fallbacks occur */
+          }}
+        >
+          <ManifestErrorMessage error={error} />
+        </IntlProvider>
+      </MemoryRouter>,
+    );
+
+  const renderAlreadyInstalled = (alreadyInstalledApp: {
+    name: string;
+    href: string;
+    isActive: boolean | null;
+    linkTarget: "app" | "settings";
+  }) =>
+    render(
+      <MemoryRouter>
+        <IntlProvider locale="en" messages={{}} onError={() => undefined}>
+          <ManifestErrorMessage error={null} alreadyInstalledApp={alreadyInstalledApp} />
+        </IntlProvider>
+      </MemoryRouter>,
     );
 
   it("renders nothing when error is null", () => {
@@ -108,6 +125,40 @@ describe("ManifestErrorMessage", () => {
     // Assert
     expect(screen.getByText(/An unexpected error occurred/)).toBeInTheDocument();
     expect(screen.getByText(/unknown/)).toBeInTheDocument();
+  });
+
+  it("renders an already-installed message with a named open link", () => {
+    // Arrange
+    renderAlreadyInstalled({
+      name: "Saleor Pulse",
+      href: "/extensions/app/pulse-app-id",
+      isActive: true,
+      linkTarget: "app",
+    });
+
+    // Assert
+    expect(screen.getByText(/Saleor Pulse is already installed/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open Saleor Pulse" })).toHaveAttribute(
+      "href",
+      "/extensions/app/pulse-app-id",
+    );
+  });
+
+  it("renders a disabled already-installed message with a settings link", () => {
+    // Arrange
+    renderAlreadyInstalled({
+      name: "Saleor Pulse",
+      href: "/extensions/app/pulse-app-id/edit",
+      isActive: false,
+      linkTarget: "settings",
+    });
+
+    // Assert
+    expect(screen.getByText(/Saleor Pulse is installed but disabled/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open settings" })).toHaveAttribute(
+      "href",
+      "/extensions/app/pulse-app-id/edit",
+    );
   });
 
   it("sets aria-live='polite' on the root Box when error is displayed", () => {

--- a/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.tsx
@@ -102,7 +102,7 @@ export const ManifestErrorMessage = ({
   className,
   ...props
 }: {
-  error: FieldError | null | undefined;
+  error?: FieldError | null;
   alreadyInstalledApp?: AlreadyInstalledApp | null;
 } & BoxProps) => {
   const intl = useIntl();

--- a/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/ManifestErrorMessage/ManifestErrorMessage.tsx
@@ -1,3 +1,4 @@
+import { MicrocopyLink } from "@dashboard/components/MicrocopyLink";
 import {
   appManifestErrorMessages,
   messages as extensionMessages,
@@ -13,6 +14,7 @@ import type * as React from "react";
 import { type FieldError } from "react-hook-form";
 import { FormattedMessage, type IntlShape, useIntl } from "react-intl";
 
+import { type AlreadyInstalledApp } from "../../hooks/useFetchManifest";
 import {
   MANIFEST_URL_CLIENT_VALIDATION_INVALID_FORMAT,
   MANIFEST_URL_CLIENT_VALIDATION_REQUIRED,
@@ -62,14 +64,63 @@ const getFieldErrorMessage = (error: FieldError, intl: IntlShape): string | Reac
   return error.message || intl.formatMessage(commonErrorMessages.unknownError);
 };
 
+const AlreadyInstalledMessage = ({
+  alreadyInstalledApp,
+}: {
+  alreadyInstalledApp: AlreadyInstalledApp;
+}) => {
+  const messageDescriptor =
+    alreadyInstalledApp.isActive === false
+      ? appManifestErrorMessages.alreadyInstalledDisabled
+      : appManifestErrorMessages.alreadyInstalled;
+  const linkMessageDescriptor =
+    alreadyInstalledApp.linkTarget === "app"
+      ? appManifestErrorMessages.openInstalledApp
+      : appManifestErrorMessages.openInstalledExtensionSettings;
+
+  return (
+    <Text size={2} color="default2" display="inline-block">
+      <FormattedMessage
+        {...messageDescriptor}
+        values={{
+          appName: alreadyInstalledApp.name,
+        }}
+      />{" "}
+      <MicrocopyLink to={alreadyInstalledApp.href}>
+        <FormattedMessage
+          {...linkMessageDescriptor}
+          values={{ appName: alreadyInstalledApp.name }}
+        />
+      </MicrocopyLink>
+    </Text>
+  );
+};
+
 export const ManifestErrorMessage = ({
   error,
+  alreadyInstalledApp,
   className,
   ...props
 }: {
   error: FieldError | null | undefined;
+  alreadyInstalledApp?: AlreadyInstalledApp | null;
 } & BoxProps) => {
   const intl = useIntl();
+
+  if (alreadyInstalledApp) {
+    return (
+      <Box
+        display="flex"
+        flexDirection="column"
+        gap={2}
+        aria-live="polite"
+        className={className}
+        {...props}
+      >
+        <AlreadyInstalledMessage alreadyInstalledApp={alreadyInstalledApp} />
+      </Box>
+    );
+  }
 
   if (!error) {
     return null;

--- a/src/extensions/views/InstallCustomExtension/components/ManifestUrlFieldController.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/ManifestUrlFieldController.tsx
@@ -3,6 +3,7 @@ import { Box } from "@saleor/macaw-ui-next";
 import { type ComponentProps } from "react";
 import { type FieldValues, useController, type UseControllerProps } from "react-hook-form";
 
+import { type AlreadyInstalledApp } from "../hooks/useFetchManifest";
 import { type ExtensionInstallFormData } from "../schema";
 import { ManifestErrorMessage } from "./ManifestErrorMessage/ManifestErrorMessage";
 
@@ -23,9 +24,20 @@ type ManifestUrlFieldControllerProps<TFormValues extends FieldValues> =
 export const ManifestUrlFieldController = <
   TFormValues extends FieldValues = ExtensionInstallFormData,
 >(
-  props: ManifestUrlFieldControllerProps<TFormValues>,
+  props: ManifestUrlFieldControllerProps<TFormValues> & {
+    alreadyInstalledApp?: AlreadyInstalledApp | null;
+  },
 ) => {
-  const { name, control, rules, defaultValue, shouldUnregister, disabled, ...inputProps } = props;
+  const {
+    name,
+    control,
+    rules,
+    defaultValue,
+    shouldUnregister,
+    disabled,
+    alreadyInstalledApp,
+    ...inputProps
+  } = props;
 
   const { field, fieldState } = useController({
     name,
@@ -44,7 +56,11 @@ export const ManifestUrlFieldController = <
         error={!!fieldState.error}
         aria-invalid={!!fieldState.error}
       />
-      {fieldState.error && <ManifestErrorMessage marginTop={2} error={fieldState.error} />}
+      {alreadyInstalledApp ? (
+        <ManifestErrorMessage marginTop={2} alreadyInstalledApp={alreadyInstalledApp} />
+      ) : (
+        fieldState.error && <ManifestErrorMessage marginTop={2} error={fieldState.error} />
+      )}
     </Box>
   );
 };

--- a/src/extensions/views/InstallCustomExtension/components/ManifestUrlForm/ManifestUrlForm.tsx
+++ b/src/extensions/views/InstallCustomExtension/components/ManifestUrlForm/ManifestUrlForm.tsx
@@ -5,6 +5,7 @@ import { type Control } from "react-hook-form";
 import { FormattedMessage } from "react-intl";
 
 import { EL_ID_MANIFEST_INPUT_LABEL, PLACEHOLDER_MANIFEST_URL } from "../../consts";
+import { type AlreadyInstalledApp } from "../../hooks/useFetchManifest";
 import { type ExtensionInstallFormData } from "../../schema";
 import { ManifestUrlFieldController } from "../ManifestUrlFieldController";
 
@@ -12,10 +13,12 @@ export const ManifestUrlForm = ({
   onSubmit,
   control,
   onPaste,
+  alreadyInstalledApp,
 }: {
   onSubmit: FormEventHandler<HTMLElement>;
   control: Control<ExtensionInstallFormData>;
   onPaste: ClipboardEventHandler<HTMLInputElement>;
+  alreadyInstalledApp?: AlreadyInstalledApp | null;
 }) => {
   return (
     <Box
@@ -35,6 +38,7 @@ export const ManifestUrlForm = ({
         aria-labelledby={EL_ID_MANIFEST_INPUT_LABEL}
         placeholder={PLACEHOLDER_MANIFEST_URL}
         onPaste={onPaste}
+        alreadyInstalledApp={alreadyInstalledApp}
       />
     </Box>
   );

--- a/src/extensions/views/InstallCustomExtension/hooks/useFetchManifest.test.ts
+++ b/src/extensions/views/InstallCustomExtension/hooks/useFetchManifest.test.ts
@@ -1,8 +1,28 @@
+import { ExtensionsUrls } from "@dashboard/extensions/urls";
 import { getAppInstallErrorMessage } from "@dashboard/extensions/utils";
-import { AppErrorCode, useAppFetchMutation } from "@dashboard/graphql";
+import { AppErrorCode, AppTypeEnum, useAppFetchMutation } from "@dashboard/graphql";
+import { PULSE_MANIFEST_URL } from "@dashboard/home/getPulsePromotionLink";
 import { act, renderHook } from "@testing-library/react";
 
 import { useFetchManifest } from "./useFetchManifest";
+
+const PULSE_IDENTIFIER = "saleor.pulse";
+
+const pulseInstalledAppNode = {
+  id: "pulse-app-id",
+  identifier: PULSE_IDENTIFIER,
+  name: "Saleor Pulse",
+  manifestUrl: PULSE_MANIFEST_URL,
+  type: AppTypeEnum.THIRDPARTY,
+  isActive: true,
+  appUrl: "https://pulse.saleor.app",
+};
+
+const saleorUniqueError = {
+  field: "identifier",
+  code: AppErrorCode.UNIQUE,
+  message: "App with the same identifier is already installed: Saleor Pulse",
+};
 
 jest.mock("@dashboard/graphql", () => {
   const originalModule = jest.requireActual("@dashboard/graphql");
@@ -10,6 +30,18 @@ jest.mock("@dashboard/graphql", () => {
   return {
     ...originalModule,
     useAppFetchMutation: jest.fn(),
+    useInstalledAppsQuery: jest.fn(() => ({
+      data: {
+        apps: {
+          edges: [
+            {
+              node: pulseInstalledAppNode,
+            },
+          ],
+        },
+      },
+      loading: false,
+    })),
   };
 });
 
@@ -20,8 +52,13 @@ jest.mock("@dashboard/extensions/utils", () => ({
 describe("useFetchManifest", () => {
   const mockGetValues = jest.fn();
   const mockSetError = jest.fn();
+  const mockClearErrors = jest.fn();
   const mockFetchManifest = jest.fn();
   const mockOnCompleted = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it("should initialize with default values", () => {
     // Arrange
@@ -37,6 +74,7 @@ describe("useFetchManifest", () => {
       useFetchManifest({
         getValues: mockGetValues,
         setError: mockSetError,
+        clearErrors: mockClearErrors,
       }),
     );
 
@@ -44,6 +82,7 @@ describe("useFetchManifest", () => {
     expect(result.current.manifest).toBeUndefined();
     expect(result.current.lastFetchedManifestUrl).toBeUndefined();
     expect(result.current.isFetchingManifest).toBe(false);
+    expect(result.current.alreadyInstalledApp).toBeNull();
   });
 
   it("should call fetchManifest with form data when submitFetchManifest is called", () => {
@@ -61,6 +100,7 @@ describe("useFetchManifest", () => {
       useFetchManifest({
         getValues: mockGetValues,
         setError: mockSetError,
+        clearErrors: mockClearErrors,
       }),
     );
 
@@ -79,50 +119,39 @@ describe("useFetchManifest", () => {
       name: "test",
     };
 
-    (useAppFetchMutation as jest.Mock).mockReturnValueOnce([
+    (useAppFetchMutation as jest.Mock).mockReturnValue([
       mockFetchManifest,
       {
         loading: false,
-        data: null,
+        data: {
+          appFetchManifest: {
+            manifest: mockedManifestValue,
+            errors: [],
+          },
+        },
       },
     ]);
 
-    const { result, rerender } = renderHook(() =>
+    const { result } = renderHook(() =>
       useFetchManifest({
         getValues: mockGetValues,
         setError: mockSetError,
+        clearErrors: mockClearErrors,
       }),
     );
 
-    // Act
-    await act(async () => {
-      (useAppFetchMutation as jest.Mock).mockReturnValue([
-        mockFetchManifest,
-        {
-          loading: false,
-          data: {
-            appFetchManifest: {
-              manifest: mockedManifestValue,
-              errors: [],
-            },
-          },
-        },
-      ]);
-      rerender();
-    });
-
     // Assert
-    expect(result.current.manifest).toStrictEqual(mockedManifestValue);
+    expect(result.current.manifest).toEqual(mockedManifestValue);
   });
 
-  it("should update lastFetchedManifestUrl when fetch is completed successfully", async () => {
+  it("should set lastFetchedManifestUrl after manifest is fetched", async () => {
     // Arrange
     const manifestUrl = "https://example.com/manifest.json";
 
     mockGetValues.mockReturnValue(manifestUrl);
 
     (useAppFetchMutation as jest.Mock).mockImplementation(({ onCompleted }) => {
-      mockOnCompleted.mockImplementation(onCompleted); // set implementation from our source
+      mockOnCompleted.mockImplementation(onCompleted);
 
       return [
         mockFetchManifest,
@@ -137,16 +166,16 @@ describe("useFetchManifest", () => {
       useFetchManifest({
         getValues: mockGetValues,
         setError: mockSetError,
+        clearErrors: mockClearErrors,
       }),
     );
 
     // Act
     await act(async () => {
       result.current.submitFetchManifest({ manifestUrl });
-      // This would be normally called by apollo-client
       mockOnCompleted({
         appFetchManifest: {
-          manifest: { name: "Test App" },
+          manifest: { name: "test" },
           errors: [],
         },
       });
@@ -180,6 +209,7 @@ describe("useFetchManifest", () => {
       useFetchManifest({
         getValues: mockGetValues,
         setError: mockSetError,
+        clearErrors: mockClearErrors,
       }),
     );
 
@@ -231,6 +261,7 @@ describe("useFetchManifest", () => {
       useFetchManifest({
         getValues: mockGetValues,
         setError: mockSetError,
+        clearErrors: mockClearErrors,
       }),
     );
 
@@ -250,5 +281,231 @@ describe("useFetchManifest", () => {
       message: errorMessages[0].message,
       type: errorMessages[0].code,
     });
+  });
+
+  it("returns an already-installed app when the manifest identifier matches an installed app", async () => {
+    // Arrange
+    const alternateManifestUrl = "https://staging.pulse.saleor.app/api/manifest";
+
+    mockGetValues.mockReturnValue(alternateManifestUrl);
+
+    (useAppFetchMutation as jest.Mock).mockImplementation(({ onCompleted }) => {
+      mockOnCompleted.mockImplementation(onCompleted);
+
+      return [
+        mockFetchManifest,
+        {
+          loading: false,
+          data: null,
+        },
+      ];
+    });
+
+    const { result } = renderHook(() =>
+      useFetchManifest({
+        getValues: mockGetValues,
+        setError: mockSetError,
+        clearErrors: mockClearErrors,
+      }),
+    );
+
+    // Act
+    await act(async () => {
+      result.current.submitFetchManifest({ manifestUrl: alternateManifestUrl });
+      mockOnCompleted({
+        appFetchManifest: {
+          manifest: { identifier: PULSE_IDENTIFIER },
+          errors: [saleorUniqueError],
+        },
+      });
+    });
+
+    // Assert
+    expect(result.current.alreadyInstalledApp).toEqual({
+      name: "Saleor Pulse",
+      href: ExtensionsUrls.resolveViewManifestExtensionUrl("pulse-app-id"),
+      isActive: true,
+      linkTarget: "app",
+    });
+    expect(mockClearErrors).toHaveBeenCalledWith("manifestUrl");
+    expect(mockSetError).not.toHaveBeenCalled();
+  });
+
+  it("returns an already-installed app from Saleor's UNIQUE error message", async () => {
+    // Arrange
+    const alternateManifestUrl = "https://staging.pulse.saleor.app/api/manifest";
+
+    mockGetValues.mockReturnValue(alternateManifestUrl);
+
+    (useAppFetchMutation as jest.Mock).mockImplementation(({ onCompleted }) => {
+      mockOnCompleted.mockImplementation(onCompleted);
+
+      return [
+        mockFetchManifest,
+        {
+          loading: false,
+          data: null,
+        },
+      ];
+    });
+
+    const { result } = renderHook(() =>
+      useFetchManifest({
+        getValues: mockGetValues,
+        setError: mockSetError,
+        clearErrors: mockClearErrors,
+      }),
+    );
+
+    // Act
+    await act(async () => {
+      result.current.submitFetchManifest({ manifestUrl: alternateManifestUrl });
+      mockOnCompleted({
+        appFetchManifest: {
+          manifest: null,
+          errors: [saleorUniqueError],
+        },
+      });
+    });
+
+    // Assert
+    expect(result.current.alreadyInstalledApp).toEqual({
+      name: "Saleor Pulse",
+      href: ExtensionsUrls.resolveViewManifestExtensionUrl("pulse-app-id"),
+      isActive: true,
+      linkTarget: "app",
+    });
+    expect(mockClearErrors).toHaveBeenCalledWith("manifestUrl");
+    expect(mockSetError).not.toHaveBeenCalled();
+  });
+
+  it("returns an already-installed app when the manifest URL matches an installed app", async () => {
+    // Arrange
+    mockGetValues.mockReturnValue(PULSE_MANIFEST_URL);
+
+    (useAppFetchMutation as jest.Mock).mockImplementation(({ onCompleted }) => {
+      mockOnCompleted.mockImplementation(onCompleted);
+
+      return [
+        mockFetchManifest,
+        {
+          loading: false,
+          data: null,
+        },
+      ];
+    });
+
+    const { result } = renderHook(() =>
+      useFetchManifest({
+        getValues: mockGetValues,
+        setError: mockSetError,
+        clearErrors: mockClearErrors,
+      }),
+    );
+
+    // Act
+    await act(async () => {
+      result.current.submitFetchManifest({ manifestUrl: PULSE_MANIFEST_URL });
+      mockOnCompleted({
+        appFetchManifest: {
+          manifest: null,
+          errors: [saleorUniqueError],
+        },
+      });
+    });
+
+    // Assert
+    expect(result.current.alreadyInstalledApp).toEqual({
+      name: "Saleor Pulse",
+      href: ExtensionsUrls.resolveViewManifestExtensionUrl("pulse-app-id"),
+      isActive: true,
+      linkTarget: "app",
+    });
+    expect(mockClearErrors).toHaveBeenCalledWith("manifestUrl");
+    expect(mockSetError).not.toHaveBeenCalled();
+  });
+
+  it("resolves already-installed app after installed apps finish loading", async () => {
+    // Arrange
+    const { useInstalledAppsQuery } = jest.requireMock("@dashboard/graphql");
+    let installedAppsLoading = true;
+
+    useInstalledAppsQuery.mockImplementation(() => ({
+      data: installedAppsLoading
+        ? undefined
+        : {
+            apps: {
+              edges: [
+                {
+                  node: pulseInstalledAppNode,
+                },
+              ],
+            },
+          },
+      loading: installedAppsLoading,
+    }));
+
+    mockGetValues.mockReturnValue(PULSE_MANIFEST_URL);
+
+    (useAppFetchMutation as jest.Mock).mockImplementation(({ onCompleted }) => {
+      mockOnCompleted.mockImplementation(onCompleted);
+
+      return [
+        mockFetchManifest,
+        {
+          loading: false,
+          data: null,
+        },
+      ];
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useFetchManifest({
+        getValues: mockGetValues,
+        setError: mockSetError,
+        clearErrors: mockClearErrors,
+      }),
+    );
+
+    // Act
+    await act(async () => {
+      result.current.submitFetchManifest({ manifestUrl: PULSE_MANIFEST_URL });
+      mockOnCompleted({
+        appFetchManifest: {
+          manifest: null,
+          errors: [saleorUniqueError],
+        },
+      });
+    });
+
+    expect(result.current.alreadyInstalledApp).toBeNull();
+    expect(mockSetError).not.toHaveBeenCalled();
+
+    installedAppsLoading = false;
+    useInstalledAppsQuery.mockImplementation(() => ({
+      data: {
+        apps: {
+          edges: [
+            {
+              node: pulseInstalledAppNode,
+            },
+          ],
+        },
+      },
+      loading: false,
+    }));
+
+    await act(async () => {
+      rerender();
+    });
+
+    // Assert
+    expect(result.current.alreadyInstalledApp).toEqual({
+      name: "Saleor Pulse",
+      href: ExtensionsUrls.resolveViewManifestExtensionUrl("pulse-app-id"),
+      isActive: true,
+      linkTarget: "app",
+    });
+    expect(mockClearErrors).toHaveBeenCalledWith("manifestUrl");
   });
 });

--- a/src/extensions/views/InstallCustomExtension/hooks/useFetchManifest.ts
+++ b/src/extensions/views/InstallCustomExtension/hooks/useFetchManifest.ts
@@ -1,20 +1,128 @@
-import { AppErrorCode, useAppFetchMutation } from "@dashboard/graphql";
+import { findAlreadyInstalledApp } from "@dashboard/extensions/utils/findInstalledAppByIdentifier";
+import {
+  resolveAlreadyInstalledAppLinkTarget,
+  resolveInstalledAppHref,
+} from "@dashboard/extensions/utils/resolveInstalledAppHref";
+import {
+  AppErrorCode,
+  type InstalledAppFragment,
+  useAppFetchMutation,
+  useInstalledAppsQuery,
+} from "@dashboard/graphql";
 import { errorTracker } from "@dashboard/services/errorTracking";
-import { useState } from "react";
-import { type SubmitHandler, type UseFormGetValues, type UseFormSetError } from "react-hook-form";
+import { mapEdgesToItems } from "@dashboard/utils/maps";
+import { useCallback, useEffect, useState } from "react";
+import {
+  type SubmitHandler,
+  type UseFormClearErrors,
+  type UseFormGetValues,
+  type UseFormSetError,
+} from "react-hook-form";
 
 import { type ExtensionInstallFormData, type Manifest } from "../types";
+
+export type AlreadyInstalledApp = {
+  name: string;
+  href: string;
+  isActive: boolean | null;
+  linkTarget: "app" | "settings";
+};
+
+type PendingUniqueResolution = {
+  manifestUrl: string;
+  identifier: string | null;
+  uniqueError: {
+    field?: string | null;
+    message?: string | null;
+  };
+};
+
+const toAlreadyInstalledApp = (app: InstalledAppFragment): AlreadyInstalledApp => ({
+  name: app.name ?? app.identifier ?? "Extension",
+  href: resolveInstalledAppHref({
+    id: app.id,
+    type: app.type,
+    isActive: app.isActive,
+    appUrl: app.appUrl,
+  }),
+  isActive: app.isActive,
+  linkTarget: resolveAlreadyInstalledAppLinkTarget({
+    type: app.type,
+    isActive: app.isActive,
+    appUrl: app.appUrl,
+  }),
+});
 
 export const useFetchManifest = ({
   getValues,
   setError,
+  clearErrors,
 }: {
   getValues: UseFormGetValues<ExtensionInstallFormData>;
   setError: UseFormSetError<ExtensionInstallFormData>;
+  clearErrors: UseFormClearErrors<ExtensionInstallFormData>;
 }) => {
+  const [alreadyInstalledApp, setAlreadyInstalledApp] = useState<AlreadyInstalledApp | null>(null);
+  const [pendingUniqueResolution, setPendingUniqueResolution] =
+    useState<PendingUniqueResolution | null>(null);
+  const { data: installedAppsData, loading: installedAppsLoading } = useInstalledAppsQuery({
+    variables: {
+      first: 100,
+    },
+  });
+  const installedApps = mapEdgesToItems(installedAppsData?.apps) ?? [];
+
   // TODO: Remove this once updated to newer Apollo version
   // In latest apollo we can call fetchManifestOpts.reset to clear data
   const [lastFetchedManifestUrl, setLastFetchedManifestUrl] = useState<string>();
+
+  const setUniqueInstallError = useCallback(() => {
+    setAlreadyInstalledApp(null);
+    setPendingUniqueResolution(null);
+    setError("manifestUrl", {
+      type: AppErrorCode.UNIQUE,
+      message: "The extension identifier is already in use.",
+    });
+  }, [setError]);
+
+  const resolveUniqueInstall = useCallback(
+    ({
+      manifestUrl,
+      identifierFromManifest,
+      uniqueError,
+    }: {
+      manifestUrl: string;
+      identifierFromManifest?: string | null;
+      uniqueError: PendingUniqueResolution["uniqueError"];
+    }) => {
+      if (installedAppsLoading) {
+        setPendingUniqueResolution({
+          manifestUrl,
+          identifier: identifierFromManifest ?? null,
+          uniqueError,
+        });
+
+        return;
+      }
+
+      const existingApp = findAlreadyInstalledApp(installedApps, {
+        identifier: identifierFromManifest,
+        manifestUrl,
+        uniqueError,
+      });
+
+      if (existingApp) {
+        clearErrors("manifestUrl");
+        setAlreadyInstalledApp(toAlreadyInstalledApp(existingApp));
+        setPendingUniqueResolution(null);
+
+        return;
+      }
+
+      setUniqueInstallError();
+    },
+    [clearErrors, installedApps, installedAppsLoading, setUniqueInstallError],
+  );
 
   const [fetchManifest, fetchManifestOpts] = useAppFetchMutation({
     // We disable default error handling to avoid showing popups on each change in input
@@ -26,6 +134,24 @@ export const useFetchManifest = ({
       const firstError = data?.appFetchManifest?.errors?.[0];
 
       if (firstError) {
+        const manifestUrl = getValues("manifestUrl");
+
+        if (firstError.code === AppErrorCode.UNIQUE && manifestUrl) {
+          resolveUniqueInstall({
+            manifestUrl,
+            identifierFromManifest: data?.appFetchManifest?.manifest?.identifier,
+            uniqueError: {
+              field: firstError.field,
+              message: firstError.message,
+            },
+          });
+
+          return;
+        }
+
+        setPendingUniqueResolution(null);
+        setAlreadyInstalledApp(null);
+
         // Use the AppErrorCode from the backend error as the 'type' field for react-hook-form.
         // We will use 'type' (AppErrorCode) to render the rich message with link to docs
         setError("manifestUrl", {
@@ -36,6 +162,9 @@ export const useFetchManifest = ({
         data?.appFetchManifest?.manifest === null &&
         !data?.appFetchManifest?.errors.length
       ) {
+        setPendingUniqueResolution(null);
+        setAlreadyInstalledApp(null);
+
         // This is an edge case and shouldn't happen
         setError("manifestUrl", {
           type: AppErrorCode.GRAPHQL_ERROR,
@@ -47,11 +176,31 @@ export const useFetchManifest = ({
             `Manifest data was empty, but no errors were returned from Saleor for manifestUrl: ${getValues("manifestUrl")}`,
           ),
         );
+      } else {
+        setPendingUniqueResolution(null);
+        setAlreadyInstalledApp(null);
       }
     },
   });
 
+  useEffect(
+    function resolveAlreadyInstalledAfterAppsLoad() {
+      if (!pendingUniqueResolution || installedAppsLoading) {
+        return;
+      }
+
+      resolveUniqueInstall({
+        manifestUrl: pendingUniqueResolution.manifestUrl,
+        identifierFromManifest: pendingUniqueResolution.identifier,
+        uniqueError: pendingUniqueResolution.uniqueError,
+      });
+    },
+    [installedAppsLoading, pendingUniqueResolution, resolveUniqueInstall],
+  );
+
   const submitFetchManifest: SubmitHandler<ExtensionInstallFormData> = data => {
+    setAlreadyInstalledApp(null);
+    setPendingUniqueResolution(null);
     fetchManifest({ variables: data });
   };
 
@@ -62,5 +211,6 @@ export const useFetchManifest = ({
     submitFetchManifest,
     lastFetchedManifestUrl,
     isFetchingManifest: fetchManifestOpts.loading,
+    alreadyInstalledApp,
   } as const;
 };

--- a/src/extensions/views/InstalledExtensions/hooks/useInstalledExtensions.tsx
+++ b/src/extensions/views/InstalledExtensions/hooks/useInstalledExtensions.tsx
@@ -12,6 +12,7 @@ import {
   type WebhookDeliveryProblem,
 } from "@dashboard/extensions/types";
 import { ExtensionsUrls } from "@dashboard/extensions/urls";
+import { resolveInstalledAppHref } from "@dashboard/extensions/utils/resolveInstalledAppHref";
 import {
   byActivePlugin,
   filterOutHiddenPlugins,
@@ -71,32 +72,6 @@ const getExtensionLogo = ({
   }
 
   return <Package size={iconSize.medium} strokeWidth={iconStrokeWidth} />;
-};
-
-const resolveExtensionHref = ({
-  id,
-  type,
-  isActive,
-  appUrl,
-}: {
-  id?: string;
-  type: AppTypeEnum | null;
-  isActive: boolean | null;
-  appUrl?: string | null;
-}) => {
-  if (!id) {
-    return undefined;
-  }
-
-  if (type === AppTypeEnum.LOCAL) {
-    return ExtensionsUrls.editCustomExtensionUrl(id);
-  }
-
-  if (!isActive || !appUrl) {
-    return ExtensionsUrls.resolveEditManifestExtensionUrl(id);
-  }
-
-  return ExtensionsUrls.resolveViewManifestExtensionUrl(id);
 };
 
 const buildWebhookProblem = (
@@ -177,7 +152,7 @@ export const useInstalledExtensions = () => {
             isActive,
             loading: !eventDeliveriesData?.apps,
           }),
-          href: resolveExtensionHref({ id, type, isActive, appUrl }),
+          href: resolveInstalledAppHref({ id, type, isActive, appUrl }),
           problems: allProblems,
           appType: type,
           activeProblemCount: activeProblemsForApp.length,

--- a/src/fragments/apps.ts
+++ b/src/fragments/apps.ts
@@ -191,6 +191,9 @@ export const InstalledApp = gql`
     identifier
     manifestUrl
     isActive
+    name
+    type
+    appUrl
   }
 `;
 

--- a/src/graphql/hooks.generated.ts
+++ b/src/graphql/hooks.generated.ts
@@ -199,6 +199,9 @@ export const InstalledAppFragmentDoc = gql`
   identifier
   manifestUrl
   isActive
+  name
+  type
+  appUrl
 }
     `;
 export const InstalledAppDetailsFragmentDoc = gql`

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -11526,7 +11526,7 @@ export type InstalledAppsQueryVariables = Exact<{
 }>;
 
 
-export type InstalledAppsQuery = { __typename: 'Query', apps: { __typename: 'AppCountableConnection', totalCount: number | null, pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null }, edges: Array<{ __typename: 'AppCountableEdge', node: { __typename: 'App', id: string, identifier: string | null, manifestUrl: string | null, isActive: boolean | null } }> } | null };
+export type InstalledAppsQuery = { __typename: 'Query', apps: { __typename: 'AppCountableConnection', totalCount: number | null, pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null }, edges: Array<{ __typename: 'AppCountableEdge', node: { __typename: 'App', id: string, identifier: string | null, manifestUrl: string | null, isActive: boolean | null, name: string | null, type: AppTypeEnum | null, appUrl: string | null } }> } | null };
 
 export type InstalledAppsListQueryVariables = Exact<{
   before?: InputMaybe<Scalars['String']['input']>;
@@ -11656,7 +11656,7 @@ export type EventDeliveryAttemptFragment = { __typename: 'EventDeliveryAttempt',
 
 export type AppEventDeliveriesFragment = { __typename: 'App', webhooks?: Array<{ __typename: 'Webhook', failedDelivers: { __typename: 'EventDeliveryCountableConnection', edges: Array<{ __typename: 'EventDeliveryCountableEdge', node: { __typename: 'EventDelivery', id: string, createdAt: any, attempts: { __typename: 'EventDeliveryAttemptCountableConnection', edges: Array<{ __typename: 'EventDeliveryAttemptCountableEdge', node: { __typename: 'EventDeliveryAttempt', id: string, status: EventDeliveryStatusEnum, createdAt: any } }> } | null } }> } | null, pendingDelivers: { __typename: 'EventDeliveryCountableConnection', edges: Array<{ __typename: 'EventDeliveryCountableEdge', node: { __typename: 'EventDelivery', id: string, attempts: { __typename: 'EventDeliveryAttemptCountableConnection', edges: Array<{ __typename: 'EventDeliveryAttemptCountableEdge', node: { __typename: 'EventDeliveryAttempt', id: string, status: EventDeliveryStatusEnum, createdAt: any } }> } | null } }> } | null }> | null };
 
-export type InstalledAppFragment = { __typename: 'App', id: string, identifier: string | null, manifestUrl: string | null, isActive: boolean | null };
+export type InstalledAppFragment = { __typename: 'App', id: string, identifier: string | null, manifestUrl: string | null, isActive: boolean | null, name: string | null, type: AppTypeEnum | null, appUrl: string | null };
 
 export type InstalledAppDetailsFragment = { __typename: 'App', id: string, isActive: boolean | null, name: string | null, type: AppTypeEnum | null, appUrl: string | null, problems: Array<{ __typename: 'AppProblem', key: string, message: string, createdAt: any, count: number, isCritical: boolean, updatedAt: any, id: string, dismissed: { __typename: 'AppProblemDismissed', by: AppProblemDismissedByEnum, userEmail: string | null } | null }> | null, brand: { __typename: 'AppBrand', logo: { __typename: 'AppBrandLogo', default: string } } | null };
 

--- a/src/home/components/PulseVideoAnnouncement/PulseVideoAnnouncement.tsx
+++ b/src/home/components/PulseVideoAnnouncement/PulseVideoAnnouncement.tsx
@@ -1,10 +1,6 @@
-import { IS_CLOUD_INSTANCE } from "@dashboard/config";
-import {
-  getPulsePromotionLink,
-  PULSE_POSTER_URL,
-  PULSE_VIDEO_URL,
-} from "@dashboard/home/getPulsePromotionLink";
+import { PULSE_POSTER_URL, PULSE_VIDEO_URL } from "@dashboard/home/getPulsePromotionLink";
 import { homeUrl } from "@dashboard/home/urls";
+import { usePulsePromotionLink } from "@dashboard/home/usePulsePromotionLink";
 import { PULSE_DOCS_URL } from "@dashboard/links";
 import { RippleVideoAnnouncement } from "@dashboard/ripples/components/RippleVideoAnnouncement/RippleVideoAnnouncement";
 import { type CornerRippleComponentProps } from "@dashboard/ripples/cornerRipples/selectActiveCornerRipple";
@@ -15,6 +11,11 @@ const messages = defineMessages({
     id: "XcwOQt",
     defaultMessage: "Install Pulse",
     description: "ripple video announcement CTA to install Saleor Pulse",
+  },
+  openCta: {
+    id: "+CE3ZW",
+    defaultMessage: "Open Pulse",
+    description: "ripple video announcement CTA when Saleor Pulse is already installed",
   },
   exploreCta: {
     id: "cNCKU1",
@@ -42,14 +43,17 @@ export const PulseVideoAnnouncement = ({
   model,
 }: CornerRippleComponentProps): JSX.Element | null => {
   const intl = useIntl();
-  const pulseLink = getPulsePromotionLink(IS_CLOUD_INSTANCE);
+  const pulseLink = usePulsePromotionLink();
 
-  // Cloud: deep-link to install. Open source: send people to Home (empty-state promo).
   const primaryAction =
     pulseLink.kind === "internal"
       ? {
           href: pulseLink.to,
-          label: <FormattedMessage {...messages.installCta} />,
+          label: (
+            <FormattedMessage
+              {...(pulseLink.intent === "open" ? messages.openCta : messages.installCta)}
+            />
+          ),
         }
       : {
           href: homeUrl(),

--- a/src/home/components/PulseVideoAnnouncement/PulseVideoAnnouncement.tsx
+++ b/src/home/components/PulseVideoAnnouncement/PulseVideoAnnouncement.tsx
@@ -1,5 +1,4 @@
 import { PULSE_POSTER_URL, PULSE_VIDEO_URL } from "@dashboard/home/getPulsePromotionLink";
-import { homeUrl } from "@dashboard/home/urls";
 import { usePulsePromotionLink } from "@dashboard/home/usePulsePromotionLink";
 import { PULSE_DOCS_URL } from "@dashboard/links";
 import { RippleVideoAnnouncement } from "@dashboard/ripples/components/RippleVideoAnnouncement/RippleVideoAnnouncement";
@@ -45,6 +44,7 @@ export const PulseVideoAnnouncement = ({
   const intl = useIntl();
   const pulseLink = usePulsePromotionLink();
 
+  // Match HomeEmptyState: cloud/install → internal path; OSS → App Store (external).
   const primaryAction =
     pulseLink.kind === "internal"
       ? {
@@ -56,7 +56,8 @@ export const PulseVideoAnnouncement = ({
           ),
         }
       : {
-          href: homeUrl(),
+          href: pulseLink.href,
+          external: true,
           label: <FormattedMessage {...messages.exploreCta} />,
         };
 

--- a/src/home/getPulsePromotionLink.test.ts
+++ b/src/home/getPulsePromotionLink.test.ts
@@ -15,6 +15,7 @@ describe("getPulsePromotionLink", () => {
     expect(link).toEqual({
       kind: "internal",
       to: ExtensionsUrls.resolveInstallCustomExtensionUrl(PULSE_MANIFEST_URL),
+      intent: "install",
     });
   });
 
@@ -26,6 +27,19 @@ describe("getPulsePromotionLink", () => {
     expect(link).toEqual({
       kind: "external",
       href: PULSE_APPS_STORE_URL,
+      intent: "explore",
+    });
+  });
+
+  it("returns the installed app page when Pulse is already installed", () => {
+    // Arrange & Act
+    const link = getPulsePromotionLink(true, { installedAppUrl: "/extensions/app/pulse-id" });
+
+    // Assert
+    expect(link).toEqual({
+      kind: "internal",
+      to: "/extensions/app/pulse-id",
+      intent: "open",
     });
   });
 });

--- a/src/home/getPulsePromotionLink.ts
+++ b/src/home/getPulsePromotionLink.ts
@@ -12,24 +12,48 @@ export const PULSE_VIDEO_URL = "https://saleor.io/blog/20260716_pulse/pulse.mp4"
 /** Local poster shown before the promo video loads / when autoplay is blocked. */
 export const PULSE_POSTER_URL: string = pulsePoster;
 
+export type PulsePromotionIntent = "install" | "open" | "explore";
+
 export type PulsePromotionLink =
-  | { kind: "internal"; to: string }
-  | { kind: "external"; href: string };
+  | { kind: "internal"; to: string; intent: PulsePromotionIntent }
+  | { kind: "external"; href: string; intent: "explore" };
+
+export const isPulseManifestUrl = (manifestUrl: string): boolean => {
+  try {
+    return new URL(manifestUrl).href === new URL(PULSE_MANIFEST_URL).href;
+  } catch {
+    return manifestUrl === PULSE_MANIFEST_URL;
+  }
+};
 
 /**
  * Cloud: deep-link into the Dashboard install flow for Pulse on the current env.
  * Open source: send merchants to the App Store listing (Pulse install is Cloud-hosted).
+ * When Pulse is already installed, link to its extension page like any other app.
  */
-export function getPulsePromotionLink(isCloudInstance: boolean): PulsePromotionLink {
+export function getPulsePromotionLink(
+  isCloudInstance: boolean,
+  options?: { installedAppUrl?: string | null },
+): PulsePromotionLink {
+  if (options?.installedAppUrl) {
+    return {
+      kind: "internal",
+      to: options.installedAppUrl,
+      intent: "open",
+    };
+  }
+
   if (isCloudInstance) {
     return {
       kind: "internal",
       to: ExtensionsUrls.resolveInstallCustomExtensionUrl(PULSE_MANIFEST_URL),
+      intent: "install",
     };
   }
 
   return {
     kind: "external",
     href: PULSE_APPS_STORE_URL,
+    intent: "explore",
   };
 }

--- a/src/home/usePulsePromotionLink.ts
+++ b/src/home/usePulsePromotionLink.ts
@@ -1,0 +1,42 @@
+import { IS_CLOUD_INSTANCE } from "@dashboard/config";
+import { findAlreadyInstalledApp } from "@dashboard/extensions/utils/findInstalledAppByIdentifier";
+import { resolveInstalledAppHref } from "@dashboard/extensions/utils/resolveInstalledAppHref";
+import { useInstalledAppsQuery } from "@dashboard/graphql";
+import { mapEdgesToItems } from "@dashboard/utils/maps";
+
+import {
+  getPulsePromotionLink,
+  PULSE_MANIFEST_URL,
+  type PulsePromotionLink,
+} from "./getPulsePromotionLink";
+
+export const usePulsePromotionLink = (): PulsePromotionLink & { loading: boolean } => {
+  const { data: installedAppsData, loading } = useInstalledAppsQuery({
+    variables: {
+      first: 100,
+    },
+  });
+  const installedApps = mapEdgesToItems(installedAppsData?.apps) ?? [];
+  const pulseApp = findAlreadyInstalledApp(installedApps, {
+    manifestUrl: PULSE_MANIFEST_URL,
+  });
+
+  if (pulseApp) {
+    const installedAppUrl = resolveInstalledAppHref({
+      id: pulseApp.id,
+      type: pulseApp.type,
+      isActive: pulseApp.isActive,
+      appUrl: pulseApp.appUrl,
+    });
+
+    return {
+      ...getPulsePromotionLink(IS_CLOUD_INSTANCE, { installedAppUrl }),
+      loading,
+    };
+  }
+
+  return {
+    ...getPulsePromotionLink(IS_CLOUD_INSTANCE),
+    loading,
+  };
+};

--- a/src/ripples/components/AllRipplesModal.test.tsx
+++ b/src/ripples/components/AllRipplesModal.test.tsx
@@ -1,9 +1,77 @@
 import { type Ripple } from "@dashboard/ripples/types";
-import { Text } from "@saleor/macaw-ui-next";
+import { Text, ThemeProvider } from "@saleor/macaw-ui-next";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ReactNode } from "react";
 import { defineMessage } from "react-intl";
+import { MemoryRouter } from "react-router-dom";
 
 import { getRipplesSortedAndGroupedByMonths, RippleGlobalDescription } from "./AllRipplesModal";
+
+const mockNavigate = jest.fn();
+const mockOnChange = jest.fn();
+
+jest.mock("@dashboard/hooks/useNavigator", () => ({
+  __esModule: true,
+  default: jest.fn(() => mockNavigate),
+}));
+
+jest.mock("@dashboard/components/ProductAnalytics/useAnalytics", () => ({
+  useAnalytics: jest.fn(() => ({
+    trackEvent: jest.fn(),
+  })),
+}));
+
+jest.mock("@dashboard/ripples/hooks/useRipplesStorage", () => ({
+  useRippleStorage: jest.fn(() => ({
+    hideAllRipples: jest.fn(),
+    setManuallyHidden: jest.fn(),
+  })),
+}));
+
+jest.mock("@dashboard/home/usePulsePromotionLink", () => ({
+  usePulsePromotionLink: jest.fn(() => ({
+    kind: "internal",
+    to: "/extensions/app/install?manifestUrl=https%3A%2F%2Fpulse.saleor.app%2Fapi%2Fmanifest",
+    intent: "install",
+    loading: false,
+  })),
+}));
+
+jest.mock("@dashboard/ripples/allRipples", () => ({
+  allRipples: [
+    {
+      type: "newApp",
+      ID: "saleor-pulse",
+      dateAdded: new Date(2026, 6, 31),
+      content: {
+        oneLiner: "Saleor Pulse",
+        global: "Analytics on your homepage.",
+        contextual: "See real-time store analytics.",
+      },
+      TTL_seconds: 3600,
+      actions: [
+        {
+          label: {
+            defaultMessage: "Install Pulse",
+            id: "testInstallPulse",
+          },
+          href: "/extensions/app/install?manifestUrl=https%3A%2F%2Fpulse.saleor.app%2Fapi%2Fmanifest",
+        },
+      ],
+    },
+  ],
+}));
+
+const { AllRipplesModal } = jest.requireActual(
+  "./AllRipplesModal",
+) as typeof import("./AllRipplesModal");
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <MemoryRouter initialEntries={["/"]}>
+    <ThemeProvider>{children}</ThemeProvider>
+  </MemoryRouter>
+);
 
 const createMockRipple = (id: string, dateAdded: Date, overrides?: Partial<Ripple>): Ripple => ({
   type: "feature",
@@ -259,5 +327,50 @@ describe("Ripple actions", () => {
 
     // Note: TypeScript enforces that actions cannot have both href and onClick,
     // and cannot have neither. This is enforced at compile time via the RippleAction union type.
+  });
+});
+
+describe("AllRipplesModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("closes the modal and navigates when an internal action link is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+
+    render(<AllRipplesModal open onChange={mockOnChange} />, { wrapper: Wrapper });
+
+    // Act
+    await user.click(screen.getByRole("link", { name: "Install Pulse" }));
+
+    // Assert
+    expect(mockOnChange).toHaveBeenCalledWith(false);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/extensions/app/install?manifestUrl=https%3A%2F%2Fpulse.saleor.app%2Fapi%2Fmanifest",
+    );
+  });
+
+  it("opens Pulse directly when it is already installed", async () => {
+    // Arrange
+    const { usePulsePromotionLink } = jest.requireMock("@dashboard/home/usePulsePromotionLink");
+
+    usePulsePromotionLink.mockReturnValue({
+      kind: "internal",
+      to: "/extensions/app/pulse-app-id",
+      intent: "open",
+      loading: false,
+    });
+
+    const user = userEvent.setup();
+
+    render(<AllRipplesModal open onChange={mockOnChange} />, { wrapper: Wrapper });
+
+    // Act
+    await user.click(screen.getByRole("link", { name: "Open Pulse" }));
+
+    // Assert
+    expect(mockOnChange).toHaveBeenCalledWith(false);
+    expect(mockNavigate).toHaveBeenCalledWith("/extensions/app/pulse-app-id");
   });
 });

--- a/src/ripples/components/AllRipplesModal.test.tsx
+++ b/src/ripples/components/AllRipplesModal.test.tsx
@@ -331,8 +331,18 @@ describe("Ripple actions", () => {
 });
 
 describe("AllRipplesModal", () => {
+  const { usePulsePromotionLink } = jest.requireMock("@dashboard/home/usePulsePromotionLink") as {
+    usePulsePromotionLink: jest.Mock;
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    usePulsePromotionLink.mockReturnValue({
+      kind: "internal",
+      to: "/extensions/app/install?manifestUrl=https%3A%2F%2Fpulse.saleor.app%2Fapi%2Fmanifest",
+      intent: "install",
+      loading: false,
+    });
   });
 
   it("closes the modal and navigates when an internal action link is clicked", async () => {
@@ -353,8 +363,6 @@ describe("AllRipplesModal", () => {
 
   it("opens Pulse directly when it is already installed", async () => {
     // Arrange
-    const { usePulsePromotionLink } = jest.requireMock("@dashboard/home/usePulsePromotionLink");
-
     usePulsePromotionLink.mockReturnValue({
       kind: "internal",
       to: "/extensions/app/pulse-app-id",
@@ -372,5 +380,28 @@ describe("AllRipplesModal", () => {
     // Assert
     expect(mockOnChange).toHaveBeenCalledWith(false);
     expect(mockNavigate).toHaveBeenCalledWith("/extensions/app/pulse-app-id");
+  });
+
+  it("links to the App Store explore URL on open-source instances", async () => {
+    // Arrange
+    usePulsePromotionLink.mockReturnValue({
+      kind: "external",
+      href: "https://apps.saleor.io/apps/pulse",
+      intent: "explore",
+      loading: false,
+    });
+
+    const user = userEvent.setup();
+
+    render(<AllRipplesModal open onChange={mockOnChange} />, { wrapper: Wrapper });
+
+    // Act
+    const exploreLink = screen.getByRole("link", { name: "Explore Pulse" });
+
+    await user.click(exploreLink);
+
+    // Assert
+    expect(exploreLink).toHaveAttribute("href", "https://apps.saleor.io/apps/pulse");
+    expect(mockOnChange).toHaveBeenCalledWith(false);
   });
 });

--- a/src/ripples/components/AllRipplesModal.tsx
+++ b/src/ripples/components/AllRipplesModal.tsx
@@ -2,9 +2,12 @@ import githubLogo from "@assets/images/github-logo.svg";
 import { Link } from "@dashboard/components/Link";
 import { DashboardModal } from "@dashboard/components/Modal";
 import { useAnalytics } from "@dashboard/components/ProductAnalytics/useAnalytics";
+import { usePulsePromotionLink } from "@dashboard/home/usePulsePromotionLink";
+import useNavigator from "@dashboard/hooks/useNavigator";
 import { getStatusColor, type PillStatusType } from "@dashboard/misc";
 import { allRipples } from "@dashboard/ripples/allRipples";
 import { useRippleStorage } from "@dashboard/ripples/hooks/useRipplesStorage";
+import { rippleActionMessages } from "@dashboard/ripples/messages";
 import { rippleIntroducedRipples } from "@dashboard/ripples/ripples/introducedRipples";
 import { type Ripple, type RippleType } from "@dashboard/ripples/types";
 import { isExternalURL } from "@dashboard/utils/urls";
@@ -68,9 +71,6 @@ export const getRipplesSortedAndGroupedByMonths = (
 
       return acc;
     }, {});
-
-const groupedRipples = getRipplesSortedAndGroupedByMonths(allRipples);
-const flattenedRipples = Object.values(groupedRipples).flat();
 
 const rippleTypeToPillStatus: Record<RippleType, PillStatusType> = {
   feature: "success",
@@ -144,13 +144,62 @@ const RippleActionContent = ({ label, isHovered }: { label: string; isHovered: b
   </>
 );
 
-const RippleAction = ({ action }: { action: NonNullable<Ripple["actions"]>[number] }) => {
+const PulseInstallRippleAction = ({
+  action,
+  onActionClick,
+}: {
+  action: NonNullable<Ripple["actions"]>[number];
+  onActionClick: () => void;
+}) => {
+  const pulseLink = usePulsePromotionLink();
+  const resolvedAction = useMemo(() => {
+    if (pulseLink.loading) {
+      return action;
+    }
+
+    if (pulseLink.kind === "internal" && pulseLink.intent === "open") {
+      return {
+        ...action,
+        href: pulseLink.to,
+        label: rippleActionMessages.openPulse,
+      };
+    }
+
+    if (pulseLink.kind === "internal") {
+      return {
+        ...action,
+        href: pulseLink.to,
+      };
+    }
+
+    return action;
+  }, [action, pulseLink]);
+
+  return <RippleAction action={resolvedAction} onActionClick={onActionClick} />;
+};
+
+const RippleAction = ({
+  action,
+  onActionClick,
+}: {
+  action: NonNullable<Ripple["actions"]>[number];
+  onActionClick: () => void;
+}) => {
   const intl = useIntl();
+  const navigate = useNavigator();
   const [isHovered, setIsHovered] = useState(false);
   const label = intl.formatMessage(action.label);
 
   if (action.href) {
     const external = isExternalURL(action.href);
+
+    const handleClick = (): void => {
+      onActionClick();
+
+      if (!external) {
+        navigate(action.href);
+      }
+    };
 
     // Internal hrefs must go through Dashboard Link (basename / SPA). Opening
     // them with target="_blank" broke in-app install deep-links under /dashboard.
@@ -162,6 +211,7 @@ const RippleAction = ({ action }: { action: NonNullable<Ripple["actions"]>[numbe
         {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
+        onClick={handleClick}
       >
         <RippleActionContent label={label} isHovered={isHovered} />
       </Link>
@@ -175,7 +225,10 @@ const RippleAction = ({ action }: { action: NonNullable<Ripple["actions"]>[numbe
       alignItems="center"
       gap={1}
       cursor="pointer"
-      onClick={action.onClick}
+      onClick={() => {
+        action.onClick?.();
+        onActionClick();
+      }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       backgroundColor="transparent"
@@ -191,9 +244,10 @@ interface RippleEntryRowProps {
   ripple: Ripple;
   dateDisplay: string;
   isLast: boolean;
+  onActionClick: () => void;
 }
 
-const RippleEntryRow = ({ ripple, dateDisplay, isLast }: RippleEntryRowProps) => {
+const RippleEntryRow = ({ ripple, dateDisplay, isLast, onActionClick }: RippleEntryRowProps) => {
   return (
     <Box display="flex" gap={4}>
       {/* Timeline column - dot and line */}
@@ -264,9 +318,21 @@ const RippleEntryRow = ({ ripple, dateDisplay, isLast }: RippleEntryRowProps) =>
           <Box display="flex" flexWrap="wrap" alignItems="center" gap={4} marginTop={3}>
             {ripple.actions
               .filter(action => !action.hideInModal)
-              .map((action, index) => (
-                <RippleAction key={`${ripple.ID}-action-${index}`} action={action} />
-              ))}
+              .map((action, index) =>
+                ripple.ID === "saleor-pulse" && action.href?.includes("pulse.saleor.app") ? (
+                  <PulseInstallRippleAction
+                    key={`${ripple.ID}-action-${index}`}
+                    action={action}
+                    onActionClick={onActionClick}
+                  />
+                ) : (
+                  <RippleAction
+                    key={`${ripple.ID}-action-${index}`}
+                    action={action}
+                    onActionClick={onActionClick}
+                  />
+                ),
+              )}
           </Box>
         ) : null}
       </Box>
@@ -283,6 +349,11 @@ export const AllRipplesModal = ({ open, onChange }: AllRipplesModalProps) => {
   const intl = useIntl();
   const { hideAllRipples, setManuallyHidden } = useRippleStorage();
   const { trackEvent } = useAnalytics();
+
+  const flattenedRipples = useMemo(
+    () => Object.values(getRipplesSortedAndGroupedByMonths(allRipples)).flat(),
+    [],
+  );
 
   const lastUpdatedDate = useMemo(() => {
     const latestRipple = allRipples.reduce((latest, ripple) =>
@@ -338,6 +409,7 @@ export const AllRipplesModal = ({ open, onChange }: AllRipplesModalProps) => {
                 ripple={entry.ripple}
                 dateDisplay={entry.dateDisplay}
                 isLast={index === flattenedRipples.length - 1}
+                onActionClick={handleClose}
               />
             ))}
           </DashboardModal.Inset>

--- a/src/ripples/components/AllRipplesModal.tsx
+++ b/src/ripples/components/AllRipplesModal.tsx
@@ -4,12 +4,13 @@ import { DashboardModal } from "@dashboard/components/Modal";
 import { useAnalytics } from "@dashboard/components/ProductAnalytics/useAnalytics";
 import { usePulsePromotionLink } from "@dashboard/home/usePulsePromotionLink";
 import useNavigator from "@dashboard/hooks/useNavigator";
+import { PULSE_DOCS_URL } from "@dashboard/links";
 import { getStatusColor, type PillStatusType } from "@dashboard/misc";
 import { allRipples } from "@dashboard/ripples/allRipples";
 import { useRippleStorage } from "@dashboard/ripples/hooks/useRipplesStorage";
 import { rippleActionMessages } from "@dashboard/ripples/messages";
 import { rippleIntroducedRipples } from "@dashboard/ripples/ripples/introducedRipples";
-import { type Ripple, type RippleType } from "@dashboard/ripples/types";
+import { type Ripple, type RippleAction, type RippleType } from "@dashboard/ripples/types";
 import { isExternalURL } from "@dashboard/utils/urls";
 import { Box, Button, Text, useTheme, vars } from "@saleor/macaw-ui-next";
 import { ChevronRightIcon } from "lucide-react";
@@ -152,31 +153,42 @@ const PulseInstallRippleAction = ({
   onActionClick: () => void;
 }) => {
   const pulseLink = usePulsePromotionLink();
-  const resolvedAction = useMemo(() => {
+  const resolvedAction = useMemo((): RippleAction => {
     if (pulseLink.loading) {
       return action;
     }
 
+    // Rebuild as RippleActionWithHref — spreading `action` can retain onClick
+    // and violate the mutually exclusive RippleAction union.
     if (pulseLink.kind === "internal" && pulseLink.intent === "open") {
       return {
-        ...action,
         href: pulseLink.to,
         label: rippleActionMessages.openPulse,
+        hideInModal: action.hideInModal,
       };
     }
 
     if (pulseLink.kind === "internal") {
       return {
-        ...action,
         href: pulseLink.to,
+        label: action.label,
+        hideInModal: action.hideInModal,
       };
     }
 
-    return action;
+    return {
+      href: pulseLink.href,
+      label: rippleActionMessages.explorePulse,
+      hideInModal: action.hideInModal,
+    };
   }, [action, pulseLink]);
 
   return <RippleAction action={resolvedAction} onActionClick={onActionClick} />;
 };
+
+/** Pulse primary CTA (install/open/explore) — not the docs link. */
+const isPulsePrimaryRippleAction = (action: RippleAction): boolean =>
+  !!action.href && action.href !== PULSE_DOCS_URL;
 
 const RippleAction = ({
   action,
@@ -319,7 +331,7 @@ const RippleEntryRow = ({ ripple, dateDisplay, isLast, onActionClick }: RippleEn
             {ripple.actions
               .filter(action => !action.hideInModal)
               .map((action, index) =>
-                ripple.ID === "saleor-pulse" && action.href?.includes("pulse.saleor.app") ? (
+                ripple.ID === "saleor-pulse" && isPulsePrimaryRippleAction(action) ? (
                   <PulseInstallRippleAction
                     key={`${ripple.ID}-action-${index}`}
                     action={action}

--- a/src/ripples/messages.ts
+++ b/src/ripples/messages.ts
@@ -24,6 +24,11 @@ export const rippleActionMessages = defineMessages({
     defaultMessage: "Install Pulse",
     description: "ripple action to install Saleor Pulse",
   },
+  openPulse: {
+    id: "r0blTm",
+    defaultMessage: "Open Pulse",
+    description: "ripple action to open Saleor Pulse when already installed",
+  },
   explorePulse: {
     id: "c5sFXi",
     defaultMessage: "Explore Pulse",


### PR DESCRIPTION
When appFetchManifest returns UNIQUE, resolve the existing app from Saleor's error payload and installed apps, then guide merchants to open it instead of showing a raw duplicate-install error.